### PR TITLE
Fixup: omit nutrient fields that have no value present

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -117,7 +117,7 @@ class SchemaOrg:
         return {
             normalize_string(nutrient): normalize_string(value)
             for nutrient, value in nutrients.items()
-            if nutrient != "@type"
+            if nutrient != "@type" and value is not None
         }
 
     def _extract_howto_instructions_text(self, schema_item):

--- a/tests/test_data/schemaorg.testhtml
+++ b/tests/test_data/schemaorg.testhtml
@@ -23,7 +23,8 @@
           "nutrition": {
             "@type": "NutritionInformation",
             "calories": "240 calories",
-            "fatContent": "9 grams fat"
+            "fatContent": "9 grams fat",
+            "servingSize": null
           },
           "prepTime": "PT15M",
           "recipeInstructions": "Preheat the oven to 350 degrees. Mix in the ingredients in a bowl. Add the flour last. Pour the mixture into a loaf pan and bake for one hour.",

--- a/tests/test_schemaorg.py
+++ b/tests/test_schemaorg.py
@@ -25,6 +25,13 @@ class TestSchemaOrg(unittest.TestCase):
         del self.schema.data["totalTime"]
         self.assertEqual(self.schema.total_time(), 0)
 
+    def test_nutrient_retrieval(self):
+        expected_nutrients = {
+            "calories": "240 calories",
+            "fatContent": "9 grams fat",
+        }
+        self.assertEqual(self.schema.nutrients(), expected_nutrients)
+
     def test_graph_schema_without_context(self):
         with open(
             "tests/test_data/schemaorg_graph.testhtml", encoding="utf-8"


### PR DESCRIPTION
I don't think it makes sense to include nutrient field names where there is no value present.  In addition, `normalize_string` does not currently work correctly for inputs of type `NoneType`.  That method could do with some attention and perhaps be refactored out eventually.