### PR TITLE
Use isodate library to attempt ISO 8601 duration parsing in get_minutes

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -33,7 +33,7 @@ SERVE_REGEX_ITEMS = re.compile(
 SERVE_REGEX_TO = re.compile(r"\d+(\s+to\s+|-)\d+", flags=re.I | re.X)
 
 
-def get_minutes(element, return_zero_on_not_found=False):
+def get_minutes(element, return_zero_on_not_found=False):  # noqa: C901: TODO
     if element is None:
         # to be removed
         if return_zero_on_not_found:

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -1,5 +1,8 @@
 # mypy: disallow_untyped_defs=False
+
 import html
+import isodate
+import math
 import re
 
 from ._exceptions import ElementNotFoundInHtml
@@ -47,6 +50,15 @@ def get_minutes(element, return_zero_on_not_found=False):
         time_text = element
     else:
         time_text = element.get_text()
+
+    # attempt iso8601 duration parsing
+    if time_text.startswith("PT"):
+        try:
+            duration = isodate.parse_duration(time_text)
+            return math.ceil(duration.total_seconds() / 60)
+        except Exception:
+            pass
+
     if time_text.startswith("P") and "T" in time_text:
         time_text = time_text.split("T", 2)[1]
     if "-" in time_text:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     install_requires=[
         "beautifulsoup4>=4.10.0",
         "extruct>=0.8.0",
+        "isodate>=0.6.1",
         "requests>=2.19.1",
         "types-beautifulsoup4>=4.11.6",
         "types-requests>=2.28.10",

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -81,5 +81,5 @@ class TestUtils(unittest.TestCase):
 
     def test_get_minutes_handles_iso8601(self):
         for text, expected_minutes in self.iso8601_fixtures.items():
-            with self.subTest(text=text, expected_minutes=expected_minutes):
+            with self.subTest(text=text):
                 self.assertEqual(expected_minutes, get_minutes(text))

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -71,3 +71,15 @@ class TestUtils(unittest.TestCase):
     def test_get_minutes_handles_to(self):
         text = "15 to 20 minutes"
         self.assertEqual(20, get_minutes(text))
+
+    iso8601_fixtures = {
+        "PT1H": 60,
+        "PT20M": 20,
+        "PT2H10M": 130,
+        "PT0H9M30S": 10,
+    }
+
+    def test_get_minutes_handles_iso8601(self):
+        for text, expected_minutes in self.iso8601_fixtures.items():
+            with self.subTest(text=text, expected_minutes=expected_minutes):
+                self.assertEqual(expected_minutes, get_minutes(text))


### PR DESCRIPTION
Use the `isodate` library to attempt to parse time durations from strings that look like potential ISO8601 date strings in `get_minutes` utility method.

Note that we already transitively depend on the `isodate` library (via `extruct -> rdflib -> isodate`).

The `get_minutes` method began failing a `flake8` complexity check after this functionality was added; that method would benefit from some simplification and refactoring (see #551).

Fixes #606.