### PR TITLE
Suggest GitHub issue templates for recipe-scrapers library

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/new_scraper.md
+++ b/.github/ISSUE_TEMPLATE/new_scraper.md
@@ -1,0 +1,20 @@
+---
+name: New website scraper request
+about: Add support for a new recipe website
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+We always enjoy adding new websites to the list of [available `recipe-scrapers` scrapers](https://github.com/hhursev/recipe-scrapers#scrapers-available-for)!
+
+To help us out, please check that recipes on the website are public - we can't currently scrape recipes that require an account login - and add sample recipe URL(s) below:
+
+- https:// ...
+
+Can you write Python and would you like to help add the scraper yourself?  We'd be glad for your assistance!  We can provide you with guidance and code review in return.  If so, tick any of the relevant boxes below:
+
+- [ ] I'd like to try adding this scraper myself
+- [ ] I'd like guidance to help me develop a scraper
+- [ ] I'd prefer if the `recipe-scrapers` team try to add this

--- a/.github/ISSUE_TEMPLATE/scraper_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/scraper_bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Scraper bug report
+about: Report a scraper that is not working correctly
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+Thanks for filing a bug report with us!  To help get the issue fixed, please fill in the information below.
+
+**The URL of the recipe(s) that are not being scraped correctly**
+
+- https:// ...
+
+**The version of the `recipe-scrapers` software you're using**
+
+...
+
+**The results you expect to see**
+
+...
+
+**The results (including any Python error messages) that you are seeing**
+
+...
+
+Can you write Python and would you like to help fix the scraper yourself?  We'd be glad for your assistance!  We can provide you with guidance and code review in return.  If so, tick any of the relevant boxes below:
+
+- [ ] I'd like to try fixing this scraper myself
+- [ ] I'd like guidance to help me develop a fix
+- [ ] I'd prefer if the `recipe-scrapers` team try to fix this

--- a/.github/ISSUE_TEMPLATE/scraper_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/scraper_bug_report.md
@@ -22,10 +22,6 @@ To help get the issue fixed, please fill in the information below.
 
 - https:// ...
 
-**The version of the `recipe-scrapers` software you're using**
-
-...
-
 **The results you expect to see**
 
 ...

--- a/.github/ISSUE_TEMPLATE/scraper_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/scraper_bug_report.md
@@ -22,6 +22,14 @@ To help get the issue fixed, please fill in the information below.
 
 - https:// ...
 
+**The version of Python you're using**
+
+...
+
+**The operating system of your environment**
+
+...
+
 **The results you expect to see**
 
 ...

--- a/.github/ISSUE_TEMPLATE/scraper_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/scraper_bug_report.md
@@ -13,6 +13,11 @@ If your request is about a website that is not supported, please open a 'new scr
 
 To help get the issue fixed, please fill in the information below.
 
+**Pre-filing checks**
+
+- [ ] I have searched for open issues that report the same problem
+- [ ] I have checked that the bug affects the latest version of the library
+
 **The URL of the recipe(s) that are not being scraped correctly**
 
 - https:// ...

--- a/.github/ISSUE_TEMPLATE/scraper_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/scraper_bug_report.md
@@ -7,7 +7,11 @@ assignees: ''
 
 ---
 
-Thanks for filing a bug report with us!  To help get the issue fixed, please fill in the information below.
+Thanks for filing a bug report with us!
+
+If your request is about a website that is not supported, please open a 'new scraper' issue request instead.
+
+To help get the issue fixed, please fill in the information below.
 
 **The URL of the recipe(s) that are not being scraped correctly**
 


### PR DESCRIPTION
It's a little tricky to test these before they're merged into to the GitHub repo, as far as I know - and maybe the issue report volume is still low enough that we don't really need them yet.  But I figured they might be helpful.  What do you think about the idea and tone of these, @bfcarpio @hhursev? 

Here are a couple of references from GitHub's documentation about issue / PR templates:

- https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates
- https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository

Resolves #146