### PR TITLE
Add PEP-396 module version number

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "8.1.0"
+
 import inspect
 import re
 from tldextract import TLDExtract

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(
     name="recipe_scrapers",
     url="https://github.com/hhursev/recipe-scrapers/",
-    version=,
+    version=__version__,
     author="Hristo Harsev",
     author_email="r+pypi@hharsev.com",
     description="Python package, scraping recipes from all over the internet",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import os
 from setuptools import setup, find_packages
 
+from recipe_scrapers import __version__
+
 README = open(os.path.join(os.path.dirname(__file__), "README.rst")).read()
 
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
@@ -8,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(
     name="recipe_scrapers",
     url="https://github.com/hhursev/recipe-scrapers/",
-    version="8.1.0",
+    version=,
     author="Hristo Harsev",
     author_email="r+pypi@hharsev.com",
     description="Python package, scraping recipes from all over the internet",


### PR DESCRIPTION
Sometimes it can be handy to inspect the version of a library after importing it - [PEP 396](https://www.python.org/dev/peps/pep-0396/) documents a standard way to do this.  After this change, you can run:

```python
>>> import recipe_scrapers
>>> recipe_scrapers.__version__
'8.1.0'
```

Pretty minor, but sometimes useful!