### PR TITLE
Allow running tests 'online'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pre-commit>=2.6.0
 black>=19.10b0
 flake8>=3.8.3
 flake8-printf-formatting>=1.1.0
+pytest>=6.1.1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,8 +15,10 @@ class ScraperTest(unittest.TestCase):
             encoding="utf-8",
         ) as testfile:
             self.harvester_class = self.scraper_class(testfile, test=True, **options)
-            canonical_url = self.harvester_class.soup.find('link', {'rel': 'canonical'})
+            canonical_url = self.harvester_class.soup.find("link", {"rel": "canonical"})
             if self.online:
                 if not canonical_url:
-                    pytest.skip(f"could not find canonical url for online test of scraper '{self.scraper_class.__name__}'")
-                self.harvester_class = self.scraper_class(url=canonical_url['href'])
+                    pytest.skip(
+                        f"could not find canonical url for online test of scraper '{self.scraper_class.__name__}'"
+                    )
+                self.harvester_class = self.scraper_class(url=canonical_url["href"])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,11 @@
+import pytest
 import unittest
 
 
 class ScraperTest(unittest.TestCase):
+
+    online = False
+
     def setUp(self):
         options = {"exception_handling": False}
         options.update(getattr(self, "scraper_options", {}))
@@ -11,3 +15,8 @@ class ScraperTest(unittest.TestCase):
             encoding="utf-8",
         ) as testfile:
             self.harvester_class = self.scraper_class(testfile, test=True, **options)
+            canonical_url = self.harvester_class.soup.find('link', {'rel': 'canonical'})
+            if self.online:
+                if not canonical_url:
+                    pytest.skip(f"could not find canonical url for online test of scraper '{self.scraper_class.__name__}'")
+                self.harvester_class = self.scraper_class(url=canonical_url['href'])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--online",
+        action="store_true",
+        default=False,
+        help="run unit tests against online web content",
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_online(request):
+    seen = {None}
+    session = request.node
+    online = request.config.getoption("--online")
+    for item in session.items:
+        cls = item.getparent(pytest.Class)
+        if cls not in seen:
+            if hasattr(cls.obj, "online"):
+                cls.obj.online = online
+            seen.add(cls)


### PR DESCRIPTION
Sometimes the structure and content of web pages changes, and when that happens it has the potential to break scrapers (or perhaps worse, cause them to return incorrect data).

A quick way to verify this is to run 'online' scraper tests - i.e. retrieve the current web content corresponding to each test at runtime.

This change adds support for a `pytest` option -- `--online` - that can be specified at the command-line in order to enable online-test behaviour.