### PR TITLE
Fixup: ensure 'scraper' variable is declared within scrape_html method

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -452,6 +452,7 @@ def scrape_html(html: str, org_url: Optional[str] = None, **options) -> Abstract
     """
     host_name = get_host_name(org_url) if org_url else None
 
+    scraper = None
     if host_name:
         with contextlib.suppress(KeyError):
             scraper = SCRAPERS[host_name]


### PR DESCRIPTION
Resolves an issue where the `scraper` variable could be accessed at https://github.com/hhursev/recipe-scrapers/blob/2e0d9680df5f83a1ecfb118012a2ddd7835c32cd/recipe_scrapers/__init__.py#L459 before it was declared (when [`host_name` is empty](https://github.com/hhursev/recipe-scrapers/blob/2e0d9680df5f83a1ecfb118012a2ddd7835c32cd/recipe_scrapers/__init__.py#L455))