### PR TITLE
Change behavior for an unsupported website

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -69,8 +69,18 @@ def url_path_to_dict(path):
     return url_dict
 
 
-def scrape_me(url_path):
-    return SCRAPERS[url_path_to_dict(url_path.replace('://www.', '://'))['host']](url_path)
+class WebsiteNotImplementedError(NotImplementedError):
+    '''Error for when the website is not supported by this library.'''
 
+
+def scrape_me(url_path):
+    host_name = url_path_to_dict(url_path.replace('://www.', '://'))['host']
+    try:
+        scraper = SCRAPERS[host_name]
+    except KeyError:
+        raise WebsiteNotImplementedError(
+            "Website ({}) is not supported".format(host_name))
+
+    return scraper(url_path)
 
 __all__ = ['scrape_me']


### PR DESCRIPTION
to additionally raise a custom WebsiteNotImplementedError exception.  I think this helps make the library slightly more user friendly.

Example Code:
```
from recipe_scrapers import scrape_me
scrape_me("http://www.cnn.com")
```

Current behavior:
```
KeyError: 'cnn.com'
```


With this pull request the new behavior:
```
KeyError: 'cnn.com'

During handling of the above exception, another exception occurred:

WebsiteNotImplementedError: Website (cnn.com) is not supported
```