### PR TITLE
Clean hosts of prefixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ Scrapers available for:
 - `https://hellofresh.com/ <https://hellofresh.com>`_
 - `https://hellofresh.co.uk/ <https://hellofresh.co.uk>`_
 - `https://www.hellofresh.de/ <https://www.hellofresh.de/>`_
-- `https://www.hellofresh.fr/ <https://www.hellofresh.de/>`_
+- `https://www.hellofresh.fr/ <https://www.hellofresh.fr/>`_
 - `https://hostthetoast.com/ <https://hostthetoast.com/>`_
 - `https://receitas.ig.com.br/ <https://receitas.ig.com.br>`_
 - `https://indianhealthyrecipes.com <https://www.indianhealthyrecipes.com>`_

--- a/recipe_scrapers/domesticateme.py
+++ b/recipe_scrapers/domesticateme.py
@@ -4,7 +4,7 @@ from ._abstract import AbstractScraper
 class DomesticateMe(AbstractScraper):
     @classmethod
     def host(cls):
-        return "domesticate-me.com/"
+        return "domesticate-me.com"
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/domesticateme.py
+++ b/recipe_scrapers/domesticateme.py
@@ -4,7 +4,7 @@ from ._abstract import AbstractScraper
 class DomesticateMe(AbstractScraper):
     @classmethod
     def host(cls):
-        return "https://domesticate-me.com/"
+        return "domesticate-me.com/"
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/heb.py
+++ b/recipe_scrapers/heb.py
@@ -5,7 +5,7 @@ from ._utils import get_minutes, get_yields, normalize_string
 class HEB(AbstractScraper):
     @classmethod
     def host(self, domain="com"):
-        return f"www.heb.{domain}"
+        return f"heb.{domain}"
 
     def title(self):
         return self.soup.find("h1", {"class": "title"}).get_text()

--- a/recipe_scrapers/streetkitchen.py
+++ b/recipe_scrapers/streetkitchen.py
@@ -5,7 +5,7 @@ from ._utils import get_yields, normalize_string
 class StreetKitchen(AbstractScraper):
     @classmethod
     def host(cls):
-        return "https://streetkitchen.hu"
+        return "streetkitchen.hu"
 
     def title(self):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()

--- a/recipe_scrapers/wholefoods.py
+++ b/recipe_scrapers/wholefoods.py
@@ -4,7 +4,7 @@ from ._abstract import AbstractScraper
 class WholeFoods(AbstractScraper):
     @classmethod
     def host(self, domain="com"):
-        return f"www.wholefoodsmarket.{domain}"
+        return f"wholefoodsmarket.{domain}"
 
     def title(self):
         return self.schema.title()

--- a/tests/test_domesticateme.py
+++ b/tests/test_domesticateme.py
@@ -7,7 +7,7 @@ class TestDomesticateMeScraper(ScraperTest):
     scraper_class = DomesticateMe
 
     def test_host(self):
-        self.assertEqual("https://domesticate-me.com/", self.harvester_class.host())
+        self.assertEqual("domesticate-me.com/", self.harvester_class.host())
 
     def test_canonical_url(self):
         self.assertEqual(

--- a/tests/test_domesticateme.py
+++ b/tests/test_domesticateme.py
@@ -7,7 +7,7 @@ class TestDomesticateMeScraper(ScraperTest):
     scraper_class = DomesticateMe
 
     def test_host(self):
-        self.assertEqual("domesticate-me.com/", self.harvester_class.host())
+        self.assertEqual("domesticate-me.com", self.harvester_class.host())
 
     def test_canonical_url(self):
         self.assertEqual(

--- a/tests/test_heb.py
+++ b/tests/test_heb.py
@@ -7,7 +7,7 @@ class TestHEBScraper(ScraperTest):
     scraper_class = HEB
 
     def test_host(self):
-        self.assertEqual("www.heb.com", self.harvester_class.host())
+        self.assertEqual("heb.com", self.harvester_class.host())
 
     def test_canonical_url(self):
         self.assertEqual(

--- a/tests/test_streetkitchen.py
+++ b/tests/test_streetkitchen.py
@@ -7,7 +7,7 @@ class TestStreetKitchenScraper(ScraperTest):
     scraper_class = StreetKitchen
 
     def test_host(self):
-        self.assertEqual("https://streetkitchen.hu", self.harvester_class.host())
+        self.assertEqual("streetkitchen.hu", self.harvester_class.host())
 
     def test_language(self):
         self.assertEqual("hu", self.harvester_class.language())

--- a/tests/test_wholefoods.py
+++ b/tests/test_wholefoods.py
@@ -7,11 +7,11 @@ class TestWholeFoodsScraper(ScraperTest):
     scraper_class = WholeFoods
 
     def test_host(self):
-        self.assertEqual("www.wholefoodsmarket.com", self.harvester_class.host())
+        self.assertEqual("wholefoodsmarket.com", self.harvester_class.host())
 
     def test_host_domain(self):
         self.assertEqual(
-            "www.wholefoodsmarket.co.uk", self.harvester_class.host(domain="co.uk")
+            "wholefoodsmarket.co.uk", self.harvester_class.host(domain="co.uk")
         )
 
     def test_title(self):


### PR DESCRIPTION
This PR aims to close #414, where I described how removing prefixes could be beneficial for application developers.  

This was also highlighted in #399, where a user asked to add support for an existing website, which was rejected because the host wasn't matching.  


This was tested by applying the changes and manually importing a recipe from each of the touched scrapers, as well as updating the tests.  
```python
from recipe_scrapers import scrape_me

scrape_me('https://domesticate-me.com/asparagus-gratin/')
scrape_me('https://www.heb.com/recipe/recipe-item/grilled-s-more-dip/1398895332108')
```

I could not test `wholefoodmarkets.{com,co.uk}` because I'm in neither of these two regions and they're not available to me.


Thanks! 