### PR TITLE
Support image URL retrieval

### DIFF
--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -25,6 +25,7 @@ class AbstractScraper():
                 'title',
                 'total_time',
                 'yields',
+                'images',
                 'instructions',
                 'ingredients',
                 'links'
@@ -35,6 +36,8 @@ class AbstractScraper():
                 to_return = 0
             if name == 'yields':
                 to_return = ''
+            if name == 'images':
+                to_return = []
             if name == 'ingredients':
                 to_return = []
             if name == 'links':
@@ -78,6 +81,9 @@ class AbstractScraper():
 
     def yields(self):
         """ The number of servings or items in the recipe """
+        raise NotImplementedError("This should be implemented.")
+
+    def images(self):
         raise NotImplementedError("This should be implemented.")
 
     def ingredients(self):

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -25,7 +25,7 @@ class AbstractScraper():
                 'title',
                 'total_time',
                 'yields',
-                'images',
+                'image',
                 'instructions',
                 'ingredients',
                 'links'
@@ -36,8 +36,6 @@ class AbstractScraper():
                 to_return = 0
             if name == 'yields':
                 to_return = ''
-            if name == 'images':
-                to_return = []
             if name == 'ingredients':
                 to_return = []
             if name == 'links':
@@ -83,7 +81,7 @@ class AbstractScraper():
         """ The number of servings or items in the recipe """
         raise NotImplementedError("This should be implemented.")
 
-    def images(self):
+    def image(self):
         raise NotImplementedError("This should be implemented.")
 
     def ingredients(self):

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -25,6 +25,17 @@ class AllRecipes(AbstractScraper):
                 'itemprop': 'recipeYield'
             }).get("content"))
 
+    def images(self):
+        images = self.soup.findAll(
+            'img',
+            {'class': 'rec-photo', 'src': True}
+        )
+
+        return [
+            image['src']
+            for image in images
+        ]
+
     def ingredients(self):
         ingredients = self.soup.findAll(
             'li',

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -25,16 +25,12 @@ class AllRecipes(AbstractScraper):
                 'itemprop': 'recipeYield'
             }).get("content"))
 
-    def images(self):
-        images = self.soup.findAll(
+    def image(self):
+        image = self.soup.find(
             'img',
             {'class': 'rec-photo', 'src': True}
         )
-
-        return [
-            image['src']
-            for image in images
-        ]
+        return image['src'] if image else None
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -30,6 +30,18 @@ class BBCFood(AbstractScraper):
             {'class': 'recipe-metadata__serving'})
         )
 
+    def images(self):
+        images = self.soup.findAll(
+            True,
+            {'class': 'recipe-media__image'}
+        )
+
+        return [
+            image.parent.find('img')['src']
+            for image in images
+            if image.parent.find('img', {'src': True})
+        ]
+
     def ingredients(self):
         ingredients = self.soup.findAll(
             'li',

--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -30,17 +30,19 @@ class BBCFood(AbstractScraper):
             {'class': 'recipe-metadata__serving'})
         )
 
-    def images(self):
-        images = self.soup.findAll(
+    def image(self):
+        container = self.soup.find(
             True,
             {'class': 'recipe-media__image'}
         )
+        if not container:
+            return None
 
-        return [
-            image.parent.find('img')['src']
-            for image in images
-            if image.parent.find('img', {'src': True})
-        ]
+        image = container.parent.find(
+            'img',
+            {'src': True}
+        )
+        return image['src'] if image else None
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/bbcgoodfood.py
+++ b/recipe_scrapers/bbcgoodfood.py
@@ -30,16 +30,12 @@ class BBCGoodFood(AbstractScraper):
             {'class': 'recipe-details__text', 'itemprop': 'recipeYield'}
         ))
 
-    def images(self):
-        images = self.soup.findAll(
+    def image(self):
+        image = self.soup.find(
             'img',
             {'itemprop': 'image', 'src': True}
         )
-
-        return [
-            image['src']
-            for image in images
-        ]
+        return image['src'] if image else None
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/bbcgoodfood.py
+++ b/recipe_scrapers/bbcgoodfood.py
@@ -30,6 +30,17 @@ class BBCGoodFood(AbstractScraper):
             {'class': 'recipe-details__text', 'itemprop': 'recipeYield'}
         ))
 
+    def images(self):
+        images = self.soup.findAll(
+            'img',
+            {'itemprop': 'image', 'src': True}
+        )
+
+        return [
+            image['src']
+            for image in images
+        ]
+
     def ingredients(self):
         ingredients = self.soup.findAll(
             'li',

--- a/recipe_scrapers/epicurious.py
+++ b/recipe_scrapers/epicurious.py
@@ -27,16 +27,12 @@ class Epicurious(AbstractScraper):
             {'itemprop': 'recipeYield'}
         ))
 
-    def images(self):
-        images = self.soup.findAll(
+    def image(self):
+        image = self.soup.find(
             'img',
             {'class': 'photo', 'srcset': True}
         )
-
-        return [
-            image['srcset']
-            for image in images
-        ]
+        return image['srcset'] if image else None
 
     def ingredients(self):
         ingredients = self.soup.findAll(

--- a/recipe_scrapers/epicurious.py
+++ b/recipe_scrapers/epicurious.py
@@ -27,6 +27,17 @@ class Epicurious(AbstractScraper):
             {'itemprop': 'recipeYield'}
         ))
 
+    def images(self):
+        images = self.soup.findAll(
+            'img',
+            {'class': 'photo', 'srcset': True}
+        )
+
+        return [
+            image['srcset']
+            for image in images
+        ]
+
     def ingredients(self):
         ingredients = self.soup.findAll(
             'li',

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -33,16 +33,12 @@ class TastyKitchen(AbstractScraper):
             {'itemprop': 'yield'})
         )
 
-    def images(self):
-        images =  self.soup.findAll(
+    def image(self):
+        image =  self.soup.find(
             'img',
             {'class': 'the_recipe_image', 'src': True}
         )
-
-        return [
-            image['src']
-            for image in images
-        ]
+        return image['src'] if image else None
 
     def ingredients(self):
         ingredients = self.soup.find(

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -33,6 +33,17 @@ class TastyKitchen(AbstractScraper):
             {'itemprop': 'yield'})
         )
 
+    def images(self):
+        images =  self.soup.findAll(
+            'img',
+            {'class': 'the_recipe_image', 'src': True}
+        )
+
+        return [
+            image['src']
+            for image in images
+        ]
+
     def ingredients(self):
         ingredients = self.soup.find(
             'ul',

--- a/recipe_scrapers/tests/test_allrecipes.py
+++ b/recipe_scrapers/tests/test_allrecipes.py
@@ -35,12 +35,10 @@ class TestAllRecipesScraper(unittest.TestCase):
     def test_yields(self):
         self.assertEqual("8 serving(s)", self.harvester_class.yields())
 
-    def test_images(self):
+    def test_image(self):
         self.assertEqual(
-            [
-                'https://images.media-allrecipes.com/userphotos/560x315/694708.jpg',
-            ],
-            self.harvester_class.images()
+            'https://images.media-allrecipes.com/userphotos/560x315/694708.jpg',
+            self.harvester_class.image()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_allrecipes.py
+++ b/recipe_scrapers/tests/test_allrecipes.py
@@ -35,6 +35,14 @@ class TestAllRecipesScraper(unittest.TestCase):
     def test_yields(self):
         self.assertEqual("8 serving(s)", self.harvester_class.yields())
 
+    def test_images(self):
+        self.assertEqual(
+            [
+                'https://images.media-allrecipes.com/userphotos/560x315/694708.jpg',
+            ],
+            self.harvester_class.images()
+        )
+
     def test_ingredients(self):
         self.assertCountEqual(
             [

--- a/recipe_scrapers/tests/test_bbcfood.py
+++ b/recipe_scrapers/tests/test_bbcfood.py
@@ -44,12 +44,10 @@ class TestBBCFoodScraper(unittest.TestCase):
             self.harvester_class.yields()
         )
 
-    def test_images(self):
+    def test_image(self):
         self.assertEqual(
-            [
-                'https://ichef.bbci.co.uk/food/ic/food_16x9_608/recipes/baileysandchocolatec_72293_16x9.jpg',
-            ],
-            self.harvester_class.images()
+            'https://ichef.bbci.co.uk/food/ic/food_16x9_608/recipes/baileysandchocolatec_72293_16x9.jpg',
+            self.harvester_class.image()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_bbcfood.py
+++ b/recipe_scrapers/tests/test_bbcfood.py
@@ -44,6 +44,14 @@ class TestBBCFoodScraper(unittest.TestCase):
             self.harvester_class.yields()
         )
 
+    def test_images(self):
+        self.assertEqual(
+            [
+                'https://ichef.bbci.co.uk/food/ic/food_16x9_608/recipes/baileysandchocolatec_72293_16x9.jpg',
+            ],
+            self.harvester_class.images()
+        )
+
     def test_ingredients(self):
         self.assertCountEqual(
             [

--- a/recipe_scrapers/tests/test_bbcgoodfood.py
+++ b/recipe_scrapers/tests/test_bbcgoodfood.py
@@ -38,12 +38,10 @@ class TestBBCGoodFoodScraper(unittest.TestCase):
             self.harvester_class.yields()
         )
 
-    def test_images(self):
+    def test_image(self):
         self.assertEqual(
-            [
-                '//www.bbcgoodfood.com/sites/default/files/styles/recipe/public/recipe_images/recipe-image-legacy-id--405483_12.jpg?itok=y0VkmKq3',
-            ],
-            self.harvester_class.images()
+            '//www.bbcgoodfood.com/sites/default/files/styles/recipe/public/recipe_images/recipe-image-legacy-id--405483_12.jpg?itok=y0VkmKq3',
+            self.harvester_class.image()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_bbcgoodfood.py
+++ b/recipe_scrapers/tests/test_bbcgoodfood.py
@@ -37,6 +37,15 @@ class TestBBCGoodFoodScraper(unittest.TestCase):
             "12 item(s)",
             self.harvester_class.yields()
         )
+
+    def test_images(self):
+        self.assertEqual(
+            [
+                '//www.bbcgoodfood.com/sites/default/files/styles/recipe/public/recipe_images/recipe-image-legacy-id--405483_12.jpg?itok=y0VkmKq3',
+            ],
+            self.harvester_class.images()
+        )
+
     def test_ingredients(self):
         self.assertCountEqual(
             [

--- a/recipe_scrapers/tests/test_epicurious.py
+++ b/recipe_scrapers/tests/test_epicurious.py
@@ -38,6 +38,14 @@ class TestEpicurious(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
+    def test_images(self):
+        self.assertEqual(
+            [
+                'https://assets.epicurious.com/photos/568194b8fb9544f72b678fd4/6:4/w_274%2Ch_169/Ramen-Noodle-Bowl-With-Escarole.jpg',
+            ],
+            self.harvester_class.images()
+        )
+
     def test_ingredients(self):
         self.assertCountEqual(
             [

--- a/recipe_scrapers/tests/test_epicurious.py
+++ b/recipe_scrapers/tests/test_epicurious.py
@@ -38,12 +38,10 @@ class TestEpicurious(unittest.TestCase):
             self.harvester_class.total_time()
         )
 
-    def test_images(self):
+    def test_image(self):
         self.assertEqual(
-            [
-                'https://assets.epicurious.com/photos/568194b8fb9544f72b678fd4/6:4/w_274%2Ch_169/Ramen-Noodle-Bowl-With-Escarole.jpg',
-            ],
-            self.harvester_class.images()
+            'https://assets.epicurious.com/photos/568194b8fb9544f72b678fd4/6:4/w_274%2Ch_169/Ramen-Noodle-Bowl-With-Escarole.jpg',
+            self.harvester_class.image()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_tastykitchen.py
+++ b/recipe_scrapers/tests/test_tastykitchen.py
@@ -38,12 +38,10 @@ class TestTastyKitchenScraper(unittest.TestCase):
             self.harvester_class.yields()
         )
 
-    def test_images(self):
+    def test_image(self):
         self.assertEqual(
-            [
-                'tasty_kitchen_files/Cheddar-and-Garlic-Scape-Biscuits-by-Superman-Cooks-410x273.jpg',
-            ],
-            self.harvester_class.images()
+            'tasty_kitchen_files/Cheddar-and-Garlic-Scape-Biscuits-by-Superman-Cooks-410x273.jpg',
+            self.harvester_class.image()
         )
 
     def test_ingredients(self):

--- a/recipe_scrapers/tests/test_tastykitchen.py
+++ b/recipe_scrapers/tests/test_tastykitchen.py
@@ -38,6 +38,14 @@ class TestTastyKitchenScraper(unittest.TestCase):
             self.harvester_class.yields()
         )
 
+    def test_images(self):
+        self.assertEqual(
+            [
+                'tasty_kitchen_files/Cheddar-and-Garlic-Scape-Biscuits-by-Superman-Cooks-410x273.jpg',
+            ],
+            self.harvester_class.images()
+        )
+
     def test_ingredients(self):
         self.assertCountEqual(
             [


### PR DESCRIPTION
This changeset adds support for a new `image()` scraper field which returns an image related to the target recipe.

This is partially implemented at the moment and is supported in the following scraper modules: `bbcfood, bbcgoodfood, allrecipes, tastykitchen, epicurious`