### PR TITLE
added .venv to flake8 ignored directories

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,5 @@ max-complexity = 18
 select = B,C,E,F,W,T4,B9
 exclude =
     tests/test_data/*
+    ./.venv/
     ./venv/

--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,4 @@ max-complexity = 18
 select = B,C,E,F,W,T4,B9
 exclude =
     tests/test_data/*
-    ./venv/*
+    ./venv/

--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,5 @@ max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
 exclude =
-    tests/test_data/*
     ./.venv/
     ./venv/

--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,6 @@ ignore = E203, E266, E501, W503, FS002
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-exclude = tests/test_data/*
+exclude =
+    tests/test_data/*
+    ./venv/*


### PR DESCRIPTION
I am not sure if this issue is special to my setup as I run on a windows PC but I noticed two things
- the pre commit hook runs quite long
- if i run flake8 manually it shows me tons of warnings for things in `.venv`

this PR adds `./venv/*` to the ignored folders in the flake8 config. Since .venv is not in control of the project anyway it should not matter if flake is run there or not. 

This speeds up the pre commit hook significantly and prevents any error messages from venv library files