### PR TITLE
Make PluginInterface abstract

### DIFF
--- a/recipe_scrapers/plugins/_interface.py
+++ b/recipe_scrapers/plugins/_interface.py
@@ -1,4 +1,8 @@
-class PluginInterface:
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+
+
+class PluginInterface(ABC):
     """
     Interface that all "Plugins" (including the ones written by programmers
     using the package) should implement.
@@ -9,10 +13,11 @@ class PluginInterface:
     - run
     """
 
-    run_on_hosts = ("*",)
-    run_on_methods = ("title",)
+    run_on_hosts: Iterable[str] = ("*",)
+    run_on_methods: Iterable[str] = ("title",)
 
     @classmethod
+    @abstractmethod
     def run(cls, decorated):
         pass
 


### PR DESCRIPTION
We definitely don't need to instantiate this class.

I started to look at implementing my other things, but this is all I could do for now. Optional for v13