### PR TITLE
Ban `printf` style formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,7 @@
 [flake8]
-ignore = E203, E266, E501, W503
+# FS002 comes from pugin "flake8-use-fstring"
+# and would error on `str.format()` usage
+ignore = E203, E266, E501, W503, FS002
 # line length is intentionally set to 80 here because black uses Bugbear
 # See https://github.com/psf/black/blob/master/README.md#line-length for more details
 max-line-length = 80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
     rev: 3.8.3
     hooks:
     - id: flake8
+      additional_dependencies: [flake8-use-fstring]

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -25,10 +25,6 @@ class AbstractScraper(metaclass=ExceptionHandlingMetaclass):
         self.soup = BeautifulSoup(page_data, "html.parser")
         self.schema = SchemaOrg(page_data, host=self.host())
         self.url = url
-        # if self.schema.data:
-        #     print("Class: %s has schema." % (
-        #         self.__class__.__name__
-        #     ))
 
     def url(self):
         return self.url

--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -5,7 +5,7 @@ from ._utils import get_minutes, normalize_string, get_yields
 class BBCFood(AbstractScraper):
     @classmethod
     def host(self, domain="com"):
-        return "bbc.{}".format(domain)
+        return f"bbc.{domain}"
 
     def title(self):
         return normalize_string(self.soup.find("h1").get_text())

--- a/recipe_scrapers/eatsmarter.py
+++ b/recipe_scrapers/eatsmarter.py
@@ -4,7 +4,7 @@ from ._abstract import AbstractScraper
 class Eatsmarter(AbstractScraper):
     @classmethod
     def host(self, domain="com"):
-        return "eatsmarter.%s" % domain
+        return f"eatsmarter.{domain}"
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/hellofresh.py
+++ b/recipe_scrapers/hellofresh.py
@@ -8,7 +8,7 @@ from ._utils import get_minutes, normalize_string, get_yields
 class HelloFresh(AbstractScraper):
     @classmethod
     def host(self, domain="com"):
-        return "hellofresh.%s" % domain
+        return f"hellofresh.{domain}"
 
     def title(self):
         return self.soup.find("h1").get_text()

--- a/recipe_scrapers/mindmegette.py
+++ b/recipe_scrapers/mindmegette.py
@@ -19,7 +19,7 @@ class Mindmegette(AbstractScraper):
         ]
 
         if image_relative_url is not None:
-            image_relative_url = "http://%s%s" % (self.host(), image_relative_url)
+            image_relative_url = f"http://{self.host()}{image_relative_url}"
 
         return image_relative_url
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tldextract==2.2.2
 pre-commit>=2.6.0
 black>=19.10b0
 flake8>=3.8.3
+flake8-printf-formatting>=1.1.0


### PR DESCRIPTION
A Therapeutic PR because guess what caused problems recently at work...

The official Python 3 documentation [doesn't recommend](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) printf-style string formatting:

> The formatting operations described here exhibit a variety of quirks that
> lead to a number of common errors (such as failing to display tuples and
> dictionaries correctly). Using the newer formatted string literals,
> the `str.format` interface, or template strings may help avoid these errors.
> Each of these alternatives provides their own trade-offs and benefits of simplicity,
> flexibility, and/or extensibility.

This PR fixes existing printf style formatting as well as adds a flake8 plugin that will throw warnings when it is used thus preventing it from passing CI checks.