### PR TITLE
giallozafferano ingredients list

### DIFF
--- a/recipe_scrapers/giallozafferano.py
+++ b/recipe_scrapers/giallozafferano.py
@@ -38,6 +38,12 @@ class GialloZafferano(AbstractScraper):
             'dd',
             {'class': "gz-ingredient"}
         )
+        
+        if len(ingredients) == 0:
+            ingredients = self.soup.findAll(
+            'li',
+            {'class': "gz-ingredient"}
+        )
 
         return [
             normalize_string(ingredient.get_text())


### PR DESCRIPTION
The scraper cannot parse the ingredients of all recipes since the list is not always within a dd element but sometimes it is a simple collection of li elements. Here an example: https://ricette.giallozafferano.it/Parmigiana-di-melanzane.html

The modification I proposed should solve this issue: during my tests the recipes that previously had an empty list of ingredients now contain all the ingredients.