### PR TITLE
Add ability to use schema.org Recipe schema to expand site support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "venv/bin/python"
+}

--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -1,5 +1,6 @@
 import re
 
+from ._schemaorg import SchemaOrg
 from .allrecipes import AllRecipes
 from .bbcfood import BBCFood
 from .bbcgoodfood import BBCGoodFood
@@ -122,6 +123,12 @@ class WebsiteNotImplementedError(NotImplementedError):
 
 
 def scrape_me(url_path):
+
+    schema = SchemaOrg(url_path)
+
+    if schema.data:
+        return schema
+
     host_name = url_path_to_dict(url_path.replace('://www.', '://'))['host']
 
     try:

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -6,7 +6,7 @@ from w3lib.html import get_base_url
 
 SCHEMA_ORG_HOST = "schema.org"
 SCHEMA_NAME = "Recipe"
-SCHEMA_URL = f"https://{SCHEMA_ORG_HOST}/{SCHEMA_NAME}"
+SCHEMA_URL = "https://" + SCHEMA_ORG_HOST + "/" + SCHEMA_NAME
 
 SYNTAXES = ["microdata", "json-ld"]
 

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -1,0 +1,84 @@
+from ._abstract import AbstractScraper, HEADERS
+import extruct
+import isodate
+import requests
+from w3lib.html import get_base_url
+
+SCHEMA_ORG_HOST = "schema.org"
+SCHEMA_NAME = "Recipe"
+SCHEMA_URL = f"https://{SCHEMA_ORG_HOST}/{SCHEMA_NAME}"
+
+SYNTAXES = ["microdata", "json-ld"]
+
+
+class SchemaOrg(AbstractScraper):
+
+    def __init__(self, url, test=False):
+        self.format = None
+        self.testing_mode = test
+        self.data = {}
+        self.format = None
+
+        if test:  # when testing, we load a file
+            with url:
+                r = url.read()
+                data = extruct.extract(
+                    r,
+                    base_url="https://www.allrecipes.com/recipe/133948/four-cheese-margherita-pizza/",
+                    syntaxes=SYNTAXES,
+                    uniform=True,
+            )
+        else:
+            r = requests.get(url, headers=HEADERS)
+            data = extruct.extract(
+                r.text,
+                base_url=get_base_url(r.text, r.url),
+                syntaxes=SYNTAXES,
+                uniform=True,
+            )
+
+        for syntax in SYNTAXES:
+            for item in data.get(syntax, []):
+                if (
+                    "@context" in item and
+                    item["@context"] == SCHEMA_ORG_HOST and
+                    "@type" in item and
+                    item["@type"].lower() == SCHEMA_NAME.lower()
+                ):
+                    self.format = syntax
+                    self.data = item
+                    return
+
+    def host(self):
+        return SCHEMA_ORG_HOST
+
+    def title(self):
+        return self.data.get("name")
+
+    def total_time(self):
+        iso_cook_time = self.data.get("cookTime")
+        iso_prep_time = self.data.get("prepTime")
+        if not iso_prep_time and not iso_cook_time:
+            return None
+
+        total = 0
+        if iso_prep_time:
+            total += isodate.parse_duration(iso_prep_time).total_seconds * 60
+        if iso_cook_time:
+            total += isodate.parse_duration(iso_cook_time).total_seconds * 60
+        return total
+
+    def yields(self):
+        return self.data.get("recipeYield")
+
+    def image(self):
+        return self.data.get("image")
+
+    def ingredients(self):
+        return self.data.get("recipeIngredient")
+
+    def instructions(self):
+        return self.data.get("recipeInstructions")
+
+    def ratings(self):
+        return self.data.get("aggregateRating")

--- a/recipe_scrapers/tests/test_schemaorg.py
+++ b/recipe_scrapers/tests/test_schemaorg.py
@@ -1,0 +1,56 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from recipe_scrapers._schemaorg import SchemaOrg
+from recipe_scrapers.tests.test_allrecipes import TestAllRecipesScraper as ars
+
+
+class TestSchemaOrgScraper(TestCase):
+
+    def setUp(self):
+        # tests are run from tests.py
+        with open(os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            'test_data',
+            'allrecipes.testhtml'
+        )) as file_opened:
+            self.harvester_class = SchemaOrg(file_opened, test=True)
+
+        patcher = patch(
+            "recipe_scrapers.tests.test_allrecipes.harvester_class",
+            create=True,
+            return_value=self.harvester_class,
+        )
+        self.ars = ars()
+
+        self.ars.setUp()
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_host(self):
+        self.assertEqual(
+            'schema.org',
+            self.harvester_class.host()
+        )
+
+    def test_title(self):
+        self.ars.test_title()
+
+    def test_total_time(self):
+        self.ars.test_total_time()
+
+    def test_yields(self):
+        self.ars.test_yields()
+
+    def test_image(self):
+        self.ars.test_image()
+
+    def test_ingredients(self):
+        self.ars.test_ingredients()
+
+    def test_instructions(self):
+        self.ars.test_instructions()
+
+    def test_ratings(self):
+        self.ars.test_ratings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 beautifulsoup4>=4.6.0
 coverage>=4.5.1
+extruct>=0.8.0
+isodate>=0.6.0
 requests>=2.19.1

--- a/tests.py
+++ b/tests.py
@@ -31,6 +31,7 @@ from recipe_scrapers.tests.test_notimplemented import *
 from recipe_scrapers.tests.test_panelinha import *
 from recipe_scrapers.tests.test_paninihappy import *
 from recipe_scrapers.tests.test_realsimple import *
+from recipe_scrapers.tests.test_schemaorg import *
 from recipe_scrapers.tests.test_seriouseats import *
 from recipe_scrapers.tests.test_simplyrecipes import *
 from recipe_scrapers.tests.test_southernliving import *


### PR DESCRIPTION
Why use custom scraping logic when you can pull the data you are looking for directly from the Recipe schema object if it's present at the site? This change would mean the schema method would be preferred but I think that's the best way to ensure the data is accurate. It also would expand your supported sites pretty significantly (from what I've seen, almost all recipe sites embed it because it's required to show rich search results in Google).