### PR TITLE
Add missing WebsiteNotImplementedError.domain property

### DIFF
--- a/recipe_scrapers/_exceptions.py
+++ b/recipe_scrapers/_exceptions.py
@@ -11,6 +11,7 @@ class WebsiteNotImplementedError(RecipeScrapersExceptions):
     """Error when website is not supported by this library."""
 
     def __init__(self, domain):
+        self.domain = domain
         message = f"Website ({self.domain}) not supported."
         super().__init__(message)
 
@@ -19,8 +20,8 @@ class NoSchemaFoundInWildMode(RecipeScrapersExceptions):
     """Error when wild_mode fails to locate schema at the url"""
 
     def __init__(self, url):
-        message = f"No Recipe Schema found at {self.url}."
         self.url = url
+        message = f"No Recipe Schema found at {self.url}."
         super().__init__(message)
 
 

--- a/tests/library/test_exceptions.py
+++ b/tests/library/test_exceptions.py
@@ -1,17 +1,19 @@
 import unittest
 
-from recipe_scrapers import (NoSchemaFoundInWildMode,
-                             WebsiteNotImplementedError, scrape_me)
+from recipe_scrapers import (
+    NoSchemaFoundInWildMode,
+    WebsiteNotImplementedError,
+    scrape_me,
+)
 
 
 class TestExceptions(unittest.TestCase):
     def test_WebsiteNotImplementedError(self):
         with self.assertRaises(WebsiteNotImplementedError):
-            scrape_me('https://example.com/recipe')
+            scrape_me("https://example.com/recipe")
 
     def test_NoSchemaFoundInWildMode(self):
-        exception = NoSchemaFoundInWildMode('example.com')
+        exception = NoSchemaFoundInWildMode("example.com")
 
-        self.assertEquals(exception.url, 'example.com')
-        self.assertEquals(exception.message,
-                          'No Recipe Schema found at example.com.')
+        self.assertEquals(exception.url, "example.com")
+        self.assertEquals(exception.message, "No Recipe Schema found at example.com.")

--- a/tests/library/test_exceptions.py
+++ b/tests/library/test_exceptions.py
@@ -1,0 +1,17 @@
+import unittest
+
+from recipe_scrapers import (NoSchemaFoundInWildMode,
+                             WebsiteNotImplementedError, scrape_me)
+
+
+class TestExceptions(unittest.TestCase):
+    def test_WebsiteNotImplementedError(self):
+        with self.assertRaises(WebsiteNotImplementedError):
+            scrape_me('https://example.com/recipe')
+
+    def test_NoSchemaFoundInWildMode(self):
+        exception = NoSchemaFoundInWildMode('example.com')
+
+        self.assertEquals(exception.url, 'example.com')
+        self.assertEquals(exception.message,
+                          'No Recipe Schema found at example.com.')


### PR DESCRIPTION
Hi again,  

In this PR, I aim to fix two issues related to errors raised in the library.  


1) `WebsiteNotImplementedError` was missing `self.domain`.   

Thus, it used to raise an `AttributeError` when initialized:

```python
In [1]: from recipe_scrapers import scrape_me

In [2]: recipe = scrape_me('https://example.com/recipe/')
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/gourmand/venv/lib/python3.9/site-packages/recipe_scrapers/__init__.py in scrape_me(url_path, **options)

KeyError: 'example.com'

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
<ipython-input-15-a004d3ee2fba> in <module>
----> 1 recipe = scrape_me('https://example.com/recipe/')

~/gourmand/venv/lib/python3.9/site-packages/recipe_scrapers/__init__.py in scrape_me(url_path, **options)

~/gourmand/venv/lib/python3.9/site-packages/recipe_scrapers/_exceptions.py in __init__(self, domain)

AttributeError: 'WebsiteNotImplementedError' object has no attribute 'domain'
```
where I'd instead expect `scrape_me` to raise a `WebsiteNotImplementedError`.



2) `NoSchemaFoundInWildMode` was using `self.url` before it was set:  

```python
In [1]: from recipe_scrapers import NoSchemaFoundInWildMode                                                                                                                                                                                   
                                                                                                                                                                                                                                              
In [2]: NoSchemaFoundInWildMode('example.com')                                                                                                                                                                                                
---------------------------------------------------------------------------                                                                                                                                                                   
AttributeError                            Traceback (most recent call last)                                                                                                                                                                   
<ipython-input-2-19570f0e73fa> in <module>                                                                                                                                                                                                    
----> 1 NoSchemaFoundInWildMode('example.com')                                                                                                                                                                                                
                                                                                                                                                                                                                                              
~/recipe-scrapers/recipe_scrapers/_exceptions.py in __init__(self, url)                                                                                                                                                                       
     21                                                                                                                                                                                                                                       
     22     def __init__(self, url):                                                                                                                                                                                                          
---> 23         message = f"No Recipe Schema found at {self.url}."                                                                                                                                                                            
     24         self.url = url                                                                                                                                                                                                                
     25         super().__init__(message)                                                                                                                                                                                                     
                                                                                                                                                                                                                                              
AttributeError: 'NoSchemaFoundInWildMode' object has no attribute 'url'   
```

The fix was tested by successfully creating an object when re-running the two lines above.

Thanks!
Cyril