### PR TITLE
Bump User Agent to win10 Firefox

### DIFF
--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -13,7 +13,7 @@ from ._schemaorg import SchemaOrg
 
 # some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.7) Gecko/2009021910 Firefox/3.0.7"
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0"
 }
 
 


### PR DESCRIPTION
Some sites block old User Agents now, so bumped it to win10 Firefox. Not particular to this specific UA, but should probably be bumped to something equally new if not this one.

Example site (in `wild_mode=True` of course): [https://thenaturalnurturer.com/chickpea-vegetable-nuggets/](https://thenaturalnurturer.com/chickpea-vegetable-nuggets/)