### PR TITLE
Add support for BettyBossi.ch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,7 @@ Scrapers available for:
 - `https://bbc.com/ <https://bbc.com/food/recipes>`_
 - `https://bbc.co.uk/ <http://bbc.co.uk/food/recipes>`_
 - `https://bbcgoodfood.com/ <https://bbcgoodfood.com>`_
+- `https://bettybossi.ch/ <https://bettybossi.ch>`_
 - `https://bettycrocker.com/ <https://bettycrocker.com>`_
 - `https://bigoven.com/ <https://bigoven.com>`_
 - `https://blueapron.com/ <https://blueapron.com>`_

--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -20,6 +20,7 @@ from .bakingmischeif import BakingMischeif
 from .bakingsense import BakingSense
 from .bbcfood import BBCFood
 from .bbcgoodfood import BBCGoodFood
+from .bettybossi import BettyBossi
 from .bettycrocker import BettyCrocker
 from .bigoven import BigOven
 from .blueapron import BlueApron
@@ -219,6 +220,7 @@ SCRAPERS = {
     BBCGoodFood.host(): BBCGoodFood,
     BakingSense.host(): BakingSense,
     BakingMischeif.host(): BakingMischeif,
+    BettyBossi.host(): BettyBossi,
     BettyCrocker.host(): BettyCrocker,
     BigOven.host(): BigOven,
     BlueApron.host(): BlueApron,

--- a/recipe_scrapers/bettybossi.py
+++ b/recipe_scrapers/bettybossi.py
@@ -1,0 +1,74 @@
+from typing import Optional, Union, Tuple, Dict
+from requests import Session
+
+from ._abstract import AbstractScraper, HEADERS
+
+
+class BettyBossi(AbstractScraper):
+    """Scrape BettyBossi.ch recipes.
+
+    This scraper is particular as the website implements a refresh after
+    loading the page the first time. It is therefore needed to do two get
+    requests in a single session, once to initialize the connection, the second
+    to load the page content.
+    """
+
+    @classmethod
+    def host(cls):
+        return "bettybossi.ch"
+
+    def __init__(
+        self,
+        url,
+        proxies: Optional[
+            Dict[str, str]
+        ] = None,  # allows us to specify optional proxy server
+        timeout: Optional[
+            Union[float, Tuple, None]
+        ] = None,  # allows us to specify optional timeout for request
+        wild_mode: Optional[bool] = False,
+        html: Union[str, None] = None,
+    ):
+        if html is None:
+            with Session() as session:
+                session.proxies.update(proxies or {})
+                session.headers.update(HEADERS)
+
+                session.get(url, timeout=timeout)
+                html = session.get(url, timeout=timeout).content  # reload the page
+
+        # As the html content is provided, the parent will not query the page
+        super().__init__(url, proxies, timeout, wild_mode, html)
+
+    def author(self):
+        return self.schema.author()
+
+    def title(self):
+        return self.schema.title()
+
+    def category(self):
+        return self.schema.category()
+
+    def total_time(self):
+        return self.schema.total_time()
+
+    def yields(self):
+        return self.schema.yields()
+
+    def image(self):
+        return self.schema.image()
+
+    def ingredients(self):
+        return self.schema.ingredients()
+
+    def instructions(self):
+        return self.schema.instructions()
+
+    def ratings(self):
+        return self.schema.ratings()
+
+    def cuisine(self):
+        return self.schema.cuisine()
+
+    def description(self):
+        return self.schema.description()

--- a/tests/test_bettybossi.py
+++ b/tests/test_bettybossi.py
@@ -1,0 +1,74 @@
+from recipe_scrapers.bettybossi import BettyBossi
+from tests import ScraperTest
+
+
+class TestBettyBossiScraper(ScraperTest):
+
+    scraper_class = BettyBossi
+
+    def test_host(self):
+        self.assertEqual("bettybossi.ch", self.harvester_class.host())
+
+    def test_author(self):
+        self.assertEqual("Betty Bossi", self.harvester_class.author())
+
+    def test_title(self):
+        self.assertEqual("Minicheesecakes", self.harvester_class.title())
+
+    def test_category(self):
+        self.assertEqual("Dessert", self.harvester_class.category())
+
+    def test_total_time(self):
+        self.assertEqual(90, self.harvester_class.total_time())
+
+    def test_yields(self):
+        self.assertEqual("12 servings", self.harvester_class.yields())
+
+    def test_image(self):
+        self.assertEqual(
+            "https://www.bettybossi.ch/rdbimg/bb_blub160501_0070a/bb_blub160501_0070a_r01_v005_x0010.jpg",
+            self.harvester_class.image(),
+        )
+
+    def test_ingredients(self):
+        self.assertEqual(
+            [
+                "120 g de biscuits au beurre (p. ex. petits-beurre)",
+                "40 g de beurre, fondu, refroidi",
+                "250 g de fromage frais double crème (p. ex. Philadelphia)",
+                "250 g de mascarpone",
+                "150 g de séré demi-gras",
+                "3 œufs, battus",
+                "120 g de sucre",
+                "1 sachet de sucre vanillé",
+                "1 citron bio, zeste râpé et 1 c.s. de jus",
+                "2 c.s. de liqueur au cassis ou de sirop de cassis",
+                "2 c.s. de farine",
+                "250 g de myrtilles surgelées, dégelées",
+                "2 c.s. de sucre",
+                "1 c.s. de jus de citron",
+                "2 c.s. de liqueur au cassis ou de sirop de cassis",
+                "1 citron bio, zeste râpé",
+            ],
+            self.harvester_class.ingredients(),
+        )
+
+    def test_instructions(self):
+        self.assertEqual(
+            "Écraser les biscuits dans un sachet en plastique à l’aide d’un rouleau à pâtisserie, mélanger avec le beurre. Répartir sur le fond du moule préparé, bien tasser avec le dos d’une cuillère ou le fond d’un verre, réserver au frais.\nBien mélanger au fouet le fromage frais, le mascarpone et le séré. Incorporer les œufs et tous les ingrédients, farine comprise.\nBien égoutter les myrtilles et mixer les myrtilles avec le reste des ingrédients, étaler sur le fond de petits-beurre, répartir dessus l’appareil au fromage frais.\nCuisson: env. 50 min dans la moitié inférieure du four préchauffé à 180° C. Laisser tiédir ensuite env. 1 h dans le four éteint, en maintenant la porte entrouverte avec le manche d’une spatule en bois. Retirer, laisser refroidir sur une grille. Ôter le bord du moule.",
+            self.harvester_class.instructions(),
+        )
+
+    def test_ratings(self):
+        self.assertEqual(5.0, self.harvester_class.ratings())
+
+    def test_cuisine(self):
+        self.assertEqual(
+            "Dessert, Patisserie salée et sucrée", self.harvester_class.cuisine()
+        )
+
+    def test_description(self):
+        self.assertEqual(
+            "Ces larges biscuits cachent une crème composée de myrtilles avec un mélange de fromage frais, de séré et de mascarpone et n’attendent que vous pour les couper!",
+            self.harvester_class.description(),
+        )

--- a/tests/test_data/bettybossi.testhtml
+++ b/tests/test_data/bettybossi.testhtml
@@ -1,0 +1,1088 @@
+
+
+<!DOCTYPE html>
+<html lang=fr class="no-js lng-fr" data-pt=220 data-id=10076 data-role="Gew&#246;hnlicherKunde_Abonnent" data-langswitchurl="/de/Rezept/ShowRezept/BB_BLUB160501_0070A-40-de">
+<head>
+	<meta charset=utf-8>
+	<!-- timestamp 2022-06-18T13:30:17.9704362Z M02 -->
+<title>
+		
+	Minicheesecakes | Recette
+ | Betty Bossi
+	</title>
+	
+	<meta name=language content=fr>
+	<meta name=viewport content="width=1024">
+	<link rel="shortcut icon" href="/favicon.ico?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=180x180 href="/shared/images/favicon-180.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=152x152 href="/shared/images/favicon-152.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=144x144 href="/shared/images/favicon-144.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=120x120 href="/shared/images/favicon-120.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=114x114 href="/shared/images/favicon-114.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=76x76 href="/shared/images/favicon-76.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=72x72 href="/shared/images/favicon-72.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed sizes=64x64 href="/shared/images/favicon-64.png?v=13.13.1.25898">
+	<link rel=apple-touch-icon-precomposed href="/shared/images/favicon-57.png?v=13.13.1.25898">
+	<meta name=msapplication-TileColor content="#EE0000">
+	<meta name=msapplication-TileImage content="/shared/images/favicon-144.png?v=13.13.1.25898">
+	
+	<meta name="description" content="Ces larges biscuits cachent une cr&#232;me compos&#233;e de myrtilles avec un m&#233;lange de fromage frais, de s&#233;r&#233; et de mascarpone et n’attendent que vous pour les couper! D&#233;couvrir la recette ici" />
+	<meta name="keywords" content="biscuits au beurre beurre fromage frais double cr&#232;me mascarpone s&#233;r&#233; demi-gras œufs sucre sucre vanill&#233; citron bio liqueur au cassis farine myrtilles surgel&#233;es sucre jus de citron liqueur au cassis citron bio" />
+	<meta name=robots content="index, follow, noodp, noydir"/>
+	<meta property="og:title" content="Minicheesecakes" />  
+	<meta property="og:description" content="Ces larges biscuits cachent une cr&#232;me compos&#233;e de myrtilles avec un m&#233;lange de fromage frais, de s&#233;r&#233; et de mascarpone et n’attendent que vous pour les couper!" />  
+	<meta property="og:image" content="https://www.bettybossi.ch/static/rezepte/x/bb_blub160501_0070a_x.jpg" />
+	<meta data-rjson='{"RezeptKopf":{"OID":10005748,"Aktiv":true,"RezeptID":"BB_BLUB160501_0070A","ExtRezeptID":"BB_BLUB160501_0070A-120-fr","Sprache":"fra","Titel":"Minicheesecakes","Beschreibung":"Ces larges biscuits cachent une crème composée de myrtilles avec un mélange de fromage frais, de séré et de mascarpone et n’attendent que vous pour les couper!","Menge_1":12,"Menge_1_Einheit":"personnes","Menge_2":30,"Menge_2_Einheit":"parts","Naehrwert_Relation":"part (1\/30)","Naehrwert_Relation_Std":"","Naehrwert_Einheit_Singular":"part","Naehrwert_Einheit_Plural":"parts","Naehrwert_Dividend":1,"Naehrwert_Divisor":30,"Naehrwert_Freitext":"","skalieren_nach":1,"Version_Subversion":"01_01","Sortorder":79839499,"SchreibweiseOID":1000101,"Channels":[1,2]},"Zeiten":[{"Wert":40,"Einheit":"min","EinheitOID":2500001,"Kategorie":"Mise en place et préparation","KategorieOID":1002099,"Zeitangabe":"Mise en place et préparation: env. 40 min","Aktiv":true},{"Wert":50,"Einheit":"min","EinheitOID":2500001,"Kategorie":"Cuisson au four","KategorieOID":1002002,"Zeitangabe":"Cuisson au four: env. 50 min","Aktiv":false}],"Hinweise":[{"HinweisKatOID":9000002,"HinweisTypeOID":1000500,"Titel":"Moule:","Hinweis":"Pour un moule à charnière carré, d’env. 23 cm, fond chemisé de papier cuisson, bord graissé ou le moule à brownies et à gâteaux «Toboggan», petit fond mobile, graissé"},{"HinweisKatOID":9000002,"HinweisTypeOID":1000500,"Titel":"Pour:","Hinweis":"Env. 30 parts"},{"HinweisKatOID":9000002,"HinweisTypeOID":1000500,"Titel":"Conservation:","Hinweis":"Env. 2 jours à couvert au réfrigérateur."}],"Naehrwerte":[{"NaehrwertOID":1002101,"Kurzbezeichnung":"E","Bezeichnung":"condensation \/ calories","Wert_1":135,"Wert_1_Einheit":"kcal"},{"NaehrwertOID":1002103,"Kurzbezeichnung":"lip","Bezeichnung":"lipides","Wert_1":9,"Wert_1_Einheit":"g"},{"NaehrwertOID":1002102,"Kurzbezeichnung":"glu","Bezeichnung":"glucides","Wert_1":12,"Wert_1_Einheit":"g"},{"NaehrwertOID":1002104,"Kurzbezeichnung":"pro","Bezeichnung":"protéines","Wert_1":3,"Wert_1_Einheit":"g"}],"Kategorisierungen":[{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650064,"Bez":"végétarien"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650127,"Bez":"Sans mollusques"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650125,"Bez":"Sans sésame"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650120,"Bez":"Sans poisson"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650124,"Bez":"Sans céleri"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650121,"Bez":"Sans crustacés"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650119,"Bez":"Sans arachides"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650123,"Bez":"Sans noix"},{"GrpOID":1004006,"GrpBez":"qualité","KatOID":2650122,"Bez":"Sans lupin"},{"GrpOID":1004000,"GrpBez":"groupe alimentaire","KatOID":2650002,"Bez":"Fruits"},{"GrpOID":1004000,"GrpBez":"groupe alimentaire","KatOID":2650006,"Bez":"Pommes de terre \/ Céréales \/ Pâtes"},{"GrpOID":1004000,"GrpBez":"groupe alimentaire","KatOID":2650007,"Bez":"Produits laitiers \/ Fromage \/ Œufs"},{"GrpOID":1004001,"GrpBez":"plat","KatOID":2650009,"Bez":"Dessert"},{"GrpOID":1004001,"GrpBez":"plat","KatOID":2650013,"Bez":"Patisserie salée et sucrée"},{"GrpOID":1004004,"GrpBez":"plat","KatOID":2650053,"Bez":"Cakes &amp; Co."}],"Bilder":[{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r01_v004_x0010.jpg","GroessenCode":"R01_V004","MigAuszeichnung":"","AufloesungsCode":"X0010"},{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r01_v005_x0010.jpg","GroessenCode":"R01_V005","MigAuszeichnung":"","AufloesungsCode":"X0010"},{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r01_v004_x0020.jpg","GroessenCode":"R01_V004","MigAuszeichnung":"","AufloesungsCode":"X0020"},{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r02_v001_x0010.jpg","GroessenCode":"R02_V001","MigAuszeichnung":"","AufloesungsCode":"X0010"},{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r02_v002_x0010.jpg","GroessenCode":"R02_V002","MigAuszeichnung":"","AufloesungsCode":"X0010"},{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r02_v003_x0010.jpg","GroessenCode":"R02_V003","MigAuszeichnung":"","AufloesungsCode":"X0010"},{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r02_v001_x0020.jpg","GroessenCode":"R02_V001","MigAuszeichnung":"","AufloesungsCode":"X0020"},{"BildFilename":"\/bb_blub160501_0070a\/bb_blub160501_0070a_r02_v003_x0020.jpg","GroessenCode":"R02_V003","MigAuszeichnung":"","AufloesungsCode":"X0020"}],"Subrezepte":[{"FlagTitel_Rezept":false,"Titel":"","Schritte":[{"Zutaten":[{"Menge_pre_text":"","Menge":120.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"g","Zutat_pre_text":"de ","Zutat":"biscuits au beurre","Zutat_post_text":" (p. ex. petits-beurre)","Kategorien":[{"Name":"","OID":1900016,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":40.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"g","Zutat_pre_text":"de ","Zutat":"beurre","Zutat_post_text":", fondu, refroidi","Kategorien":[{"Name":"","OID":1900005,"GruppenOID":1800000}]}],"Anleitungen":[{"Text":"Écraser les biscuits dans un sachet en plastique à l’aide d’un rouleau à pâtisserie, mélanger avec le beurre. Répartir sur le fond du moule préparé, bien tasser avec le dos d’une cuillère ou le fond d’un verre, réserver au frais."}]},{"Zutaten":[{"Menge_pre_text":"","Menge":250.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"g","Zutat_pre_text":"de ","Zutat":"fromage frais double crème","Zutat_post_text":" (p. ex. Philadelphia)","Kategorien":[{"Name":"Fromage","OID":1900004,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":250.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"g","Zutat_pre_text":"de ","Zutat":"mascarpone","Zutat_post_text":"","Kategorien":[{"Name":"Fromage","OID":1900004,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":150.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"g","Zutat_pre_text":"de ","Zutat":"séré demi-gras","Zutat_post_text":"","Kategorien":[{"Name":"","OID":1900005,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":3.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"","Zutat_pre_text":"","Zutat":"œufs","Zutat_post_text":",  battus","Kategorien":null},{"Menge_pre_text":"","Menge":120.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"g","Zutat_pre_text":"de ","Zutat":"sucre","Zutat_post_text":"","Kategorien":[{"Name":"","OID":1900015,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":1.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"sachet","Zutat_pre_text":"de ","Zutat":"sucre vanillé","Zutat_post_text":"","Kategorien":[{"Name":"","OID":1900015,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":1.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"","Zutat_pre_text":"","Zutat":"citron bio","Zutat_post_text":", zeste râpé et 1 c.s. de jus","Kategorien":[{"Name":"Fruits","OID":1900003,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":2.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"c.s.","Zutat_pre_text":"de ","Zutat":"liqueur au cassis","Zutat_post_text":" ou de sirop de cassis","Kategorien":[{"Name":"","OID":1900009,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":2.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"c.s.","Zutat_pre_text":"de ","Zutat":"farine","Zutat_post_text":"","Kategorien":[{"Name":"","OID":1900011,"GruppenOID":1800000}]}],"Anleitungen":[{"Text":"Bien mélanger au fouet le fromage frais, le mascarpone et le séré. Incorporer les œufs et tous les ingrédients, farine comprise."}]},{"Zutaten":[{"Menge_pre_text":"","Menge":250.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"g","Zutat_pre_text":"de ","Zutat":"myrtilles surgelées","Zutat_post_text":", dégelées","Kategorien":[{"Name":"Fruits","OID":1900003,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":2.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"c.s.","Zutat_pre_text":"de ","Zutat":"sucre","Zutat_post_text":"","Kategorien":[{"Name":"","OID":1900015,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":1.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"c.s.","Zutat_pre_text":"de ","Zutat":"jus de citron","Zutat_post_text":"","Kategorien":[{"Name":"Fruits","OID":1900003,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":2.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"c.s.","Zutat_pre_text":"de ","Zutat":"liqueur au cassis","Zutat_post_text":" ou de sirop de cassis","Kategorien":[{"Name":"","OID":1900009,"GruppenOID":1800000}]},{"Menge_pre_text":"","Menge":1.00,"Menge_bis_text":"","Menge_max":null,"Menge_text":null,"Einheit":"","Zutat_pre_text":"","Zutat":"citron bio","Zutat_post_text":", zeste râpé","Kategorien":[{"Name":"Fruits","OID":1900003,"GruppenOID":1800000}]}],"Anleitungen":[{"Text":"Bien égoutter les myrtilles et mixer les myrtilles avec le reste des ingrédients, étaler sur le fond de petits-beurre, répartir dessus l’appareil au fromage frais."}]},{"Anleitungen":[{"Text":"Cuisson: env. 50 min dans la moitié inférieure du four préchauffé à 180° C. Laisser tiédir ensuite env. 1 h dans le four éteint, en maintenant la porte entrouverte avec le manche d’une spatule en bois. Retirer, laisser refroidir sur une grille. Ôter le bord du moule."}]}]}],"PubliziertInBuch":[{"BuchTitel":"Gâteaux sur plaque &amp; brownies","AngebotsNr":"27095","Seite":0}]}
+' />
+	<script type="application/ld+json">{"@context":"http://schema.org","author":{"name":"Betty Bossi","@type":"Organization"},"publisher":{"name":"Betty Bossi","@type":"Organization"},"image":"https://www.bettybossi.ch/rdbimg/bb_blub160501_0070a/bb_blub160501_0070a_r01_v005_x0010.jpg","name":"Minicheesecakes","description":"Ces larges biscuits cachent une crème composée de myrtilles avec un mélange de fromage frais, de séré et de mascarpone et n’attendent que vous pour les couper!","keywords":"biscuits au beurre, beurre, fromage frais double crème, mascarpone, séré demi-gras, œufs, sucre, sucre vanillé, citron bio, liqueur au cassis, farine, myrtilles surgelées, sucre, jus de citron, liqueur au cassis, citron bio","cookTime":"PT50M","prepTime":"PT40M","totalTime":"PT90M","recipeYield":"12 personnes","recipeCategory":"Dessert","recipeCuisine":"Dessert, Patisserie salée et sucrée","recipeIngredient":["120 g de biscuits au beurre (p. ex. petits-beurre)","40 g de beurre, fondu, refroidi","250 g de fromage frais double crème (p. ex. Philadelphia)","250 g de mascarpone","150 g de séré demi-gras","3 œufs,  battus","120 g de sucre","1 sachet de sucre vanillé","1 citron bio, zeste râpé et 1 c.s. de jus","2 c.s. de liqueur au cassis ou de sirop de cassis","2 c.s. de farine","250 g de myrtilles surgelées, dégelées","2 c.s. de sucre","1 c.s. de jus de citron","2 c.s. de liqueur au cassis ou de sirop de cassis","1 citron bio, zeste râpé"],"nutrition":{"calories":"135 kcal","fatContent":"9 g","carbohydrateContent":"12 g","proteinContent":"3 g","servingSize":"30 parts","@type":"NutritionInformation"},"suitableForDiet":["https://schema.org/VegetarianDiet"],"recipeInstructions":[{"position":1,"text":"Écraser les biscuits dans un sachet en plastique à l’aide d’un rouleau à pâtisserie, mélanger avec le beurre. Répartir sur le fond du moule préparé, bien tasser avec le dos d’une cuillère ou le fond d’un verre, réserver au frais.","@type":"HowToStep"},{"position":2,"text":"Bien mélanger au fouet le fromage frais, le mascarpone et le séré. Incorporer les œufs et tous les ingrédients, farine comprise.","@type":"HowToStep"},{"position":3,"text":"Bien égoutter les myrtilles et mixer les myrtilles avec le reste des ingrédients, étaler sur le fond de petits-beurre, répartir dessus l’appareil au fromage frais.","@type":"HowToStep"},{"position":4,"text":"Cuisson: env. 50 min dans la moitié inférieure du four préchauffé à 180° C. Laisser tiédir ensuite env. 1 h dans le four éteint, en maintenant la porte entrouverte avec le manche d’une spatule en bois. Retirer, laisser refroidir sur une grille. Ôter le bord du moule.","@type":"HowToStep"}],"datePublished":"2016-06-20","aggregateRating":{"ratingCount":1,"reviewCount":1,"ratingValue":5.00,"worstRating":1,"bestRating":5,"@type":"AggregateRating"},"@type":"Recipe"}</script><meta name=robots content="max-image-preview:large" />
+	<link rel="canonical" href="https://www.bettybossi.ch/fr/Rezept/ShowRezept/BB_BLUB160501_0070A-40-fr" />
+<link rel="alternate" media="only screen and (max-width: 640px)" href="https://m.bettybossi.ch/fr/Rezept/ShowRezept/BB_BLUB160501_0070A-40-fr" />
+<link rel="alternate" hreflang="fr" href="https://www.bettybossi.ch/fr/Rezept/ShowRezept/BB_BLUB160501_0070A-40-fr" />
+<link rel="alternate" hreflang="fr-CH" href="https://www.bettybossi.ch/fr/Rezept/ShowRezept/BB_BLUB160501_0070A-40-fr" />
+<link rel="alternate" hreflang="de" href="https://www.bettybossi.ch/de/Rezept/ShowRezept/BB_BLUB160501_0070A-40-de" />
+<link rel="alternate" hreflang="de-CH" href="https://www.bettybossi.ch/de/Rezept/ShowRezept/BB_BLUB160501_0070A-40-de" />
+<link rel="alternate" hreflang="x-default" href="https://www.bettybossi.ch/de/Rezept/ShowRezept/BB_BLUB160501_0070A-40-de" />
+
+	<script>window.PDAT={ch:'1',l:'fr',ct:'rezept',ctv:'Recettes',rid:'BB_BLUB160501_0070A-40-fr',rsid:'BB_BLUB160501_0070A',pp:'10',bx:'Detail',rf:'[\"Früchte\",\"Kartoffeln / Getreide / Teigwaren\",\"Milchprodukte / Käse / Eier\",\"Dessert\",\"Gebäck\",\"30 Minuten oder mehr\",\"Vegetarisch\"]',rat:'[0,0,0,0,1]',rd:'Dessert',bc:'[\"Home\",\"Recettes\",\"Recherche de recette\",\"Minicheesecakes\"]'}</script>
+
+	<link rel=stylesheet href=/styles/all.min.13.13.1.25898.css>
+<style>.bb-header + *{margin-top: 160px}</style><style>.stock.avail0:before{background-color:#80083E}.stock.avail1:before{background-color:#80083E}.stock.avail2:before{background-color:transparent;border:3px solid #C5D76A}.stock.avail3:before{background-color:#FF9C00}.stock.avail4:before{background-color:#C5D76A}</style>
+<link rel=stylesheet href="/static/tags/tags.css?v=13.13.1.25898_1">
+	<script src="/fr/Data/Get?v=13.13.1.25898"></script>
+
+	<script src=/scripts/all.min.13.13.1.25898.js></script>
+	<!-- START SpecPag_ALL_X_11111_1000.txt -->
+
+<!-- END   SpecPag_ALL_X_11111_1000.txt -->
+
+	<!-- START SpecPag_ALL_X_11111_0100.txt -->
+
+<!-- END   SpecPag_ALL_X_11111_0100.txt -->
+
+	<!-- publicweb webtrends-spec start -->
+<link rel="dns-prefetch" href="https://tags.tiqcdn.com">
+<link rel="dns-prefetch" href="https://www.googletagmanager.com">
+<link rel="dns-prefetch" href="https://connect.facebook.net">
+<link rel="dns-prefetch" href="https://www.google-analytics.com">
+<link rel="dns-prefetch" href="https://www.google.com">
+<link rel="dns-prefetch" href="https://stats.g.doubleclick.net">
+<link rel="dns-prefetch" href="https://ad.doubleclick.net">
+<link rel="dns-prefetch" href="https://adservice.google.com">
+<link rel="dns-prefetch" href="https://www.googleadservices.com">
+<link rel="dns-prefetch" href="https://www.facebook.com">
+<link rel="dns-prefetch" href="https://googleads.g.doubleclick.net">
+
+<script type="text/javascript">
+	function incfnc_downloadpdf()
+	{
+	}
+	function incfnc_addtocart()
+	{
+	}
+</script>
+
+<!-- Start Tealium Code -->
+<script type="text/javascript">
+	
+	//webtrends source
+	window.logaction = function (action, id, anzahl)
+	{
+		console.log('params: ' + action + ' ' + id + ' ' + anzahl);
+	}
+	
+	window.utaglink = function (o)
+	{
+		if(window.utag){
+			utag.link(o);
+		}
+		console.log('utaglink o:', o);
+	}
+
+	window.utagview = function (o)
+	{
+		if(window.utag){
+			utag.view(o);
+		}
+		console.log('utagview o:', o);
+	}
+
+	window.psys = function (a)
+	{
+		console.log('psys event:', a);
+		var url = 'https://prudsys.bettybossi.ch/rde_server/res/bettybossi/plugins/exec/prudsys/prudsys/event/' + a;
+		if (navigator.sendBeacon)
+		{
+			navigator.sendBeacon(url);
+		}
+		else
+		{
+			$.ajax(url);
+		}
+	}
+</script>
+<!-- End Tealium Code -->
+
+
+<!-- publicweb webtrends-spec end -->
+
+</head>
+<body>
+	
+	<!-- Standardweb piwik-spec.inc start -->
+
+<!-- Standardweb piwik-spec.inc end -->
+
+	<input id="_hst" name="_hst" type="text" value="" style="display:none">
+
+	<script>bb.init(0)</script>
+	<div class=hribbon style=height:32px></div><div class=pre-header style=top:32px><div class=layout-width id=add-ph><!-- Start TopTopRow_RezeptDetail_fr.inc -->
+<div id="rdb_detail_f_p01_c004_d"></div>
+<!-- End TopTopRow_RezeptDetail_fr.inc --></div></div>
+<header class="bb-header" style=top:32px>
+	<div class="bb-masthead-wrapper">
+		<div class=bb-tophead>
+
+			<div class=layout-width>
+				<nav class="bb-tophead-tools novis">
+					<button class="topheadbtn wishlist" data-href="/fr/MyBereich/Merkliste" data-rlink=1>
+						Mes favoris
+						<span class=callout></span>
+					</button>
+					<button class="topheadbtn user js-loginlink">
+						S’identifier
+					</button>
+				</nav>
+			</div>
+
+		</div>
+		<div class=layout-width>
+			<div class=bb-masthead>
+				<a href="/fr/Home/Index" title="Betty Bossi Home" class=logo></a>
+<nav class=nav-main><ul><li><a href="/fr/Shop/Index">Boutique</a></li><li class=selected><a href="/fr/Rezept/List">Recettes</a></li><li><a href="/fr/Magazin/Index">Magazine</a></li></ul></nav>
+
+				<div class=bb-head-search>
+					<form class=ajaxform>
+						<div class="input-group input-group-fh search js-sayt">
+							<span class=input-group-btn>
+								<button type=button class="btn btn-default dropdown-toggle bb-ghost-select-trigger hsearch"><span class="btn-label bb-ghost-select-label">Recettes</span></button>
+								<select class=bb-ghost-select id=hdrsa>
+									<option value=0>Tous
+									<option value=5>Boutique
+									<option value=13 selected>Recettes
+									<option value=10>magazine
+								</select>
+							</span>
+							<input id=hdrsearch type=text placeholder=Rechercher… class="form-control hsearch" maxlength=100 autocomplete=off>
+							<span class=input-group-btn><button class="btn btn-icon search hsearch js-hdrsearch">go</button></span>
+						</div>
+					</form>
+				</div>
+				<nav class="bb-header-tools novis">
+					<button class=cart data-href="/fr/Checkout/Warenkorb" title="Panier">
+						<span class=callout></span>
+					</button>
+				</nav>
+
+			</div>
+		</div>
+	</div>
+<div class=nav-second-wrapper><div class=layout-width><div class=nav-second><nav><ul><li><div class="menuhead" data-url="/fr/Rezept/Dossiers">Collections</div><li><div class="menuhead" data-url="/fr/Rezept/Tagesrezept">Qu’est-ce que je cuisine aujourd’hui</div><li><div class="menuhead sel" data-url="/fr/Rezept/List">Recherche de recette</div><li><div class="menuhead" data-url="/fr/Magazin/Display/1068078/Betty-Family">Recettes familiales</div></ul></nav></div></div></div>
+
+</header>
+
+
+<div class=content-wrapper data-page=rec data-n=10076 data-titlede="Cheesecake-Schnittli" data-oid="10005748">
+	<div class=full-width>
+		<div class=layout-width>
+			<div class=ad-hr id=add-hr><!-- START StickyHeaderRight_RezeptDetail_fr.inc -->
+<!-- END StickyHeaderRight_RezeptDetail_fr.inc -->
+</div><nav class=bb-breadcrumb><span class=divider>&gt;</span><a href="/fr/Home/Index">Home</a><span class=divider>&gt;</span><span>Recettes</span><span class=divider>&gt;</span><a href="/fr/Rezept/List">Recherche de recette</a><span class=divider>&gt;</span><span>Minicheesecakes</span></nav><div class=ad-bc id=add-rt><!-- Start TopRow_RezeptDetail_fr.inc -->
+<div id="rdb_detail_f_p02_c004_d"></div>
+<!-- /21778175723/Betty_Bossi/Betty_Bossi_Rezepte/RDB_Slot_2 -->
+<script type="text/javascript" src="/static/js/bundle.umd.js"></script>
+<script type="text/javascript">
+	var isOpera = (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
+	if (!isOpera) {
+		var resultstestad = justDetectAdblock['detectAnyAdblocker']();
+		var displayResult = function(detected) {
+			if(!detected) {
+				document.write('<style type="text/css">.ad-bc{margin-bottom: 20px !important;}</style>');
+				document.write('<div style="height: 250px;">');
+				document.write('<div id="div-gpt-ad-1549870342774-0"></div></div>');
+			}
+		};
+		if(resultstestad instanceof Promise) {
+			resultstestad.then(function(detected) {
+				displayResult(detected);
+			});
+		}
+	} else {
+		document.write('<style type="text/css">.ad-bc{margin-bottom: 20px !important;}</style>');
+		document.write('<div style="height: 250px;">');
+		document.write('<div id="div-gpt-ad-1549870342774-0"></div></div>');
+	}
+</script>
+<!-- End TopRow_RezeptDetail_fr.inc -->
+</div><article class="bb-detail-page bb-recipe-detail bb-has-kochmodus"><header class="layout-cols-7"><div class="cols-7 rposter"><img src="/static/rezepte/x/bb_blub160501_0070a_x.jpg" alt="Minicheesecakes" class="header-image"></div>
+    <div class="bb-detail-overview bb-recipe-overview cols-5 cols-last">
+      <h1 class="title">Minicheesecakes</h1>
+      <p class="description">Ces larges biscuits cachent une crème composée de myrtilles avec un mélange de fromage frais, de séré et de mascarpone et n’attendent que vous pour les couper!</p>
+      <div class="aggregated-rating" data-rat="5.00"></div>
+      <div class="popup-box" style="display:none"></div>
+      <div class="bb-tagcloud">
+        <div class="bb-tag bb-icon-tag icon-duration">Mise en place et préparation: env. 40 min</div>
+        <div class="bb-tag bb-icon-tag icon-pass-2">Cuisson au four: env. 50 min</div>
+        <div class="bb-tag bb-icon-tag icon-vegetarian">végétarien</div>
+      </div>
+    </div>
+    <div class="action-pane"><button class="btn btn-icon-labeled kochen-white kochmodus nodisp" data-id="10005748" data-recimg="/static/rezepte/x/bb_blub160501_0070a_x.jpg">Je cuisine</button><button class="btn btn-icon-labeled btn-frm cherry heart-cherry novis" data-t="r" data-id="10005748">Favorite</button><button class="btn btn-icon-labeled btn-frm cherry pdf">Télécharger la recette</button></div></header><div class="bb-detail-pinboard">
+    <div class="js-kochmodus"><aside class="cols-4 bb-recipe-leftcol"><section class="bb-recipe-ingredients"><h2>Ingrédients</h2>
+          <div class="quantity-stepper rec"><span class="label">Nombre de personnes</span><div class="bb-numeric-stepper input-group input-group-fh mini" data-np="12"><span class="input-group-btn"><button class="btn btn-default btn-icon minus-mini stepper-minus">-</button></span><input value="12" data-min-value="1" data-max-value="99" class="form-control stepper-value" maxlength="2"><span class="input-group-btn"><button class="btn btn-default btn-icon plus-mini stepper-plus">+</button></span></div>
+          </div>
+          <table>
+            <tr class="first-of-group" data-step="1-1">
+              <td class="quantity" data-q="120 g">120 g</td>
+              <td class="ingredient">de  biscuits au beurre<span class="post-ingredient">  (p. ex. petits-beurre)</span></td>
+            </tr>
+            <tr class="last-of-group" data-step="1-1">
+              <td class="quantity" data-q="40 g">40 g</td>
+              <td class="ingredient">de  beurre<span class="post-ingredient">, fondu, refroidi</span></td>
+            </tr>
+            <tr class="first-of-group" data-step="1-2">
+              <td class="quantity" data-q="250 g">250 g</td>
+              <td class="ingredient">de  fromage frais double crème<span class="post-ingredient">  (p. ex. Philadelphia)</span></td>
+            </tr>
+            <tr data-step="1-2">
+              <td class="quantity" data-q="250 g">250 g</td>
+              <td class="ingredient">de  mascarpone</td>
+            </tr>
+            <tr data-step="1-2">
+              <td class="quantity" data-q="150 g">150 g</td>
+              <td class="ingredient">de  séré demi-gras</td>
+            </tr>
+            <tr data-step="1-2">
+              <td class="quantity" data-q="3">3</td>
+              <td class="ingredient">œufs<span class="post-ingredient">,  battus</span></td>
+            </tr>
+            <tr data-step="1-2">
+              <td class="quantity" data-q="120 g">120 g</td>
+              <td class="ingredient">de  sucre</td>
+            </tr>
+            <tr data-step="1-2">
+              <td class="quantity" data-q="1 sachet">1 sachet</td>
+              <td class="ingredient">de  sucre vanillé</td>
+            </tr>
+            <tr data-step="1-2">
+              <td class="quantity" data-q="1">1</td>
+              <td class="ingredient">citron bio<span class="post-ingredient">, zeste râpé et 1 c.s. de jus</span></td>
+            </tr>
+            <tr data-step="1-2">
+              <td class="quantity" data-q="2 c.s.">2 c.s.</td>
+              <td class="ingredient">de  liqueur au cassis<span class="post-ingredient">  ou de sirop de cassis</span></td>
+            </tr>
+            <tr class="last-of-group" data-step="1-2">
+              <td class="quantity" data-q="2 c.s.">2 c.s.</td>
+              <td class="ingredient">de  farine</td>
+            </tr>
+            <tr class="first-of-group" data-step="1-3">
+              <td class="quantity" data-q="250 g">250 g</td>
+              <td class="ingredient">de  myrtilles surgelées<span class="post-ingredient">, dégelées</span></td>
+            </tr>
+            <tr data-step="1-3">
+              <td class="quantity" data-q="2 c.s.">2 c.s.</td>
+              <td class="ingredient">de  sucre</td>
+            </tr>
+            <tr data-step="1-3">
+              <td class="quantity" data-q="1 c.s.">1 c.s.</td>
+              <td class="ingredient">de  jus de citron</td>
+            </tr>
+            <tr data-step="1-3">
+              <td class="quantity" data-q="2 c.s.">2 c.s.</td>
+              <td class="ingredient">de  liqueur au cassis<span class="post-ingredient">  ou de sirop de cassis</span></td>
+            </tr>
+            <tr data-step="1-3">
+              <td class="quantity" data-q="1">1</td>
+              <td class="ingredient">citron bio<span class="post-ingredient">, zeste râpé</span></td>
+            </tr>
+          </table></section><section class="bb-recipe-buttons"><button class="btn btn-icon-labeled btn-frm cherry doc" title="Liste d’achats">Liste d’achats</button><!-- start bring_fr.inc -->
+<script>
+function weneedclick()
+{
+	var p = getRecipeParams(),
+		url = 'https://app.weneed.ch?recipe=' + encodeURIComponent(p.url) + '&baseQuantity=' + p.oq + '&requestedQuantity=' + p.q;
+	window.open(url, '_blank');
+}
+</script>
+<br>
+<button class="btn btn-icon-labeled btn-frm cherry weneed" onclick="weneedclick();" title="WeNeed" style="margin-bottom: 0.5em;">Liste d'achats WeNeed</button>
+<!-- end bring_fr.inc --><div class="MondoContainer" style="display:none"><button class="btn mondo btn-frm cherry" title="Déjà vu: notre recommandation pour le vin"><img src="/shared/images/Icon_Beverage_Recommendation.png" srcset="/shared/images/Icon_Beverage_Recommendation@2x.png 2x">Recommandation pour le vin</button></div>
+          <div id="ad-rl"></div></section><div id="rdst0"></div>
+        <div id="rdst1"></div></aside><div class="bb-recipe-rightcol"><section class="bb-recipe-steps"><h2>Comment c'est fait:</h2>
+          <ul>
+            <li class="recipe-step-with-figure ingredient-group recipeInstructions" data-step="1-1">Écraser les biscuits dans un sachet en plastique à l’aide d’un rouleau à pâtisserie, mélanger avec le beurre. Répartir sur le fond du moule préparé, bien tasser avec le dos d’une cuillère ou le fond d’un verre, réserver au frais.</li>
+            <li class="recipe-step-with-figure ingredient-group recipeInstructions" data-step="1-2">Bien mélanger au fouet le fromage frais, le mascarpone et le séré. Incorporer les œufs et tous les ingrédients, farine comprise.</li>
+            <li class="recipe-step-with-figure ingredient-group recipeInstructions" data-step="1-3">Bien égoutter les myrtilles et mixer les myrtilles avec le reste des ingrédients, étaler sur le fond de petits-beurre, répartir dessus l’appareil au fromage frais.</li>
+            <li class="recipe-step-with-figure ingredient-group recipeInstructions" data-step="1-4">Cuisson: env. 50 min dans la moitié inférieure du four préchauffé à 180° C. Laisser tiédir ensuite env. 1 h dans le four éteint, en maintenant la porte entrouverte avec le manche d’une spatule en bois. Retirer, laisser refroidir sur une grille. Ôter le bord du moule.</li>
+          </ul>
+          <div class="bb-nutrition-tags"><span class="caption">Profil nutritionnel par part (1/30):
+				</span><div class="bb-nutrition-tag">
+              <div class="label">kcal</div>
+              <div class="value">135</div>
+            </div>
+            <div class="bb-nutrition-tag">
+              <div class="label">lip</div>
+              <div class="value"><span>9</span>g</div>
+            </div>
+            <div class="bb-nutrition-tag">
+              <div class="label">glu</div>
+              <div class="value"><span>12</span>g</div>
+            </div>
+            <div class="bb-nutrition-tag">
+              <div class="label">pro</div>
+              <div class="value"><span>3</span>g</div>
+            </div>
+          </div></section><section class="bb-recipe-additional-informations"><h2 class="title">Informations supplémentaires</h2>
+          <ul class="bb-bulletlist"><li>Moule: Pour un moule à charnière carré, d’env. 23 cm, fond chemisé de papier cuisson, bord graissé ou le moule à brownies et à gâteaux «Toboggan», petit fond mobile, graissé</li><li>Pour: Env. 30 parts</li><li>Conservation: Env. 2 jours à couvert au réfrigérateur.</li></ul></section><section class="bb-user-reviews"><div class="reviews">
+            <h2 class="title">Notations</h2><button class="btn red  revbtn js-rev-write">Évaluer</button></div>
+          <div id="stattopbar" class="stattopbar"></div>
+          <div id="statbar"></div>
+          <div id="bb-reviews-accordion" class="bb-accordion light collapsereviews desktop">
+            <div class="bb-accordion-title larger">Voir les appréciations</div><section class="bb-user-reviews bb-accordion-content"><ul id="reviews" data-itemid="BB_BLUB160501_0070A-40-fr" data-itemtype="4"></ul></section></div></section></div>
+    </div>
+  </div><a href="https://www.miele.ch/fr?utm_source=bettybossi_desktop&utm_term=desktop" target="_blank" title="Appareils électriques miele" class=cooperation-miele>
+	<span>Betty Bossi développe toutes ses recettes avec les appareils Miele</span>
+	<img src="/static/partner/logo-miele-114x40_fr.png" alt="Appareils électriques miele">
+</a></article>
+			
+				<div id="rating-type-recipes" data-rtr="commentoptional"  data-rtra="off" data-rrh="0"></div>
+
+			
+	
+		<div class="bb-shop-dyn cols-3 cols-last">
+			<div class=ad-rc id=add-rr><!-- Start TopColumnRight_RezeptDetail_fr.inc -->
+<div id="rdb_detail_f_p03_c004_d"></div>
+<!-- /21778175723/Betty_Bossi/Betty_Bossi_Rezepte/RDB_Slot_3 -->
+<div id='div-gpt-ad-1549870384946-0'>
+</div>
+<!-- End TopColumnRight_RezeptDetail_fr.inc -->
+</div>
+			<div class="bb-most-popular rec"></div>
+			<div class=ad-rcb id=add-rrb><!-- START BottomColumnRight_RezeptDetail_fr.inc -->
+<!-- END BottomColumnRight_RezeptDetail_fr.inc -->
+</div>
+		</div>
+	
+		</div>
+	</div>
+
+</div>
+<div id="rsrc0" style="display:none"></div>
+<div id="rsrc1" style="display:none">
+
+	<section class="bb-detail-share pb-3">
+		<p>Partager cette recette</p>
+		
+<ul class=bb-share-btns>
+	<li><a onclick="utes('Facebook')" href="http://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.bettybossi.ch%2Ffr%2FRezept%2FShowRezept%2FBB_BLUB160501_0070A-40-fr%3Ftitle%3DMinicheesecakes&amp;title=D%C3%A9couvert%20chez%20Betty%20Bossi%21" title="Partager via Facebook" class="share-btn share-btn-facebook share-external">Partager via Facebook</a></li>
+	<li><a onclick="utes('Twitter')" href="http://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.bettybossi.ch%2Ffr%2FRezept%2FShowRezept%2FBB_BLUB160501_0070A-40-fr%3Ftitle%3DMinicheesecakes&amp;text=D%C3%A9couvert%20chez%20Betty%20Bossi%21" title="Partager via Twitter" class="share-btn share-btn-twitter share-external">Partager via Twitter</a></li>
+	<li><a onclick="utes('Pinterest')" href="http://pinterest.com/pin/create/bookmarklet/?url=https%3A%2F%2Fwww.bettybossi.ch%2Ffr%2FRezept%2FShowRezept%2FBB_BLUB160501_0070A-40-fr%3Ftitle%3DMinicheesecakes&amp;is_video=false&amp;description=D%C3%A9couvert%20chez%20Betty%20Bossi%21" title="Partager via Pinterest" class="share-btn share-btn-pinterest share-external">Partager via Pinterest</a></li>
+
+</ul>
+	</section>
+
+</div>
+
+	<style type='text/css'>
+	.srs1h5{
+		font-family: "PlutoBold",Helvetica,Arial,sans-serif;
+		font-size: 16px;
+		font-weight: normal;
+		padding: 0 0 8px 76px;
+	}
+	.srs2h5{
+		font-family: "PlutoBold",Helvetica,Arial,sans-serif;
+		font-size: 16px;
+		font-weight: normal;
+		margin: 0;
+		padding: 21px 0 1px 0;
+	}
+	.srs2ah5{
+		font-family: "PlutoBold",Helvetica,Arial,sans-serif;
+		font-size: 16px;
+		font-weight: normal;
+		margin: 0;
+		padding: 0 0 1px 0;
+	}
+	.srdh2{
+		font-family: "PlutoBold",Helvetica,Arial,sans-serif;
+		font-size: 22px;
+		line-height: 32px;
+		font-weight: normal;
+		margin: 0;
+		padding: 21px 0 29px 0;
+	}
+</style>
+
+<footer class="bb-footer full-width">
+	<div class=fsect1>
+		<div class="layout-width layout-cols-4">
+			<div class="cols-4">
+				<div style="display: block; width: 48px; height: 50px; float: left;"><img src="https://www.bettybossi.ch/static/customers/lastwagen.png"></div>
+				<div class="srs1h5">
+					Payer les frais d’expédition<br>
+					avec les superpoints Coop
+				</div>
+			</div>
+			<div class="cols-4" style="display:none;">
+				<div class=ficon-hotline style="display: block; float: left;"></div>
+				<div class="srs1h5">
+					Téléphone jusqu`à 17 h 00<br>
+					+41 (0)44 209 19 29
+				</div>
+			</div>
+			<div class="cols-4">
+				<a href="https://helpcenter.bettybossi.ch/hc/fr-ch/articles/4403475384466" target=_blank>
+					<div class=ficon-cart style="display: block; float: left;"></div>
+					<div class="srs1h5">
+						Achats<br>
+						sur facture
+					</div>
+				</a>
+			</div>
+		</div>
+	</div>
+	<div class=fsect2>
+		<div class="layout-width layout-cols-4">
+			<div class="cols-4">
+				<div class="srdh2">Vous avez des questions ?</div>
+				<ul class=flist>
+					<li><a href="https://helpcenter.bettybossi.ch/hc/fr-ch/requests/new" target=_blank>Ici, nous vous aidons avec plaisir</a></li>
+					<li><a href="https://helpcenter.bettybossi.ch/hc/fr-ch" target=_blank>Réponses, conseils et astuces</a></li>
+				</ul>
+				<span id="GuruuLinkStart"></span>
+				<div class="srs2h5">Espace client</div>
+				<ul class=flist>
+					<li><a href="/fr/MyBereich/Profil">Mon Betty Bossi</a></li>
+					<li><a href="/fr/Shop/Category/100000474">Carte-cadeau</a></li>
+				</ul>
+			</div>
+			<div class="cols-4">
+				<div class="srdh2">Betty Bossi</div>
+				<ul class=flist>
+					<li><a href="/fr/Magazin/Display/1068069">Entreprise</a></li>
+					<li><a href="/fr/Magazin/Display/36">Carrière</a></li>
+					<li><a href="/fr/Admin/Display/39">Impressum</a></li>
+					<li><a href="/fr/Admin/Display/1067200">Sitemap</a></li>
+					<li><a href="/fr/Magazin/Display/1068070">Durabilité</a></li>
+					<li><a href="/fr/Admin/Display/25">CG</a></li>
+					<li><a href="/fr/Admin/Display/27">Confidentialité</a></li>
+				</ul>
+				<div class="srs2h5">Médias</div>
+				<ul class=flist>
+					<li><a href="/fr/Admin/Display/37">Communiqués de presse</a></li>
+					<li><a href="/fr/Admin/Display/1063081">Données médias</a></li>
+				</ul>
+			</div>
+			<div class="bb-footer-newsletterlight cols-4">
+				<div class="srdh2">Newsletter</div>
+				<div class="ns-registration-msg bb-margin-bottom clear" style="display: none;">
+					Votre inscription a été reçue avec succès.
+				</div>
+				<div class="content pane-ns-registration clear">
+					Vous ne voulez manquer aucune information?
+					<form class="mt-4">
+						<div class=ns-registration-rad style="display:none">
+							<div class="cb-group mb-2">
+								<input type=radio id=footerTitleF name=anredeid value=2>
+								<label for=footerTitleF>Madame</label>
+								<input type=radio id=footerTitleM name=anredeid value=1>
+								<label for=footerTitleM>Monsieur</label>
+							</div>
+						</div>
+						<div class="bb-input-field">
+							<input id="nsfirstname" placeholder="Prénom" value="" name="firstname" maxlength="25" class="form-control">
+						</div>
+						<div class="bb-input-field">
+							<input id="nssurname" placeholder="Nom" value="" name="surname" maxlength="25" class="form-control">
+						</div>
+						<div class="bb-input-field">
+							<input id="regemail1" placeholder="Votre adresse e-mail" autocomplete="off" spellcheck="false" name="email" class="form-control" maxlength="320">
+						</div>
+						<button type=submit class="btn red js-nsregister">Je m’abonne à la newsletter</button>
+					</form>
+				</div>
+			</div>
+		</div>
+		<div class="layout-width layout-cols-4 fsect2a">
+			<div class="cols-4">
+				<div class="srs2ah5">Suivez-nous</div>
+				<div class="mt-25">
+					<a href="https://www.facebook.com/BettyBossienfrancais" target=_blank><div class=fshare-facebook></div></a>
+					<a href="https://www.youtube.com/user/BettyBossienfrancais" target=_blank><div class=fshare-youtube></div></a>
+					<a href="https://www.pinterest.com/bettybossi/" target=_blank><div class=fshare-pinterest></div></a>
+					<a href="https://www.instagram.com/bettybossi.ch/" target=_blank><div class=fshare-instagram></div></a>
+					<a href="https://twitter.com/bettybossi" target=_blank><div class=fshare-twitter></div></a>
+				</div>
+			</div>
+			<div class="cols-4">
+				<div class="srs2ah5">Nos applications</div>
+				<div class="mt-25">
+					<a href="/links/_PT_MABD_181114_01_iOS_App_Store_f" target=_blank><div class=fapp-apple></div></a>
+					<a href="/links/_PT_MABD_181114_01_Android_App_Store_f" target=_blank><div class=fapp-android></div></a>
+				</div>
+			</div>
+			<div class="cols-4">
+				<div class="srs2ah5">Changer la langue</div>
+				<div class="mt-25">
+					<div class=flng></div>
+					<div class=flnglinks>
+						<a class=js-langswitch>Deutsch</a>&nbsp;&nbsp;|&nbsp;&nbsp;<span class=flngact>Français</span>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class=fsect3>
+		<div class="layout-width layout-cols-4">
+			<div class="finfo cols-4">
+				<div class="fpostquick">
+					<a href="https://www.post.ch/fr" target=_blank>
+						<div class=fpost></div>
+					</a>
+					<a href="https://www.quickpac.ch/fr/home" target=_blank>
+						<div class=fquickpac></div>
+					</a>
+				</div>
+				<div class=finfotext>
+					Nous envoyons tous nos colis avec<br/>La Poste Suisse ou Quickpac.<br/>
+				</div>
+			</div>
+			<div class="finfo cols-4">
+				<a href="https://www.vsv-versandhandel.ch/fr/members/detail/betty-bossi-ag/" target=_blank>
+					<div class=fgarantie></div>
+					<div class=finfotext>
+						Betty Bossi est membre de<br/>l’Association Suisse de Vente à Distance.
+					</div>
+				</a>
+			</div>
+		</div>
+	</div>
+</footer>
+
+<script language="JavaScript" type="text/javascript">
+//	function simulateGuruu() {
+//		document.getElementsByClassName("guuru-launcher-button")[0].click();
+//	}
+//	function expand_link() {
+//		var guruu_elementsS = document.getElementById("GuruuLinkStart");
+//		guruu_elementsS.insertAdjacentHTML('afterbegin', '<div class="srs2h5">Live Chat</div><ul class=flist><li ><a href="#" onclick="simulateGuruu();return false;" target=_blank>Tous les jours de 8 h 00 à 22 h 00</a></li></ul>');
+//	}
+//	if (document.getElementById("GuuruMain")) {
+//		expand_link();
+//	} else {
+//		setTimeout(function(){ if (document.getElementById("GuuruMain")) { expand_link(); } else { setTimeout(function(){ if (document.getElementById("GuuruMain")) { expand_link(); }}, 5000);}}, 10);
+//	}
+</script>
+
+
+<!-- Start Tealium Code -->
+<script type="text/javascript">
+	var utag_data = DAT.utag();
+	utag_data.platform = "bettybossi-web";
+	utag_data.toolFP_referer_overwrite = (DAT.raw('rr') || document.referrer);
+	var cucode = DAT.raw('cc','-');
+	utag_data.transaction_total_voucherCode = cucode.toUpperCase();
+	if (document.getElementById('barilla')) {
+		utag_data.content_attributes_category = "grill";
+	} else {
+		utag_data.content_attributes_category = "normal";
+	}
+	if ((window.location.href.indexOf('ShowRezept') != -1)) {
+		var bc = DAT.o('rf'), ii, pp;
+		if (bc) { 
+			for (ii = 0; ii < bc.length; ++ii) {
+				pp = bc[ii];
+				utag_data.content_attributes_category += ' / ' + pp;
+			}
+		}
+	}
+	var o = DAT.o('cart'), i, p;
+	utag_data.product_in_cart_attributes_basePrice = [];
+	utag_data.product_in_cart_attributes_quantity = [];
+	utag_data.product_in_cart_productInfo_sku = [];
+	if (o && o.p) {
+	    for (i = 0; i < o.p.length; i++) {
+	        p = o.p[i];
+	        utag_data.product_in_cart_attributes_basePrice.push(p.p + '');
+	        utag_data.product_in_cart_attributes_quantity.push(p.c + '');
+	        utag_data.product_in_cart_productInfo_sku.push(p.a + '');
+	    }
+	}
+</script>
+
+<!-- Anforderung an Teaser-Img -->
+<!-- id: teaser_0 - teaser_9 -->
+<!-- alt: Name der Promo -->
+<!-- src: ID der Promo -->
+<!-- data-pos: PositionsInfo (10,11,12,20,21) -->
+
+<script type="text/javascript">
+	var showTeaser = [], posxyTeaser = [], clickinfoId = [], clickinfoName = [], clickinfoPos = [];
+	var lastPosition = 0;
+
+	function getCoords(elem) {
+		let box = elem.getBoundingClientRect();
+		return {
+			top: box.top + pageYOffset,
+			height: box.height
+		};
+	}
+
+	function teaserClick(locId,locName,locPos,locSRC) {
+		console.log("Click=>" +locId+"|"+locName+"|"+locPos+"|"+locSRC); // Konsolenausgabe
+		// The following information should be sent in a utag.link event
+		utag.link({
+			event_category_primaryCategory : "Leads",
+			event_eventInfo_effect : "ecommerce",
+			transaction_attributes_eventType : 'promo_click',
+			event_attributes_tgtURL : locSRC,
+			promo_promoInfo_id : [locId],
+			promo_promoInfo_name : [locName],
+			promo_promoInfo_creative : ["Kachel"],
+			promo_promoInfo_position : [locPos]
+		});
+	}
+
+	function scanTeaserInfo() {
+		var divElements = document.getElementsByClassName('bb-shred fs-kilo');
+		for (iet = 0;iet < divElements.length;iet++) {
+			let textTeaser = divElements[iet].innerHTML;
+			let urlStart = textTeaser.indexOf('href=')+6;
+			let urlEnd = textTeaser.indexOf('"',urlStart+1);
+			let srcURL = textTeaser.substr(urlStart,urlEnd-urlStart);
+			let teaserStart = textTeaser.indexOf('teaser_');
+			let teaserEnd = textTeaser.indexOf('"',teaserStart+1);
+			let teaserID = textTeaser.substr(teaserStart,teaserEnd-teaserStart);
+			let elementTeaser = null;
+			elementTeaser = document.getElementById(teaserID);
+			if (elementTeaser) {
+				posxyTeaser.push(getCoords(elementTeaser));
+				let idSrc = elementTeaser.getAttribute('src');
+				let attrSrc = idSrc.split("/");
+				let TeaserId = attrSrc[attrSrc.length - 1].split(".");
+				clickinfoId.push(TeaserId[0]);
+				clickinfoName.push(elementTeaser.getAttribute('alt'));
+				clickinfoPos.push(elementTeaser.getAttribute('datapos'));
+				showTeaser.push(0);
+
+			}
+			let promoId = clickinfoId[iet];
+			let promoName = clickinfoName[iet];
+			let promoPos = clickinfoPos[iet];
+			let promoSRC = srcURL;
+			divElements[iet].addEventListener('click', function () {
+				teaserClick(promoId,promoName,promoPos,promoSRC);
+			},false);
+		}
+	}
+
+	function lookForTeaser() {
+		fensterOben = window.pageYOffset;
+		fensterUnten = fensterOben + window.innerHeight;
+		let headerClass = document.getElementsByClassName('bb-header');
+		let headerDimension = getCoords(headerClass[0]);
+		fensterObenKorr = fensterOben + headerDimension.height;
+		for (iet = 0;iet < posxyTeaser.length;iet++) {	// Teaser durchscannen
+			if ((posxyTeaser[iet].top >= fensterObenKorr) && ((posxyTeaser[iet].top + posxyTeaser[iet].height) <= fensterUnten)) {	// Teaser sichtbar
+				if (showTeaser[iet] < 1) {	// Teaser noch nicht gemeldet
+					console.log('showTeaser melden: ', iet); // Konsolenausgabe
+					showTeaser[iet] = 1;
+				}
+			}
+		}
+	}
+
+	function scrolling(lastYPos) {
+		let diffPixel = 100;
+		if ((window.pageYOffset > (lastYPos + diffPixel)) || (window.pageYOffset < (lastYPos - diffPixel))) {
+			return {
+				scroll: true,
+				pos: window.pageYOffset
+			};
+		} else {
+			return {
+				scroll: false,
+				pos: window.pageYOffset
+			};
+		}
+	}
+
+	function searchTeaser() {
+		let scrollData = scrolling(lastPosition);
+		if (scrollData.scroll == false) { // Scrollpause
+			lookForTeaser();
+			promoInfo_id = [], promoInfo_name = [], promoInfo_position = [], promoInfo_creative = [];
+			for (iet = 0;iet < showTeaser.length;iet++) {	// Teaser durchscannen
+				if (showTeaser[iet] == 1) {	// Teaser für Tealium interessant
+					showTeaser[iet] = 2;	// Nur 1 Mal registrieren
+					promoInfo_id.push(clickinfoId[iet]);
+					promoInfo_name.push(clickinfoName[iet]);
+					promoInfo_position.push(clickinfoPos[iet]);
+					promoInfo_creative.push("Kachel");
+				}
+			}
+			if (promoInfo_id.length > 0) {	// Es wurde erfasst => Senden nach Tealium
+				console.log('Anzahl Teaser zum melden: ', promoInfo_id.length); // Konsolenausgabe
+				utag.link(
+				{
+					event_name : "ga_track",
+					promo_promoInfo_id : promoInfo_id,
+					promo_promoInfo_name : promoInfo_name,
+					promo_promoInfo_creative : promoInfo_creative,
+					promo_promoInfo_position : promoInfo_position,
+					event_category_primaryCategory : "Leads",
+					event_eventInfo_effect : "ecommerce",
+					event_eventInfo_eventLabel : "promo view"
+				});
+				console.log('utaglink: event');	// Konsolenausgabe
+			}
+		}
+		lastPosition = scrollData.pos;
+		setTimeout(function(){ searchTeaser();},200);
+	}
+
+	function initTeaserSend() {
+		setTimeout(function(){ scanTeaserInfo();},100);
+		setTimeout(function(){ searchTeaser();},200);
+	}
+
+
+	var showSlider = [], posxyTeaser = [], clickinfoId = [], clickinfoName = [], clickinfoPos = [], clickSlideinfoId = [], clickSlideinfoName = [], clickSlideinfoPos = [], clickSlideinfoURL = [], arraySlide = [];
+	var posySlider = 0; activSlide = 0;
+
+	function slideClick() {
+		// The following information should be sent in a utag.link event
+		let locId = clickSlideinfoId[activSlide];
+		let locName = clickSlideinfoName[activSlide];
+		let locPos = clickSlideinfoPos[activSlide];
+		let locSRC = clickSlideinfoURL[activSlide];
+		utag.link({
+			event_category_primaryCategory : "Leads",
+			event_eventInfo_effect : "ecommerce",
+			transaction_attributes_eventType : 'promo_click',
+			event_attributes_tgtURL : locSRC,
+			promo_promoInfo_id : [locId],
+			promo_promoInfo_name : [locName],
+			promo_promoInfo_creative : ["Slider"],
+			promo_promoInfo_position : [locPos]
+		});
+	}
+
+	function scanSlideInfo() {
+		var collection = document.getElementsByTagName("body");
+		let textAlles = collection[0].innerHTML;
+		textAlles = textAlles.replace(/\s+/g, '').trim();
+		let slideArrayStart = textAlles.indexOf('bbposter')+8;
+		slideArrayStart = textAlles.indexOf('[',slideArrayStart+8);
+		let slideArrayEnd = textAlles.indexOf(']',slideArrayStart+1)-3;
+		let slideArray = textAlles.substr(slideArrayStart+2,slideArrayEnd-slideArrayStart);
+		arraySlide = slideArray.split('},{');
+		for (var i = arraySlide.length - 1; i >= 0; i--) {
+			console.log('scanSlideInfo: ',"Pos: "+ (i+1) +" - " + arraySlide[i]);
+			showSlider[i] = 0;
+
+			let textSlider = arraySlide[i];
+			let pos_1 = textSlider.indexOf('img:') + 5;
+			let pos_2 = textSlider.indexOf(",",pos_1) - 1;
+			let text_picpath = textSlider.substring(pos_1, pos_2);
+			let text_picarr = text_picpath.split("/");
+			let text_pic = text_picarr[text_picarr.length-1];
+			let text_picname = text_pic.split(".");
+			clickSlideinfoId[i] = text_picname[0];
+			clickSlideinfoName[i] = text_picname[0];
+			clickSlideinfoPos[i] = i+1;
+			pos_1 = textSlider.indexOf('link:') + 6;
+			pos_2 = textSlider.indexOf(",",pos_1) - 1;
+			let text_linkpath = textSlider.substring(pos_1, pos_2);
+			if (text_linkpath.indexOf('bettybossi') < 0) {
+				text_linkpath = "https://bettybossi.ch" + text_linkpath;
+			}
+			clickSlideinfoURL[i] = text_linkpath;
+		}
+	}
+
+	function lookForSlider(islide) {
+		fensterOben = window.pageYOffset;
+		fensterUnten = fensterOben + window.innerHeight;
+		if ((posySlider.top >= fensterOben) && ((posySlider.top + posySlider.height) <= fensterUnten)) {	// Slider sichtbar
+			if (showSlider[islide] < 1) { // Slider noch nicht gemeldet
+				console.log('showSlider melden: ', islide); // Konsolenausgabe
+				console.log('showSlider melden: Id', clickSlideinfoId[islide]); // Konsolenausgabe
+				console.log('showSlider melden: Name', clickSlideinfoName[islide]); // Konsolenausgabe
+				console.log('showSlider melden: Pos', clickSlideinfoPos[islide]); // Konsolenausgabe
+				console.log('showSlider melden: URL', clickSlideinfoURL[islide]); // Konsolenausgabe
+				showSlider[islide] = 1;
+				utag.link(
+				{
+					event_name : "ga_track",
+					promo_promoInfo_id : clickSlideinfoId[islide],
+					promo_promoInfo_name : clickSlideinfoName[islide],
+					promo_promoInfo_creative : ["Slider"],
+					promo_promoInfo_position : clickSlideinfoPos[islide],
+					event_category_primaryCategory : "Leads",
+					event_eventInfo_effect : "ecommerce",
+					event_eventInfo_eventLabel : "promo view"
+				});
+				console.log('utaglink: event'); // Konsolenausgabe
+			}
+			activSlide = islide;
+		}
+	}
+
+	function scanSlidePos() {
+		var divSlider = document.getElementsByClassName('npslider bbslider');
+		if (divSlider) {
+			posySlider = getCoords(divSlider[0]);
+			divSlider[0].addEventListener('click', function () {
+				slideClick();
+			},false);
+		}
+	}
+
+	function scanSlideInfo2() {
+		var divSlider = document.getElementsByClassName('npslider bbslider');
+		if (divSlider) {
+			let textSlider = divSlider[0].innerHTML;
+			let pos_1 = textSlider.indexOf('<img') + 9;
+			let pos_2 = textSlider.indexOf("</a>") - 2;
+			let text_picpath = textSlider.substring(pos_1, pos_2);
+			let text_picarr = text_picpath.split("/");
+			let text_pic = text_picarr[text_picarr.length-1];
+			for (var i = arraySlide.length - 1; i >= 0; i--) {
+				if (arraySlide[i].indexOf(text_pic) > 1){
+					lookForSlider(i);
+				}
+			}
+			setTimeout(function(){ scanSlideInfo2();},200);
+		}
+	}
+
+	if ((window.location.href.indexOf('Home') != -1)||(window.location.href.indexOf('Shop/Index') != -1)){
+		initTeaserSend();
+		scanSlideInfo();
+		scanSlidePos();
+		setTimeout(function(){ scanSlideInfo2();},1500);
+	}
+
+
+</script>
+
+
+<!-- Skript wird asynchron geladen -->
+<script type="text/javascript">
+	(function(a,b,c,d){
+	a='//tags.tiqcdn.com/utag/coop-ch/bettybossi-web/prod/utag.js';
+	b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true;
+	a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a);
+	})();
+</script>
+<!-- End Tealium Code -->
+
+
+<!-- START Overlay-Desktop Babynewsletter -->
+<style type='text/css'>
+	#popupbox_bb1610380775{
+		position: fixed;
+		border: none;
+		top: 50%; 
+		left: 50%; 
+		margin-top: -351px; 
+		margin-left: -450px; 
+		z-index: 999;
+		font-family: arial;
+		visibility: hidden;
+	}
+	div#shade_bb1610380775{
+		position: fixed;
+		border: none;
+		width: 100%;
+		height: 100%;
+		top: 0%;
+		left: 0%;
+		overflow: visible;
+		background-image: url(https://www.bettybossi.ch/static/overlay/000.png);
+		z-index: 990;
+		visibility: hidden;
+	}
+</style>
+	
+<script language='JavaScript' type='text/javascript'>
+
+	var heute = new Date();
+	var tag_1 = new Date(heute.getFullYear(),0,1);
+	var tag_im_Jahr = Math.floor(1+(heute.getTime() - tag_1.getTime())/86400000);
+	var tag = heute.getDate();
+	
+
+	function setCookie_bb1610380775(cname, cvalue, exminutes) {
+		var d = new Date();
+		d.setTime(d.getTime() + (exminutes*60*1000));
+		var expires = 'expires='+ d.toUTCString();
+		document.cookie = cname + '=' + cvalue + '; ' + expires + '; path=/';
+	}
+	
+
+	function popwindow_bb1610380775(showhide){
+		if(showhide == 'show'){
+			var makeVisible = false;
+			try {
+				if(isWindowShow == false){
+					isWindowShow = 1;
+					makeVisible = true;
+				}
+			} catch (e) {
+				isWindowShow = 1;
+				makeVisible = true;
+			}
+			if (makeVisible)
+			{
+				document.getElementById('popupbox_bb1610380775').style.visibility='visible';
+				document.getElementById('shade_bb1610380775').style.visibility='visible';
+				setCookie_bb1610380775('bb1610380775','BettyBossi',7000); 
+			}
+		}
+		else if(showhide == 'hide'){
+			document.getElementById('popupbox_bb1610380775').style.visibility='hidden';
+			document.getElementById('shade_bb1610380775').style.visibility='hidden';
+		}
+	}
+
+	document.writeln("<div id='popupbox_bb1610380775'></div>");
+	document.writeln("<div id='shade_bb1610380775' onClick='popwindow_bb1610380775(\"hide\")'></div>");
+
+	if ((tag_im_Jahr > 0) && (tag_im_Jahr < 366)) {
+	if ((window.location.href.indexOf('102000053') != -1)||(window.location.href.indexOf('1066874') != -1)||(window.location.href.indexOf('1066873') != -1)||(window.location.href.indexOf('1066821') != -1)||(window.location.href.indexOf('1066876') != -1)||(window.location.href.indexOf('1066869') != -1)||(window.location.href.indexOf('1066877') != -1)||(window.location.href.indexOf('1066911') != -1)||(window.location.href.indexOf('1066871') != -1)||(window.location.href.indexOf('1066883') != -1)||(window.location.href.indexOf('1066872') != -1)||(window.location.href.indexOf('1066884') != -1)||(window.location.href.indexOf('1066864') != -1)||(window.location.href.indexOf('1066875') != -1)||(window.location.href.indexOf('1067693') != -1)||(window.location.href.indexOf('BB_BBZC050315_0011C') != -1)||(window.location.href.indexOf('BB_BBZG140715_0027A') != -1)||(window.location.href.indexOf('MK_PIPA110905_K001A') != -1)||(window.location.href.indexOf('BB_CZ14200331_0118A') != -1)||(window.location.href.indexOf('BB_BBZC110315_0026A') != -1)||(window.location.href.indexOf('BB_BBZF110615_0021B') != -1)||(window.location.href.indexOf('BB_BBZI111015_0027A') != -1)) {
+		if (document.cookie.indexOf('bb1610380775')<0) { 
+			var slot_popupbox = document.getElementById('popupbox_bb1610380775');
+			var div1 = '<img src="https://www.bettybossi.ch/static/overlay/Overlay_200915_Newsletter_Baby_f.png" alt="Overlay" style="border: none;" usemap="#backmapbb1610380775" />';
+			var div2 = '<map name="backmapbb1610380775">';
+			var div3 = '<area shape="rect" coords="0,200,900,641" href="https://www.bettybossi.ch/links/_PT_OVBD_200915_01_babynewsletter_f" alt="Shortcut">';
+			var div4 = '<area shape="rect" coords="720,0,900,150" href="javascript:void(0)" onClick="popwindow_bb1610380775(\'hide\')" alt="fermer">';
+			var div5 = '</map>';
+			slot_popupbox.insertAdjacentHTML('afterbegin', div1 + div2 + div3 + div4 + div5 );
+			popwindow_bb1610380775('show');
+		}
+	}
+	}
+</script>
+
+
+	<div class="bb-header-flyout bb-header-menu cart" data-tname=cart></div>
+	
+	<!-- START SpecPag_REZEPTDETAIL_F_10000_0001.txt -->
+
+<!-- Ratingausblenden -->
+<script type="text/javascript">
+	// Rezepte
+	const ratingminimum = 3.0;	// Ratingnote
+	const ratingone = 5;	// Rating 1 Anzahl
+	var ratingbad = false;
+	var ratingstar = DAT.o('rat');
+	if (ratingstar)
+	{
+		var meta = document.getElementsByTagName("meta");
+		for(var i=0; i<meta.length; i++) {
+			if (meta[i].getAttribute("itemprop") === "ratingValue") {
+				if((meta[i].getAttribute("content")) < ratingminimum) {
+					if (ratingstar[0] >= ratingone) {
+//						zitatelement = document.getElementById ("zitat_mitarbeiter");
+//						zitatelement.style.display="none";
+						// alte Variante
+						let items = document.getElementsByClassName ("quote");
+						let numItems = items.length;
+						for (let j=0; j<numItems; j++) {
+							mitarbeiter_zitat = items[j].innerHTML;
+							if (mitarbeiter_zitat.indexOf("bb_mitarbeiter_") > 10) {
+								items[j].style.display="none";
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+</script>
+
+<script language="JavaScript" type="text/javascript">
+	var slot_4_elements = document.getElementById("ad-rl");
+	slot_4_elements.insertAdjacentHTML('afterbegin', '<!-- /21778175723/Betty_Bossi/Betty_Bossi_Rezepte/RDB_Slot_4 --><div id="div-gpt-ad-1559896059797-0"></div>');
+</script>
+<script language="JavaScript" type="text/javascript">
+	var mondo_elements = document.getElementById("ad-rl");
+	mondo_elements.insertAdjacentHTML('afterbegin', '<div id="rdb_detail_f_p04_c004_m"></div>');
+</script>
+
+<!-- Desktop -->
+
+<script type="text/javascript">
+
+var metaanalyse = document.getElementsByTagName('meta');
+for (var i=0; i<metaanalyse.length; i++) {
+	var e_meta = metaanalyse[i];
+	if (e_meta.hasAttribute("data-rjson")) {
+		var rezeptjson = e_meta.getAttribute("data-rjson");
+	}
+}
+var rezobj = JSON.parse(rezeptjson);
+var rezepttyp = "";
+
+for (var i = rezobj.Kategorisierungen.length - 1; i >= 0; i--) {
+	if (rezobj.Kategorisierungen[i].KatOID == "2650117") {
+		rezepttyp = "backhelfer";	// Kategorie Backhelfer
+	}
+	if (rezobj.Kategorisierungen[i].KatOID == "2650063") {
+		rezepttyp = "vegan";	// Kategorie vegan
+	}
+	if (rezobj.Kategorisierungen[i].KatOID == "2650068") {
+		rezepttyp = "schlank";	// Kategorie schlank
+	}
+}
+
+if (rezepttyp == "backhelfer") {
+	var row_elements = document.getElementsByClassName("bb-detail-pinboard");
+	if (row_elements) {
+		row_elements[0].insertAdjacentHTML('afterend', '<a href="/links/_PT_REBD_211201_01_vegan_backhelfer_f" style="text-decoration-line: none;"><div class="bb-recipe-quotes"><div class="quote"><div class="img-galerie"><img src="https://www.bettybossi.ch/static/customers/eigenwerbung/backhelfer.jpg" alt="Aide à la pâtisserie végane de Betty"></div><div class="content-galerie"><h2>Aide à la pâtisserie végane de Betty</h2><div class="quote-text">Vous voulez faire des gâteaux véganes? L’aide à la pâtisserie de Betty, vous aide à trouver des alternatives aux œufs et aux produits laitiers pour vos recettes préférées.</div><div class="signature"><button class="btn red">Testez sans attendre cet outil pratique!</button></div></div></div></div></a>');
+	}
+}
+
+if (rezepttyp == "vegan") {
+	var row_elements = document.getElementsByClassName("bb-detail-pinboard");
+	if (row_elements) {
+		row_elements[0].insertAdjacentHTML('afterend', '<a href="/links/_PT_REBD_211201_01_vegan_sammlung_f" style="text-decoration-line: none;"><div class="bb-recipe-quotes"><div class="quote"><div class="img-galerie"><img src="https://www.bettybossi.ch/static/customers/eigenwerbung/vegan.jpg" alt="Délicieux et végane"></div><div class="content-galerie"><h2>Délicieux et végane</h2><div class="quote-text">À la recherche de délicieux plats végétaliens? Les recettes véganes de Betty Bossi vous montrent qu’il est facile de cuisiner sans produits d’origine animale. Découvrez régulièrement des nouveautés dans notre collection de recettes.<br>&nbsp;</div><div class="signature"><button class="btn red">Découvrez!</button></div></div></div></div></a>');
+	}
+}
+
+if (rezepttyp == "schlank") {
+	var row_elements = document.getElementsByClassName("bb-detail-pinboard");
+	if (row_elements) {
+		row_elements[0].insertAdjacentHTML('afterend', '<a href="/links/_PT_REBD_220601_01_gs_app_1_f" style="text-decoration-line: none;"><div class="bb-recipe-quotes"><div class="quote"><div class="img-galerie"><img src="https://www.bettybossi.ch/static/customers/eigenwerbung/gs_app_f.jpg" alt="Maigrir en se régalant"></div><div class="content-galerie"><h2>Maigrir en se régalant</h2><div class="quote-text">Grâce à votre programme personnalisé, retrouvez votre poids de forme.<br>&nbsp;<br>Betty Bossi vous apporte son soutien par plusieurs moyens:<ul><li>&#9726; &nbsp; Plus de 700 recettes saines</li><li>&#9726; &nbsp; Un compteur de calories et un lecteur de code-barres</li><li>&#9726; &nbsp; Des vidéos de fitness et un traqueur d’activité</li><li>&#9726; &nbsp; Des conseils en alimentation et bien plus encore</li></ul></div><div class="signature"><button class="btn red">Pour en savoir plus</button></div></div></div></div></a>');
+	}
+}
+
+if (rezepttyp != "") {
+	var eadd = document.getElementById("div-gpt-ad-1549870342774-0");
+	if (eadd) {
+		eadd.id = "jetzt-kommt-betty";
+	}
+	document.writeln('<style type="text/css">#add-rt {height: 20px;visibility: hidden;}</style>');
+}
+
+</script>
+
+
+
+<!-- END   SpecPag_REZEPTDETAIL_F_10000_0001.txt -->
+
+</body>
+</html>
+


### PR DESCRIPTION
The BettyBossi website was requested in #531 and stores its data in the json-ld format.  
However, the website implements a refresh


Here I propose a solution where the scraper first gets the page content using a `requests.Session`, then calls the parent's constructor providing the `html`.  

I tested this with the unit test and the following:  
```python
from recipe_scrapers import scrape_me
URL = https://www.bettybossi.ch/fr/Rezept/ShowRezept/BB_BLUB160501_0070A-40-fr
r = scrape_me(URL)
print(r.ingredients())
```  

On an unrelated note, I think that the type annotation for `AbstractScraper` might be wrong.  
According [to the source documentation](https://github.com/psf/requests/blob/73793ce43e3d940a0f8d6b9b8ff125617828d8a1/requests/sessions.py#L400), the proxies should be a `Dict[str, str]` rather than a string.  
Would it be okay to update that signature?

closes #531 