### PR TITLE
Re-introduce use of a file open contextmanager during unit test data loading

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,9 +32,9 @@ class ScraperTest(unittest.TestCase):
             start_url = None
             for method, url, path in self.expected_requests:
                 start_url = start_url or url
-                content = open(path, encoding="utf-8").read()
-                response = responses.Response(method, url, body=content)
-                response.passthrough = self.online
-                rsps.add(response)
+                with open(path, encoding="utf-8") as f:
+                    response = responses.Response(method, url, body=f.read())
+                    response.passthrough = self.online
+                    rsps.add(response)
 
             self.harvester_class = self.scraper_class(url=start_url)


### PR DESCRIPTION
Re-introduce use of a file `open` [context manager](https://docs.python.org/3/reference/datamodel.html#context-managers) during unit test data loading to avoid noisy ResourceWarning output when running unit tests with `python -m unittest`

Fixes #608