### PR TITLE
Make Jamie Oliver instructions() more consistent with other scrapers

### DIFF
--- a/recipe_scrapers/jamieoliver.py
+++ b/recipe_scrapers/jamieoliver.py
@@ -38,5 +38,9 @@ class JamieOliver(AbstractScraper):
         instructions = self.soup.find(
             'div',
             {'class': 'instructions-wrapper'}
-        )
-        return normalize_string(instructions.get_text())
+        ).findAll('li')
+
+        return '\n'.join([
+            normalize_string(instruction.get_text())
+            for instruction in instructions
+        ])


### PR DESCRIPTION
Adds `\n`s between each line of instructions in Jamie Oliver recipes.