### PR TITLE
Add description method to WikiCookbook scraper

### DIFF
--- a/recipe_scrapers/wikicookbook.py
+++ b/recipe_scrapers/wikicookbook.py
@@ -38,3 +38,25 @@ class WikiCookbook(AbstractScraper):
         return "\n".join(
             [normalize_string(instruction.get_text()) for instruction in instructions]
         )
+
+    def description(self):
+        paragraphs = list()
+        for tag in self.soup.find(class_="mw-parser-output"):
+            try:
+                # get all paragraphs except for links
+                if (
+                    tag.text.strip()
+                    and tag.name == "p"
+                    and not tag.find("span", {"id": "displaytitle"})
+                ):
+                    paragraphs.append(tag)
+                # End at the TOC or second section
+                if tag.attrs.get("id") == "toc" or tag.name == "h2":
+                    break
+            except AttributeError:
+                # Ignore tags that are not <p> but raise errors
+                pass
+
+        return "\n\n".join(
+            [normalize_string(paragraph.get_text()) for paragraph in paragraphs]
+        )

--- a/tests/test_wikibooks.py
+++ b/tests/test_wikibooks.py
@@ -53,3 +53,9 @@ class TestWikiCookbookScraper(ScraperTest):
             "Preheat oven to 350 °F (180 °C).\nBlend all ingredients, except the pie shell, together.\nPour into the unbaked pie shell.\nBake at 350 °F (180 °C) for 45 minutes.\nLet cool and serve.",
             self.harvester_class.instructions(),
         )
+
+    def test_description(self):
+        return self.assertEqual(
+            "Pumpkin pie is a traditional American and Canadian holiday dessert. It consists of a pumpkin-based custard baked in a single pie shell. The pie is traditionally served with whipped cream.",
+            self.harvester_class.description(),
+        )


### PR DESCRIPTION
Hey. This PR implements the `description()` method for the wikibooks scraper. I updated the unit tests, and also manually tested different types of recipes, like:

- https://en.wikibooks.org/wiki/Cookbook:Pumpkin_Pie (one `<p>` tag and a TOC)
- https://en.wikibooks.org/wiki/Cookbook:Afghan_Bread (multiple `<p>` tags and a TOC)
- https://en.wikibooks.org/wiki/Cookbook:Aubergine_and_Onion_Vegetable_Pie (one `<p>` tag and no TOC)