### PR TITLE
SchemaOrg: adjust parser error handling

### DIFF
--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -38,9 +38,6 @@ class AbstractScraper:
         self.wild_mode = wild_mode
         self.soup = BeautifulSoup(page_data, "html.parser")
         self.url = url
-
-        # Attempt to read Schema.org data. Gracefully fail if it raises an exception parsing the JSON.
-        # The scraper subclass can use BeautifulSoup to extract the information.
         self.schema = SchemaOrg(page_data)
 
         # attach the plugins as instructed in settings.PLUGINS

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -1,6 +1,5 @@
 import inspect
 from collections import OrderedDict
-from json.decoder import JSONDecodeError
 from typing import Optional, Tuple, Union
 from urllib.parse import urljoin
 

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -41,10 +41,7 @@ class AbstractScraper:
 
         # Attempt to read Schema.org data. Gracefully fail if it raises an exception parsing the JSON.
         # The scraper subclass can use BeautifulSoup to extract the information.
-        try:
-            self.schema = SchemaOrg(page_data)
-        except JSONDecodeError:
-            pass
+        self.schema = SchemaOrg(page_data)
 
         # attach the plugins as instructed in settings.PLUGINS
         for name, func in inspect.getmembers(self, inspect.ismethod):

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -18,7 +18,7 @@ class SchemaOrg:
         self.format = None
         self.data = {}
 
-        data = extruct.extract(page_data, syntaxes=SYNTAXES, uniform=True)
+        data = extruct.extract(page_data, syntaxes=SYNTAXES, errors='log', uniform=True)
 
         low_schema = {s.lower() for s in SCHEMA_NAMES}
         for syntax in SYNTAXES:

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -18,7 +18,7 @@ class SchemaOrg:
         self.format = None
         self.data = {}
 
-        data = extruct.extract(page_data, syntaxes=SYNTAXES, errors='log', uniform=True)
+        data = extruct.extract(page_data, syntaxes=SYNTAXES, errors="log", uniform=True)
 
         low_schema = {s.lower() for s in SCHEMA_NAMES}
         for syntax in SYNTAXES:


### PR DESCRIPTION
We currently skip assigning a `self.schema` attribute when `SchemaOrg` JSON parsing fails, but we don't check for presence of that attribute in the scraper code.  It might be safer to unconditionally store a `SchemaOrg` on each scraper -- even if that means it may contain empty parsing results.

The underlying `extruct` library call is updated to log parsing errors instead of throwing them as exceptions.

Relates to the thread at https://github.com/hhursev/recipe-scrapers/pull/286#issuecomment-753405193 (cc @adamkeys @hhursev)