### PR TITLE
Refactor unit test data loading and request mocking

### DIFF
--- a/recipe_scrapers/kptncook.py
+++ b/recipe_scrapers/kptncook.py
@@ -3,8 +3,6 @@ from urllib.parse import parse_qs, urlparse
 
 import requests
 
-from recipe_scrapers.settings import settings
-
 from ._abstract import AbstractScraper
 
 HEADERS = {

--- a/recipe_scrapers/marleyspoon.py
+++ b/recipe_scrapers/marleyspoon.py
@@ -27,17 +27,15 @@ class MarleySpoon(AbstractScraper):
     def __init__(self, url, proxies=None, timeout=None, *args, **kwargs):
         super().__init__(url=url, proxies=proxies, timeout=timeout, *args, **kwargs)
 
-        # skip during the test, we will test the method separately
-        if url != "https://test.example.com/":  # pragma: no cover
-            # The website's html does not contain any recipe data, but it loads it with a json request.
-            # We read the request parameters from html and preform additional request it to fetch recipe data.
-            api_url, api_token = self._get_json_params()
-            self.page_data = requests.get(
-                api_url,
-                headers={"authorization": api_token, **HEADERS},
-                proxies=proxies,
-                timeout=timeout,
-            ).content
+        # The website's html does not contain any recipe data, but it loads it with a json request.
+        # We read the request parameters from html and preform additional request it to fetch recipe data.
+        api_url, api_token = self._get_json_params()
+        self.page_data = requests.get(
+            api_url,
+            headers={"authorization": api_token, **HEADERS},
+            proxies=proxies,
+            timeout=timeout,
+        ).content
 
         self.data = json.loads(self.page_data)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ flake8>=3.8.3
 flake8-printf-formatting>=1.1.0
 pre-commit>=2.6.0
 pytest>=6.1.1
+responses>=0.21.0
 unittest-parallel>=1.5.0
 # language-tags>=1.0.0
 # tld>=0.12.3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,8 @@
 import os
+from typing import Dict
 import unittest
 
-import pytest
+import responses
 
 
 class ScraperTest(unittest.TestCase):
@@ -11,27 +12,27 @@ class ScraperTest(unittest.TestCase):
     test_file_name = None
     test_file_extension = "testhtml"
 
+    @property
+    def expected_requests(self) -> Dict[str, str]:
+        """
+        A mapping of expected HTTP GET URLs to filenames that contain response content.
+        """
+        filename = self.test_file_name or self.scraper_class.__name__.lower()
+        path = f"tests/test_data/{filename}.{self.test_file_extension}"
+        yield "https://test.example.com", path
+
     def setUp(self):
         os.environ[
             "RECIPE_SCRAPERS_SETTINGS"
         ] = "tests.test_data.test_settings_module.test_settings"
 
-        test_file_name = (
-            self.test_file_name
-            if self.test_file_name
-            else self.scraper_class.__name__.lower()
-        )
-        with open(
-            f"tests/test_data/{test_file_name}.{self.test_file_extension}",
-            encoding="utf-8",
-        ) as testfile:
-            self.harvester_class = self.scraper_class(
-                url="https://test.example.com/", html=testfile.read()
-            )
-            canonical_url = self.harvester_class.canonical_url()
-            if self.online:
-                if not canonical_url:
-                    pytest.skip(
-                        f"could not find canonical url for online test of scraper '{self.scraper_class.__name__}'"
-                    )
-                self.harvester_class = self.scraper_class(url=canonical_url)
+        with responses.RequestsMock() as rsps:
+            start_url = None
+            for url, path in self.expected_requests:
+                start_url = start_url or url
+                content = open(path, encoding="utf-8").read()
+                response = responses.Response(responses.GET, url, body=content)
+                response.passthrough = self.online
+                rsps.add(response)
+
+            self.harvester_class = self.scraper_class(url=start_url)

--- a/tests/test_data/foodnetwork.testhtml
+++ b/tests/test_data/foodnetwork.testhtml
@@ -195,7 +195,7 @@ div.PlayerControlLabelSelectedFont { color : #ffffff !important; }
 
 
 
-      <link rel="canonical" href="foodnetwork.testhtml_files/chicken-marsala-recipe-1951778.html">
+      <link rel="canonical" href="http://www.foodnetwork.com/recipes/tyler-florence/chicken-marsala-recipe-1951778">
 
 
 

--- a/tests/test_foodnetwork.py
+++ b/tests/test_foodnetwork.py
@@ -1,4 +1,7 @@
+from responses import GET
+
 from recipe_scrapers.foodnetwork import FoodNetwork
+
 from tests import ScraperTest
 
 
@@ -6,13 +9,16 @@ class TestFoodNetworkScraper(ScraperTest):
 
     scraper_class = FoodNetwork
 
+    @property
+    def expected_requests(self):
+        yield GET, "https://www.foodnetwork.com/recipes/tyler-florence/chicken-marsala-recipe-1951778", "tests/test_data/foodnetwork.testhtml"
+
     def test_host(self):
         self.assertEqual("foodnetwork.com", self.harvester_class.host())
 
     def test_canonical_url(self):
-        # TODO: Find a way to supply original content base URL at test-time (via WARC-file?)
         self.assertEqual(
-            "https://test.example.com/foodnetwork.testhtml_files/chicken-marsala-recipe-1951778.html",
+            "http://www.foodnetwork.com/recipes/tyler-florence/chicken-marsala-recipe-1951778",
             self.harvester_class.canonical_url(),
         )
 

--- a/tests/test_gousto.py
+++ b/tests/test_gousto.py
@@ -1,4 +1,7 @@
+from responses import GET
+
 from recipe_scrapers.gousto import Gousto
+
 from tests import ScraperTest
 
 
@@ -6,13 +9,12 @@ class TestGoustoScraper(ScraperTest):
 
     scraper_class = Gousto
 
+    @property
+    def expected_requests(self):
+        yield GET, "https://www.foodnetwork.com/recipes/tyler-florence/chicken-marsala-recipe-1951778", "tests/test_data/gousto.testhtml"
+
     def test_host(self):
         self.assertEqual("gousto.co.uk", self.harvester_class.host())
-
-    def test_canonical_url(self):
-        self.assertEqual(
-            "https://test.example.com/", self.harvester_class.canonical_url()
-        )
 
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Creamy Pork Tagliatelle")

--- a/tests/test_kptncook.py
+++ b/tests/test_kptncook.py
@@ -1,10 +1,18 @@
+import responses
+
 from recipe_scrapers.kptncook import KptnCook
+
 from tests import ScraperTest
 
 
 class TestKptnCookScraper(ScraperTest):
 
     scraper_class = KptnCook
+
+    @property
+    def expected_requests(self):
+        yield responses.GET, "https://mobile.kptncook.com/recipe/pinterest/Low-Carb-Tarte-Flamb%C3%A9e-with-Serrano-Ham-%26-Cream-Cheese/315c3c32?lang=en", "tests/test_data/kptncook.testhtml"
+        yield responses.POST, "https://mobile.kptncook.com/recipes/search?kptnkey=6q7QNKy-oIgk-IMuWisJ-jfN7s6&lang=en", "tests/test_data/kptncook.testhtml"
 
     def test_host(self):
         self.assertEqual("mobile.kptncook.com", self.harvester_class.host())

--- a/tests/test_marleyspoon.py
+++ b/tests/test_marleyspoon.py
@@ -1,4 +1,3 @@
-from bs4 import BeautifulSoup
 import responses
 
 from recipe_scrapers.marleyspoon import MarleySpoon

--- a/tests/test_marleyspoon.py
+++ b/tests/test_marleyspoon.py
@@ -1,21 +1,21 @@
-from recipe_scrapers.marleyspoon import MarleySpoon
-from tests import ScraperTest
 from bs4 import BeautifulSoup
+import responses
+
+from recipe_scrapers.marleyspoon import MarleySpoon
+
+from tests import ScraperTest
 
 
 class TestMarleySpoonScraper(ScraperTest):
 
     scraper_class = MarleySpoon
-    test_file_name = "marleyspoon"
-    test_file_extension = "testjson"
+
+    @property
+    def expected_requests(self):
+        yield responses.GET, "https://marleyspoon.de/menu/113813-glasierte-veggie-burger-mit-roestkartoffeln-und-apfel-gurken-salat", "tests/test_data/marleyspoon.testhtml"
+        yield responses.GET, "https://api.marleyspoon.com/recipes/113813?brand=ms&country=de&product_type=web", "tests/test_data/marleyspoon.testjson"
 
     def test__get_json_params(self):
-        with open(
-            f"tests/test_data/{self.test_file_name}.testhtml", encoding="utf-8"
-        ) as testfile:
-            self.harvester_class.url = "https://marleyspoon.de/menu/113813-glasierte-veggie-burger-mit-roestkartoffeln-und-apfel-gurken-salat"
-            self.harvester_class.soup = BeautifulSoup(testfile.read(), "html.parser")
-
         self.assertEqual(
             (
                 "https://api.marleyspoon.com/recipes/113813?brand=ms&country=de&product_type=web",
@@ -101,4 +101,4 @@ class TestMarleySpoonScraper(ScraperTest):
         )
 
     def test_language(self):
-        self.assertEqual("de", self.harvester_class.language())
+        self.assertEqual("de-DE", self.harvester_class.language())


### PR DESCRIPTION
Roughly speaking, two significant changes here:

- Use the [`responses`](https://pypi.org/project/responses/) library to mock the result of HTTP requests, simplifying some of the unit test base class (83d96c1cd34d3848aff76f82a6d407228fa2f2c7)
- Allow unit tests to (optionally) mock multiple requests by overriding an `expected_requests` property (example: https://github.com/hhursev/recipe-scrapers/commit/e795707fb9e1769931ca46732202c3f60bc35ca0#diff-e58d4f5bec87567559c9de25b031039ff9ae89c4e3319b2224ae0dda3425a16fR14-R15)

The good and the bad:

- :heavy_plus_sign: Makes multi-request scrapers easier to test
- :heavy_minus_sign: Adds a dependency
- :heavy_minus_sign: Might not be as simple as possible - is it more complicated than the code was originally?

Resolves #550.

cc @hhursev @bfcarpio @astappiev - all input welcome