### PR TITLE
Broken links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,10 +59,10 @@ Scrapers available for:
 - `http://epicurious.com/ <http://epicurious.com>`_
 - `http://finedininglovers.com/ <https://www.finedininglovers.com>`_
 - `https://food.com/ <https://www.food.com>`_
-- `http://foodnetwork.com/ <http://www.foodnetwork.co>`_
-- `http://foodrepublic.com/ <http://foodrepublic.co>`_
+- `http://foodnetwork.com/ <http://www.foodnetwork.com>`_
+- `http://foodrepublic.com/ <http://foodrepublic.com>`_
 - `https://geniuskitchen.com/ <https://geniuskitchen.com>`_
-- `http://giallozafferano.it/ <http://giallozafferano.i>`_
+- `http://giallozafferano.it/ <http://giallozafferano.it>`_
 - `https://healthyeating.nhlbi.nih.gov/ <https://healthyeating.nhlbi.nih.gov>`_
 - `https://www.hellofresh.com/ <https://www.hellofresh.com>`_
 - `https://www.hellofresh.co.uk/ <https://www.hellofresh.co.uk>`_


### PR DESCRIPTION
There were a few links that were broken and needed to be fixed in the README.
foodnetwork.com
foodrepublic.com
giallozafferano.it