### PR TITLE
Added serving-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ then:
 
     scraper.title()
     scraper.total_time()
+    scraper.yields()
     scraper.ingredients()
     scraper.instructions()
     scraper.links()

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -24,6 +24,7 @@ class AbstractScraper():
             decorated_methods = [
                 'title',
                 'total_time',
+                'servings',
                 'instructions',
                 'ingredients',
                 'links'
@@ -31,6 +32,8 @@ class AbstractScraper():
             if name in decorated_methods:
                 to_return = ''
             if name == 'total_time':
+                to_return = 0
+            if name == 'servings':
                 to_return = 0
             if name == 'ingredients':
                 to_return = []
@@ -67,6 +70,10 @@ class AbstractScraper():
         raise NotImplementedError("This should be implemented.")
 
     def title(self):
+        raise NotImplementedError("This should be implemented.")
+
+    def servings(self):
+        """ total time it takes to preparate the recipe in minutes """
         raise NotImplementedError("This should be implemented.")
 
     def total_time(self):

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -72,12 +72,12 @@ class AbstractScraper():
     def title(self):
         raise NotImplementedError("This should be implemented.")
 
-    def servings(self):
+    def total_time(self):
         """ total time it takes to preparate the recipe in minutes """
         raise NotImplementedError("This should be implemented.")
 
-    def total_time(self):
-        """ total time it takes to preparate the recipe in minutes """
+    def servings(self):
+        """ The number of servings of given recipe """
         raise NotImplementedError("This should be implemented.")
 
     def ingredients(self):

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -24,7 +24,7 @@ class AbstractScraper():
             decorated_methods = [
                 'title',
                 'total_time',
-                'servings',
+                'yields',
                 'instructions',
                 'ingredients',
                 'links'
@@ -33,8 +33,8 @@ class AbstractScraper():
                 to_return = ''
             if name == 'total_time':
                 to_return = 0
-            if name == 'servings':
-                to_return = 0
+            if name == 'yields':
+                to_return = ''
             if name == 'ingredients':
                 to_return = []
             if name == 'links':
@@ -76,8 +76,8 @@ class AbstractScraper():
         """ total time it takes to preparate the recipe in minutes """
         raise NotImplementedError("This should be implemented.")
 
-    def servings(self):
-        """ The number of servings of given recipe """
+    def yields(self):
+        """ The number of servings or items in the recipe """
         raise NotImplementedError("This should be implemented.")
 
     def ingredients(self):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -36,6 +36,12 @@ def get_minutes(element):
 
 
 def get_servings(element):
+    """
+    Will return an int if number is in number of servings, if the receipt is for number of items and not servings
+    the method will return the string "x item(s)" where x is the quantity.
+    :param element: Should be BeautifulSoup.TAG, in some cases not feasible and will then be text.
+    :return: The number of servings or items.
+    """
     try:
 
         if isinstance(element, str):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -35,9 +35,9 @@ def get_minutes(element):
         return 0
 
 
-def get_servings(element):
+def get_yields(element):
     """
-    Will return an int if number is in number of servings, if the receipt is for number of items and not servings
+    Will return a string of servings or items, if the receipt is for number of items and not servings
     the method will return the string "x item(s)" where x is the quantity.
     :param element: Should be BeautifulSoup.TAG, in some cases not feasible and will then be text.
     :return: The number of servings or items.
@@ -52,19 +52,19 @@ def get_servings(element):
         if SERV_REGEX_TO.search(tstring):
             tstring = tstring.split(SERV_REGEX_TO.split(tstring)[1])[1]
 
-        matched = SERV_REGEX_NUMBER.search(tstring)
-        servings = int(matched.groupdict().get('items') or 0)
+        matched = SERV_REGEX_NUMBER.search(tstring).groupdict().get('items') or 0
+        servings = "{} serving(s)".format(matched)
 
         if SERV_REGEX_ITEMS.search(tstring) is not None:
             # This assumes if object(s), like sandwiches, it is 1 person.
             # Issue: "Makes one 9-inch pie, (realsimple-testcase, gives "9 items")
-            servings = "{} {}".format(servings, "item(s)")
+            servings = "{} item(s)".format(matched)
 
         return servings
 
     except AttributeError as e:  # if dom_element not found or no matched
         print("get_serving_numbers error {}".format(e))
-        return 0
+        return ''
 
 
 def normalize_string(string):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -7,6 +7,18 @@ TIME_REGEX = re.compile(
     r'(\D*(?P<hours>\d+)\s*(hours|hrs|hr|h|Hours|H))?(\D*(?P<minutes>\d+)\s*(minutes|mins|min|m|Minutes|M))?'
 )
 
+SERV_REGEX_NUMBER = re.compile(
+    r'(\D*(?P<items>\d+)?\D*)'
+)
+
+SERV_REGEX_ITEMS = re.compile(
+    r'\bsandwiches\b |\btacquitos\b | \bmakes\b', flags=re.I | re.X
+)
+
+SERV_REGEX_TO = re.compile(
+    r'\d+(\s+to\s+|-)\d+', flags=re.I | re.X
+)
+
 
 def get_minutes(element):
     try:
@@ -20,6 +32,32 @@ def get_minutes(element):
 
         return minutes
     except AttributeError:  # if dom_element not found or no matched
+        return 0
+
+
+def get_servings(element):
+    try:
+
+        if isinstance(element, str):
+            tstring = element
+        else:
+            tstring = element.get_text()
+
+        if SERV_REGEX_TO.search(tstring):
+            tstring = tstring.split(SERV_REGEX_TO.split(tstring)[1])[1]
+
+        matched = SERV_REGEX_NUMBER.search(tstring)
+        servings = int(matched.groupdict().get('items') or 0)
+
+        if SERV_REGEX_ITEMS.search(tstring) is not None:
+            # This assumes if object(s), like sandwiches, it is 1 person.
+            # Issue: "Makes one 9-inch pie, (realsimple-testcase, gives "9 items")
+            servings = "{} {}".format(servings, "item(s)")
+
+        return servings
+
+    except AttributeError as e:  # if dom_element not found or no matched
+        print("get_serving_numbers error {}".format(e))
         return 0
 
 

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class AllRecipes(AbstractScraper):
@@ -15,6 +15,12 @@ class AllRecipes(AbstractScraper):
         return get_minutes(self.soup.find(
             'span',
             {'class': 'ready-in-time'})
+        )
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'meta',
+            {'id': 'metaRecipeServings', 'itemprop': 'recipeYield'}).get("content")
         )
 
     def ingredients(self):

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class AllRecipes(AbstractScraper):
@@ -17,11 +17,11 @@ class AllRecipes(AbstractScraper):
             {'class': 'ready-in-time'})
         )
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'meta',
             {'id': 'metaRecipeServings', 'itemprop': 'recipeYield'}).get("content")
-        )
+                          )
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/allrecipesbr.py
+++ b/recipe_scrapers/allrecipesbr.py
@@ -30,7 +30,7 @@ class AllRecipesBr(AbstractScraper):
             for ingredient in ingredients
         ]
 
-    def servings(self):
+    def yields(self):
         return 0
 
     def instructions(self):

--- a/recipe_scrapers/allrecipesbr.py
+++ b/recipe_scrapers/allrecipesbr.py
@@ -30,6 +30,9 @@ class AllRecipesBr(AbstractScraper):
             for ingredient in ingredients
         ]
 
+    def servings(self):
+        return 0
+
     def instructions(self):
         instructions = self.soup.find(
             'ol', {'itemprop': 'recipeInstructions'}

--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class BBCFood(AbstractScraper):
@@ -24,8 +24,8 @@ class BBCFood(AbstractScraper):
             )
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'p',
             {'class': 'recipe-metadata__serving'})
         )

--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class BBCFood(AbstractScraper):
@@ -23,6 +23,12 @@ class BBCFood(AbstractScraper):
                 {'class': 'recipe-metadata__cook-time'})
             )
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'p',
+            {'class': 'recipe-metadata__serving'})
+        )
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/bbcgoodfood.py
+++ b/recipe_scrapers/bbcgoodfood.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class BBCGoodFood(AbstractScraper):
@@ -23,6 +23,12 @@ class BBCGoodFood(AbstractScraper):
                 {'class': 'recipe-details__cooking-time-cook'}
             ).find('span'))
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+                'span',
+                {'class': 'recipe-details__text', 'itemprop': 'recipeYield'}
+            ))
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/bbcgoodfood.py
+++ b/recipe_scrapers/bbcgoodfood.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class BBCGoodFood(AbstractScraper):
@@ -24,8 +24,8 @@ class BBCGoodFood(AbstractScraper):
             ).find('span'))
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
                 'span',
                 {'class': 'recipe-details__text', 'itemprop': 'recipeYield'}
             ))

--- a/recipe_scrapers/bonappetit.py
+++ b/recipe_scrapers/bonappetit.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string
+from ._utils import normalize_string, get_servings
 
 
 class BonAppetit(AbstractScraper):
@@ -16,6 +16,14 @@ class BonAppetit(AbstractScraper):
 
     def total_time(self):
         return 0
+
+    def servings(self):
+        return get_servings(
+            self.soup.find(
+                'span',
+                {'class': "recipe__header__servings recipe__header__servings--basically"}
+            ).find('span')
+        )
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/bonappetit.py
+++ b/recipe_scrapers/bonappetit.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_servings
+from ._utils import normalize_string, get_yields
 
 
 class BonAppetit(AbstractScraper):
@@ -17,8 +17,8 @@ class BonAppetit(AbstractScraper):
     def total_time(self):
         return 0
 
-    def servings(self):
-        return get_servings(
+    def yields(self):
+        return get_yields(
             self.soup.find(
                 'span',
                 {'class': "recipe__header__servings recipe__header__servings--basically"}

--- a/recipe_scrapers/closetcooking.py
+++ b/recipe_scrapers/closetcooking.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class ClosetCooking(AbstractScraper):
@@ -16,6 +16,10 @@ class ClosetCooking(AbstractScraper):
 
     def total_time(self):
         return get_minutes(self.soup.find(itemprop='totalTime').parent)
+
+
+    def servings(self):
+        return get_servings(self.soup.find(itemprop='recipeYield').parent)
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/closetcooking.py
+++ b/recipe_scrapers/closetcooking.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class ClosetCooking(AbstractScraper):
@@ -18,8 +18,8 @@ class ClosetCooking(AbstractScraper):
         return get_minutes(self.soup.find(itemprop='totalTime').parent)
 
 
-    def servings(self):
-        return get_servings(self.soup.find(itemprop='recipeYield').parent)
+    def yields(self):
+        return get_yields(self.soup.find(itemprop='recipeYield').parent)
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/cookstr.py
+++ b/recipe_scrapers/cookstr.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class Cookstr(AbstractScraper):
@@ -26,7 +26,7 @@ class Cookstr(AbstractScraper):
                 total_time += get_minutes(time.parent.parent)
         return total_time
 
-    def servings(self):
+    def yields(self):
         sections = self.soup.findAll(
             'span',
             {'class': 'attrLabel'}
@@ -35,7 +35,7 @@ class Cookstr(AbstractScraper):
         for section in sections:
             serves = section.find(text='Serves')
             if serves:
-                total_serves += get_servings(serves.parent.parent)
+                total_serves += get_yields(serves.parent.parent)
         return total_serves
 
     def ingredients(self):

--- a/recipe_scrapers/cookstr.py
+++ b/recipe_scrapers/cookstr.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class Cookstr(AbstractScraper):
@@ -25,6 +25,18 @@ class Cookstr(AbstractScraper):
             if time:
                 total_time += get_minutes(time.parent.parent)
         return total_time
+
+    def servings(self):
+        sections = self.soup.findAll(
+            'span',
+            {'class': 'attrLabel'}
+        )
+        total_serves = 0
+        for section in sections:
+            serves = section.find(text='Serves')
+            if serves:
+                total_serves += get_servings(serves.parent.parent)
+        return total_serves
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/epicurious.py
+++ b/recipe_scrapers/epicurious.py
@@ -2,7 +2,7 @@ import re
 
 
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_servings
+from ._utils import normalize_string, get_yields
 
 
 class Epicurious(AbstractScraper):
@@ -21,8 +21,8 @@ class Epicurious(AbstractScraper):
     def total_time(self):
         return 0
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'dd',
             {'itemprop': 'recipeYield'}
         ))

--- a/recipe_scrapers/epicurious.py
+++ b/recipe_scrapers/epicurious.py
@@ -2,7 +2,7 @@ import re
 
 
 from ._abstract import AbstractScraper
-from ._utils import normalize_string
+from ._utils import normalize_string, get_servings
 
 
 class Epicurious(AbstractScraper):
@@ -20,6 +20,12 @@ class Epicurious(AbstractScraper):
 
     def total_time(self):
         return 0
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'dd',
+            {'itemprop': 'recipeYield'}
+        ))
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/finedininglovers.py
+++ b/recipe_scrapers/finedininglovers.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class FineDiningLovers(AbstractScraper):
@@ -18,6 +18,13 @@ class FineDiningLovers(AbstractScraper):
         return get_minutes(self.soup.find(
             'time',
             {'itemprop': 'prepTime'})
+        )
+
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'span',
+            {'itemprop': 'recipeYield'})
         )
 
     def ingredients(self):

--- a/recipe_scrapers/finedininglovers.py
+++ b/recipe_scrapers/finedininglovers.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class FineDiningLovers(AbstractScraper):
@@ -21,8 +21,8 @@ class FineDiningLovers(AbstractScraper):
         )
 
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'span',
             {'itemprop': 'recipeYield'})
         )

--- a/recipe_scrapers/foodnetwork.py
+++ b/recipe_scrapers/foodnetwork.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class FoodNetwork(AbstractScraper):
@@ -15,6 +15,13 @@ class FoodNetwork(AbstractScraper):
         return get_minutes(self.soup.find(
             'span',
             {'class': 'm-RecipeInfo__a-Description--Total'})
+        )
+
+    def servings(self):
+        return get_servings(self.soup.find(
+                'ul',
+                {'class': 'o-RecipeInfo__m-Yield'}
+            ).find('span', {'class': 'o-RecipeInfo__a-Description'})
         )
 
     def ingredients(self):

--- a/recipe_scrapers/foodnetwork.py
+++ b/recipe_scrapers/foodnetwork.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class FoodNetwork(AbstractScraper):
@@ -17,12 +17,12 @@ class FoodNetwork(AbstractScraper):
             {'class': 'm-RecipeInfo__a-Description--Total'})
         )
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
                 'ul',
                 {'class': 'o-RecipeInfo__m-Yield'}
             ).find('span', {'class': 'o-RecipeInfo__a-Description'})
-        )
+                          )
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/foodrepublic.py
+++ b/recipe_scrapers/foodrepublic.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class FoodRepublic(AbstractScraper):
@@ -23,6 +23,12 @@ class FoodRepublic(AbstractScraper):
                 {'class': 'cook-time'})
             )
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'span',
+            {'itemprop': 'recipeYield'}
+        ))
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/foodrepublic.py
+++ b/recipe_scrapers/foodrepublic.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class FoodRepublic(AbstractScraper):
@@ -24,8 +24,8 @@ class FoodRepublic(AbstractScraper):
             )
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'span',
             {'itemprop': 'recipeYield'}
         ))

--- a/recipe_scrapers/geniuskitchen.py
+++ b/recipe_scrapers/geniuskitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class GeniusKitchen(AbstractScraper):
@@ -17,12 +17,12 @@ class GeniusKitchen(AbstractScraper):
             {'class': 'time'})
         )
                 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'td',
             {'class': 'servings'}
         ).find('span', {'class': 'count'})
-        )
+                          )
 
 
     def ingredients(self):

--- a/recipe_scrapers/geniuskitchen.py
+++ b/recipe_scrapers/geniuskitchen.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
+
 
 class GeniusKitchen(AbstractScraper):
 
@@ -16,6 +17,13 @@ class GeniusKitchen(AbstractScraper):
             {'class': 'time'})
         )
                 
+    def servings(self):
+        return get_servings(self.soup.find(
+            'td',
+            {'class': 'servings'}
+        ).find('span', {'class': 'count'})
+        )
+
 
     def ingredients(self):
         ingredients = []

--- a/recipe_scrapers/giallozafferano.py
+++ b/recipe_scrapers/giallozafferano.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 import json
 
 
@@ -24,6 +24,12 @@ class GialloZafferano(AbstractScraper):
                 {'class': 'cooktime'})
             )
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+                'li',
+                {'class': 'yield'})
+            )
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/giallozafferano.py
+++ b/recipe_scrapers/giallozafferano.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 import json
 
 
@@ -25,8 +25,8 @@ class GialloZafferano(AbstractScraper):
             )
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
                 'li',
                 {'class': 'yield'})
             )

--- a/recipe_scrapers/hellofresh.py
+++ b/recipe_scrapers/hellofresh.py
@@ -20,6 +20,9 @@ class HelloFresh(AbstractScraper):
             {'data-translation-id': "recipe-detail.preparation-time"}
         ).parent.parent)
 
+    def servings(self):
+        return 0
+
     def ingredients(self):
         ingredients_container = self.soup.find(
             'div',

--- a/recipe_scrapers/hellofresh.py
+++ b/recipe_scrapers/hellofresh.py
@@ -20,7 +20,7 @@ class HelloFresh(AbstractScraper):
             {'data-translation-id': "recipe-detail.preparation-time"}
         ).parent.parent)
 
-    def servings(self):
+    def yields(self):
         return 0
 
     def ingredients(self):

--- a/recipe_scrapers/hundredandonecookbooks.py
+++ b/recipe_scrapers/hundredandonecookbooks.py
@@ -17,6 +17,9 @@ class HundredAndOneCookbooks(AbstractScraper):
             {'class': 'preptime'})
         )
 
+    def servings(self):
+        return 0
+
     def ingredients(self):
         ingredients = self.soup.find(
             'div',

--- a/recipe_scrapers/hundredandonecookbooks.py
+++ b/recipe_scrapers/hundredandonecookbooks.py
@@ -17,7 +17,7 @@ class HundredAndOneCookbooks(AbstractScraper):
             {'class': 'preptime'})
         )
 
-    def servings(self):
+    def yields(self):
         return 0
 
     def ingredients(self):

--- a/recipe_scrapers/inspiralized.py
+++ b/recipe_scrapers/inspiralized.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class Inspiralized(AbstractScraper):
@@ -15,6 +15,12 @@ class Inspiralized(AbstractScraper):
         return get_minutes(self.soup.find(
             'span',
             {'itemprop': 'totalTime'})
+        )
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'span',
+            {'itemprop': 'recipeYield'})
         )
 
     def ingredients(self):

--- a/recipe_scrapers/inspiralized.py
+++ b/recipe_scrapers/inspiralized.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class Inspiralized(AbstractScraper):
@@ -17,8 +17,8 @@ class Inspiralized(AbstractScraper):
             {'itemprop': 'totalTime'})
         )
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'span',
             {'itemprop': 'recipeYield'})
         )

--- a/recipe_scrapers/jamieoliver.py
+++ b/recipe_scrapers/jamieoliver.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class JamieOliver(AbstractScraper):
@@ -15,6 +15,12 @@ class JamieOliver(AbstractScraper):
         return get_minutes(self.soup.find(
             'div',
             {'class': 'time'})
+        )
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'div',
+            {'class': 'recipe-detail serves'})
         )
 
     def ingredients(self):

--- a/recipe_scrapers/jamieoliver.py
+++ b/recipe_scrapers/jamieoliver.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class JamieOliver(AbstractScraper):
@@ -17,8 +17,8 @@ class JamieOliver(AbstractScraper):
             {'class': 'time'})
         )
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'div',
             {'class': 'recipe-detail serves'})
         )

--- a/recipe_scrapers/mybakingaddiction.py
+++ b/recipe_scrapers/mybakingaddiction.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class MyBakingAddiction(AbstractScraper):
@@ -24,8 +24,8 @@ class MyBakingAddiction(AbstractScraper):
             ).parent)
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
                 'span',
                 {'itemprop': 'recipeYield'}
             ))

--- a/recipe_scrapers/mybakingaddiction.py
+++ b/recipe_scrapers/mybakingaddiction.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class MyBakingAddiction(AbstractScraper):
@@ -23,6 +23,12 @@ class MyBakingAddiction(AbstractScraper):
                 {'itemprop': 'cookTime'}
             ).parent)
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+                'span',
+                {'itemprop': 'recipeYield'}
+            ))
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_minutes, get_servings
+from ._utils import normalize_string, get_minutes, get_yields
 
 
 class NIHHealthyEating(AbstractScraper):
@@ -22,7 +22,7 @@ class NIHHealthyEating(AbstractScraper):
             for td in time_table.find_all('td')
         ])
 
-    def servings(self):
+    def yields(self):
         time_table = self.soup.find(
             'table',
             {'class': 'recipe_time_table'}
@@ -36,7 +36,7 @@ class NIHHealthyEating(AbstractScraper):
 
         if i >= len(time_table.findAll('td')):
             return 0
-        return get_servings(time_table.find_all('td')[i])
+        return get_yields(time_table.find_all('td')[i])
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_minutes
+from ._utils import normalize_string, get_minutes, get_servings
 
 
 class NIHHealthyEating(AbstractScraper):
@@ -21,6 +21,22 @@ class NIHHealthyEating(AbstractScraper):
             get_minutes(td)
             for td in time_table.find_all('td')
         ])
+
+    def servings(self):
+        time_table = self.soup.find(
+            'table',
+            {'class': 'recipe_time_table'}
+        )
+
+        i = 0
+        for t in time_table.findAll('th'):
+            if "Yields" in t:
+                break
+            i += 1
+
+        if i >= len(time_table.findAll('td')):
+            return 0
+        return get_servings(time_table.find_all('td')[i])
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/paninihappy.py
+++ b/recipe_scrapers/paninihappy.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class PaniniHappy(AbstractScraper):
@@ -20,8 +20,8 @@ class PaniniHappy(AbstractScraper):
             {'class': 'duration'})
         )
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'span',
             {'class': 'yield'})
         )

--- a/recipe_scrapers/paninihappy.py
+++ b/recipe_scrapers/paninihappy.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class PaniniHappy(AbstractScraper):
@@ -18,6 +18,12 @@ class PaniniHappy(AbstractScraper):
         return get_minutes(self.soup.find(
             'span',
             {'class': 'duration'})
+        )
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'span',
+            {'class': 'yield'})
         )
 
     def ingredients(self):

--- a/recipe_scrapers/realsimple.py
+++ b/recipe_scrapers/realsimple.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class RealSimple(AbstractScraper):
@@ -17,12 +17,12 @@ class RealSimple(AbstractScraper):
             {'class': 'recipe-meta-item'}
         )[1])
 
-    def servings(self):
-        return get_servings(self.soup.findAll(
+    def yields(self):
+        return get_yields(self.soup.findAll(
             'div',
             {'class': 'recipe-meta-item'}
         )[2].find('div', {'class': 'recipe-meta-item-body'}).get_text()
-                            )
+                          )
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/realsimple.py
+++ b/recipe_scrapers/realsimple.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class RealSimple(AbstractScraper):
@@ -16,6 +16,13 @@ class RealSimple(AbstractScraper):
             'div',
             {'class': 'recipe-meta-item'}
         )[1])
+
+    def servings(self):
+        return get_servings(self.soup.findAll(
+            'div',
+            {'class': 'recipe-meta-item'}
+        )[2].find('div', {'class': 'recipe-meta-item-body'}).get_text()
+                            )
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/simplyrecipes.py
+++ b/recipe_scrapers/simplyrecipes.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class SimplyRecipes(AbstractScraper):
@@ -23,6 +23,12 @@ class SimplyRecipes(AbstractScraper):
                 {'class': 'cooktime'})
             )
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+                'span',
+                {'class': 'yield', 'itemprop': 'recipeYield'})
+            )
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/simplyrecipes.py
+++ b/recipe_scrapers/simplyrecipes.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class SimplyRecipes(AbstractScraper):
@@ -24,8 +24,8 @@ class SimplyRecipes(AbstractScraper):
             )
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
                 'span',
                 {'class': 'yield', 'itemprop': 'recipeYield'})
             )

--- a/recipe_scrapers/steamykitchen.py
+++ b/recipe_scrapers/steamykitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class SteamyKitchen(AbstractScraper):
@@ -19,6 +19,9 @@ class SteamyKitchen(AbstractScraper):
             get_minutes(self.soup.find(itemprop='prepTime').parent),
             get_minutes(self.soup.find(itemprop='cookTime').parent)
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find('span', itemprop='recipeYield'))
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/steamykitchen.py
+++ b/recipe_scrapers/steamykitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class SteamyKitchen(AbstractScraper):
@@ -20,8 +20,8 @@ class SteamyKitchen(AbstractScraper):
             get_minutes(self.soup.find(itemprop='cookTime').parent)
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find('span', itemprop='recipeYield'))
+    def yields(self):
+        return get_yields(self.soup.find('span', itemprop='recipeYield'))
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/tastesoflizzyt.py
+++ b/recipe_scrapers/tastesoflizzyt.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class TastesOfLizzyT(AbstractScraper):
@@ -22,8 +22,8 @@ class TastesOfLizzyT(AbstractScraper):
             )
         )
 
-    def servings(self):
-        return get_servings(
+    def yields(self):
+        return get_yields(
             self.soup.find(
                 'span',
                 {'class': 'wprm-recipe-servings'}

--- a/recipe_scrapers/tastesoflizzyt.py
+++ b/recipe_scrapers/tastesoflizzyt.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class TastesOfLizzyT(AbstractScraper):
@@ -19,6 +19,14 @@ class TastesOfLizzyT(AbstractScraper):
             self.soup.find(
                 'div',
                 {'class': 'wprm-recipe-total-time-container'}
+            )
+        )
+
+    def servings(self):
+        return get_servings(
+            self.soup.find(
+                'span',
+                {'class': 'wprm-recipe-servings'}
             )
         )
 

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class TastyKitchen(AbstractScraper):
@@ -27,8 +27,8 @@ class TastyKitchen(AbstractScraper):
             )
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'span',
             {'itemprop': 'yield'})
         )

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class TastyKitchen(AbstractScraper):
@@ -26,6 +26,12 @@ class TastyKitchen(AbstractScraper):
                 {'itemprop': 'cookTime'})
             )
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'span',
+            {'itemprop': 'yield'})
+        )
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/tests/test_allrecipes.py
+++ b/recipe_scrapers/tests/test_allrecipes.py
@@ -32,8 +32,8 @@ class TestAllRecipesScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
-        self.assertEqual(8, self.harvester_class.servings())
+    def test_yields(self):
+        self.assertEqual("8 serving(s)", self.harvester_class.yields())
 
     def test_ingredients(self):
         self.assertCountEqual(

--- a/recipe_scrapers/tests/test_allrecipes.py
+++ b/recipe_scrapers/tests/test_allrecipes.py
@@ -8,9 +8,7 @@ class TestAllRecipesScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'allrecipes.testhtml'
         )) as file_opened:
@@ -33,6 +31,9 @@ class TestAllRecipesScraper(unittest.TestCase):
             40,
             self.harvester_class.total_time()
         )
+
+    def test_servings(self):
+        self.assertEqual(8, self.harvester_class.servings())
 
     def test_ingredients(self):
         self.assertCountEqual(

--- a/recipe_scrapers/tests/test_bbcfood.py
+++ b/recipe_scrapers/tests/test_bbcfood.py
@@ -8,9 +8,7 @@ class TestBBCFoodScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'bbc_food.testhtml'
         )) as file_opened:
@@ -38,6 +36,12 @@ class TestBBCFoodScraper(unittest.TestCase):
         self.assertEqual(
             130,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            "1 item(s)",
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_bbcfood.py
+++ b/recipe_scrapers/tests/test_bbcfood.py
@@ -38,10 +38,10 @@ class TestBBCFoodScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             "1 item(s)",
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_bbcgoodfood.py
+++ b/recipe_scrapers/tests/test_bbcgoodfood.py
@@ -32,10 +32,10 @@ class TestBBCGoodFoodScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             "12 item(s)",
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
     def test_ingredients(self):
         self.assertCountEqual(

--- a/recipe_scrapers/tests/test_bbcgoodfood.py
+++ b/recipe_scrapers/tests/test_bbcgoodfood.py
@@ -8,9 +8,7 @@ class TestBBCGoodFoodScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'bbc_good_food.testhtml'
         )) as file_opened:
@@ -34,6 +32,11 @@ class TestBBCGoodFoodScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
+    def test_servings(self):
+        self.assertEqual(
+            "12 item(s)",
+            self.harvester_class.servings()
+        )
     def test_ingredients(self):
         self.assertCountEqual(
             [

--- a/recipe_scrapers/tests/test_bonappetit.py
+++ b/recipe_scrapers/tests/test_bonappetit.py
@@ -32,10 +32,10 @@ class TestBonAppetitScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            4,
-            self.harvester_class.servings()
+            "4 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_bonappetit.py
+++ b/recipe_scrapers/tests/test_bonappetit.py
@@ -8,9 +8,7 @@ class TestBonAppetitScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'bonappetit.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestBonAppetitScraper(unittest.TestCase):
         self.assertEqual(
             0,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            4,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_closetcooking.py
+++ b/recipe_scrapers/tests/test_closetcooking.py
@@ -32,10 +32,10 @@ class TestClosetCooking(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            5,
-            self.harvester_class.servings()
+            "5 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_closetcooking.py
+++ b/recipe_scrapers/tests/test_closetcooking.py
@@ -8,9 +8,7 @@ class TestClosetCooking(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'closetcooking.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestClosetCooking(unittest.TestCase):
         self.assertEqual(
             20,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            5,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_cookstr.py
+++ b/recipe_scrapers/tests/test_cookstr.py
@@ -35,7 +35,7 @@ class TestCookstrScraper(unittest.TestCase):
     def test_total_time(self):
         self.assertEqual(
             0,
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_cookstr.py
+++ b/recipe_scrapers/tests/test_cookstr.py
@@ -8,9 +8,7 @@ class TestCookstrScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'cookstr.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestCookstrScraper(unittest.TestCase):
         self.assertEqual(
             60,
             self.harvester_class.total_time()
+        )
+
+    def test_total_time(self):
+        self.assertEqual(
+            0,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_epicurious.py
+++ b/recipe_scrapers/tests/test_epicurious.py
@@ -32,7 +32,7 @@ class TestEpicurious(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             0,
             self.harvester_class.total_time()

--- a/recipe_scrapers/tests/test_epicurious.py
+++ b/recipe_scrapers/tests/test_epicurious.py
@@ -8,9 +8,7 @@ class TestEpicurious(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'epicurious.testhtml'
         )) as file_opened:
@@ -29,6 +27,12 @@ class TestEpicurious(unittest.TestCase):
         )
 
     def test_total_time(self):
+        self.assertEqual(
+            0,
+            self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
         self.assertEqual(
             0,
             self.harvester_class.total_time()

--- a/recipe_scrapers/tests/test_finedininglovers.py
+++ b/recipe_scrapers/tests/test_finedininglovers.py
@@ -32,10 +32,10 @@ class TestFineDiningLoversScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_serving(self):
+    def test_yields(self):
         self.assertEqual(
-            4,
-            self.harvester_class.servings()
+            "4 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_finedininglovers.py
+++ b/recipe_scrapers/tests/test_finedininglovers.py
@@ -8,9 +8,7 @@ class TestFineDiningLoversScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'finedininglovers.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestFineDiningLoversScraper(unittest.TestCase):
         self.assertEqual(
             50,
             self.harvester_class.total_time()
+        )
+
+    def test_serving(self):
+        self.assertEqual(
+            4,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_foodnetwork.py
+++ b/recipe_scrapers/tests/test_foodnetwork.py
@@ -32,10 +32,10 @@ class TestFoodNetworkScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            4,
-            self.harvester_class.servings()
+            "4 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_foodnetwork.py
+++ b/recipe_scrapers/tests/test_foodnetwork.py
@@ -8,9 +8,7 @@ class TestFoodNetworkScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'foodnetwork.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestFoodNetworkScraper(unittest.TestCase):
         self.assertEqual(
             40,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            4,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_foodrepublic.py
+++ b/recipe_scrapers/tests/test_foodrepublic.py
@@ -32,10 +32,10 @@ class TestFoodRepublicScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_serving(self):
+    def test_yields(self):
         self.assertEqual(
-            4,
-            self.harvester_class.servings()
+            "4 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_foodrepublic.py
+++ b/recipe_scrapers/tests/test_foodrepublic.py
@@ -8,9 +8,7 @@ class TestFoodRepublicScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'foodrepublic.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestFoodRepublicScraper(unittest.TestCase):
         self.assertEqual(
             60,
             self.harvester_class.total_time()
+        )
+
+    def test_serving(self):
+        self.assertEqual(
+            4,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_geniuskitchen.py
+++ b/recipe_scrapers/tests/test_geniuskitchen.py
@@ -32,10 +32,10 @@ class TestAllRecipesScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            6,
-            self.harvester_class.servings()
+            "6 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_geniuskitchen.py
+++ b/recipe_scrapers/tests/test_geniuskitchen.py
@@ -8,9 +8,7 @@ class TestAllRecipesScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'geniuskitchen.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestAllRecipesScraper(unittest.TestCase):
         self.assertEqual(
             40,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            6,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_giallozafferano.py
+++ b/recipe_scrapers/tests/test_giallozafferano.py
@@ -32,10 +32,10 @@ class TestGialloZafferanoScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            10,
-            self.harvester_class.servings()
+            "10 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_giallozafferano.py
+++ b/recipe_scrapers/tests/test_giallozafferano.py
@@ -8,9 +8,7 @@ class TestGialloZafferanoScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'giallozafferano.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestGialloZafferanoScraper(unittest.TestCase):
         self.assertEqual(
             45,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            10,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_hellofresh.py
+++ b/recipe_scrapers/tests/test_hellofresh.py
@@ -38,10 +38,10 @@ class TestHelloFreshScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             0,
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_hellofresh.py
+++ b/recipe_scrapers/tests/test_hellofresh.py
@@ -8,9 +8,7 @@ class TestHelloFreshScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'hellofresh.testhtml'
         )) as file_opened:
@@ -38,6 +36,12 @@ class TestHelloFreshScraper(unittest.TestCase):
         self.assertEqual(
             20,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            0,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_hundredandonecookbooks.py
+++ b/recipe_scrapers/tests/test_hundredandonecookbooks.py
@@ -32,10 +32,10 @@ class TestHundredAndOneCookbooksScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             0,
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_hundredandonecookbooks.py
+++ b/recipe_scrapers/tests/test_hundredandonecookbooks.py
@@ -8,9 +8,7 @@ class TestHundredAndOneCookbooksScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             '101cookbooks.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestHundredAndOneCookbooksScraper(unittest.TestCase):
         self.assertEqual(
             0,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            0,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_inspiralized.py
+++ b/recipe_scrapers/tests/test_inspiralized.py
@@ -8,9 +8,7 @@ class TestInspiralizedScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'inspiralized.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestInspiralizedScraper(unittest.TestCase):
         self.assertEqual(
             20,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            2,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_inspiralized.py
+++ b/recipe_scrapers/tests/test_inspiralized.py
@@ -32,10 +32,10 @@ class TestInspiralizedScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            2,
-            self.harvester_class.servings()
+            "2 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_jamieoliver.py
+++ b/recipe_scrapers/tests/test_jamieoliver.py
@@ -32,10 +32,10 @@ class TestJamieOliverScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            20,
-            self.harvester_class.servings()
+            "20 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_jamieoliver.py
+++ b/recipe_scrapers/tests/test_jamieoliver.py
@@ -8,9 +8,7 @@ class TestJamieOliverScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'jamieoliver.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestJamieOliverScraper(unittest.TestCase):
         self.assertEqual(
             40,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            20,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_mybakingaddiction.py
+++ b/recipe_scrapers/tests/test_mybakingaddiction.py
@@ -9,9 +9,7 @@ class TestMyBakingAddictionScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'mybakingaddiction.testhtml'
         )) as file_opened:
@@ -33,6 +31,12 @@ class TestMyBakingAddictionScraper(unittest.TestCase):
         self.assertEqual(
             40,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            10,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_mybakingaddiction.py
+++ b/recipe_scrapers/tests/test_mybakingaddiction.py
@@ -33,10 +33,10 @@ class TestMyBakingAddictionScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            10,
-            self.harvester_class.servings()
+            "10 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_nihhealthyeating.py
+++ b/recipe_scrapers/tests/test_nihhealthyeating.py
@@ -11,9 +11,7 @@ class TestNIHHealthyEatingRecipesScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'nihhealthyeating.testhtml'
         )) as file_opened:
@@ -35,6 +33,12 @@ class TestNIHHealthyEatingRecipesScraper(unittest.TestCase):
         self.assertEqual(
             15,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            8,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_nihhealthyeating.py
+++ b/recipe_scrapers/tests/test_nihhealthyeating.py
@@ -35,10 +35,10 @@ class TestNIHHealthyEatingRecipesScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            8,
-            self.harvester_class.servings()
+            "8 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_notimplemented.py
+++ b/recipe_scrapers/tests/test_notimplemented.py
@@ -12,9 +12,7 @@ class TestNotImplemented(unittest.TestCase):
             pass
 
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'paninihappy.testhtml'
         )) as file_opened:

--- a/recipe_scrapers/tests/test_paninihappy.py
+++ b/recipe_scrapers/tests/test_paninihappy.py
@@ -8,9 +8,7 @@ class TestPaniniHappyScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'paninihappy.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestPaniniHappyScraper(unittest.TestCase):
         self.assertEqual(
             30,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            "4 item(s)",
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_paninihappy.py
+++ b/recipe_scrapers/tests/test_paninihappy.py
@@ -32,10 +32,10 @@ class TestPaniniHappyScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             "4 item(s)",
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_realsimple.py
+++ b/recipe_scrapers/tests/test_realsimple.py
@@ -32,10 +32,10 @@ class TestRealSimpleScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             "9 item(s)",
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_realsimple.py
+++ b/recipe_scrapers/tests/test_realsimple.py
@@ -8,9 +8,7 @@ class TestRealSimpleScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'realsimple.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestRealSimpleScraper(unittest.TestCase):
         self.assertEqual(
             540,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            "9 item(s)",
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_simplyrecipes.py
+++ b/recipe_scrapers/tests/test_simplyrecipes.py
@@ -32,11 +32,11 @@ class TestSimplyRecipesScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         # 6 to 8 servings (makes about 3 quarts), debatable it should be 8 servings.
         self.assertEqual(
             "8 item(s)",
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_simplyrecipes.py
+++ b/recipe_scrapers/tests/test_simplyrecipes.py
@@ -8,9 +8,7 @@ class TestSimplyRecipesScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'simpyrecipes.testhtml'
         )) as file_opened:
@@ -32,6 +30,13 @@ class TestSimplyRecipesScraper(unittest.TestCase):
         self.assertEqual(
             45,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        # 6 to 8 servings (makes about 3 quarts), debatable it should be 8 servings.
+        self.assertEqual(
+            "8 item(s)",
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_steamykitchen.py
+++ b/recipe_scrapers/tests/test_steamykitchen.py
@@ -32,10 +32,10 @@ class TestSteamyKitchenScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            10,
-            self.harvester_class.servings()
+            "10 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_steamykitchen.py
+++ b/recipe_scrapers/tests/test_steamykitchen.py
@@ -8,9 +8,7 @@ class TestSteamyKitchenScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'steamykitchen.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestSteamyKitchenScraper(unittest.TestCase):
         self.assertEqual(
             120,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            10,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_tastesoflizzyt.py
+++ b/recipe_scrapers/tests/test_tastesoflizzyt.py
@@ -8,9 +8,7 @@ class TestTastesOfLizzyTScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'tastesoflizzyt.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestTastesOfLizzyTScraper(unittest.TestCase):
         self.assertEqual(
             27,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            60,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_tastesoflizzyt.py
+++ b/recipe_scrapers/tests/test_tastesoflizzyt.py
@@ -32,10 +32,10 @@ class TestTastesOfLizzyTScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            60,
-            self.harvester_class.servings()
+            "60 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_tastykitchen.py
+++ b/recipe_scrapers/tests/test_tastykitchen.py
@@ -32,10 +32,10 @@ class TestTastyKitchenScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            12,
-            self.harvester_class.servings()
+            "12 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_tastykitchen.py
+++ b/recipe_scrapers/tests/test_tastykitchen.py
@@ -8,9 +8,7 @@ class TestTastyKitchenScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'tasty_kitchen.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestTastyKitchenScraper(unittest.TestCase):
         self.assertEqual(
             30,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            12,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_thehappyfoodie.py
+++ b/recipe_scrapers/tests/test_thehappyfoodie.py
@@ -27,8 +27,8 @@ class TestTheHappyFoodie(unittest.TestCase):
     def test_total_time(self):
         self.assertEqual(90, self.harvester_class.total_time())
 
-    def test_servings(self):
-        self.assertEqual(6, self.harvester_class.servings())
+    def test_yields(self):
+        self.assertEqual("6 serving(s)", self.harvester_class.yields())
 
     def test_ingredients(self):
         self.assertCountEqual(

--- a/recipe_scrapers/tests/test_thehappyfoodie.py
+++ b/recipe_scrapers/tests/test_thehappyfoodie.py
@@ -7,11 +7,8 @@ from recipe_scrapers.thehappyfoodie import TheHappyFoodie
 class TestTheHappyFoodie(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
-        with open(
-            os.path.join(
-                os.getcwd(),
-                'recipe_scrapers',
-                'tests',
+        with open(os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
                 'test_data',
                 'thehappyfoodie.testhtml',
             )
@@ -29,6 +26,9 @@ class TestTheHappyFoodie(unittest.TestCase):
 
     def test_total_time(self):
         self.assertEqual(90, self.harvester_class.total_time())
+
+    def test_servings(self):
+        self.assertEqual(6, self.harvester_class.servings())
 
     def test_ingredients(self):
         self.assertCountEqual(

--- a/recipe_scrapers/tests/test_thepioneerwoman.py
+++ b/recipe_scrapers/tests/test_thepioneerwoman.py
@@ -32,10 +32,10 @@ class TestThePioneerWomanScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            4,
-            self.harvester_class.servings()
+            "4 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_thepioneerwoman.py
+++ b/recipe_scrapers/tests/test_thepioneerwoman.py
@@ -8,9 +8,7 @@ class TestThePioneerWomanScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'thepioneerwoman.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestThePioneerWomanScraper(unittest.TestCase):
         self.assertEqual(
             35,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            4,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_thevintagemixer.py
+++ b/recipe_scrapers/tests/test_thevintagemixer.py
@@ -8,9 +8,7 @@ class TestTheVintageMixerScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'thevintagemixer.testhtml'
         )) as file_opened:

--- a/recipe_scrapers/tests/test_twopeasandtheirpod.py
+++ b/recipe_scrapers/tests/test_twopeasandtheirpod.py
@@ -33,10 +33,10 @@ class TestTwoPeasAndTheirPodScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
             "20 item(s)",
-            self.harvester_class.servings()
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_twopeasandtheirpod.py
+++ b/recipe_scrapers/tests/test_twopeasandtheirpod.py
@@ -8,9 +8,7 @@ class TestTwoPeasAndTheirPodScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'twopeasandtheirpod.testhtml'
         )) as file_opened:
@@ -33,6 +31,12 @@ class TestTwoPeasAndTheirPodScraper(unittest.TestCase):
         self.assertEqual(
             40,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            "20 item(s)",
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_utils_exceptions.py
+++ b/recipe_scrapers/tests/test_utils_exceptions.py
@@ -15,6 +15,9 @@ class TestingExceptionsHandling(AbstractScraper):
     def total_time(self):
         raise Exception
 
+    def servings(self):
+        raise Exception
+
     def ingredients(self):
         raise Exception
 
@@ -26,9 +29,7 @@ class TestExceptionsHandlingScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'allrecipes.testhtml'
         )) as file_opened:
@@ -44,6 +45,9 @@ class TestExceptionsHandlingScraper(unittest.TestCase):
 
     def test_total_time(self):
         return self.assertEqual(0, self.harvester_class.total_time())
+
+    def test_servings(self):
+        return self.assertEqual(0, self.harvester_class.servings())
 
     def test_ingredients(self):
         return self.assertCountEqual([], self.harvester_class.ingredients())

--- a/recipe_scrapers/tests/test_utils_exceptions.py
+++ b/recipe_scrapers/tests/test_utils_exceptions.py
@@ -15,7 +15,7 @@ class TestingExceptionsHandling(AbstractScraper):
     def total_time(self):
         raise Exception
 
-    def servings(self):
+    def yields(self):
         raise Exception
 
     def ingredients(self):
@@ -46,8 +46,8 @@ class TestExceptionsHandlingScraper(unittest.TestCase):
     def test_total_time(self):
         return self.assertEqual(0, self.harvester_class.total_time())
 
-    def test_servings(self):
-        return self.assertEqual(0, self.harvester_class.servings())
+    def test_yields(self):
+        return self.assertEqual("", self.harvester_class.yields())
 
     def test_ingredients(self):
         return self.assertCountEqual([], self.harvester_class.ingredients())

--- a/recipe_scrapers/tests/test_whatsgabycooking.py
+++ b/recipe_scrapers/tests/test_whatsgabycooking.py
@@ -8,9 +8,7 @@ class TestWhatsGabyCookingScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'whatsgabycooking.testhtml'
         )) as file_opened:

--- a/recipe_scrapers/tests/test_yummly.py
+++ b/recipe_scrapers/tests/test_yummly.py
@@ -8,9 +8,7 @@ class TestYummlyScraper(unittest.TestCase):
     def setUp(self):
         # tests are run from tests.py
         with open(os.path.join(
-            os.getcwd(),
-            'recipe_scrapers',
-            'tests',
+            os.path.dirname(os.path.realpath(__file__)),
             'test_data',
             'yummly.testhtml'
         )) as file_opened:
@@ -32,6 +30,12 @@ class TestYummlyScraper(unittest.TestCase):
         self.assertEqual(
             30,
             self.harvester_class.total_time()
+        )
+
+    def test_servings(self):
+        self.assertEqual(
+            4,
+            self.harvester_class.servings()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_yummly.py
+++ b/recipe_scrapers/tests/test_yummly.py
@@ -32,10 +32,10 @@ class TestYummlyScraper(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_servings(self):
+    def test_yields(self):
         self.assertEqual(
-            4,
-            self.harvester_class.servings()
+            "4 serving(s)",
+            self.harvester_class.yields()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/thehappyfoodie.py
+++ b/recipe_scrapers/thehappyfoodie.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_minutes, get_servings
+from ._utils import normalize_string, get_minutes, get_yields
 
 
 class TheHappyFoodie(AbstractScraper):
@@ -18,11 +18,11 @@ class TheHappyFoodie(AbstractScraper):
             get_minutes(self.soup.find('div', {'class': 'recipe__data__cook-time'}))
         ])
 
-    def servings(self):
+    def yields(self):
         #<div class="recipe__data__field recipe__data__yield">
-        return get_servings(self.soup.find(
+        return get_yields(self.soup.find(
             'div', {'class': 'recipe__data__yield'}).get_text()
-        )
+                          )
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/thehappyfoodie.py
+++ b/recipe_scrapers/thehappyfoodie.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_minutes
+from ._utils import normalize_string, get_minutes, get_servings
 
 
 class TheHappyFoodie(AbstractScraper):
@@ -17,6 +17,12 @@ class TheHappyFoodie(AbstractScraper):
             get_minutes(self.soup.find('div', {'class': 'recipe__data__prep-time'})),
             get_minutes(self.soup.find('div', {'class': 'recipe__data__cook-time'}))
         ])
+
+    def servings(self):
+        #<div class="recipe__data__field recipe__data__yield">
+        return get_servings(self.soup.find(
+            'div', {'class': 'recipe__data__yield'}).get_text()
+        )
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/thepioneerwoman.py
+++ b/recipe_scrapers/thepioneerwoman.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class ThePioneerWoman(AbstractScraper):
@@ -22,6 +22,11 @@ class ThePioneerWoman(AbstractScraper):
                 {'class': 'recipe-summary-time'}
             ).findAll('dd')
         ])
+
+    def servings(self):
+        return get_servings(self.soup.find(
+            'span', {'itemprop': 'recipeYield'}
+        ))
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/thepioneerwoman.py
+++ b/recipe_scrapers/thepioneerwoman.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class ThePioneerWoman(AbstractScraper):
@@ -23,8 +23,8 @@ class ThePioneerWoman(AbstractScraper):
             ).findAll('dd')
         ])
 
-    def servings(self):
-        return get_servings(self.soup.find(
+    def yields(self):
+        return get_yields(self.soup.find(
             'span', {'itemprop': 'recipeYield'}
         ))
 

--- a/recipe_scrapers/thevintagemixer.py
+++ b/recipe_scrapers/thevintagemixer.py
@@ -19,7 +19,7 @@ class TheVintageMixer(AbstractScraper):
             'meta', {'itemprop': 'totalTime'}).parent
         )
 
-    def servings(self):
+    def yields(self):
         return 0  # Servings do not exist in this site.
 
     def ingredients(self):

--- a/recipe_scrapers/thevintagemixer.py
+++ b/recipe_scrapers/thevintagemixer.py
@@ -19,6 +19,9 @@ class TheVintageMixer(AbstractScraper):
             'meta', {'itemprop': 'totalTime'}).parent
         )
 
+    def servings(self):
+        return 0  # Servings do not exist in this site.
+
     def ingredients(self):
         ingredients = self.soup.findAll(
             'li', {'itemprop': "recipeIngredient"}

--- a/recipe_scrapers/twopeasandtheirpod.py
+++ b/recipe_scrapers/twopeasandtheirpod.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class TwoPeasAndTheirPod(AbstractScraper):
@@ -20,9 +20,9 @@ class TwoPeasAndTheirPod(AbstractScraper):
             {'itemprop': 'totalTime'}
         ).parent)
 
-    def servings(self):
+    def yields(self):
         #<span itemprop="recipeYield">
-        return get_servings(self.soup.find(
+        return get_yields(self.soup.find(
             'span',
             {'itemprop': 'recipeYield'}
         ))

--- a/recipe_scrapers/twopeasandtheirpod.py
+++ b/recipe_scrapers/twopeasandtheirpod.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class TwoPeasAndTheirPod(AbstractScraper):
@@ -19,6 +19,13 @@ class TwoPeasAndTheirPod(AbstractScraper):
             'meta',
             {'itemprop': 'totalTime'}
         ).parent)
+
+    def servings(self):
+        #<span itemprop="recipeYield">
+        return get_servings(self.soup.find(
+            'span',
+            {'itemprop': 'recipeYield'}
+        ))
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/whatsgabycooking.py
+++ b/recipe_scrapers/whatsgabycooking.py
@@ -20,6 +20,9 @@ class WhatsGabyCooking(AbstractScraper):
             {'class': 'ready-in-time'})
         )
 
+    def servings(self):
+        return 0
+
     def ingredients(self):
         ingredients = self.soup.findAll(
             'li',

--- a/recipe_scrapers/whatsgabycooking.py
+++ b/recipe_scrapers/whatsgabycooking.py
@@ -20,7 +20,7 @@ class WhatsGabyCooking(AbstractScraper):
             {'class': 'ready-in-time'})
         )
 
-    def servings(self):
+    def yields(self):
         return 0
 
     def ingredients(self):

--- a/recipe_scrapers/yummly.py
+++ b/recipe_scrapers/yummly.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_minutes, normalize_string, get_servings
 
 
 class Yummly(AbstractScraper):
@@ -14,6 +14,11 @@ class Yummly(AbstractScraper):
     def total_time(self):
         return get_minutes(
             self.soup.find('div', {'class': 'recipe-summary-item unit'})
+        )
+
+    def servings(self):
+        return get_servings(
+            self.soup.find('div', {'class': 'servings'}).find('input').get('value')
         )
 
     def ingredients(self):

--- a/recipe_scrapers/yummly.py
+++ b/recipe_scrapers/yummly.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_servings
+from ._utils import get_minutes, normalize_string, get_yields
 
 
 class Yummly(AbstractScraper):
@@ -16,8 +16,8 @@ class Yummly(AbstractScraper):
             self.soup.find('div', {'class': 'recipe-summary-item unit'})
         )
 
-    def servings(self):
-        return get_servings(
+    def yields(self):
+        return get_yields(
             self.soup.find('div', {'class': 'servings'}).find('input').get('value')
         )
 


### PR DESCRIPTION
Most of the given pages already have serving-size on the page. It gives a better overview when getting recipes when possible. Some pages, like *All Recipes (BR)*, *The vintage mixer* and *What's Gaby cooking* do not have this possibility, no testcase created but will return 0. 

The `_utils.get_servings` is not clean logic, it tries to see if the given element is for serving (defaults to serving) or items. Might not be the best practice.  