### PR TITLE
fixed wild mode for unordered schemas

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -33,7 +33,15 @@ class SchemaOrg:
 
         low_schema = {s.lower() for s in SCHEMA_NAMES}
         for syntax in SYNTAXES:
-            for item in data.get(syntax, []):
+            # make sure entries of type Recipe are always parsed first
+            syntax_data = data.get(syntax, [])
+            try:
+                index = [x.get("@type", "") for x in syntax_data].index("Recipe")
+                syntax_data.insert(0, syntax_data.pop(index))
+            except ValueError:
+                pass
+
+            for item in syntax_data:
                 in_context = SCHEMA_ORG_HOST in item.get("@context", "")
                 item_type = item.get("@type", "")
                 if isinstance(item_type, list):

--- a/tests/test_comidinhasdochef.py
+++ b/tests/test_comidinhasdochef.py
@@ -15,7 +15,7 @@ class TestComidinhasDoChefScraper(ScraperTest):
         self.assertEqual("Pernil de Cordeiro com Vinho", self.harvester_class.title())
 
     def test_total_time(self):
-        self.assertEqual(None, self.harvester_class.total_time())
+        self.assertEqual(105, self.harvester_class.total_time())
 
     def test_yields(self):
         self.assertEqual("6 porções", self.harvester_class.yields())


### PR DESCRIPTION
## Issue 
certain recipe pages don't yield proper results when parsed with wild mode even tough they have a microdata/json+ld schema.
The reason for that is that the schema function in `_schemaorg.py` iterates over the website data and stops iteration when it finds an entry of type `WebPage` even if a type `Recipe` comes afterwards. 

## Possible solutions
- rewrite the parsing function to consider schemas of all types and choose which suits the best afterwards
- order the schema list in the raw data so recipe always comes first

## Implemented solution
since i wasn't to familiar with the codebase i choose to implement the least intrusive method of ordering the schema data without changing any of the following logic.

## What this PR does
this PR should significantly improve parsing results for wild_mode pages as many websites that contain a `WebPage` schema before a `Recipe` schema would previously result in weak parsing results.

fixes #561