### PR TITLE
Substitute 'community' for 'team' in scraper request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_scraper.md
+++ b/.github/ISSUE_TEMPLATE/new_scraper.md
@@ -17,4 +17,4 @@ Can you write Python and would you like to help add the scraper yourself?  We'd 
 
 - [ ] I'd like to try adding this scraper myself
 - [ ] I'd like guidance to help me develop a scraper
-- [ ] I'd prefer if the `recipe-scrapers` team try to add this
+- [ ] I'd prefer if the `recipe-scrapers` community try to add this


### PR DESCRIPTION
This is to reduce the notion that only existing contributors / members of the `recipe-scrapers` repo can implement additional scrapers.  In practice we often receive pull requests for scrapers, and could/should use the 'help wanted' and 'good first issue' labels to help new contributors find ways they can get involved. 