### PR TITLE
isort uses Black profile

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,9 +2,7 @@
 # FS002 comes from pugin "flake8-use-fstring"
 # and would error on `str.format()` usage
 ignore = E203, E266, E501, W503, FS002
-# line length is intentionally set to 80 here because black uses Bugbear
-# See https://github.com/psf/black/blob/master/README.md#line-length for more details
-max-line-length = 80
+max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
 exclude = tests/test_data/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
     rev: 5.7.0
     hooks:
     - id: isort
+      args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,6 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 19.3b0
-    hooks:
-    - id: black
 -   repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.8.3
     hooks:
@@ -19,3 +15,7 @@ repos:
     hooks:
     - id: isort
       args: ["--profile", "black", "--filter-files"]
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    - id: black

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -1,15 +1,14 @@
 from collections import OrderedDict
 from json.decoder import JSONDecodeError
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
-from typing import Tuple, Optional, Union, Any, Dict, List
 
 import requests
 from bs4 import BeautifulSoup
 
+from ._decorators import Decorators
 from ._exception_handling import ExceptionHandlingMetaclass
 from ._schemaorg import SchemaOrg
-from ._decorators import Decorators
-
 
 # some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {

--- a/recipe_scrapers/_decorators.py
+++ b/recipe_scrapers/_decorators.py
@@ -1,4 +1,5 @@
 import functools
+
 from language_tags import tags
 
 from ._schemaorg import SchemaOrgException

--- a/recipe_scrapers/_exception_handling.py
+++ b/recipe_scrapers/_exception_handling.py
@@ -1,6 +1,5 @@
-import logging
 import functools
-
+import logging
 
 ON_EXCEPTION_RETURN_VALUES = {
     "title": "",

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -1,6 +1,7 @@
 # IF things in this file continue get messy (I'd say 300+ lines) it may be time to
 # find a package that parses https://schema.org/Recipe properly (or create one ourselves).
 import extruct
+
 from ._utils import get_minutes, normalize_string
 
 SCHEMA_ORG_HOST = "schema.org"

--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class BBCFood(AbstractScraper):

--- a/recipe_scrapers/bbcgoodfood.py
+++ b/recipe_scrapers/bbcgoodfood.py
@@ -1,5 +1,6 @@
-from ._abstract import AbstractScraper
 from bs4 import BeautifulSoup
+
+from ._abstract import AbstractScraper
 
 
 class BBCGoodFood(AbstractScraper):

--- a/recipe_scrapers/closetcooking.py
+++ b/recipe_scrapers/closetcooking.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class ClosetCooking(AbstractScraper):

--- a/recipe_scrapers/cookieandkate.py
+++ b/recipe_scrapers/cookieandkate.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class CookieAndKate(AbstractScraper):

--- a/recipe_scrapers/cookstr.py
+++ b/recipe_scrapers/cookstr.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Cookstr(AbstractScraper):

--- a/recipe_scrapers/countryliving.py
+++ b/recipe_scrapers/countryliving.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class CountryLiving(AbstractScraper):

--- a/recipe_scrapers/delish.py
+++ b/recipe_scrapers/delish.py
@@ -4,7 +4,7 @@
 # March 1st, 2020
 # ==========================================================
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Delish(AbstractScraper):

--- a/recipe_scrapers/epicurious.py
+++ b/recipe_scrapers/epicurious.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_yields, get_minutes
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Epicurious(AbstractScraper):

--- a/recipe_scrapers/finedininglovers.py
+++ b/recipe_scrapers/finedininglovers.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class FineDiningLovers(AbstractScraper):

--- a/recipe_scrapers/fitmencook.py
+++ b/recipe_scrapers/fitmencook.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class FitMenCook(AbstractScraper):

--- a/recipe_scrapers/food.py
+++ b/recipe_scrapers/food.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Food(AbstractScraper):

--- a/recipe_scrapers/foodnetwork.py
+++ b/recipe_scrapers/foodnetwork.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class FoodNetwork(AbstractScraper):

--- a/recipe_scrapers/foodrepublic.py
+++ b/recipe_scrapers/foodrepublic.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class FoodRepublic(AbstractScraper):

--- a/recipe_scrapers/geniuskitchen.py
+++ b/recipe_scrapers/geniuskitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class GeniusKitchen(AbstractScraper):

--- a/recipe_scrapers/gousto.py
+++ b/recipe_scrapers/gousto.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Gousto(AbstractScraper):

--- a/recipe_scrapers/heb.py
+++ b/recipe_scrapers/heb.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class HEB(AbstractScraper):

--- a/recipe_scrapers/hellofresh.py
+++ b/recipe_scrapers/hellofresh.py
@@ -1,8 +1,7 @@
 import re
 
-
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class HelloFresh(AbstractScraper):

--- a/recipe_scrapers/hundredandonecookbooks.py
+++ b/recipe_scrapers/hundredandonecookbooks.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class HundredAndOneCookbooks(AbstractScraper):

--- a/recipe_scrapers/ig.py
+++ b/recipe_scrapers/ig.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_yields
+from ._utils import get_yields, normalize_string
 
 
 class IG(AbstractScraper):

--- a/recipe_scrapers/inspiralized.py
+++ b/recipe_scrapers/inspiralized.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Inspiralized(AbstractScraper):

--- a/recipe_scrapers/jamieoliver.py
+++ b/recipe_scrapers/jamieoliver.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class JamieOliver(AbstractScraper):

--- a/recipe_scrapers/kennymcgovern.py
+++ b/recipe_scrapers/kennymcgovern.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class KennyMcGovern(AbstractScraper):

--- a/recipe_scrapers/matprat.py
+++ b/recipe_scrapers/matprat.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Matprat(AbstractScraper):

--- a/recipe_scrapers/mindmegette.py
+++ b/recipe_scrapers/mindmegette.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Mindmegette(AbstractScraper):

--- a/recipe_scrapers/momswithcrockpots.py
+++ b/recipe_scrapers/momswithcrockpots.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class MomsWithCrockPots(AbstractScraper):

--- a/recipe_scrapers/motherthyme.py
+++ b/recipe_scrapers/motherthyme.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class MotherThyme(AbstractScraper):

--- a/recipe_scrapers/mybakingaddiction.py
+++ b/recipe_scrapers/mybakingaddiction.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class MyBakingAddiction(AbstractScraper):

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_minutes, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class NIHHealthyEating(AbstractScraper):

--- a/recipe_scrapers/nutritionbynathalie.py
+++ b/recipe_scrapers/nutritionbynathalie.py
@@ -1,8 +1,6 @@
 import re
 
-
 from ._abstract import AbstractScraper
-
 
 BULLET_CHARACTER_ORD = 8226
 

--- a/recipe_scrapers/onehundredonecookbooks.py
+++ b/recipe_scrapers/onehundredonecookbooks.py
@@ -1,5 +1,6 @@
-from ._abstract import AbstractScraper
 import re
+
+from ._abstract import AbstractScraper
 
 
 class OneHundredOneCookBooks(AbstractScraper):

--- a/recipe_scrapers/paninihappy.py
+++ b/recipe_scrapers/paninihappy.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class PaniniHappy(AbstractScraper):

--- a/recipe_scrapers/popsugar.py
+++ b/recipe_scrapers/popsugar.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_yields, get_minutes
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class PopSugar(AbstractScraper):

--- a/recipe_scrapers/przepisy.py
+++ b/recipe_scrapers/przepisy.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Przepisy(AbstractScraper):

--- a/recipe_scrapers/realsimple.py
+++ b/recipe_scrapers/realsimple.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class RealSimple(AbstractScraper):

--- a/recipe_scrapers/seriouseats.py
+++ b/recipe_scrapers/seriouseats.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class SeriousEats(AbstractScraper):

--- a/recipe_scrapers/simplyquinoa.py
+++ b/recipe_scrapers/simplyquinoa.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class SimplyQuinoa(AbstractScraper):

--- a/recipe_scrapers/simplyrecipes.py
+++ b/recipe_scrapers/simplyrecipes.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class SimplyRecipes(AbstractScraper):

--- a/recipe_scrapers/southernliving.py
+++ b/recipe_scrapers/southernliving.py
@@ -4,7 +4,7 @@
 # 9 February, 2020
 # =======================================================
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class SouthernLiving(AbstractScraper):

--- a/recipe_scrapers/streetkitchen.py
+++ b/recipe_scrapers/streetkitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_yields
+from ._utils import get_yields, normalize_string
 
 
 class StreetKitchen(AbstractScraper):

--- a/recipe_scrapers/sunbasket.py
+++ b/recipe_scrapers/sunbasket.py
@@ -1,8 +1,7 @@
 import re
 
-
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class SunBasket(AbstractScraper):

--- a/recipe_scrapers/tastesoflizzyt.py
+++ b/recipe_scrapers/tastesoflizzyt.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class TastesOfLizzyT(AbstractScraper):

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class TastyKitchen(AbstractScraper):

--- a/recipe_scrapers/thehappyfoodie.py
+++ b/recipe_scrapers/thehappyfoodie.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_minutes, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class TheHappyFoodie(AbstractScraper):

--- a/recipe_scrapers/thekitchn.py
+++ b/recipe_scrapers/thekitchn.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class TheKitchn(AbstractScraper):

--- a/recipe_scrapers/thepioneerwoman.py
+++ b/recipe_scrapers/thepioneerwoman.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class ThePioneerWoman(AbstractScraper):

--- a/recipe_scrapers/tineno.py
+++ b/recipe_scrapers/tineno.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class TineNo(AbstractScraper):

--- a/recipe_scrapers/twopeasandtheirpod.py
+++ b/recipe_scrapers/twopeasandtheirpod.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class TwoPeasAndTheirPod(AbstractScraper):

--- a/recipe_scrapers/vegolosi.py
+++ b/recipe_scrapers/vegolosi.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class Vegolosi(AbstractScraper):

--- a/recipe_scrapers/wikicookbook.py
+++ b/recipe_scrapers/wikicookbook.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string, get_yields
+from ._utils import get_minutes, get_yields, normalize_string
 
 
 class WikiCookbook(AbstractScraper):

--- a/recipe_scrapers/yummly.py
+++ b/recipe_scrapers/yummly.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import normalize_string, get_yields
+from ._utils import get_yields, normalize_string
 
 
 class Yummly(AbstractScraper):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
-import pytest
 import unittest
+
+import pytest
 
 
 class ScraperTest(unittest.TestCase):

--- a/tests/test_750g.py
+++ b/tests/test_750g.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.g750g import G750g
+from tests import ScraperTest
 
 
 class TestG750gScraper(ScraperTest):

--- a/tests/test_abril.py
+++ b/tests/test_abril.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.abril import Abril
+from tests import ScraperTest
 
 
 class TestAbrilScraper(ScraperTest):

--- a/tests/test_acouplecooks.py
+++ b/tests/test_acouplecooks.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.acouplecooks import ACoupleCooks
+from tests import ScraperTest
 
 
 # test recipe's URL

--- a/tests/test_allrecipes.py
+++ b/tests/test_allrecipes.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.allrecipes import AllRecipes
+from tests import ScraperTest
 
 
 class TestAllRecipesScraper(ScraperTest):

--- a/tests/test_amazingribs.py
+++ b/tests/test_amazingribs.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.amazingribs import AmazingRibs
+from tests import ScraperTest
 
 
 class TestAmazingRibsScraper(ScraperTest):

--- a/tests/test_ambitiouskitchen.py
+++ b/tests/test_ambitiouskitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.ambitiouskitchen import AmbitiousKitchen
+from tests import ScraperTest
 
 
 class TestAmbitiousKitchenScraper(ScraperTest):

--- a/tests/test_archanaskitchen.py
+++ b/tests/test_archanaskitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.archanaskitchen import ArchanasKitchen
+from tests import ScraperTest
 
 
 class TestArchanasKitchenScraper(ScraperTest):

--- a/tests/test_atelierdeschefs.py
+++ b/tests/test_atelierdeschefs.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.atelierdeschefs import AtelierDesChefs
+from tests import ScraperTest
 
 
 class TestAtelierDesChefsScraper(ScraperTest):

--- a/tests/test_averiecooks.py
+++ b/tests/test_averiecooks.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.averiecooks import AverieCooks
+from tests import ScraperTest
 
 
 class TestAverieCooksScraper(ScraperTest):

--- a/tests/test_bakingmischeif.py
+++ b/tests/test_bakingmischeif.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.bakingmischeif import BakingMischeif
+from tests import ScraperTest
 
 
 class TestBakingMischeifScraper(ScraperTest):

--- a/tests/test_bbc.py
+++ b/tests/test_bbc.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.bbcfood import BBCFood
+from tests import ScraperTest
 
 
 class TestBBCFoodScraper(ScraperTest):

--- a/tests/test_bbcgoodfood.py
+++ b/tests/test_bbcgoodfood.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.bbcgoodfood import BBCGoodFood
+from tests import ScraperTest
 
 
 class TestBBCGoodFoodScraper(ScraperTest):

--- a/tests/test_bettycrocker.py
+++ b/tests/test_bettycrocker.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.bettycrocker import BettyCrocker
+from tests import ScraperTest
 
 
 class TestBettyCrocker(ScraperTest):

--- a/tests/test_bigoven.py
+++ b/tests/test_bigoven.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.bigoven import BigOven
+from tests import ScraperTest
 
 
 class TestBigOven(ScraperTest):

--- a/tests/test_blueapron.py
+++ b/tests/test_blueapron.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.blueapron import BlueApron
+from tests import ScraperTest
 
 
 class TestBlueApronScraper(ScraperTest):

--- a/tests/test_bonappetit.py
+++ b/tests/test_bonappetit.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.bonappetit import BonAppetit
+from tests import ScraperTest
 
 
 class TestBonAppetitScraper(ScraperTest):

--- a/tests/test_bowlofdelicious.py
+++ b/tests/test_bowlofdelicious.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.bowlofdelicious import BowlOfDelicious
+from tests import ScraperTest
 
 
 class TestBowlOfDeliciousScraper(ScraperTest):

--- a/tests/test_budgetbytes.py
+++ b/tests/test_budgetbytes.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.budgetbytes import BudgetBytes
+from tests import ScraperTest
 
 
 class TestBudgetBytesScraper(ScraperTest):

--- a/tests/test_castironketo.py
+++ b/tests/test_castironketo.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.castironketo import CastIronKeto
+from tests import ScraperTest
 
 
 class TestCastIronKetoScraper(ScraperTest):

--- a/tests/test_cdkitchen.py
+++ b/tests/test_cdkitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cdkitchen import CdKitchen
+from tests import ScraperTest
 
 
 class TestCdKitchen(ScraperTest):

--- a/tests/test_chefkoch.py
+++ b/tests/test_chefkoch.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.chefkoch import Chefkoch
+from tests import ScraperTest
 
 
 class TestChefkochScraper(ScraperTest):

--- a/tests/test_closetcooking.py
+++ b/tests/test_closetcooking.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.closetcooking import ClosetCooking
+from tests import ScraperTest
 
 
 class TestClosetCooking(ScraperTest):

--- a/tests/test_cookeatshare.py
+++ b/tests/test_cookeatshare.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cookeatshare import CookEatShare
+from tests import ScraperTest
 
 
 class TestCookEatShare(ScraperTest):

--- a/tests/test_cookieandkate.py
+++ b/tests/test_cookieandkate.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cookieandkate import CookieAndKate
+from tests import ScraperTest
 
 
 class TestCookieAndKateScraper(ScraperTest):

--- a/tests/test_cookinglight.py
+++ b/tests/test_cookinglight.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cookinglight import CookingLight
+from tests import ScraperTest
 
 
 class TestCookingLight(ScraperTest):
@@ -24,8 +23,7 @@ class TestCookingLight(ScraperTest):
 
     def test_title(self):
         self.assertEqual(
-            self.harvester_class.title(),
-            "Avocado, Black Bean, and Charred Tomato Bowl",
+            self.harvester_class.title(), "Avocado, Black Bean, and Charred Tomato Bowl"
         )
 
     def test_total_time(self):

--- a/tests/test_cookpad.py
+++ b/tests/test_cookpad.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cookpad import CookPad
+from tests import ScraperTest
 
 
 class TestCookPadScraper(ScraperTest):

--- a/tests/test_cookstr.py
+++ b/tests/test_cookstr.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cookstr import Cookstr
+from tests import ScraperTest
 
 
 class TestCookstrScraper(ScraperTest):

--- a/tests/test_copykat.py
+++ b/tests/test_copykat.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.copykat import CopyKat
+from tests import ScraperTest
 
 
 class TestCopyKat(ScraperTest):

--- a/tests/test_countryliving.py
+++ b/tests/test_countryliving.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.countryliving import CountryLiving
+from tests import ScraperTest
 
 
 class TestCountryLivingScraper(ScraperTest):

--- a/tests/test_cuisineaz.py
+++ b/tests/test_cuisineaz.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cuisineaz import CuisineAZ
+from tests import ScraperTest
 
 
 class CuisineAZScraper(ScraperTest):

--- a/tests/test_cybercook.py
+++ b/tests/test_cybercook.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.cybercook import Cybercook
+from tests import ScraperTest
 
 
 class TestCybercook(ScraperTest):

--- a/tests/test_delish.py
+++ b/tests/test_delish.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.delish import Delish
+from tests import ScraperTest
 
 
 class TestDelishScraper(ScraperTest):

--- a/tests/test_domesticateme.py
+++ b/tests/test_domesticateme.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.domesticateme import DomesticateMe
+from tests import ScraperTest
 
 
 class TestDomesticateMeScraper(ScraperTest):

--- a/tests/test_downshiftology.py
+++ b/tests/test_downshiftology.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.downshiftology import Downshiftology
+from tests import ScraperTest
 
 
 class TestDownshiftologyScraper(ScraperTest):

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.dr import Dr
+from tests import ScraperTest
 
 
 class TestDrMeScraper(ScraperTest):

--- a/tests/test_eatingbirdfood.py
+++ b/tests/test_eatingbirdfood.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.eatingbirdfood import EatingBirdFood
+from tests import ScraperTest
 
 
 class TestEatingBirdFoodScraper(ScraperTest):

--- a/tests/test_eatsmarter.py
+++ b/tests/test_eatsmarter.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.eatsmarter import Eatsmarter
+from tests import ScraperTest
 
 
 class TestClosetCooking(ScraperTest):

--- a/tests/test_eatwhattonight.py
+++ b/tests/test_eatwhattonight.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.eatwhattonight import EatWhatTonight
+from tests import ScraperTest
 
 
 class TestEatWhatTonight(ScraperTest):

--- a/tests/test_epicurious.py
+++ b/tests/test_epicurious.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.epicurious import Epicurious
+from tests import ScraperTest
 
 
 class TestEpicurious(ScraperTest):

--- a/tests/test_farmhousedelivery_1.py
+++ b/tests/test_farmhousedelivery_1.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.farmhousedelivery import FarmhouseDelivery
+from tests import ScraperTest
 
 
 class TestFarmhouseDeliveryScraper(ScraperTest):

--- a/tests/test_farmhousedelivery_2.py
+++ b/tests/test_farmhousedelivery_2.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.farmhousedelivery import FarmhouseDelivery
+from tests import ScraperTest
 
 
 class TestFarmhouseDeliveryScraper(ScraperTest):

--- a/tests/test_fifteenspatulas.py
+++ b/tests/test_fifteenspatulas.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.fifteenspatulas import FifteenSpatulas
+from tests import ScraperTest
 
 
 class TestFifteenSpatulasScraper(ScraperTest):

--- a/tests/test_finedininglovers.py
+++ b/tests/test_finedininglovers.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.finedininglovers import FineDiningLovers
+from tests import ScraperTest
 
 
 class TestFineDiningLoversScraper(ScraperTest):

--- a/tests/test_fitmencook.py
+++ b/tests/test_fitmencook.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.fitmencook import FitMenCook
+from tests import ScraperTest
 
 # test recipe's URL
 # https://fitmencook.com/healthy-chili-recipe/

--- a/tests/test_food.py
+++ b/tests/test_food.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.food import Food
+from tests import ScraperTest
 
 
 class TestFoodScraper(ScraperTest):

--- a/tests/test_food52.py
+++ b/tests/test_food52.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.food52 import Food52
+from tests import ScraperTest
 
 
 class TestFood52(ScraperTest):

--- a/tests/test_foodandwine.py
+++ b/tests/test_foodandwine.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.foodandwine import FoodAndWine
+from tests import ScraperTest
 
 
 class TestFoodAndWineScraper(ScraperTest):

--- a/tests/test_foodnetwork.py
+++ b/tests/test_foodnetwork.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.foodnetwork import FoodNetwork
+from tests import ScraperTest
 
 
 class TestFoodNetworkScraper(ScraperTest):

--- a/tests/test_foodrepublic.py
+++ b/tests/test_foodrepublic.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.foodrepublic import FoodRepublic
+from tests import ScraperTest
 
 
 class TestFoodRepublicScraper(ScraperTest):

--- a/tests/test_geniuskitchen.py
+++ b/tests/test_geniuskitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.geniuskitchen import GeniusKitchen
+from tests import ScraperTest
 
 
 class TestGeniusKitchenScraper(ScraperTest):

--- a/tests/test_giallozafferano.py
+++ b/tests/test_giallozafferano.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.giallozafferano import GialloZafferano
+from tests import ScraperTest
 
 
 class TestGialloZafferanoScraper(ScraperTest):

--- a/tests/test_gimmesomeoven.py
+++ b/tests/test_gimmesomeoven.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.gimmesomeoven import GimmeSomeOven
+from tests import ScraperTest
 
 
 class TestGimmeSomeOvenScraper(ScraperTest):

--- a/tests/test_globo.py
+++ b/tests/test_globo.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.globo import Globo
+from tests import ScraperTest
 
 
 class TestGloboScraper(ScraperTest):

--- a/tests/test_gonnawantseconds.py
+++ b/tests/test_gonnawantseconds.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.gonnawantseconds import GonnaWantSeconds
+from tests import ScraperTest
 
 
 class TestGonnaWantSeconds(ScraperTest):

--- a/tests/test_gousto.py
+++ b/tests/test_gousto.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.gousto import Gousto
+from tests import ScraperTest
 
 
 class TestGoustoScraper(ScraperTest):

--- a/tests/test_greatbritishchefs.py
+++ b/tests/test_greatbritishchefs.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.greatbritishchefs import GreatBritishChefs
+from tests import ScraperTest
 
 
 class TestGreatBritishChefsScraper(ScraperTest):

--- a/tests/test_halfbakedharvest.py
+++ b/tests/test_halfbakedharvest.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.halfbakedharvest import HalfBakedHarvest
+from tests import ScraperTest
 
 
 class TestHalfBakedHarvestScraper(ScraperTest):

--- a/tests/test_hassanchef.py
+++ b/tests/test_hassanchef.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.hassenchef import Hassanchef
+from tests import ScraperTest
 
 
 class TestClosetCooking(ScraperTest):

--- a/tests/test_heb.py
+++ b/tests/test_heb.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.heb import HEB
+from tests import ScraperTest
 
 
 class TestHEBScraper(ScraperTest):

--- a/tests/test_heinzbrasil.py
+++ b/tests/test_heinzbrasil.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.heinzbrasil import HeinzBrasil
+from tests import ScraperTest
 
 
 class TestHeinzBrasilScraper(ScraperTest):

--- a/tests/test_hellofresh.py
+++ b/tests/test_hellofresh.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.hellofresh import HelloFresh
+from tests import ScraperTest
 
 
 class TestHelloFreshScraper(ScraperTest):

--- a/tests/test_hostthetoast.py
+++ b/tests/test_hostthetoast.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.hostthetoast import Hostthetoast
+from tests import ScraperTest
 
 
 class TestHostthetoastScraper(ScraperTest):

--- a/tests/test_hundredandonecookbooks.py
+++ b/tests/test_hundredandonecookbooks.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.hundredandonecookbooks import HundredAndOneCookbooks
+from tests import ScraperTest
 
 
 class TestHundredAndOneCookbooksScraper(ScraperTest):

--- a/tests/test_ig.py
+++ b/tests/test_ig.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.ig import IG
+from tests import ScraperTest
 
 
 class TestIGScraper(ScraperTest):

--- a/tests/test_indianhealthyrecipes.py
+++ b/tests/test_indianhealthyrecipes.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.indianhealthyrecipes import IndianHealthyRecipes
+from tests import ScraperTest
 
 
 class TestIndianHealthyRecipesScraper(ScraperTest):

--- a/tests/test_innit.py
+++ b/tests/test_innit.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.innit import Innit
+from tests import ScraperTest
 
 
 class TestInnitScraper(ScraperTest):

--- a/tests/test_inspiralized.py
+++ b/tests/test_inspiralized.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.inspiralized import Inspiralized
+from tests import ScraperTest
 
 
 class TestInspiralizedScraper(ScraperTest):

--- a/tests/test_jamieoliver.py
+++ b/tests/test_jamieoliver.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.jamieoliver import JamieOliver
+from tests import ScraperTest
 
 
 class TestJamieOliverScraper(ScraperTest):

--- a/tests/test_justbento.py
+++ b/tests/test_justbento.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.justbento import JustBento
+from tests import ScraperTest
 
 
 class TestJustBentoScraper(ScraperTest):

--- a/tests/test_kennymcgovern.py
+++ b/tests/test_kennymcgovern.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.kennymcgovern import KennyMcGovern
+from tests import ScraperTest
 
 
 class TestKennyMcGovernScraper(ScraperTest):

--- a/tests/test_kingarthur.py
+++ b/tests/test_kingarthur.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.kingarthur import KingArthur
+from tests import ScraperTest
 
 
 class TestKingArthurScraper(ScraperTest):

--- a/tests/test_kochbar.py
+++ b/tests/test_kochbar.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.kochbar import Kochbar
+from tests import ScraperTest
 
 
 class TestKochbarScraper(ScraperTest):

--- a/tests/test_kuchniadomowa.py
+++ b/tests/test_kuchniadomowa.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.kuchniadomowa import KuchniaDomowa
+from tests import ScraperTest
 
 
 class TestKuchniaDomowaScraper(ScraperTest):

--- a/tests/test_lecremedelacrumb.py
+++ b/tests/test_lecremedelacrumb.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.lecremedelacrumb import LeCremeDeLaCrumb
+from tests import ScraperTest
 
 
 class TestLeCremeDeLaCrumbScraper(ScraperTest):

--- a/tests/test_littlespicejar.py
+++ b/tests/test_littlespicejar.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.littlespicejar import LittleSpiceJar
+from tests import ScraperTest
 
 
 class TestLittleSpiceJarScraper(ScraperTest):

--- a/tests/test_livelytable.py
+++ b/tests/test_livelytable.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.livelytable import LivelyTable
+from tests import ScraperTest
 
 
 class TestLivelyTableScraper(ScraperTest):

--- a/tests/test_lovingitvegan.py
+++ b/tests/test_lovingitvegan.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.lovingitvegan import Lovingitvegan
+from tests import ScraperTest
 
 
 class TestLovingitveganScraper(ScraperTest):

--- a/tests/test_marmiton.py
+++ b/tests/test_marmiton.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.marmiton import Marmiton
+from tests import ScraperTest
 
 
 class TestMarmitonScraper(ScraperTest):

--- a/tests/test_matprat.py
+++ b/tests/test_matprat.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.matprat import Matprat
+from tests import ScraperTest
 
 
 class TestMatprat(ScraperTest):

--- a/tests/test_melskitchencafe.py
+++ b/tests/test_melskitchencafe.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.melskitchencafe import MelsKitchenCafe
+from tests import ScraperTest
 
 
 class TestMelsKitchenCafeScraper(ScraperTest):

--- a/tests/test_mindmegette.py
+++ b/tests/test_mindmegette.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.mindmegette import Mindmegette
+from tests import ScraperTest
 
 
 class TestMindmegetteScraper(ScraperTest):

--- a/tests/test_minimalistbaker.py
+++ b/tests/test_minimalistbaker.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.minimalistbaker import Minimalistbaker
+from tests import ScraperTest
 
 
 class TestMinimalistbakerScraper(ScraperTest):

--- a/tests/test_misya.py
+++ b/tests/test_misya.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.misya import Misya
+from tests import ScraperTest
 
 
 class TestMisya(ScraperTest):

--- a/tests/test_momswithcrockpots.py
+++ b/tests/test_momswithcrockpots.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.momswithcrockpots import MomsWithCrockPots
+from tests import ScraperTest
 
 
 class TestMomsWithCrockPotsScraper(ScraperTest):

--- a/tests/test_motherthyme.py
+++ b/tests/test_motherthyme.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.motherthyme import MotherThyme
+from tests import ScraperTest
 
 
 class TestMotherThymeScraper(ScraperTest):

--- a/tests/test_mybakingaddiction.py
+++ b/tests/test_mybakingaddiction.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.mybakingaddiction import MyBakingAddiction
+from tests import ScraperTest
 
 
 class TestMyBakingAddictionScraper(ScraperTest):

--- a/tests/test_myrecipes.py
+++ b/tests/test_myrecipes.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.myrecipes import MyRecipes
+from tests import ScraperTest
 
 
 class TestMyRecipesScraper(ScraperTest):

--- a/tests/test_nih.py
+++ b/tests/test_nih.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.nihhealthyeating import NIHHealthyEating
+from tests import ScraperTest
 
 # test recipe's URL
 # https://healthyeating.nhlbi.nih.gov/recipedetail.aspx?linkId=17&cId=10&rId=247

--- a/tests/test_nourishedbynutrition.py
+++ b/tests/test_nourishedbynutrition.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.nourishedbynutrition import NourishedByNutrition
+from tests import ScraperTest
 
 
 class TestNourishedByNutritionScraper(ScraperTest):

--- a/tests/test_nutritionbynathalie.py
+++ b/tests/test_nutritionbynathalie.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.nutritionbynathalie import NutritionByNathalie
+from tests import ScraperTest
 
 
 class TestNutritionByNathalieScraper(ScraperTest):

--- a/tests/test_nytimes.py
+++ b/tests/test_nytimes.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.nytimes import NYTimes
+from tests import ScraperTest
 
 
 class TestNYTimesScraper(ScraperTest):

--- a/tests/test_ohsheglows.py
+++ b/tests/test_ohsheglows.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.ohsheglows import OhSheGlows
+from tests import ScraperTest
 
 
 class TestOhSheGlowsScraper(ScraperTest):

--- a/tests/test_onehundredonecookbooks.py
+++ b/tests/test_onehundredonecookbooks.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.onehundredonecookbooks import OneHundredOneCookBooks
+from tests import ScraperTest
 
 
 class TestOneHundredOneCookBooksScraper(ScraperTest):

--- a/tests/test_paleorunningmomma.py
+++ b/tests/test_paleorunningmomma.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.paleorunningmomma import PaleoRunningMomma
+from tests import ScraperTest
 
 
 class TestPaleoRunningMommaScraper(ScraperTest):

--- a/tests/test_panelinha.py
+++ b/tests/test_panelinha.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.panelinha import Panelinha
+from tests import ScraperTest
 
 
 class TestPanelinhaScraper(ScraperTest):

--- a/tests/test_paninihappy.py
+++ b/tests/test_paninihappy.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.paninihappy import PaniniHappy
+from tests import ScraperTest
 
 
 class TestPaniniHappyScraper(ScraperTest):

--- a/tests/test_popsugar.py
+++ b/tests/test_popsugar.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.popsugar import PopSugar
+from tests import ScraperTest
 
 
 class TestPopSugarScraper(ScraperTest):

--- a/tests/test_przepisy.py
+++ b/tests/test_przepisy.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.przepisy import Przepisy
+from tests import ScraperTest
 
 # test recipe's URL
 # https://www.przepisy.pl/przepis/placki-ziemniaczane

--- a/tests/test_purelypope.py
+++ b/tests/test_purelypope.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.purelypope import PurelyPope
+from tests import ScraperTest
 
 
 class TestPurelyPopeScraper(ScraperTest):

--- a/tests/test_purplecarrot.py
+++ b/tests/test_purplecarrot.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.purplecarrot import PurpleCarrot
+from tests import ScraperTest
 
 
 class TestPurpleCarrotScraper(ScraperTest):

--- a/tests/test_rachlmansfield.py
+++ b/tests/test_rachlmansfield.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.rachlmansfield import RachlMansfield
+from tests import ScraperTest
 
 
 class TestRachlMansfieldScraper(ScraperTest):

--- a/tests/test_realsimple.py
+++ b/tests/test_realsimple.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.realsimple import RealSimple
+from tests import ScraperTest
 
 
 class TestRealSimpleScraper(ScraperTest):

--- a/tests/test_recipietineats.py
+++ b/tests/test_recipietineats.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.recipietineats import RecipieTinEats
+from tests import ScraperTest
 
 
 class TestRecipieTinEatsScraper(ScraperTest):

--- a/tests/test_seriouseats.py
+++ b/tests/test_seriouseats.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.seriouseats import SeriousEats
+from tests import ScraperTest
 
 
 class TestSeriousEats(ScraperTest):

--- a/tests/test_simplyquinoa.py
+++ b/tests/test_simplyquinoa.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.simplyquinoa import SimplyQuinoa
+from tests import ScraperTest
 
 
 class TestSimplyQuinoaScraper(ScraperTest):

--- a/tests/test_simplyrecipes.py
+++ b/tests/test_simplyrecipes.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.simplyrecipes import SimplyRecipes
+from tests import ScraperTest
 
 
 class TestSimplyRecipesScraper(ScraperTest):

--- a/tests/test_skinnytaste.py
+++ b/tests/test_skinnytaste.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.skinnytaste import SkinnyTaste
+from tests import ScraperTest
 
 
 class TestSkinnyTasteScraper(ScraperTest):

--- a/tests/test_southernliving.py
+++ b/tests/test_southernliving.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.southernliving import SouthernLiving
+from tests import ScraperTest
 
 
 class TestSouthernLiving(ScraperTest):

--- a/tests/test_spendwithpennies.py
+++ b/tests/test_spendwithpennies.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.spendwithpennies import SpendWithPennies
+from tests import ScraperTest
 
 
 class TestSpendWithPenniesScraper(ScraperTest):

--- a/tests/test_spruceeats.py
+++ b/tests/test_spruceeats.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.spruceeats import SpruceEats
+from tests import ScraperTest
 
 
 class TestSpruceEatsScraper(ScraperTest):

--- a/tests/test_steamykitchen.py
+++ b/tests/test_steamykitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.steamykitchen import SteamyKitchen
+from tests import ScraperTest
 
 
 class TestSteamyKitchenScraper(ScraperTest):

--- a/tests/test_streetkitchen.py
+++ b/tests/test_streetkitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.streetkitchen import StreetKitchen
+from tests import ScraperTest
 
 
 class TestStreetKitchenScraper(ScraperTest):

--- a/tests/test_sunbasket.py
+++ b/tests/test_sunbasket.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.sunbasket import SunBasket
+from tests import ScraperTest
 
 
 class TestSunBasketScraper(ScraperTest):

--- a/tests/test_sweetpeasandsaffron.py
+++ b/tests/test_sweetpeasandsaffron.py
@@ -1,5 +1,5 @@
-from tests import ScraperTest
 from recipe_scrapers.sweetpeasandsaffron import SweetPeasAndSaffron
+from tests import ScraperTest
 
 
 class TestSweetPeasAndSaffron(ScraperTest):

--- a/tests/test_tasteofhome.py
+++ b/tests/test_tasteofhome.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.tasteofhome import TasteOfHome
+from tests import ScraperTest
 
 
 class TestTasteOfHomeScraper(ScraperTest):

--- a/tests/test_tastesoflizzyt.py
+++ b/tests/test_tastesoflizzyt.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.tastesoflizzyt import TastesOfLizzyT
+from tests import ScraperTest
 
 
 class TestTastesOfLizzyTScraper(ScraperTest):

--- a/tests/test_tasty.py
+++ b/tests/test_tasty.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.tasty import Tasty
+from tests import ScraperTest
 
 
 class TestTastyScraper(ScraperTest):

--- a/tests/test_tastykitchen.py
+++ b/tests/test_tastykitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.tastykitchen import TastyKitchen
+from tests import ScraperTest
 
 
 class TestTastyKitchenScraper(ScraperTest):

--- a/tests/test_theclevercarrot.py
+++ b/tests/test_theclevercarrot.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.theclevercarrot import TheCleverCarrot
+from tests import ScraperTest
 
 
 class TestTheCleverCarrotScraper(ScraperTest):

--- a/tests/test_thehappyfoodie.py
+++ b/tests/test_thehappyfoodie.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.thehappyfoodie import TheHappyFoodie
+from tests import ScraperTest
 
 
 class TestTheHappyFoodie(ScraperTest):

--- a/tests/test_thekitchn.py
+++ b/tests/test_thekitchn.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.thekitchn import TheKitchn
+from tests import ScraperTest
 
 
 class TestKitchnScraper(ScraperTest):

--- a/tests/test_thenutritiouskitchen.py
+++ b/tests/test_thenutritiouskitchen.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.thenutritiouskitchen import TheNutritiousKitchen
+from tests import ScraperTest
 
 
 class TestTheNutritiousKitchenScraper(ScraperTest):

--- a/tests/test_thepioneerwoman.py
+++ b/tests/test_thepioneerwoman.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.thepioneerwoman import ThePioneerWoman
+from tests import ScraperTest
 
 
 class TestThePioneerWomanScraper(ScraperTest):

--- a/tests/test_thespruceeats.py
+++ b/tests/test_thespruceeats.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.thespruceeats import TheSpruceEats
+from tests import ScraperTest
 
 
 class TestTheSpruceEatsScraper(ScraperTest):

--- a/tests/test_thevintagemixer.py
+++ b/tests/test_thevintagemixer.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.thevintagemixer import TheVintageMixer
+from tests import ScraperTest
 
 
 class TestTheVintageMixerScraper(ScraperTest):

--- a/tests/test_thewoksoflife.py
+++ b/tests/test_thewoksoflife.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.thewoksoflife import Thewoksoflife
+from tests import ScraperTest
 
 
 class TestThewoksoflifeScraper(ScraperTest):

--- a/tests/test_tine.py
+++ b/tests/test_tine.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.tineno import TineNo
+from tests import ScraperTest
 
 
 class TestTineNoScraper(ScraperTest):

--- a/tests/test_tudogostoso.py
+++ b/tests/test_tudogostoso.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.tudogostoso import TudoGostoso
+from tests import ScraperTest
 
 
 class TestTudoGostosoScraper(ScraperTest):

--- a/tests/test_twopeasandtheirpod.py
+++ b/tests/test_twopeasandtheirpod.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.twopeasandtheirpod import TwoPeasAndTheirPod
+from tests import ScraperTest
 
 
 class TestTwoPeasAndTheirPodScraper(ScraperTest):

--- a/tests/test_vanillaandbean.py
+++ b/tests/test_vanillaandbean.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.vanillaandbean import VanillaAndBean
+from tests import ScraperTest
 
 
 class TestVanillaAndBeanScraper(ScraperTest):

--- a/tests/test_vegolosi.py
+++ b/tests/test_vegolosi.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.vegolosi import Vegolosi
+from tests import ScraperTest
 
 
 class TestVegolosiScraper(ScraperTest):

--- a/tests/test_vegrecipesofindia.py
+++ b/tests/test_vegrecipesofindia.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.vegrecipesofindia import VegRecipesOfIndia
+from tests import ScraperTest
 
 
 class TestVegRecipesOfIndiaScraper(ScraperTest):

--- a/tests/test_watchwhatueat.py
+++ b/tests/test_watchwhatueat.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.watchwhatueat import WatchWhatUEat
+from tests import ScraperTest
 
 
 class TestWatchWhatUEatScraper(ScraperTest):

--- a/tests/test_whatsgabycooking.py
+++ b/tests/test_whatsgabycooking.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.whatsgabycooking import WhatsGabyCooking
+from tests import ScraperTest
 
 
 class TestWhatsGabyCookingScraper(ScraperTest):

--- a/tests/test_wholefoods.py
+++ b/tests/test_wholefoods.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.wholefoods import WholeFoods
+from tests import ScraperTest
 
 
 class TestWholeFoodsScraper(ScraperTest):

--- a/tests/test_wikibooks.py
+++ b/tests/test_wikibooks.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.wikicookbook import WikiCookbook
+from tests import ScraperTest
 
 
 class TestWikiCookbookScraper(ScraperTest):

--- a/tests/test_yummly.py
+++ b/tests/test_yummly.py
@@ -1,6 +1,5 @@
-from tests import ScraperTest
-
 from recipe_scrapers.yummly import Yummly
+from tests import ScraperTest
 
 
 class TestYummlyScraper(ScraperTest):


### PR DESCRIPTION
Turns out the boffins have figured out how to make some of our tools work together. Who knew reading the docs actually makes things work. :100: 

https://github.com/psf/black/blob/master/docs/compatible_configs.md#black-compatible-configurations
https://pycqa.github.io/isort/docs/configuration/black_compatibility/

@jayaddison You might like the hanging changes shown in the first link.

---

The only interesting changes are in `.flake8` and `.pre-commit-config.yaml`. The rest is auto formatting etc.

`--filter-files` means that isort will only run on files that were changed in that commit. I *think* black does something like this by default. Regardless, the entire repo is black enforced anyways via CI/CD. Imports is only for those who run `pre-commit`. I don't intend to put everything into CI/CD just to keep the barrier low, but I'll take consistent styling where I can from those who use the setup guide.