### PR TITLE
Call the right method from MadensVerden in test_prep_time

### DIFF
--- a/tests/test_madensverden.py
+++ b/tests/test_madensverden.py
@@ -28,7 +28,7 @@ class TestMadensVerdenScraper(ScraperTest):
         self.assertEqual(15, self.harvester_class.cook_time())
 
     def test_prep_time(self):
-        self.assertEqual(15, self.harvester_class.cook_time())
+        self.assertEqual(15, self.harvester_class.prep_time())
 
     def test_yields(self):
         self.assertEqual("6 serving(s)", self.harvester_class.yields())


### PR DESCRIPTION
There was a copy/paste error that caused the method `test_prep_time` to call the `cook_time` method in `MadensVerden`. Coincidentally, the expected value for both of them was the same, and so the test passed.