### PR TITLE
Migrate to the 'tld' Python library

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -1,5 +1,5 @@
 import inspect
-from tldextract import TLDExtract
+from tld import get_tld
 
 from ._factory import SchemaScraperFactory
 from ._utils import get_host_name
@@ -271,9 +271,8 @@ class NoSchemaFoundInWildMode(Exception):
 
 
 def get_domain(url):
-    tldextract = TLDExtract(suffix_list_urls=None)
-    url_info = tldextract(url)
-    return "{}.{}".format(url_info.domain, url_info.suffix)
+    url_info = get_tld(url, as_object=True, search_private=False)
+    return url_info.fld
 
 
 def harvest(url, **options):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "extruct>=0.8.0",
         "language-tags>=1.0.0",
         "requests>=2.19.1",
-        "tldextract==2.2.2",
+        "tld>=0.12.3",
     ],
     packages=find_packages(),
     package_data={"": ["LICENSE"]},


### PR DESCRIPTION
This is a non-user-facing change to swap out the existing [`tldextract`](https://pypi.org/project/tldextract/) library for the [`tld`](https://pypi.org/project/tld/) library instead.

I was looking into updating to the latest `tldextract` version as part of keeping dependencies fresh, and noticed that the constructor arguments for the `TLDExtract` class have been changing a bit over time, and in particular there is some caching/TLD update logic that requires pulling in the `requests` library, performing network connections, and writing cache contents.  I've provided some feedback in their issue tracker regarding the caching topic (basically suggesting re-use of existing libraries).

It's a little arbitrary, but `tld` seems lighter-weight and less dependency-burdened than `tldextract`, while performing less network and disk I/O.  I care about those a bit when building stable containers, so it's slightly selfish of me to suggest migration on these grounds, but I think they're signs that `tld` may be more reliable.