### PR TITLE
Fix re import in koket scraper

### DIFF
--- a/recipe_scrapers/koket.py
+++ b/recipe_scrapers/koket.py
@@ -1,6 +1,5 @@
 import json
-
-import regex as re
+import re
 
 from ._abstract import AbstractScraper
 


### PR DESCRIPTION
Hi,

This PR fixes an unfortunate import in the `koket.se` scraper, introduced [here](https://github.com/hhursev/recipe-scrapers/commit/8500fd8e0f8a982325a2dc56b226416b749c5f7e).  
This also breaks the latest release.  

I tested this change by running `pytest -vv tests/` first, seeing the keket test fail, doing the change, and seeing all tests pass.  
I also checked that this fix makes my application start again.

Thanks!
Cyril