### PR TITLE
Add isort to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,13 @@ repos:
 -   repo: https://github.com/psf/black
     rev: 19.3b0
     hooks:
-      - id: black
+    - id: black
 -   repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.8.3
     hooks:
     - id: flake8
       additional_dependencies: [flake8-use-fstring]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.7.0
+    hooks:
+    - id: isort


### PR DESCRIPTION
Totally optional. I just used this tool to fix the many changes I made in #331 and thought it might be interesting to keep things organized in the automated way that we do. 