### PR TITLE
Unset maximum diff size for scraper tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,7 @@ import pytest
 
 class ScraperTest(unittest.TestCase):
 
+    maxDiff = None
     online = False
     test_file_name = None
 

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -50,7 +50,6 @@ class TestDrMeScraper(ScraperTest):
         )
 
     def test_instructions(self):
-        self.maxDiff = None
         return self.assertEqual(
             """Opskriften giver cirka 16 styks, afhængig af størrelsen.
 

--- a/tests/test_forksoverknives.py
+++ b/tests/test_forksoverknives.py
@@ -50,7 +50,6 @@ class TestTimesOfIndiaScraper(ScraperTest):
         )
 
     def test_instructions(self):
-        self.assertEqual.__self__.maxDiff = None
         self.assertEqual(
             "Peel squash; halve squash and remove seeds. Cut squash into large pieces. Place squash pieces in a steamer basket in a large pan. Add water to saucepan to just below basket. Bring to boiling. Steam, covered, about 12 minutes or until tender.\nHeat a large saucepan over medium. Add onion, garlic, thyme, and ¼ cup water to pan. Cook about 10 minutes or until onion is tender, stirring occasionally and adding water, 1 to 2 Tbsp. at a time, as needed to prevent sticking.\nTransfer onion mixture to a blender. Add squash and the next five ingredients (through pepper). Cover and blend until smooth. Pour squash mixture into a large saucepan.\nCook pasta according to package directions, adding broccoli the last 5 minutes of cooking; drain. Add drained pasta and broccoli to squash mixture; toss to coat. Serve warm topped with fresh basil.",
             self.harvester_class.instructions(),

--- a/tests/test_marthastewart.py
+++ b/tests/test_marthastewart.py
@@ -6,8 +6,6 @@ class TestMarthaStewart(ScraperTest):
 
     scraper_class = MarthaStewart
 
-    maxDiff = None
-
     def test_host(self):
         self.assertEqual("marthastewart.com", self.harvester_class.host())
 

--- a/tests/test_nytimes.py
+++ b/tests/test_nytimes.py
@@ -37,7 +37,6 @@ class TestNYTimesScraper(ScraperTest):
         self.assertEqual("160 item(s)", self.harvester_class.yields())
 
     def test_ingredients(self):
-        self.maxDiff = None
         self.assertCountEqual(
             [
                 "1 1/2 cups/190 grams unbleached all-purpose flour (see Tip)",

--- a/tests/test_thekitchn.py
+++ b/tests/test_thekitchn.py
@@ -6,8 +6,6 @@ class TestKitchnScraper(ScraperTest):
 
     scraper_class = TheKitchn
 
-    maxDiff = None
-
     def test_host(self):
         self.assertEqual("thekitchn.com", self.harvester_class.host())
 


### PR DESCRIPTION
It can be useful when investigating scraper test failures to have a complete diff displayed in the test failure logs.  Python's `unittest` library allows configuration of diff limits using the [`TestCase.maxDiff` setting](https://docs.python.org/3/library/unittest.html#unittest.TestCase.maxDiff).  Here we disable the diff limit at the base scraper level, so that the setting is applied to all scraper tests.