### PR TITLE
Fix ingredients for simplyrecipes.com scraper

### DIFF
--- a/recipe_scrapers/simplyrecipes.py
+++ b/recipe_scrapers/simplyrecipes.py
@@ -28,7 +28,9 @@ class SimplyRecipes(AbstractScraper):
         )
 
     def ingredients(self):
-        ingredients = self.soup.find("ul", {"class": "ingredient-list"}).findAll("li")
+        ingredients = self.soup.find(
+            "ul", {"class": "structured-ingredients__list"}
+        ).findAll("li")
 
         return [normalize_string(ingredient.get_text()) for ingredient in ingredients]
 
@@ -40,7 +42,7 @@ class SimplyRecipes(AbstractScraper):
         return "\n".join(
             [
                 normalize_string(
-                    step.div.text + ": " + "".join([p.text for p in step.findAll("p")])
+                    step.div.text + "".join([p.text for p in step.findAll("p")])
                 )
                 for step in steps
             ]

--- a/tests/test_data/simplyrecipes.testhtml
+++ b/tests/test_data/simplyrecipes.testhtml
@@ -1,51 +1,50 @@
 <!DOCTYPE html>
-<html id="structuredProjectTemplate_1-0" class="comp   structuredProjectTemplate article-html html mntl-html" data-ab="99,99,99,99,50,99,99,99,99,99" data-resource-version="5.66.0" lang="en" data-lazy-threshold="100" data-simplyrecipes-resource-version="5.66.0" data-mantle-resource-version="3.12.350" data-lifestyle-food-resource-version="5.65.0" data-tracking-container="true">				
+<html id="structuredProjectTemplate_1-0" class="comp no-js simplyrecipes   structuredProjectTemplate article-html html mntl-html" data-ab="99,58,62,63,99,34" data-resource-version="5.193.0" lang="en" data-lazy-threshold="100" data-simplyrecipes-resource-version="5.193.0" data-mantle-resource-version="3.13.484" data-lifestyle-food-resource-version="5.193.0" data-tracking-container="true">				
 <!--
-<globe-environment environment="prod" application="simplyrecipes" dataCenter="us-east-1"/>
+<globe-environment environment="k8s-prod" application="simplyrecipes" dataCenter="us-west-1"/>
 -->
 <head class="loc head">				
 					
-					<script type="text/javascript"></script>
+					<script type="text/javascript">var Mntl = window.Mntl || {};</script>
 					
 					    <link rel="preconnect" href="//js-sec.indexww.com">
     <link rel="preconnect" href="//c.amazon-adsystem.com">
-    <link rel="preconnect" href="//cdn.adsafeprotected.com">
-    <link rel="preconnect" href="//grid-cdn.pdc.bidswitch.net">
-    <link rel="preconnect" href="//grid.bidswitch.net">
+    <link rel="preconnect" href="//tags.crwdcntrl.net">
     <link rel="preconnect" href="//securepubads.g.doubleclick.net">
 
 					
-					<meta charset="utf-8">
+					
+<meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-<meta name="robots" content="max-image-preview:large, NOODP, NOYDIR" />
+<meta name="robots" content="max-image-preview:large, NOODP, NOYDIR, max-video-preview:0" />
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="canonical" href="https://www.simplyrecipes.com/recipes/one_pot_chicken_and_rice_soup/" />
-<title>Homemade Chicken & Rice Soup {One-Pot}</title>
+<title>One-Pot Chicken and Rice Soup Recipe</title>
 <meta name="description" content="One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&#39;re done. It&#39;s the easiest soup ever, ready in under an hour." itemprop="description">
 <meta name="emailcontenttype" content="RECIPESC" />
 <meta name="emailvertical" content="SIMPLYRECIPES" />
 <meta name="sailthru.author" content="Aaron Hutcherson" />
 <meta name="sailthru.tags" content="recipes,dinner-recipes,dinner-recipes-by-type,soup-recipes,chicken-soup-recipes" />
-<meta name="fexy-relish" data-recipe-id="58008" />
+<meta name="fexy-relish" data-recipe-id="5102671" />
 <!-- Pinterest Pins -->
-<meta itemprop="name" content="Homemade Chicken &amp; Rice Soup {One-Pot}" />
+<meta itemprop="name" content="One-Pot Chicken and Rice Soup Recipe" />
 <meta property="article:section" content="Simply Recipes" />
 <!-- Facebook Open Graph Tags -->
 <meta property="fb:app_id" content="138323699531998" />
 <meta property="og:type" content="article" />
 <meta property="og:site_name" content="Simply Recipes" />
 <meta property="og:url" content="https://www.simplyrecipes.com/recipes/one_pot_chicken_and_rice_soup/" />
-<meta property="og:title" content="Homemade Chicken &amp; Rice Soup {One-Pot}" />
+<meta property="og:title" content="One-Pot Chicken and Rice Soup Recipe" />
 <meta property="og:description" content="One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&#39;re done. It&#39;s the easiest soup ever, ready in under an hour." />
 <meta property="og:image" content="https://www.simplyrecipes.com/thmb/Uny40Q_8ypYmJtF7G7dal7-3qDQ=/2000x1333/filters:fill(auto,1)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg" />
 <meta property="article:author" content="https://www.facebook.com/simplyrecipes/" />
 <!-- Twitter Cards -->
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@simplyrecipes" />
-<meta name="twitter:title" content="Homemade Chicken &amp; Rice Soup {One-Pot}" />
+<meta name="twitter:title" content="One-Pot Chicken and Rice Soup Recipe" />
 <meta name="twitter:description" content="One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&#39;re done. It&#39;s the easiest soup ever, ready in under an hour." />
 <meta name="twitter:image" content="https://www.simplyrecipes.com/thmb/Uny40Q_8ypYmJtF7G7dal7-3qDQ=/2000x1333/filters:fill(auto,1)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg" />
 <meta property="og:tax5" content="sr_chicken-soup-recipes"/>
@@ -55,52 +54,184 @@
 <meta property="og:tax2" content="sr_dinner-recipes"/>
 <meta property="og:tax0" content="sr"/>
 					
-					<link type="text/css" rel="stylesheet" data-glb-css href="/static/5.66.0/cache/eNqtVlu6oyAM3tDwuYjzOptAiJoWiR_g6emsfgJoq6dIncuLufAnQm7Q-CADqkZ530QWfjQbDY6yBzEZqWAgo8HtVn24G_BPFY0TWbDBN1L7hPhEDVQDMC0t31D3wHQA7IfwMUjbw0_0ASy4orL4D8cKAyutQQJ8BTFJ7_m4O-GEX6HI8h4CI92swuxAP1Q5Sg_1iZ38uVMOwFQMopWf2LOSbNM6kFq5eWz9li9ZxdNziKVG26_0zIZHCHIn1PIaiEzAaaUlaHs3aKFpkUQF9X0Xi9VDrFtvIuRJoTSCNRu2dgTHC7Z_0DPQmLjM19CsGlkhLvM4CT7N9VVTjNccAtmVVrcDCifI3jK6oKo5WALkB-kgHWq0gcWN9rR12YhdTg75xCNolLX50Rn4wpYzfTBIVpzhQgbXknS6BDM8RhjIqyKyT64YaUPqmtH5WwKlnef5mb-HvRZ7Rey5Y4cd9tz0CynBCvPizSYedTfQlD616npkOwIrpXI0ttRRogoGQxhN-pw9p429n66cLf9_p212LA495zSl5Xhv3vm-2gq1BOyM4m8vt4rVPxzhqBJis7RoTGoTvldQXe8vikpHLFMkSTuhPo24z4amI9Ii8yfQx8DUSOkGz9t4sjW3k6MLqJAvsa1QLD1exNgMC7PS48HicZw4RWm0bPjajjoA3Up1XY6xF2v14Gl2CvxKS9DeUCtNutzTc0rqconlWjbUU_qUIB25kR3GJ1gc4yCdGr6Jby7evJl08T7ZWmQsBexQJWvRSmuXbino69csXRFE0dvhUiWaXMCBbTM5DpWFmzcQGCM89naeXjXFgP2dWS4_5EHA1WznJ_cmKQM5_MXTY0nMXqw-7NzM71GOlo4P6Y3w5oeagpZ-EJ0c0dzTT2NOX9W_AUIF5ps.min.css"></link>
+					<link type="text/css" rel="stylesheet" data-glb-css href="/static/5.193.0/cache/eNqtF1uSpCDsQkt5iPndSyBGZBrBApyZ3tNvAB_YjYhV8yNJSEJCQhIb66gTrBmpchIaZm3jKfCned8QI-VAJkkZDFp2YDamKPaUYN_k9DhpBcrZhnY2MH6JDvQu-s6Aa0HNt-g44DqA4IP7GKji8FdYBwpMllgyySB98W6Bs4YtbBUsUvQQboL0WnekTC4pcvDjyEStxTs_IBUGEqYVuu6Q08zMzQa6jRRDtZHrvb6hFO99sjmVin4JjkStGkc5QXRdL7ilUA8iMaA7lJPw94Q5QDuh-LrWuDaCowekkDPtE02AmKkLXDpiZb_BSmc3aEOc1tKJqZS-zhnRzv6GlpezE4hwMFY8o-WUpuK0g1nxvFpLk1BazQSVIfYhbTb0IgUSubLM6pnBDcW3teIuVglvV4RL-pE0IoF8zuNEfFq-U3LiGB7n4xXXogPAxARRW-TOkCrcWq7LDtTEUjciJ0mpJSsO0ldCkxFYDsIX31EnaI4pbDS94FgslqXgRabchEYUvzcKV1ip8G3idOeeHSF_GUn7VcEMvBOjj9jvlt0eaAQOqVflyeBGGT43A6F8xQoNPYV_162omJxqjukUtv1w8sT4pkjFAznI-tM_v1-Ff8eTs4xtpWaP7cEH7ICUqwR2w6EJc0WEK7jPGUMLDfNGNGMHS2onoz-BudhIU-T0CL9JjlCO16Ki0N4WYF1zvH4qeMkcjot4zd6EXNMUsjeWH28V7n0lNTbipYtTM3bs4NgG3WQnPWWuWICsng0Du64VI7rxUzQxVMgL5lZI2WpqFjmLnI8n2amlMX_jIlHs3lGZM8796SX8iBbfKi2bJHFkBBPU1rz8SVvnB3qXtJSEdp6jzHsdxtkNKpQFFp0-MSqWv4uWyKVuqQwjcfhLol3evGTeiiJh3trBcwOk5jp8ciy9NiMa4f_G_PQA1LDhBa2I4kV0Fh-XeJyHIBqj4NtKcMhDrOBqnt4ppXn2hvRb9AW2ByyOat6hi1jgkC3--RklxuOIluoFFj38GSMt7fxfZILUzeqddh21A5kVljFjk7E9u_MfJV1OMg.min.css"></link>
 
 					
-					<style type="text/css"></style>
+					<style type="text/css">#onetrust-banner-sdk{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}#onetrust-banner-sdk .onetrust-vendors-list-handler{cursor:pointer;color:#1f96db;font-size:inherit;font-weight:bold;text-decoration:none;margin-left:5px}#onetrust-banner-sdk .onetrust-vendors-list-handler:hover{color:#1f96db}#onetrust-banner-sdk:focus{outline:2px solid #000;outline-offset:-2px}#onetrust-banner-sdk a:focus{outline:2px solid #000}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{outline-offset:1px}#onetrust-banner-sdk .ot-close-icon,#onetrust-pc-sdk .ot-close-icon,#ot-sync-ntfy .ot-close-icon{background-image:url("data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iMzQ4LjMzM3B4IiBoZWlnaHQ9IjM0OC4zMzNweCIgdmlld0JveD0iMCAwIDM0OC4zMzMgMzQ4LjMzNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzQ4LjMzMyAzNDguMzM0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGc+PHBhdGggZmlsbD0iIzU2NTY1NiIgZD0iTTMzNi41NTksNjguNjExTDIzMS4wMTYsMTc0LjE2NWwxMDUuNTQzLDEwNS41NDljMTUuNjk5LDE1LjcwNSwxNS42OTksNDEuMTQ1LDAsNTYuODVjLTcuODQ0LDcuODQ0LTE4LjEyOCwxMS43NjktMjguNDA3LDExLjc2OWMtMTAuMjk2LDAtMjAuNTgxLTMuOTE5LTI4LjQxOS0xMS43NjlMMTc0LjE2NywyMzEuMDAzTDY4LjYwOSwzMzYuNTYzYy03Ljg0Myw3Ljg0NC0xOC4xMjgsMTEuNzY5LTI4LjQxNiwxMS43NjljLTEwLjI4NSwwLTIwLjU2My0zLjkxOS0yOC40MTMtMTEuNzY5Yy0xNS42OTktMTUuNjk4LTE1LjY5OS00MS4xMzksMC01Ni44NWwxMDUuNTQtMTA1LjU0OUwxMS43NzQsNjguNjExYy0xNS42OTktMTUuNjk5LTE1LjY5OS00MS4xNDUsMC01Ni44NDRjMTUuNjk2LTE1LjY4Nyw0MS4xMjctMTUuNjg3LDU2LjgyOSwwbDEwNS41NjMsMTA1LjU1NEwyNzkuNzIxLDExLjc2N2MxNS43MDUtMTUuNjg3LDQxLjEzOS0xNS42ODcsNTYuODMyLDBDMzUyLjI1OCwyNy40NjYsMzUyLjI1OCw1Mi45MTIsMzM2LjU1OSw2OC42MTF6Ii8+PC9nPjwvc3ZnPg==");background-size:contain;background-repeat:no-repeat;background-position:center;height:12px;width:12px}#onetrust-banner-sdk .powered-by-logo,#onetrust-banner-sdk .ot-pc-footer-logo a,#onetrust-pc-sdk .powered-by-logo,#onetrust-pc-sdk .ot-pc-footer-logo a,#ot-sync-ntfy .powered-by-logo,#ot-sync-ntfy .ot-pc-footer-logo a{background-size:contain;background-repeat:no-repeat;background-position:center;height:25px;width:152px;display:block}#onetrust-banner-sdk h3 *,#onetrust-banner-sdk h4 *,#onetrust-banner-sdk h6 *,#onetrust-banner-sdk button *,#onetrust-banner-sdk a[data-parent-id] *,#onetrust-pc-sdk h3 *,#onetrust-pc-sdk h4 *,#onetrust-pc-sdk h6 *,#onetrust-pc-sdk button *,#onetrust-pc-sdk a[data-parent-id] *,#ot-sync-ntfy h3 *,#ot-sync-ntfy h4 *,#ot-sync-ntfy h6 *,#ot-sync-ntfy button *,#ot-sync-ntfy a[data-parent-id] *{font-size:inherit;font-weight:inherit;color:inherit}#onetrust-banner-sdk .ot-hide,#onetrust-pc-sdk .ot-hide,#ot-sync-ntfy .ot-hide{display:none !important}#onetrust-pc-sdk .ot-sdk-row .ot-sdk-column{padding:0}#onetrust-pc-sdk .ot-sdk-container{padding-right:0}#onetrust-pc-sdk .ot-sdk-row{flex-direction:initial;width:100%}#onetrust-pc-sdk [type="checkbox"]:checked,#onetrust-pc-sdk [type="checkbox"]:not(:checked){pointer-events:initial}#onetrust-pc-sdk [type="checkbox"]:disabled+label::before,#onetrust-pc-sdk [type="checkbox"]:disabled+label:after,#onetrust-pc-sdk [type="checkbox"]:disabled+label{pointer-events:none;opacity:0.7}#onetrust-pc-sdk #vendor-list-content{transform:translate3d(0, 0, 0)}#onetrust-pc-sdk li input[type="checkbox"]{z-index:1}#onetrust-pc-sdk li .ot-checkbox label{z-index:2}#onetrust-pc-sdk li .ot-checkbox input[type="checkbox"]{height:auto;width:auto}#onetrust-pc-sdk li .host-title a,#onetrust-pc-sdk li .ot-host-name a,#onetrust-pc-sdk li .accordion-text,#onetrust-pc-sdk li .ot-acc-txt{z-index:2;position:relative}#onetrust-pc-sdk input{margin:3px 0.1ex}#onetrust-pc-sdk .pc-logo,#onetrust-pc-sdk .ot-pc-logo{height:60px;width:180px;background-position:center;background-size:contain;background-repeat:no-repeat}#onetrust-pc-sdk .screen-reader-only,#onetrust-pc-sdk .ot-scrn-rdr,.ot-sdk-cookie-policy .screen-reader-only,.ot-sdk-cookie-policy .ot-scrn-rdr{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}#onetrust-pc-sdk.ot-fade-in,.onetrust-pc-dark-filter.ot-fade-in,#onetrust-banner-sdk.ot-fade-in{animation-name:onetrust-fade-in;animation-duration:400ms;animation-timing-function:ease-in-out}#onetrust-pc-sdk.ot-hide{display:none !important}.onetrust-pc-dark-filter.ot-hide{display:none !important}#ot-sdk-btn.ot-sdk-show-settings,#ot-sdk-btn.optanon-show-settings{color:#68b631;border:1px solid #68b631;height:auto;white-space:normal;word-wrap:break-word;padding:0.8em 2em;font-size:0.8em;line-height:1.2;cursor:pointer;-moz-transition:0.1s ease;-o-transition:0.1s ease;-webkit-transition:1s ease;transition:0.1s ease}#ot-sdk-btn.ot-sdk-show-settings:hover,#ot-sdk-btn.optanon-show-settings:hover{color:#fff;background-color:#68b631}.onetrust-pc-dark-filter{background:rgba(0,0,0,0.5);z-index:2147483646;width:100%;height:100%;overflow:hidden;position:fixed;top:0;bottom:0;left:0}@keyframes onetrust-fade-in{0%{opacity:0}100%{opacity:1}}.ot-cookie-label{text-decoration:underline}@media only screen and (min-width: 426px) and (max-width: 896px) and (orientation: landscape){#onetrust-pc-sdk p{font-size:0.75em}}#onetrust-banner-sdk .banner-option-input:focus+label{outline:1px solid #000;outline-style:auto}.category-vendors-list-handler+a:focus,.category-vendors-list-handler+a:focus-visible{outline:2px solid #000}#onetrust-pc-sdk .ot-userid-title{margin-top:10px}#onetrust-pc-sdk .ot-userid-title>span,#onetrust-pc-sdk .ot-userid-timestamp>span{font-weight:700}#onetrust-pc-sdk .ot-userid-desc{font-style:italic}#onetrust-pc-sdk .ot-host-desc a{pointer-events:initial}#onetrust-pc-sdk .ot-ven-hdr>p a{position:relative;z-index:2;pointer-events:initial}
+#onetrust-banner-sdk,#onetrust-pc-sdk,#ot-sdk-cookie-policy,#ot-sync-ntfy{font-size:16px}#onetrust-banner-sdk *,#onetrust-banner-sdk ::after,#onetrust-banner-sdk ::before,#onetrust-pc-sdk *,#onetrust-pc-sdk ::after,#onetrust-pc-sdk ::before,#ot-sdk-cookie-policy *,#ot-sdk-cookie-policy ::after,#ot-sdk-cookie-policy ::before,#ot-sync-ntfy *,#ot-sync-ntfy ::after,#ot-sync-ntfy ::before{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}#onetrust-banner-sdk div,#onetrust-banner-sdk span,#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-banner-sdk p,#onetrust-banner-sdk img,#onetrust-banner-sdk svg,#onetrust-banner-sdk button,#onetrust-banner-sdk section,#onetrust-banner-sdk a,#onetrust-banner-sdk label,#onetrust-banner-sdk input,#onetrust-banner-sdk ul,#onetrust-banner-sdk li,#onetrust-banner-sdk nav,#onetrust-banner-sdk table,#onetrust-banner-sdk thead,#onetrust-banner-sdk tr,#onetrust-banner-sdk td,#onetrust-banner-sdk tbody,#onetrust-banner-sdk .ot-main-content,#onetrust-banner-sdk .ot-toggle,#onetrust-banner-sdk #ot-content,#onetrust-banner-sdk #ot-pc-content,#onetrust-banner-sdk .checkbox,#onetrust-pc-sdk div,#onetrust-pc-sdk span,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#onetrust-pc-sdk p,#onetrust-pc-sdk img,#onetrust-pc-sdk svg,#onetrust-pc-sdk button,#onetrust-pc-sdk section,#onetrust-pc-sdk a,#onetrust-pc-sdk label,#onetrust-pc-sdk input,#onetrust-pc-sdk ul,#onetrust-pc-sdk li,#onetrust-pc-sdk nav,#onetrust-pc-sdk table,#onetrust-pc-sdk thead,#onetrust-pc-sdk tr,#onetrust-pc-sdk td,#onetrust-pc-sdk tbody,#onetrust-pc-sdk .ot-main-content,#onetrust-pc-sdk .ot-toggle,#onetrust-pc-sdk #ot-content,#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk .checkbox,#ot-sdk-cookie-policy div,#ot-sdk-cookie-policy span,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy p,#ot-sdk-cookie-policy img,#ot-sdk-cookie-policy svg,#ot-sdk-cookie-policy button,#ot-sdk-cookie-policy section,#ot-sdk-cookie-policy a,#ot-sdk-cookie-policy label,#ot-sdk-cookie-policy input,#ot-sdk-cookie-policy ul,#ot-sdk-cookie-policy li,#ot-sdk-cookie-policy nav,#ot-sdk-cookie-policy table,#ot-sdk-cookie-policy thead,#ot-sdk-cookie-policy tr,#ot-sdk-cookie-policy td,#ot-sdk-cookie-policy tbody,#ot-sdk-cookie-policy .ot-main-content,#ot-sdk-cookie-policy .ot-toggle,#ot-sdk-cookie-policy #ot-content,#ot-sdk-cookie-policy #ot-pc-content,#ot-sdk-cookie-policy .checkbox,#ot-sync-ntfy div,#ot-sync-ntfy span,#ot-sync-ntfy h1,#ot-sync-ntfy h2,#ot-sync-ntfy h3,#ot-sync-ntfy h4,#ot-sync-ntfy h5,#ot-sync-ntfy h6,#ot-sync-ntfy p,#ot-sync-ntfy img,#ot-sync-ntfy svg,#ot-sync-ntfy button,#ot-sync-ntfy section,#ot-sync-ntfy a,#ot-sync-ntfy label,#ot-sync-ntfy input,#ot-sync-ntfy ul,#ot-sync-ntfy li,#ot-sync-ntfy nav,#ot-sync-ntfy table,#ot-sync-ntfy thead,#ot-sync-ntfy tr,#ot-sync-ntfy td,#ot-sync-ntfy tbody,#ot-sync-ntfy .ot-main-content,#ot-sync-ntfy .ot-toggle,#ot-sync-ntfy #ot-content,#ot-sync-ntfy #ot-pc-content,#ot-sync-ntfy .checkbox{font-family:inherit;font-weight:normal;-webkit-font-smoothing:auto;letter-spacing:normal;line-height:normal;padding:0;margin:0;height:auto;min-height:0;max-height:none;width:auto;min-width:0;max-width:none;border-radius:0;border:none;clear:none;float:none;position:static;bottom:auto;left:auto;right:auto;top:auto;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;white-space:normal;background:none;overflow:visible;vertical-align:baseline;visibility:visible;z-index:auto;box-shadow:none}#onetrust-banner-sdk label:before,#onetrust-banner-sdk label:after,#onetrust-banner-sdk .checkbox:after,#onetrust-banner-sdk .checkbox:before,#onetrust-pc-sdk label:before,#onetrust-pc-sdk label:after,#onetrust-pc-sdk .checkbox:after,#onetrust-pc-sdk .checkbox:before,#ot-sdk-cookie-policy label:before,#ot-sdk-cookie-policy label:after,#ot-sdk-cookie-policy .checkbox:after,#ot-sdk-cookie-policy .checkbox:before,#ot-sync-ntfy label:before,#ot-sync-ntfy label:after,#ot-sync-ntfy .checkbox:after,#ot-sync-ntfy .checkbox:before{content:"";content:none}
+#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{position:relative;width:100%;max-width:100%;margin:0 auto;padding:0 20px;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{width:100%;float:left;box-sizing:border-box;padding:0;display:initial}@media (min-width: 400px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:90%;padding:0}}@media (min-width: 550px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:100%}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{margin-left:4%}#onetrust-banner-sdk .ot-sdk-column:first-child,#onetrust-banner-sdk .ot-sdk-columns:first-child,#onetrust-pc-sdk .ot-sdk-column:first-child,#onetrust-pc-sdk .ot-sdk-columns:first-child,#ot-sdk-cookie-policy .ot-sdk-column:first-child,#ot-sdk-cookie-policy .ot-sdk-columns:first-child{margin-left:0}#onetrust-banner-sdk .ot-sdk-two.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-two.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-two.ot-sdk-columns{width:13.3333333333%}#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-three.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-three.ot-sdk-columns{width:22%}#onetrust-banner-sdk .ot-sdk-four.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-four.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-four.ot-sdk-columns{width:30.6666666667%}#onetrust-banner-sdk .ot-sdk-eight.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eight.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eight.ot-sdk-columns{width:65.3333333333%}#onetrust-banner-sdk .ot-sdk-nine.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-nine.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-nine.ot-sdk-columns{width:74%}#onetrust-banner-sdk .ot-sdk-ten.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-ten.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-ten.ot-sdk-columns{width:82.6666666667%}#onetrust-banner-sdk .ot-sdk-eleven.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eleven.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eleven.ot-sdk-columns{width:91.3333333333%}#onetrust-banner-sdk .ot-sdk-twelve.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-twelve.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-twelve.ot-sdk-columns{width:100%;margin-left:0}}#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6{margin-top:0;font-weight:600;font-family:inherit}#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem;line-height:1.2}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem;line-height:1.25}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem;line-height:1.3}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem;line-height:1.35}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem;line-height:1.5}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem;line-height:1.6}@media (min-width: 550px){#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem}}#onetrust-banner-sdk p,#onetrust-pc-sdk p,#ot-sdk-cookie-policy p{margin:0 0 1em 0;font-family:inherit;line-height:normal}#onetrust-banner-sdk a,#onetrust-pc-sdk a,#ot-sdk-cookie-policy a{color:#565656;text-decoration:underline}#onetrust-banner-sdk a:hover,#onetrust-pc-sdk a:hover,#ot-sdk-cookie-policy a:hover{color:#565656;text-decoration:none}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{display:inline-block;height:38px;padding:0 30px;color:#555;text-align:center;font-size:0.9em;font-weight:400;line-height:38px;letter-spacing:0.01em;text-decoration:none;white-space:nowrap;background-color:transparent;border-radius:2px;border:1px solid #bbb;cursor:pointer;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{color:#333;border-color:#888;opacity:0.7}#onetrust-banner-sdk .ot-sdk-button:focus,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:focus,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:focus,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{outline:2px solid #000}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-banner-sdk button.ot-sdk-button-primary,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-pc-sdk button.ot-sdk-button-primary,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary,#ot-sdk-cookie-policy button.ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary{color:#fff;background-color:#33c3f0;border-color:#33c3f0}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-banner-sdk button.ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:hover,#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-banner-sdk button.ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:focus,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-pc-sdk button.ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:hover,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-pc-sdk button.ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:focus{color:#fff;background-color:#1eaedb;border-color:#1eaedb}#onetrust-banner-sdk input[type="text"],#onetrust-pc-sdk input[type="text"],#ot-sdk-cookie-policy input[type="text"]{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #d1d1d1;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-banner-sdk input[type="text"],#onetrust-pc-sdk input[type="text"],#ot-sdk-cookie-policy input[type="text"]{-webkit-appearance:none;-moz-appearance:none;appearance:none}#onetrust-banner-sdk input[type="text"]:focus,#onetrust-pc-sdk input[type="text"]:focus,#ot-sdk-cookie-policy input[type="text"]:focus{border:1px solid #000;outline:0}#onetrust-banner-sdk label,#onetrust-pc-sdk label,#ot-sdk-cookie-policy label{display:block;margin-bottom:0.5rem;font-weight:600}#onetrust-banner-sdk input[type="checkbox"],#onetrust-pc-sdk input[type="checkbox"],#ot-sdk-cookie-policy input[type="checkbox"]{display:inline}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{list-style:circle inside}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{padding-left:0;margin-top:0}#onetrust-banner-sdk ul ul,#onetrust-pc-sdk ul ul,#ot-sdk-cookie-policy ul ul{margin:1.5rem 0 1.5rem 3rem;font-size:90%}#onetrust-banner-sdk li,#onetrust-pc-sdk li,#ot-sdk-cookie-policy li{margin-bottom:1rem}#onetrust-banner-sdk th,#onetrust-banner-sdk td,#onetrust-pc-sdk th,#onetrust-pc-sdk td,#ot-sdk-cookie-policy th,#ot-sdk-cookie-policy td{padding:12px 15px;text-align:left;border-bottom:1px solid #e1e1e1}#onetrust-banner-sdk button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-container:after,#onetrust-banner-sdk .ot-sdk-row:after,#onetrust-pc-sdk .ot-sdk-container:after,#onetrust-pc-sdk .ot-sdk-row:after,#ot-sdk-cookie-policy .ot-sdk-container:after,#ot-sdk-cookie-policy .ot-sdk-row:after{content:"";display:table;clear:both}#onetrust-banner-sdk .ot-sdk-row,#onetrust-pc-sdk .ot-sdk-row,#ot-sdk-cookie-policy .ot-sdk-row{margin:0;max-width:none;display:block}
+#onetrust-banner-sdk{box-shadow:0 0 18px rgba(0,0,0,.2)}#onetrust-banner-sdk.otFlat{position:fixed;z-index:2147483645;bottom:0;right:0;left:0;background-color:#fff;max-height:90%;overflow-x:hidden;overflow-y:auto}#onetrust-banner-sdk.otFlat.top{top:0px;bottom:auto}#onetrust-banner-sdk.otRelFont{font-size:1rem}#onetrust-banner-sdk>.ot-sdk-container{overflow:hidden}#onetrust-banner-sdk::-webkit-scrollbar{width:11px}#onetrust-banner-sdk::-webkit-scrollbar-thumb{border-radius:10px;background:#c1c1c1}#onetrust-banner-sdk{scrollbar-arrow-color:#c1c1c1;scrollbar-darkshadow-color:#c1c1c1;scrollbar-face-color:#c1c1c1;scrollbar-shadow-color:#c1c1c1}#onetrust-banner-sdk #onetrust-policy{margin:1.25em 0 .625em 2em;overflow:hidden}#onetrust-banner-sdk #onetrust-policy .ot-gv-list-handler{float:left;font-size:.82em;padding:0;margin-bottom:0;border:0;line-height:normal;height:auto;width:auto}#onetrust-banner-sdk #onetrust-policy-title{font-size:1.2em;line-height:1.3;margin-bottom:10px}#onetrust-banner-sdk #onetrust-policy-text{clear:both;text-align:left;font-size:.88em;line-height:1.4}#onetrust-banner-sdk #onetrust-policy-text *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk #onetrust-policy-text a{font-weight:bold;margin-left:5px}#onetrust-banner-sdk #onetrust-policy-title,#onetrust-banner-sdk #onetrust-policy-text{color:dimgray;float:left}#onetrust-banner-sdk #onetrust-button-group-parent{min-height:1px;text-align:center}#onetrust-banner-sdk #onetrust-button-group{display:inline-block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{background-color:#68b631;color:#fff;border-color:#68b631;margin-right:1em;min-width:125px;height:auto;white-space:normal;word-break:break-word;word-wrap:break-word;padding:12px 10px;line-height:1.2;font-size:.813em;font-weight:600}#onetrust-banner-sdk #onetrust-pc-btn-handler.cookie-setting-link{background-color:#fff;border:none;color:#68b631;text-decoration:underline;padding-left:0;padding-right:0}#onetrust-banner-sdk .onetrust-close-btn-ui{width:44px;height:44px;background-size:12px;border:none;position:relative;margin:auto;padding:0}#onetrust-banner-sdk .banner_logo{display:none}#onetrust-banner-sdk .ot-b-addl-desc{clear:both;float:left;display:block}#onetrust-banner-sdk #banner-options{float:left;display:table;margin-right:0;margin-left:1em;width:calc(100% - 1em)}#onetrust-banner-sdk .banner-option-input{cursor:pointer;width:auto;height:auto;border:none;padding:0;padding-right:3px;margin:0 0 10px;font-size:.82em;line-height:1.4}#onetrust-banner-sdk .banner-option-input *{pointer-events:none;font-size:inherit;line-height:inherit}#onetrust-banner-sdk .banner-option-input[aria-expanded=true]~.banner-option-details{display:block;height:auto}#onetrust-banner-sdk .banner-option-input[aria-expanded=true] .ot-arrow-container{transform:rotate(90deg)}#onetrust-banner-sdk .banner-option{margin-bottom:12px;margin-left:0;border:none;float:left;padding:0}#onetrust-banner-sdk .banner-option:first-child{padding-left:2px}#onetrust-banner-sdk .banner-option:not(:first-child){padding:0;border:none}#onetrust-banner-sdk .banner-option-header{cursor:pointer;display:inline-block}#onetrust-banner-sdk .banner-option-header :first-child{color:dimgray;font-weight:bold;float:left}#onetrust-banner-sdk .banner-option-header .ot-arrow-container{display:inline-block;border-top:6px solid transparent;border-bottom:6px solid transparent;border-left:6px solid dimgray;margin-left:10px;vertical-align:middle}#onetrust-banner-sdk .banner-option-details{display:none;font-size:.83em;line-height:1.5;padding:10px 0px 5px 10px;margin-right:10px;height:0px}#onetrust-banner-sdk .banner-option-details *{font-size:inherit;line-height:inherit;color:dimgray}#onetrust-banner-sdk .ot-arrow-container,#onetrust-banner-sdk .banner-option-details{transition:all 300ms ease-in 0s;-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s}#onetrust-banner-sdk .ot-dpd-container{float:left}#onetrust-banner-sdk .ot-dpd-title{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-title,#onetrust-banner-sdk .ot-dpd-desc{font-size:.88em;line-height:1.4;color:dimgray}#onetrust-banner-sdk .ot-dpd-title *,#onetrust-banner-sdk .ot-dpd-desc *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text *{margin-bottom:0}#onetrust-banner-sdk.ot-iab-2 .onetrust-vendors-list-handler{display:block;margin-left:0;margin-top:5px;clear:both;margin-bottom:0;padding:0;border:0;height:auto;width:auto}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk.ot-close-btn-link{padding-top:25px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container{top:15px;transform:none;right:15px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container button{padding:0;white-space:pre-wrap;border:none;height:auto;line-height:1.5;text-decoration:underline;font-size:.69em}#onetrust-banner-sdk #onetrust-policy-text,#onetrust-banner-sdk .ot-dpd-desc,#onetrust-banner-sdk .ot-b-addl-desc{font-size:.813em;line-height:1.5}#onetrust-banner-sdk .ot-dpd-desc{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-desc>.ot-b-addl-desc{margin-top:10px;margin-bottom:10px;font-size:1em}@media only screen and (max-width: 425px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:6px;right:2px}#onetrust-banner-sdk #onetrust-policy{margin-left:0;margin-top:3em}#onetrust-banner-sdk #onetrust-button-group{display:block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk .onetrust-close-btn-ui{top:auto;transform:none}#onetrust-banner-sdk #onetrust-policy-title{display:inline;float:none}#onetrust-banner-sdk #banner-options{margin:0;padding:0;width:100%}}@media only screen and (min-width: 426px)and (max-width: 896px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:0;right:0}#onetrust-banner-sdk #onetrust-policy{margin-left:1em;margin-right:1em}#onetrust-banner-sdk .onetrust-close-btn-ui{top:10px;right:10px}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:95%}#onetrust-banner-sdk.ot-iab-2 #onetrust-group-container{width:100%}#onetrust-banner-sdk #onetrust-button-group-parent{width:100%;position:relative;margin-left:0}#onetrust-banner-sdk #onetrust-button-group button{display:inline-block}#onetrust-banner-sdk #onetrust-button-group{margin-right:0;text-align:center}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler{float:left}#onetrust-banner-sdk .has-reject-all-button #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-accept-btn-handler{float:right}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group{width:calc(100% - 2em);margin-right:0}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler.cookie-setting-link{padding-left:0px;text-align:left}#onetrust-banner-sdk.ot-buttons-fw .ot-sdk-three button{width:100%;text-align:center}#onetrust-banner-sdk.ot-buttons-fw #onetrust-button-group-parent button{float:none}#onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link{text-align:center}}@media only screen and (min-width: 550px){#onetrust-banner-sdk .banner-option:not(:first-child){border-left:1px solid #d8d8d8;padding-left:25px}}@media only screen and (min-width: 425px)and (max-width: 550px){#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group,#onetrust-banner-sdk.ot-iab-2 #onetrust-policy,#onetrust-banner-sdk.ot-iab-2 .banner-option{width:100%}}@media only screen and (min-width: 769px){#onetrust-banner-sdk #onetrust-button-group{margin-right:30%}#onetrust-banner-sdk #banner-options{margin-left:2em;margin-right:5em;margin-bottom:1.25em;width:calc(100% - 7em)}}@media only screen and (min-width: 897px)and (max-width: 1023px){#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:75%;transform:translateY(-50%)}#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;padding:0;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{position:relative;margin:0;right:-22px;top:2px}}@media only screen and (min-width: 1024px){#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{right:-12px}#onetrust-banner-sdk #onetrust-policy{margin-left:2em}#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:60%;transform:translateY(-50%)}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-title{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text,#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:1em;width:50%;border-right:1px solid #d8d8d8;padding-right:1rem}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-container{width:45%;padding-left:1rem;display:inline-block;float:none}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-title{line-height:1.7}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent{left:auto;right:4%;margin-left:0}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{margin:auto;width:30%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:60%}#onetrust-banner-sdk #onetrust-button-group{margin-right:auto}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{margin-top:1em}}@media only screen and (min-width: 890px){#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group-parent{padding-left:3%;padding-right:4%;margin-left:0}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group{margin-right:0;margin-top:1.25em;width:100%}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button{width:100%;margin-bottom:5px;margin-top:5px}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button:last-of-type{margin-bottom:20px}}@media only screen and (min-width: 1280px){#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:55%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{width:44%;padding-left:2%;padding-right:2%}#onetrust-banner-sdk:not(.ot-iab-2).vertical-align-content #onetrust-button-group-parent{position:absolute;left:55%}}
+#onetrust-consent-sdk #onetrust-banner-sdk {background-color: #F1F9F8;}
+#onetrust-consent-sdk #onetrust-policy-title,
+#onetrust-consent-sdk #onetrust-policy-text,
+#onetrust-consent-sdk .ot-b-addl-desc,
+#onetrust-consent-sdk .ot-dpd-desc,
+#onetrust-consent-sdk .ot-dpd-title,
+#onetrust-consent-sdk #onetrust-policy-text *:not(.onetrust-vendors-list-handler),
+#onetrust-consent-sdk .ot-dpd-desc *:not(.onetrust-vendors-list-handler),
+#onetrust-consent-sdk #onetrust-banner-sdk #banner-options *,
+#onetrust-banner-sdk .ot-cat-header {
+color: #222222;
+}
+#onetrust-consent-sdk #onetrust-banner-sdk .banner-option-details {
+background-color: #E9E9E9;}
+#onetrust-consent-sdk #onetrust-banner-sdk a[href],
+#onetrust-consent-sdk #onetrust-banner-sdk a[href] font,
+#onetrust-consent-sdk #onetrust-banner-sdk .ot-link-btn
+{
+color: #004D4D;
+}#onetrust-consent-sdk #onetrust-accept-btn-handler,
+#onetrust-banner-sdk #onetrust-reject-all-handler {
+background-color: #117777;border-color: #117777;
+color: #FFFFFF;
+}
+#onetrust-consent-sdk #onetrust-banner-sdk *:focus,
+#onetrust-consent-sdk #onetrust-banner-sdk:focus {
+outline-color: #000000;
+outline-width: 1px;
+}
+#onetrust-consent-sdk #onetrust-pc-btn-handler,
+#onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+color: #004D4D; border-color: #004D4D;
+background-color:
+#F1F9F8;
+} #onetrust-consent-sdk #onetrust-banner-sdk #onetrust-close-btn-container {
+top: 25px;
+right: 25px;
+}
+#onetrust-consent-sdk #onetrust-banner-sdk .onetrust-close-btn-ui {
+width: 12px;
+height: 12px;
+}
+#onetrust-banner-sdk #onetrust-policy-text a.ot-sdk-show-settings {
+margin-left: 0;
+}
+#onetrust-consent-sdk #onetrust-button-group {
+text-align: center;
+}
+@media only screen and (min-width: 425px) and (max-width: 550px) {
+#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent #onetrust-button-group {
+width: auto;
+}
+}
+@media only screen and (min-width: 426px) and (max-width: 896px) {
+#onetrust-consent-sdk #onetrust-banner-sdk .onetrust-close-btn-ui {
+top: 0;
+right: 0;
+}
+}
+@media (min-width: 896px) {
+#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns {
+left: auto;
+right: 4%;
+margin-left: 0;
+margin-top: 5%;
+}
+}
+@media only screen and (min-width: 769px) {
+#onetrust-banner-sdk #onetrust-button-group {
+margin-right: 0;
+}
+}
+@media only screen and (min-width: 1024px){
+#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent {
+margin-top: 5%;
+}
+}
+#onetrust-consent-sdk #onetrust-banner-sdk {
+display: none;
+}
+/* hides banner after it has already been interacted with */
+#onetrust-consent-sdk:not(.show-banner) #onetrust-banner-sdk {
+display: none;
+}</style>
 					
-					<script type="text/javascript" data-glb-js="top" src="/static/5.66.0/cache/eNptkVtOAzEMRTdElD1UQvyiajaQhzu4eTg4TtGwejJVBZmSTx9f31w7uooRdPpadSTjwb_oB4lo6443E9ov7HWhuF0wxpHdIHtincgDZ_xmlUyWCKPEEQWE-s_-swFvVRjzOsqbYEQZBzq8ZDXlntK88fa-TGLKB5M8xWPozQYLGxeeolgGEwphloN3abY2O5LzchpL2b3OYl-783E0mc3-ve4oFcq7Rht_v8laZNbtV2pOGoNXjrJ0tourU33skMysoG4IXzOTVdL9OyK6oOSx7g-EUcIs.min.js"></script>
+					<script type="text/javascript" data-glb-js="top" src="/static/5.193.0/cache/eNqFUu1uwyAMfKEh3mHTtF-TqqovQMClbgjOjMmUPP2gq7p-sFTKD-I7H2d8OokRtHowUQJoS8NIEaIkHcxMWfQxlU_ZA9j-Rd-Sj5W0zAkXKAyKe_T3lPNfwC7d0FtSZBy4BjBBdMR6IAcccWH1CzWYlqjHR_E7E18ZeE7CGH1DIwsGFGxa3Ee1BjsaVvGPze7_8eTAJO2xGAonw46N7dumh3JQHYPpR8KyvAulmiZyq7bG3KXcNYDt7rVRlWpjK937BNc3XZkxc9ca4-1zc1-9iptxp-XkiGU_KgUSVZNy6Xik-lFW9MqCs5XM4Go0pdRqT7KqdD-3wegPothgeM7FEvyIAuqvqUbUeODWa5e6mhC-V4S9DKc4B7S9kvPafwAVp2Id.min.js"></script>
 
 					
-					<script type="text/javascript">var Mntl = window.Mntl || {};
+					<script type="text/javascript">var Mntl = window.Mntl || {};window.Mntl = window.Mntl || {};
+
+window.Mntl.csrf = function() {
+    return '6bad3e5efc975f57734aff7b3d2e0617';
+};window.Mntl = window.Mntl || {};
 Mntl.RTB = Mntl.RTB || {};
 Mntl.RTB.setTaxonomyStampValues({"tax1":"sr_recipes","tax2":"sr_dinner-recipes","tax0":"sr_root","tax5":"sr_chicken-soup-recipes","tax3":"sr_dinner-recipes-by-type","tax4":"sr_soup-recipes"});
 Mntl.RTB.indexFirstPartyData = 'tax1:sr_recipes';
 Mntl.RTB.setTimeoutLength([500,800]);
-Mntl.RTB.Plugins.amazon.amazonConfigs = {"mapTaxValues":{"tax1":"sr_recipes","tax2":"sr_dinner-recipes","si_section":"sr_dinner-recipes","tax0":"sr_root","tax3":"sr_dinner-recipes-by-type"},"mapFBValues":{},"amazonSlotName":false,"amazonSection":"Dinner Recipes By Type"};
-Mntl.RTB.Plugins.s2s.s2sConfigs = {"partners":"","timeout":500};
-Mntl.RTB.initBidders([{ type: "amazon", id: '3222'},{ type: "ias", id: '926268'}]);
-Mntl.RTBTracking.init(['amazon','ias']);
-Mntl.RTB.Plugins.lotameLightning.init({"tax1":"sr_recipes","tax2":"sr_dinner-recipes","tax0":"sr","clientId":"15918","tax5":"sr_chicken-soup-recipes","tax3":"sr_dinner-recipes-by-type","tax4":"sr_soup-recipes"});
+Mntl.RTB.Plugins.amazon.amazonConfigs = {"mapTaxValues":{"tax1":"sr_recipes","tax2":"sr_dinner-recipes","si_section":"sr_dinner-recipes","tax0":"sr_root","tax3":"sr_dinner-recipes-by-type"},"mapFBValues":{"adunitid":"mapFBID"},"amazonSlotName":false,"amazonSection":"Dinner Recipes By Type"};
+Mntl.RTB.initVideoBidders([{ type: 'amazon', id: '3222' }, { type: 'prebid', id: 'true' } ]);
+Mntl.RTB.initDisplayAndOutstreamBidders([{ type: "amazon", id: '3222'},{ type: "lotameLightning", id: 'true'},{ type: "ixid", id: 'true'},{ type: "prebid", id: 'true'}]);
+Mntl.RTBTracking.init(['amazon','lotameLightning','ixid','prebid']);
+Mntl.RTB.Plugins.lotameLightning.init({"tax1":"sr_recipes","tax2":"sr_dinner-recipes","tax0":"sr_root","clientId":"15918","tax5":"sr_chicken-soup-recipes","tax3":"sr_dinner-recipes-by-type","tax4":"sr_soup-recipes"});
+Mntl.RTB.Plugins.prebid.setConfig({"square-fixed\/tier1":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442276","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9694b2018180ffe245028aff3c008b"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515069","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482721","type":"display"}},{"bidder":"ix","params":{"siteId":"830512","type":"display"}},{"bidder":"trustx","params":{"uid":"351512","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboard-fixed\/tier2":[{"bidder":"appnexus","params":{"placementId":"25482717","type":"display"}},{"bidder":"ix","params":{"siteId":"830503","type":"display"}},{"bidder":"trustx","params":{"uid":"351507","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515065","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9698d2018180ffd7df028af8510072"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442268","type":"display"}}],"square-fixed\/tier2":[{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515070","type":"display"}},{"bidder":"trustx","params":{"uid":"351511","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442278","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482722","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9691af018180ffdca0028b0112007c"}},{"bidder":"ix","params":{"siteId":"830511","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboard-fixed\/tier1":[{"bidder":"ix","params":{"siteId":"830498","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482716","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9694b2018180ffe245028af6a30089"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442266","type":"display"}},{"bidder":"trustx","params":{"uid":"351506","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515357","type":"display"}}],"leaderboardac\/tier2":[{"bidder":"appnexus","params":{"placementId":"25482720","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515068","type":"display"}},{"bidder":"trustx","params":{"uid":"351510","useNewFormat":true,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9698d2018180ffd7df028afd7b0073"}},{"bidder":"ix","params":{"siteId":"830509","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442274","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"square-fixed\/tier3":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442280","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482723","type":"display"}},{"bidder":"trustx","params":{"uid":"351516","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"830515","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515071","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9698d2018180ffd7df028b02d10074"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboard-fixed\/tier4":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442272","type":"display"}},{"bidder":"trustx","params":{"uid":"351509","useNewFormat":true,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482719","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515067","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ix","params":{"siteId":"830504","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9691af018180ffdca0028afbc9007b"}}],"square-fixed\/tier4":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442282","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482724","type":"display"}},{"bidder":"ix","params":{"siteId":"830516","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515072","type":"display"}},{"bidder":"trustx","params":{"uid":"351513","useNewFormat":true,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9694b2018180ffe245028b047c008c"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"preroll":[{"bidder":"trustx","params":{"uid":"351804","useNewFormat":true,"type":"instream"}},{"bidder":"ix","params":{"siteId":"830521","type":"instream"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442286","type":"instream"}},{"bidder":"roundel","params":{"siteId":578566,"type":"instream"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515074","type":"instream"}},{"bidder":"appnexus","params":{"placementId":"25482726","type":"instream"}}],"leaderboard-fixed\/tier3":[{"bidder":"appnexus","params":{"placementId":"25482718","type":"display"}},{"bidder":"trustx","params":{"uid":"351508","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515066","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442270","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9694b2018180ffe245028afa0d008a"}},{"bidder":"ix","params":{"siteId":"830505","type":"display"}}],"leaderboardfooter-flex\/tier2":[{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9698d2018180ffd7df028af8510072"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442268","type":"display"}},{"bidder":"trustx","params":{"uid":"351507","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"830503","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482717","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515065","type":"display"}}],"leaderboardfooter-flex\/tier1":[{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9694b2018180ffe245028af6a30089"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515357","type":"display"}},{"bidder":"trustx","params":{"uid":"351506","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442266","type":"display"}},{"bidder":"ix","params":{"siteId":"830498","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482716","type":"display"}}],"leaderboardfooter-flex\/tier4":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515067","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482719","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9691af018180ffdca0028afbc9007b"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442272","type":"display"}},{"bidder":"trustx","params":{"uid":"351509","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"830504","type":"display"}}],"leaderboardfooter-flex\/tier3":[{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515066","type":"display"}},{"bidder":"trustx","params":{"uid":"351508","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442270","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482718","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9694b2018180ffe245028afa0d008a"}},{"bidder":"ix","params":{"siteId":"830505","type":"display"}}],"square-flex\/tier1":[{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515073","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9691af018180ffdca0028b0655007d"}},{"bidder":"appnexus","params":{"placementId":"25482725","type":"display"}},{"bidder":"ix","params":{"siteId":"830517","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"trustx","params":{"uid":"351514","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442284","type":"display"}}],"square-flex\/tier2":[{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515073","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9691af018180ffdca0028b0655007d"}},{"bidder":"ix","params":{"siteId":"830517","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482725","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"trustx","params":{"uid":"351514","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442284","type":"display"}}],"leaderboard-flex\/tier1":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ix","params":{"siteId":"830509","type":"display"}},{"bidder":"appnexus","params":{"placementId":"25482720","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4515068","type":"display"}},{"bidder":"trustx","params":{"uid":"351510","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426852","zoneId":"2442274","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9694b2018180ffe245026a8e6b0033","pos":"8a9698d2018180ffd7df028afd7b0073"}}]});
 Mntl.RTB.Plugins.prebid.setPriceGranularity({"buckets":[{"max":"20","increment":"0.05"},{"max":"100","increment":"0.5"}]});
-Mntl.RTB.setGDPR(true);
 Mntl.RTB.setLatencyBuffer(0);
+(function() {
+    Mntl.utilities.onLoad(function() {
+        var geolocationResponse = {};
+        const externalJS = {
+            src: '\//cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+            'data-domain-script': '7637a2a2-34ba-48ec-9bbe-6b40501ab557',
+            'data-ignore-ga': true,
+            'data-language': 'en',
+            async: true,
+            charset: 'UTF-8',
+            onerror: 'Mntl.CMP.onError()',
+            id: 'onetrust-script'
+        };
+        geolocationResponse.stateCode = 'CA';
+        geolocationResponse.countryCode = 'US';
+        geolocationResponse.regionCode = 'US';
+        if (Object.keys(geolocationResponse).length) {
+            window.OneTrust = window.OneTrust || {};
+            window.OneTrust.geolocationResponse = geolocationResponse;
+        }
+        const preferenceCenterTrigger = document.querySelector('.ot-pref-trigger');
+        preferenceCenterTrigger.addEventListener('click', (e) => {
+            e.preventDefault();
+            Mntl.utilities.loadExternalJS(
+                externalJS
+            , () => {
+                Mntl.CMP.onSdkLoaded(() => {
+                    OneTrust.ToggleInfoDisplay();
+                })
+            });
+        },
+        { once: true });
+    });
+    Mntl.CMP.init(true, 'ccpa', false, 3000);
+})();
 (function(){
-var pageTargeting = {
+const pageTargeting = {
 rec: 0
 ,customSeries: ''
 ,tax0: 'sr'
-,leuid: '148150260780971'
+,leuid: '155784473543710'
 ,custom: ''
 ,sbj: ''
-,rid: 'n8160dd4b888845e3b192b970816a40de22'
-,sid: 'n8160dd4b888845e3b192b970816a40de22'
+,rid: 'n4c9bd4475f33401ab0ce844f317dd64900'
+,sid: 'n4c9bd4475f33401ab0ce844f317dd64900'
 }
 ;
-var baseSlotTargeting = {
-leaid: '235779'
+const baseSlotTargeting = {
+gtemplate: 'recipe'
+,leaid: '235779'
+,revenueGroup: ''
 ,docId: '5102671'
+,viewtype: ''
+,type: 'recipe'
 ,ptax: ''
 ,vid: '0'
 ,tax1: 'sr_recipes'
 ,tax2: 'sr_dinner-recipes'
 ,t: '120'
 ,au: '235779'
+,tier: 'l'
 ,jny: '0'
-,leuid: '148150260780971'
+,leuid: '155784473543710'
 ,dload: '0'
 ,sbj: ''
+,id: '5102671'
 ,tax5: 'sr_chicken-soup-recipes'
 ,aid: ''
 ,tax3: 'sr_dinner-recipes-by-type'
@@ -108,40 +239,78 @@ leaid: '235779'
 ,tax4: 'sr_soup-recipes'
 }
 ;
+pageTargeting.mtax = ['11184','13562','13196','11053','11374','10764'];
 pageTargeting.w = Mntl.utilities.getW();
-Lifestyle.GPT.testIds(pageTargeting, baseSlotTargeting);
-Mntl.utilities.onLoad(function() {
-Mntl.utilities.loadExternalJS({
-src: '//www.googletagservices.com/tag/js/gpt.js',
-async: false
-});
-});
-var options = {
-domain: 'www.simplyrecipes.com',
-isMobile: false,
-dfpId: '479',
-singleRequest: false,
-pageTargeting: pageTargeting,
-baseSlotTargeting: baseSlotTargeting,
-initialSlots: [{
+const refreshAdhesive = {
+timeoutRefreshOnceOnly: true
+,afterAdhesiveRenderedTimeout: '30000'
+}
+;
+const initialSlots = [];
+initialSlots.push({
 config: {
-id: 'leaderboard',
-sizes: [[728, 90], [970, 250], [1, 1], 'fluid'],
+id: 'oop',
+sizes: [[1, 1]],
+type: 'outofpage',
+rtb: false,
+waitForThirdParty: true
+},
+targeting: Mntl.fnUtilities.deepExtend({}, {
+pos: 'atf',
+priority: 0
+,floor_id: '34d5a53a01884f4ebcebc7cbd8412baf'
+,floor: '50'
+})
+})
+initialSlots.push({
+config: {
+id: 'leaderboard-flex-1',
+sizes: [[728, 90], [970,90], [970, 250]],
 type: 'leaderboard',
-rtb: true
+rtb: true,
+waitForThirdParty: false
 },
 targeting: Mntl.fnUtilities.deepExtend({}, {
 pos: 'atf',
 priority: 1
-,floor_id: 'd1b00d8b6c084037ac97343987b00035'
-,floor: 210
+,floor_id: 'ca04f866bee249ef895b0d07d0a0ecad'
+,floor: '180'
 })
-}],
+})
+const testIds = Mntl.GPT.getTestIds();
+pageTargeting.ab = testIds;
+pageTargeting.bts = testIds;
+Mntl.utilities.onLoad(function() {
+Mntl.utilities.loadExternalJS({
+src: '//securepubads.g.doubleclick.net/tag/js/gpt.js',
+async: false
+});
+});
+const options = {
+domain: 'www.simplyrecipes.com',
+templateName: 'recipesc',
+isMobile: false,
+dfpId: '3865',
+publisherProvidedId: '1e367eb2-2ea3-4ec0-ba6d-8c32013b982c',
+singleRequest: false,
+useLmdFormat: true,
+useOxygen: true,
+useInfiniteRightRail: true,
+bundlePrebid: false,
+lmdSiteCode: 'hlt',
+pageTargeting,
+baseSlotTargeting,
+geo: {
+isInEurope: false,
+isInUsa: true
+},
+initialSlots,
 utils: {
 buildGptUrl: Lifestyle.GPT.buildGptUrl
 },
 displayOnScroll: 'false',
-displayOnConsent: 'true'
+displayOnConsent: 'true',
+refreshAdhesive
 };
 Mntl.GPT.init(options);
 }());// moved from gtm.ftl so we can initialize GTM only onLoad. From https://support.google.com/tagmanager/answer/6103696?hl=en
@@ -153,186 +322,392 @@ dataLayer.push({
 event: 'ab-proctor',
 'abTests-proctor': {
 "99-0"
-: "fbAdMapAmazon | useMap | Use fb id map | 1"
+: "useOxygen | useOxygen | use the Oxygenated ad unit format and slot names | 1"
 ,
-"99-1"
-: "includeIAS | includeIAS | Includes IAS header script | 1"
+"58"
+: "rightRailVideo | control | T2 slot contains display ad, primary video kept if it exists on the page | 0"
 ,
-"99-2"
-: "rtbTimeout | test2 | test2 | 2"
+"62"
+: "jumpToRecipe | control | control | 0"
 ,
-"99-3"
-: "IASdirectOnly | inTest | In test | 1"
+"63"
+: "useInfiniteRightRail | useInfiniteRightRail | Use infinite right rail | 1"
 ,
-"50"
-: "imageToggler | control | Control | 0"
+"99-4"
+: "useRTBforVideoAds | control | | 0"
 ,
-"99-5"
-: "mediaGrid | active | Media grid enabled | 1"
-,
-"99-6"
-: "pbGrid | grid | enable the prebid grid adapter | 1"
-,
-"99-7"
-: "cmpTimeout | t1 | Test 1 | 1"
-,
-"99-8"
-: "pbTeads | teads | teads | 1"
-,
-"99-9"
-: "prebid | ixId | Active with index identity adapter | 2"
+"34"
+: "vpbFloorPricing | activetesta | | 1"
 }
 });
 dataLayer.push({
 envData: {
 environment: {
-environment: "prod",
+environment: "k8s-prod",
 application: "simplyrecipes",
-dataCenter: "us-east-1"
+dataCenter: "us-west-1"
 },
 server: {
-version: "5.66.0",
+version: "5.193.0",
 title: "simplyrecipes-launcher"
 },
 client : {
 browserUA: navigator.userAgent,
-serverUA: "Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
+serverUA: "curl/7.68.0",
 deviceType: "pc",
-usStateCode: ""
+usStateCode: "CA"
 },
-mantle: "3.12.350",
-commerce: "2.23.0"
+mantle: "3.13.484",
+commerce: ""
 }
 });
-(function(win, fnUtils) {
-var pageViewDataAsJSON = {"country":"GB","description":"One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&#39;re done. It&#39;s the easiest soup ever, ready in under an hour.","contentGroup":"Other","revenueGroup":"","documentId":5102671,"templateName":"RECIPESC","title":"Homemade Chicken & Rice Soup {One-Pot}" || document.title || '',"viewType":"","lastEditingAuthorId":"235779","lastEditingUserId":"148150260780971","templateId":"120","authorId":"235779","fullUrl":"https://www.simplyrecipes.com/recipes/one_pot_chicken_and_rice_soup/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"socialImage":"https://www.simplyrecipes.com/thmb/7jbac2vJiGvh9kB-cfN9pvZnWyA=/735x0/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-5-eece1a9bf1f34a5bb0a9ca4baab2edb2.jpg","internalSessionId":"n8160dd4b888845e3b192b970816a40de22","internalRequestId":"n8160dd4b888845e3b192b970816a40de22","experienceTypeName":"","recircDocIdsFooter":"S-5102102|S-5103153|S-5102051|S-5103774|S-5104236|S-5102236|S-5102528|S-5102994|S-5103751|S-5101811|S-5104433|S-5103631|S-5103254|S-5102019|S-5102800|S-5102214","euTrafficFlag":true,"mantleVersion":"3.12.350","commerceVersion":"2.23.0","primaryTaxonomyIds":"5083469|5090746|5091433|5091419|5091377|5091375","primaryTaxonomyNames":"Simply Recipes|Recipes|Dinners|Dinners By Types|Soups|Chicken Soups"};
+(function(win, fnUtils, CMP) {
+var pageViewDataAsJSON = {"description":"One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&#39;re done. It&#39;s the easiest soup ever, ready in under an hour.","country":"US","contentGroup":"Other","revenueGroup":"","authorId":"235779","documentId":5102671,"muid":"1e367eb2-2ea3-4ec0-ba6d-8c32013b982c","lastEditingAuthorId":"235779","lastEditingUserId":"155784473543710","templateId":"120","templateName":"RECIPESC","title":"One-Pot Chicken and Rice Soup Recipe" || document.title || '',"viewType":"","fullUrl":"https://www.simplyrecipes.com/recipes/one_pot_chicken_and_rice_soup/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"socialImage":"https://www.simplyrecipes.com/thmb/7jbac2vJiGvh9kB-cfN9pvZnWyA=/735x0/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-5-eece1a9bf1f34a5bb0a9ca4baab2edb2.jpg","internalSessionId":"n4c9bd4475f33401ab0ce844f317dd64900","internalRequestId":"n4c9bd4475f33401ab0ce844f317dd64900","hid":"","experienceTypeName":"","recircDocIdsFooter":"S-5102051|S-5102102|S-5102528|S-5187376|S-5104236|S-5194212|S-5104178|S-5103774|S-5103751|S-5212747|S-5212102|S-5104251|S-5324248|S-5225178|S-5212710|S-5102800","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"3.13.484","commerceVersion":"","primaryTaxonomyIds":"5083469|5090746|5091433|5091419|5091377|5091375","primaryTaxonomyNames":"Simply Recipes|Recipes|Dinners|Dinners By Types|Soups|Chicken Soups"};
+var deferLoadTime = 5000;
 var readyForThirdPartyTrackingEvent = new CustomEvent('readyForThirdPartyTracking', { bubbles: true });
 var readyForThirdPartyTracking = fnUtils.once(function() {
 dataLayer.push({event: 'readyForThirdPartyTracking'});
 window.dispatchEvent(readyForThirdPartyTrackingEvent);
 });
+var hasTargetingConsentHandler = function() {
+const hasConsent = CMP.hasTargetingConsent();
+if (hasConsent) {
+readyForThirdPartyTracking();
+}
+return hasConsent;
+};
+var onRequiredDomEvent = fnUtils.once(function() {
+if (!CMP) {
+readyForThirdPartyTracking();
+return;
+}
+if (!CMP.isLoading()) {
+hasTargetingConsentHandler();
+}
+CMP.onConsentChange(hasTargetingConsentHandler);
+});
 [
-['adRendered', readyForThirdPartyTracking],
-['beforeunload', readyForThirdPartyTracking],
-['load', function() { setTimeout(readyForThirdPartyTracking, 5000); }]
+['adRendered', onRequiredDomEvent],
+['beforeunload', onRequiredDomEvent],
+['load', function() { setTimeout(onRequiredDomEvent, deferLoadTime); }]
 ].forEach(function(event) {
 win.addEventListener(event[0], event[1], { once: true });
 });
-pageViewDataAsJSON.breakpointName = Mntl.utilities.getW();
+pageViewDataAsJSON.breakpointName = Lifestyle.Utilities.getW();
 pageViewDataAsJSON.bounceExchangeId = '';
+pageViewDataAsJSON.descriptiveTaxonomy = '11184,13562,13196,11053,11374,10764';
+Mntl.utilities.onLoad(function() {
 Mntl.PageView.init(pageViewDataAsJSON);
-})(window || {}, Mntl.fnUtilities || {});</script>
+});
+})(window || {}, Mntl.fnUtilities || {}, Mntl.CMP);</script>
 					
-					<link rel="shortcut icon" href="/static/5.66.0/icons/favicons/favicon.ico">
-<link rel="icon" type="image/x-icon" href="/static/5.66.0/icons/favicons/favicon.ico">
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="/static/5.66.0/icons/favicons/apple-touch-icon-57x57.png">
-<link rel="apple-touch-icon-precomposed" sizes="60x60" href="/static/5.66.0/icons/favicons/apple-touch-icon-60x60.png">
-<link rel="apple-touch-icon-precomposed" sizes="76x76" href="/static/5.66.0/icons/favicons/apple-touch-icon-76x76.png">
-<link rel="apple-touch-icon-precomposed" sizes="120x120" href="/static/5.66.0/icons/favicons/apple-touch-icon-120x120.png">
-<link rel="apple-touch-icon-precomposed" sizes="152x152" href="/static/5.66.0/icons/favicons/apple-touch-icon-152x152.png">
-<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/static/5.66.0/icons/favicons/apple-touch-icon-180x180.png">
+					<link rel="shortcut icon" href="/favicon.ico">
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon-precomposed" sizes="60x60" href="/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon-precomposed" sizes="76x76" href="/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon-precomposed" sizes="120x120" href="/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon-precomposed" sizes="152x152" href="/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/apple-touch-icon-180x180.png">
 
 <meta name="msapplication-TileColor" content="#F4F4F4"/>
-<meta name="msapplication-TileImage" content="/static/5.66.0/icons/favicons/mstile-144x144.png">
-<meta name="msapplication-square70x70logo" content="/static/5.66.0/icons/favicons/mstile-70x70.png">
-<meta name="msapplication-square150x150logo" content="/static/5.66.0/icons/favicons/mstile-150x150.png">
-<meta name="msapplication-square310x310logo" content="/static/5.66.0/icons/favicons/mstile-310x310.png">
-<meta name="msapplication-wide310x150logo" content="/static/5.66.0/icons/favicons/mstile-310x150.png">
+<meta name="msapplication-TileImage" content="/static/5.193.0/icons/favicons/mstile-144x144.png">
+<meta name="msapplication-square70x70logo" content="/static/5.193.0/icons/favicons/mstile-70x70.png">
+<meta name="msapplication-square150x150logo" content="/static/5.193.0/icons/favicons/mstile-150x150.png">
+<meta name="msapplication-square310x310logo" content="/static/5.193.0/icons/favicons/mstile-310x310.png">
+<meta name="msapplication-wide310x150logo" content="/static/5.193.0/icons/favicons/mstile-310x150.png">
 
 
 					
-					<script id="schema-lifestyle_1-0" class="comp  schema-lifestyle mntl-schema-unified" type="application/ld+json" data-defer="load" data-defer-params></script>		
+					<script id="schema-lifestyle_1-0" class="comp  schema-lifestyle mntl-schema-unified" type="application/ld+json">				
+{
+"@context": "http://schema.org",
+
+"@type": ["Recipe"]
+,"headline": "One-Pot Chicken and Rice Soup"
+,"datePublished": "2017-10-23T05:00:31.000-04:00"
+,"dateModified": "2022-02-10T22:23:06.339-05:00"
+,"author": [
+{"@type": "Person"
+,"name": "Aaron Hutcherson"
+,"description": "Aaron has over 10 years recipe development experience for his blog The Hungry Hutch. He has written for NYTimes, Washington Post, Simply Recipes, and others."
+,"url": "https://www.simplyrecipes.com/aaron-hutcherson-5091796"
+,"sameAs": [
+"https://www.facebook.com/thehungryhutch/",
+"https://twitter.com/thehungryhutch",
+"https://www.instagram.com/thehungryhutch/"
+]
+,"knowsAbout": ["Comfort food, Baking, Soul food"]
+,"alumniOf": [
+{
+"@type": "Organization",
+"Name": "Classic Culinary Arts from the Institute of Culinary Education "
+}
+]
+}
+]
+,"description": "One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&#39;re done. It&#39;s the easiest soup ever, ready in under an hour."
+,"image": [
+{
+"@type": "ImageObject",
+"url": "https://www.simplyrecipes.com/thmb/rMTPadQOWL-eu59WVqGf9d8quYU=/1333x1333/smart/filters:no_upscale()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg",
+"height": 1333,
+"width": 1333
+},
+{
+"@type": "ImageObject",
+"url": "https://www.simplyrecipes.com/thmb/5XUn1ycNHcTAbCk3QY85GL0kkXE=/1777x1333/smart/filters:no_upscale()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg",
+"height": 1333,
+"width": 1777
+},
+{
+"@type": "ImageObject",
+"url": "https://www.simplyrecipes.com/thmb/SnRhWn7gy6-JXTF6UIEWSzaqG40=/2000x1125/smart/filters:no_upscale()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg",
+"height": 1125,
+"width": 2000
+}
+]
+,"video": {
+"@type": "VideoObject",
+"contentUrl": "https://cdn.jwplayer.com/videos/28e6KvWZ-tXzwfO7V.mp4",
+"description": "One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they're done. It's the easiest soup ever, ready in under an hour.",
+"duration": "PT1M",
+"name": "One-Pot Chicken and Rice Soup",
+"thumbnailUrl": "https://cdn.jwplayer.com/v2/media/28e6KvWZ/poster.jpg?width=720",
+"uploadDate": "2021-01-20T22:29:29.631Z"}
+,"publisher": {
+"@type": "Organization",
+"name": "Simply Recipes",
+"url": "https://www.simplyrecipes.com",
+"logo": {
+"@type": "ImageObject",
+"url": "https://www.simplyrecipes.com/thmb/QvixEwCD02s_lnkgkVb6mHwKS7c=/1125x320/filters:no_upscale():max_bytes(150000):strip_icc()/SimplyRecipesLogoTransparent-07a297c54b2142ae9c079abb2f0fa639.png",
+"width": 1125,
+"height": 320
+},
+"brand": "Simply Recipes"
+, "publishingPrinciples": "https://www.simplyrecipes.com/about-us-5096129#toc-editorial-guidelines"
+, "sameAs" : [
+"https://www.facebook.com/simplyrecipes",
+"https://www.instagram.com/simplyrecipes",
+"https://www.pinterest.com/simplyrecipes"
+]
+}
+,"name": "One-Pot Chicken and Rice Soup"
+,"aggregateRating": {
+"@type": "AggregateRating",
+"ratingValue": "4.7",
+"ratingCount": "7"
+}
+,"cookTime": "PT30M"
+,"keywords": "1-Pot, Comfort Food, Freezer-friendly, Make-ahead, Quick and Easy, American, Gluten-Free, Dinner, Soup, Favorite Fall, Favorite Winter"
+,"nutrition": {
+"@type": "NutritionInformation"
+,"calories": "160 kcal"
+,"carbohydrateContent": "10 g"
+,"cholesterolContent": "62 mg"
+,"fiberContent": "1 g"
+,"proteinContent": "23 g"
+,"saturatedFatContent": "1 g"
+,"sodiumContent": "878 mg"
+,"sugarContent": "2 g"
+,"fatContent": "2 g"
+,"servingSize": "6 to 8 servings (makes about 3 quarts)"
+,"unsaturatedFatContent": "0 g"
+}
+,"prepTime": "PT15M"
+, "recipeCategory": ["Dinner","Soup","1-Pot","Comfort Food","Freezer-friendly","Make-ahead","Quick and Easy"]
+,"recipeCuisine": ["American"]
+,"recipeIngredient": [
+"2 bone-in chicken breasts, skin removed (1 to 1 1/2 pounds)",
+"1 cup long-grain white rice, like basmati",
+"2 celery ribs, diced small",
+"2 medium carrots, peeled and diced small",
+"1 onion, diced small",
+"2 cloves garlic, peeled but left whole",
+"1 teaspoon salt, plus more to taste (see Recipe Note)",
+"1/2 teaspoon ground black pepper",
+"2 quarts unsalted or low-sodium chicken stock",
+"Juice of 1/2 lemon (about 3 tablespoons)",
+"Chopped fresh parsley, for serving" ]
+,"recipeInstructions": [
+{
+"@type": "HowToStep"
+,"image": {
+"@type": "ImageObject",
+"url": "https://www.simplyrecipes.com/thmb/rcxx83jXbzVTEyMkDWgFNF4GIww=/1200x800/filters:no_upscale()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg",
+"height": 800,
+"width": 1200
+}
+,"text": "Assemble the soup and bring to a simmer: Combine the chicken, white rice, celery, carrots, onions, garlic, salt, and pepper in a large pot. Add the chicken stock and bring to a boil over high heat. Once the soup is boiling, reduce the heat to keep the soup at a gentle simmer."
+} ,{
+"@type": "HowToStep"
+,"text": "Simmer for about 25 minutes: As the soup simmers, skim off any foam that collects on the surface with a spoon. Continue to simmer until the rice and vegetables are tender, about 25 minutes. Remove the soup from heat."
+} ,{
+"@type": "HowToStep"
+,"image": {
+"@type": "ImageObject",
+"url": "https://www.simplyrecipes.com/thmb/C4CcW_vhpwe6J_u56o84t7S38mM=/1200x800/filters:no_upscale()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg",
+"height": 800,
+"width": 1200
+}
+,"text": "Shred the chicken and make the garlic paste: Remove the chicken and garlic cloves using a slotted spoon or tongs. Transfer the chicken breasts to a bowl and shred with two forks. Discard the bones. Return the shredded chicken to the pot. Smash the garlic cloves into a paste against a cutting board using a fork or the flat of your knife. Stir the paste back into the soup."
+} ,{
+"@type": "HowToStep"
+,"text": "Season and serve: Stir the lemon juice into to the soup, and taste. The soup should taste rich, barely salty, and with just a hint of lemon. Add more salt or lemon juice as needed until it tastes good to you. Divide among bowls and sprinkle with some parsley for serving. Leftovers will keep for about a week refrigerated, or up to 3 months frozen. Links: Chicken Noodle Soup here on Simply Recipes, also great for when you are under the weather!"
+} ]
+,"recipeYield": "8"
+,"totalTime": "PT45M"
+,"review": [
+{
+"@type": "Review",
+"author": {
+"@type": "Person",
+"name": "Jj ply"
+},
+"reviewBody": "Not enough veggies. 25 min cook time results in soggy mess. Good flavor but visually unappealing"
+}
+,
+{
+"@type": "Review",
+"author": {
+"@type": "Person",
+"name": "Kathleen"
+},
+"reviewBody": "Skewer the garlic cloves together to make them easier to find and mash when the soup is finished."
+}
+,
+{
+"@type": "Review",
+"author": {
+"@type": "Person",
+"name": "SHERIHAN"
+},
+"reviewBody": "Just made this soup today and it was heartwarming and delicious!\n\nI used what I had in my pantry already, chicken breasts, 1-quart veggie broth and 1-quart chicken, and asparagus instead of celery.\n\nI loved it and my roommate loved it as well and commented on the lemon addition!\n\nThis soup will be my go-to.\n\nThe only adjustment I would make is use less rice next time."
+}
+,
+{
+"@type": "Review",
+"author": {
+"@type": "Person",
+"name": "Andrea"
+},
+"reviewBody": "Easy and delish. I Need to add more aromatics since I am a no salt kind of person."
+}
+,
+{
+"@type": "Review",
+"author": {
+"@type": "Person",
+"name": "PThomas"
+},
+"reviewBody": "I'd already made up a chicken and rice recipe that's almost identical to this except it has fresh thyme and a bay leaf in the broth while simmering, and no lemon juice. Next time I'm going to add the lemon!"
+}
+]
+,"mainEntityOfPage": {
+"@type": ["WebPage"]
+,"@id": "https://www.simplyrecipes.com/recipes/one_pot_chicken_and_rice_soup/"
+,"breadcrumb": {
+"@type": "BreadcrumbList",
+"itemListElement": [
+{
+"@type": "ListItem",
+"position": 1,
+"item": {
+"@id": "https://www.simplyrecipes.com/soup-recipes-5091377",
+"name": "Soups"
+}
+}
+,
+{
+"@type": "ListItem",
+"position": 2,
+"item": {
+"@id": "https://www.simplyrecipes.com/chicken-soup-recipes-5091375",
+"name": "Chicken Soups"
+}
+}
+,
+{
+"@type": "ListItem",
+"position": 3,
+"item": {
+"@id": "https://www.simplyrecipes.com/recipes/one_pot_chicken_and_rice_soup/",
+"name": "One-Pot Chicken and Rice Soup Recipe"
+}
+}
+]
+}
+}
+, "about": [
+]		
+}
+</script>		
 
 </head>		
 <body>
 <svg class="mntl-svg-resource is-hidden">
 <defs>
-<symbol id="icon-breadcrumb-arrow">
-<svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg">
-<line y1="-0.7" x2="7.86373" y2="-0.7" transform="matrix(0.694636 -0.719361 0.694636 0.719361 1.91895 11.7236)" stroke="#B5460F" stroke-width="1.4"/>
-<line y1="-0.7" x2="7.86373" y2="-0.7" transform="matrix(0.694636 0.719361 0.694636 -0.719361 1.91895 0.423828)" stroke="#B5460F" stroke-width="1.4"/>
-</svg>
-</symbol>
+<symbol id="icon-arrow--double">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23.929 15.643">
+<path d="M.594,2.118A13.286,13.286,0,0,0,0,4.529C1.611,5.4,3.337,5.788,5,6.565c1.069.5,3.231,1.683,4.2,2.123-1.129.975-5.156,2.043-6.537,2.882A7.194,7.194,0,0,1,.31,12.73a11.93,11.93,0,0,0,.46,2.558c1.513.025,3.615-1.727,5.066-2.422,1.536-.736,3.443-2.118,4.985-2.786,2.449-1.061,2.868-1.674.363-3.214A40.161,40.161,0,0,0,5.957,4.4,47.343,47.343,0,0,0,.8,2.087"/><path d="M9.886,0C9.338.214,8.992,1.582,8.6,2.277c1.736.594,4.291,1.786,6.222,2.555C16.455,5.481,19.639,6.074,20,7.2c.125.858-6.958,4.388-10.094,6.472a8.122,8.122,0,0,1,1.474,1.969c1.116-.044,2.543-1.6,3.473-2.21,1.165-.767,2.394-1.409,3.567-2.164,1.391-.9,2.745-1.853,4.13-2.728,2.233-1.41,1.581-2.463-.785-3.661-2.314-1.171-5.013-1.763-7.361-3.019A18.137,18.137,0,0,0,9.886,0"/>
+</svg> </symbol>
 <symbol id="icon-info">
 <svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <ellipse cx="8" cy="8.19506" rx="8" ry="7.80492" fill="currentColor"/>
 <path d="M7.28223 4.79688C7.10645 4.61133 7.01855 4.39648 7.01855 4.15234C7.01855 3.89844 7.10645 3.68359 7.28223 3.50781C7.45801 3.33203 7.67285 3.24414 7.92676 3.24414C8.18066 3.24414 8.39551 3.33203 8.57129 3.50781C8.74707 3.68359 8.83496 3.89844 8.83496 4.15234C8.83496 4.39648 8.74707 4.61133 8.57129 4.79688C8.39551 4.97266 8.18066 5.06055 7.92676 5.06055C7.67285 5.06055 7.45801 4.97266 7.28223 4.79688ZM8.80566 10.9199C8.80566 11.5156 8.84473 11.9551 8.92285 12.2383C8.94238 12.3066 9.07422 12.3799 9.31836 12.458C9.5625 12.5264 9.72852 12.5605 9.81641 12.5605C9.85547 12.5605 9.875 12.6338 9.875 12.7803C9.88477 12.917 9.87988 13.0098 9.86035 13.0586C9.79199 13.0488 9.52832 13.0293 9.06934 13C8.62012 12.9707 8.28809 12.9561 8.07324 12.9561C7.8291 12.9561 7.48242 12.9707 7.0332 13C6.59375 13.0293 6.33984 13.0488 6.27148 13.0586C6.23242 13.0195 6.21289 12.9268 6.21289 12.7803C6.21289 12.6338 6.23242 12.5605 6.27148 12.5605C6.37891 12.5605 6.55469 12.5264 6.79883 12.458C7.04297 12.3799 7.1748 12.3066 7.19434 12.2383C7.2627 11.9453 7.29688 11.5889 7.29688 11.1689V8.78125C7.29688 8.32227 7.21875 8.00977 7.0625 7.84375C6.97461 7.74609 6.8623 7.67285 6.72559 7.62402C6.58887 7.5752 6.47168 7.5459 6.37402 7.53613C6.27637 7.52637 6.22754 7.51172 6.22754 7.49219C6.22754 7.20898 6.25684 7.0625 6.31543 7.05273C6.58887 7.0332 6.98438 6.97461 7.50195 6.87695C8.01953 6.7793 8.40527 6.69141 8.65918 6.61328C8.66895 6.61328 8.68848 6.6084 8.71777 6.59863C8.75684 6.58887 8.77637 6.58398 8.77637 6.58398C8.8252 6.58398 8.86426 6.61816 8.89355 6.68652C8.92285 6.75488 8.93262 6.80859 8.92285 6.84766C8.84473 7.47266 8.80566 7.89258 8.80566 8.10742V10.9199Z" fill="black"/>
 </svg> </symbol>
-<symbol id="icon-bio-avatar">
-<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-<g fill="none" fill-rule="evenodd">
-<circle fill="currentColor" cx="10" cy="10" r="10"/>
-<path d="M16 18a9.979 9.979 0 0 1-2.542 1.386v-4.52c0-.072-.046-.12-.114-.12h-.357c-.068 0-.2 0-.2.12v4.74c-.885.257-1.82.394-2.787.394-.971 0-1.91-.138-2.798-.397v-4.737c0-.072-.09-.12-.158-.12h-.388c-.068 0-.114.048-.114.12v4.52A9.979 9.979 0 0 1 4 18.001v-3.135c0-1.908 1.626-3.481 3.595-3.481h4.787c1.992 0 3.618 1.573 3.618 3.48v3.136z" fill="#FFF" fill-rule="nonzero"/>
-<circle fill="#FFF" fill-rule="nonzero" cx="10" cy="7.231" r="3.231"/>
-<circle stroke="currentColor" cx="10" cy="10" r="9.5"/>
-</g>
-</svg>
-</symbol>
-<symbol id="icon-facebook--follow-footer">
-<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17.7629" cy="17.7629" r="17.7629"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M21.1173 18.7207L21.5861 15.7666H18.6534V13.8496C18.6534 13.0414 19.063 12.2536 20.3766 12.2536H21.71V9.73866C21.71 9.73866 20.4999 9.53906 19.343 9.53906C16.9276 9.53906 15.3489 10.9538 15.3489 13.5151V15.7666H12.6641V18.7207H15.3489V25.9862C15.9535 25.9862 18.4206 25.9862 18.6534 25.9862V18.7207H21.1173Z" fill="white"/>
-</svg>
-</symbol>
-<symbol id="icon-pinterest--follow-footer">
-<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17.7629" cy="17.7629" r="17.7629"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M16.7462 20.4169C16.2891 22.6806 15.7313 24.8515 14.0795 25.9862C13.5692 22.5636 14.8286 19.9935 15.4134 17.2649C14.4168 15.6779 15.5332 12.4853 17.6355 13.2721C20.222 14.2396 15.395 19.17 18.6359 19.7867C22.0188 20.4295 23.4 14.2358 21.3026 12.2214C18.2715 9.31307 12.4779 12.1548 13.1903 16.3187C13.3642 17.3374 14.4758 17.6458 13.6349 19.0511C11.695 18.6442 11.1151 17.1973 11.1905 15.268C11.3103 12.1113 14.1907 9.90074 17.0797 9.59434C20.7333 9.20772 24.1626 10.8634 24.6362 14.113C25.1688 17.7811 22.9873 21.7536 19.0795 21.4675C18.0211 21.3892 17.5765 20.8934 16.7462 20.4169Z" fill="white"/>
-</svg>
-</symbol>
-<symbol id="icon-instagram--follow-footer">
-<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17.7629" cy="17.7629" r="17.7629"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M21.0353 9.53906H14.49C11.76 9.53906 9.53906 11.7024 9.53906 14.3613V21.1639C9.53906 23.8229 11.76 25.9862 14.49 25.9862H21.0353C23.7653 25.9862 25.9862 23.8229 25.9862 21.1639V14.3613C25.9862 11.7024 23.7653 9.53906 21.0353 9.53906ZM24.1984 21.1639C24.1984 22.8627 22.7794 24.2448 21.0353 24.2448H14.49C12.7459 24.2448 11.3269 22.8627 11.3269 21.1639V14.3613C11.3269 12.6625 12.7459 11.2804 14.49 11.2804H21.0353C22.7794 11.2804 24.1984 12.6625 24.1984 14.3613V21.1639ZM13.0711 17.7406C13.0711 15.1763 15.2005 13.0975 17.7945 13.1714C19.2411 13.2125 20.4475 13.6936 21.2834 14.5627C22.0776 15.3886 22.4824 16.4955 22.454 17.7638C22.4267 18.9786 21.9342 20.1167 21.0671 20.9684C20.1862 21.8337 19.0127 22.3102 17.7627 22.3102C15.1758 22.3102 13.0711 20.2603 13.0711 17.7406ZM17.7627 20.1818C19.1373 20.1818 20.2384 19.0993 20.2693 17.7173C20.2803 17.2289 20.1884 16.5375 19.6885 16.0178C19.2595 15.5716 18.5826 15.3231 17.7308 15.2989C17.7079 15.2982 17.6851 15.2979 17.6623 15.2979C17.0279 15.2979 16.4276 15.5515 15.972 16.0119C15.5105 16.4784 15.2563 17.0923 15.2563 17.7406C15.2563 19.0867 16.3806 20.1818 17.7627 20.1818ZM22.1956 12.4228C21.638 12.4228 21.1861 12.863 21.1861 13.406C21.1861 13.949 21.638 14.3892 22.1956 14.3892C22.7531 14.3892 23.2051 13.949 23.2051 13.406C23.2051 12.863 22.7531 12.4228 22.1956 12.4228Z" fill="white"/>
-</svg>
-</symbol>
-<symbol id="icon-twitter--follow-footer">
-<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17.7629" cy="17.7629" r="17.7629"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M26.8086 12.114C26.1433 12.4109 25.4277 12.6116 24.6768 12.7029C25.4433 12.2398 26.0314 11.5079 26.3086 10.6352C25.5906 11.0637 24.7977 11.3746 23.9514 11.5416C23.2745 10.8153 22.3106 10.3613 21.2422 10.3613C19.1918 10.3613 17.5304 12.0351 17.5304 14.0986C17.5304 14.3922 17.5633 14.6768 17.6266 14.9507C14.5423 14.7953 11.8068 13.3074 9.97682 11.0464C9.65688 11.5975 9.47429 12.2398 9.47429 12.925C9.47429 14.2212 10.1298 15.3652 11.125 16.0347C10.5164 16.015 9.94474 15.8472 9.44386 15.5676V15.6153C9.44386 17.4255 10.7228 18.9356 12.422 19.2794C12.1103 19.3641 11.783 19.411 11.4441 19.411C11.2048 19.411 10.972 19.3871 10.7458 19.3427C11.2179 20.8272 12.589 21.908 14.2125 21.9384C12.9426 22.941 11.3421 23.5381 9.6026 23.5381C9.30322 23.5381 9.00713 23.52 8.7168 23.4863C10.3593 24.5465 12.3102 25.165 14.4066 25.165C21.234 25.165 24.9671 19.4702 24.9671 14.5321C24.9671 14.37 24.963 14.2097 24.9564 14.0493C25.6819 13.5221 26.3111 12.8641 26.8086 12.1148V12.114Z" fill="white"/>
-</svg>
-</symbol>
-<symbol id="icon-website--follow-footer">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 103.51 103.42">
-<g data-name="Layer 2"><g data-name="Layer 1"><g data-name="562rng.tif"><path d="M27.54,38.81c.88-.64,1.72-1.32,2.63-1.9q13.3-8.41,27.29-1.19A23.34,23.34,0,0,1,63.15,40a6.5,6.5,0,0,1,.39,9.15,6.43,6.43,0,0,1-8.6,1c-1.15-.83-2.16-1.86-3.35-2.6a13,13,0,0,0-16,1.86Q26.22,58.64,16.93,68a13.1,13.1,0,0,0,17,19.82,13.66,13.66,0,0,0,1.68-1.45q4.47-4.44,8.9-8.9a6.55,6.55,0,0,1,10.18,8.2,2.21,2.21,0,0,0-.18.34L43.76,96.73l-.43.28a41.34,41.34,0,0,1-4.39,3c-9.34,4.89-18.5,4.47-27.39-1.21-1-.63-1.88-1.4-2.82-2.1l-2-2c-.09-.14-.18-.29-.28-.43a41.34,41.34,0,0,1-3-4.39c-4.89-9.34-4.47-18.5,1.22-27.39.63-1,1.39-1.88,2.09-2.82Z"/><path d="M75.92,64.57c-.88.64-1.72,1.33-2.63,1.9Q60,74.88,46,67.66a23.34,23.34,0,0,1-5.69-4.23,6.5,6.5,0,0,1-.39-9.15,6.42,6.42,0,0,1,8.6-1c1.15.82,2.16,1.85,3.35,2.6a13,13,0,0,0,16-1.87q9.33-9.28,18.62-18.62a13.1,13.1,0,0,0-17-19.83,14.65,14.65,0,0,0-1.68,1.46q-4.47,4.43-8.9,8.89a6.55,6.55,0,0,1-10.18-8.2A1.83,1.83,0,0,0,49,17.4L59.7,6.65a4.5,4.5,0,0,0,.43-.27c1.07-.8,2.08-1.68,3.2-2.37a26,26,0,0,1,36.75,9.52c5,9.26,4.47,18.49-1.22,27.37-.63,1-1.39,1.88-2.09,2.82Z"/></g></g></g>
+<symbol id="reviewer-icon">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 153.4 122.3">
+<path d="M150.1,7.2l-3.9-3.9c-4.3-4.3-11.4-4.3-15.8,0L55.2,87.4L22.9,55.2c-4.3-4.3-11.5-4.3-15.8,0l-3.9,3.9c-4.3,4.3-4.3,11.4,0,15.8L43.1,115c0.1,0.1,0.1,0.1,0.2,0.2l3.9,3.9c4.3,4.3,11.4,4.3,15.8,0l87.2-96.1C154.5,18.6,154.5,11.5,150.1,7.2z"/>
 </svg> </symbol>
-<symbol id="icon-linkedIn--follow-footer">
-<svg viewBox="0 0 145 144" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g stroke="none" stroke-width="1" fill-rule="evenodd">
-<g transform="translate(-1136.000000, -861.000000)">
-<path d="M1258.708,983.707 L1237.364,983.707 L1237.364,950.287 C1237.364,942.318 1237.218,932.067 1226.265,932.067 C1215.152,932.067 1213.446,940.748 1213.446,949.711 L1213.446,983.707 L1192.106,983.707 L1192.106,914.985 L1212.591,914.985 L1212.591,924.375 L1212.877,924.375 C1215.729,918.973 1222.696,913.277 1233.087,913.277 C1254.715,913.277 1258.708,927.511 1258.708,946.013 L1258.708,983.707 Z M1168.034,905.591 C1161.188,905.591 1155.648,900.042 1155.648,893.205 C1155.648,886.374 1161.188,880.825 1168.034,880.825 C1174.863,880.825 1180.412,886.374 1180.412,893.205 C1180.412,900.042 1174.863,905.591 1168.034,905.591 Z M1157.35,983.707 L1178.71,983.707 L1178.71,914.985 L1157.35,914.985 L1157.35,983.707 Z M1269.345,861 L1146.629,861 C1140.765,861 1136,865.648 1136,871.376 L1136,994.61 C1136,1000.345 1140.765,1005 1146.629,1005 L1269.345,1005 C1275.219,1005 1280.004,1000.345 1280.004,994.61 L1280.004,871.376 C1280.004,865.648 1275.219,861 1269.345,861 Z" id="Fill-1"></path>
-</g>
-</g>
+<symbol id="recipe-tester-icon">
+<svg width="22" height="21" viewBox="0 0 22 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 16.9526C20.0001 17.5049 20.4478 17.9526 21.0001 17.9526C21.5523 17.9526 22.0001 17.5049 22 16.9526L20 16.9526ZM1 5V4C0.653422 4 0.331556 4.17945 0.149349 4.47427C-0.0328574 4.76909 -0.0494214 5.13723 0.105573 5.44721L1 5ZM18.4581 8.59131L17.4688 8.44534L18.4581 8.59131ZM17.1251 17.6255L18.1144 17.7714L17.1251 17.6255ZM2.55515 10.4629L3.57765 17.7504L5.55825 17.4725L4.53575 10.185L2.55515 10.4629ZM6.54855 20.3335H15.1465V18.3335H6.54855V20.3335ZM18.1144 17.7714L19.4473 8.73728L17.4688 8.44534L16.1358 17.4795L18.1144 17.7714ZM20 8.77783L20 16.9526L22 16.9526L22 8.77782L20 8.77783ZM0.105573 5.44721L2.45928 10.1546L4.24813 9.2602L1.89443 4.55279L0.105573 5.44721ZM1 6H15V4H1V6ZM19.7222 6.5C18.5926 6.5 17.6336 7.32785 17.4688 8.44534L19.4473 8.73728C19.4675 8.60097 19.5844 8.5 19.7222 8.5V6.5ZM15.1465 20.3335C16.6342 20.3335 17.8972 19.2432 18.1144 17.7714L16.1358 17.4795C16.0634 17.9701 15.6424 18.3335 15.1465 18.3335V20.3335ZM3.57765 17.7504C3.78549 19.2317 5.05275 20.3335 6.54855 20.3335V18.3335C6.04995 18.3335 5.62753 17.9662 5.55825 17.4725L3.57765 17.7504ZM4.53575 10.185C4.4906 9.86319 4.39346 9.55086 4.24813 9.2602L2.45928 10.1546C2.50772 10.2515 2.5401 10.3556 2.55515 10.4629L4.53575 10.185ZM19.7222 8.5C19.8756 8.5 20 8.62439 20 8.77783L22 8.77782C22 7.51982 20.9802 6.5 19.7222 6.5V8.5Z" fill="#117777"/>
+<path d="M20.9874 3.48744C21.6709 2.80402 21.6709 1.69598 20.9874 1.01256C20.304 0.329146 19.196 0.329146 18.5126 1.01256L9.75 9.77513L8.48744 8.51256C7.80402 7.82915 6.69598 7.82915 6.01256 8.51256C5.32915 9.19598 5.32915 10.304 6.01256 10.9874L8.51256 13.4874C9.19598 14.1709 10.304 14.1709 10.9874 13.4874L20.9874 3.48744Z" fill="#117777" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>
 </symbol>
-<symbol id="icon-instagram--follow-bio">
-<svg viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M17.3086 0.416504H7.69136C3.68004 0.416504 0.416626 3.59516 0.416626 7.50214V17.4975C0.416626 21.4046 3.68004 24.5832 7.69136 24.5832H17.3086C21.32 24.5832 24.5833 21.4046 24.5833 17.4975V7.50214C24.5833 3.59516 21.32 0.416504 17.3086 0.416504ZM21.9564 17.4976C21.9564 19.9937 19.8714 22.0245 17.3086 22.0245H7.69136C5.12857 22.0245 3.04361 19.9937 3.04361 17.4976V7.50217C3.04361 5.006 5.12857 2.97524 7.69136 2.97524H17.3086C19.8714 2.97524 21.9564 5.006 21.9564 7.50217V17.4976ZM5.60644 12.4674C5.60644 8.69964 8.73531 5.6451 12.5468 5.75368C14.6723 5.8141 16.445 6.52097 17.6731 7.79802C18.8402 9.01152 19.435 10.638 19.3933 12.5015C19.3532 14.2865 18.6294 15.9588 17.3553 17.2102C16.0611 18.4816 14.3368 19.1818 12.5 19.1818C8.6989 19.1818 5.60644 16.1698 5.60644 12.4674ZM12.5 16.0545C14.5198 16.0545 16.1377 14.4639 16.1832 12.4333C16.1993 11.7156 16.0643 10.6997 15.3298 9.936C14.6994 9.28051 13.7048 8.91529 12.4532 8.87968C12.4195 8.87873 12.386 8.87829 12.3526 8.87829C11.4204 8.87829 10.5384 9.25088 9.86889 9.92739C9.19073 10.6128 8.81719 11.5149 8.81719 12.4674C8.81719 14.4453 10.4693 16.0545 12.5 16.0545ZM19.0135 4.65376C18.1943 4.65376 17.5302 5.30057 17.5302 6.0985C17.5302 6.89636 18.1943 7.54317 19.0135 7.54317C19.8327 7.54317 20.4968 6.89636 20.4968 6.0985C20.4968 5.30057 19.8327 4.65376 19.0135 4.65376Z" />
+<symbol id="fact-checker-icon">
+<svg width="23" height="21" viewBox="0 0 23 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="11" r="9" stroke="#117777" stroke-width="2"/>
+<path d="M21.091 4.84099C21.9697 3.96231 21.9697 2.53769 21.091 1.65901C20.2123 0.78033 18.7877 0.78033 17.909 1.65901L9.5 10.068L8.59099 9.15901C7.71231 8.28033 6.28769 8.28033 5.40901 9.15901C4.53033 10.0377 4.53033 11.4623 5.40901 12.341L7.90901 14.841C8.78769 15.7197 10.2123 15.7197 11.091 14.841L21.091 4.84099Z" fill="#117777" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>
 </symbol>
-<symbol id="icon-facebook--follow-bio">
+<symbol id="nutrition-reviewer-icon">
+<svg width="27" height="24" viewBox="0 0 27 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5 2.19296L13.5 2.19298C13.5 2.19297 13.5 2.19297 13.5 2.19296C16.424 -0.730986 21.1646 -0.730986 24.0886 2.19296C27.0125 5.1169 27.0125 9.85755 24.0886 12.7815C24.0886 12.7815 24.0886 12.7815 24.0886 12.7815C24.0878 12.7823 24.0871 12.783 24.0863 12.7838L13.5 23.3701L2.91147 12.7815L2.91149 12.7815L2.91146 12.7815C-0.0124804 9.85755 -0.0124804 5.1169 2.91146 2.19296C5.83541 -0.730986 10.5761 -0.730986 13.5 2.19296Z" fill="#DAE8FB"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M14.4999 6.13956C14.4999 5.58727 14.0522 5.13956 13.4999 5.13956C12.9476 5.13956 12.4999 5.58727 12.4999 6.13956V10.0812H8.55838C8.0061 10.0812 7.55838 10.5289 7.55838 11.0812C7.55838 11.6334 8.0061 12.0812 8.55838 12.0812H12.4999V16.0227C12.4999 16.575 12.9476 17.0227 13.4999 17.0227C14.0522 17.0227 14.4999 16.575 14.4999 16.0227V12.0812H18.4415C18.9938 12.0812 19.4415 11.6334 19.4415 11.0812C19.4415 10.5289 18.9938 10.0812 18.4415 10.0812H14.4999V6.13956Z" fill="#576C8D"/>
+</svg>
+</symbol>
+<symbol id="icon-facebook">
 <svg viewBox="0 0 12 20" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M10.5592 10.8666L11.1055 7.42403H7.68789V5.19002C7.68789 4.2482 8.16528 3.33018 9.69606 3.33018H11.2499V0.399353C11.2499 0.399353 9.83972 0.166748 8.49152 0.166748C5.67677 0.166748 3.83706 1.81545 3.83706 4.80024V7.42403H0.708252V10.8666H3.83706V19.3334C4.54159 19.3334 7.41659 19.3334 7.68789 19.3334V10.8666H10.5592Z" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.5592 10.8666L11.1055 7.42403H7.68789V5.19002C7.68789 4.2482 8.16528 3.33018 9.69606 3.33018H11.2499V0.399353C11.2499 0.399353 9.83972 0.166748 8.49152 0.166748C5.67677 0.166748 3.83706 1.81545 3.83706 4.80024V7.42403H0.708252V10.8666H3.83706V19.3334C4.54159 19.3334 7.41659 19.3334 7.68789 19.3334V10.8666H10.5592Z"/>
 </svg>
 </symbol>
-<symbol id="icon-linkedIn--follow-bio">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.88 12.86">
-<path d="M4.77,7.84H7.44v8.59H4.77V7.84ZM6.11,3.57A1.55,1.55,0,1,1,4.56,5.12,1.55,1.55,0,0,1,6.11,3.57" transform="translate(-4.56 -3.57)"/>
-<path d="M9.12,7.84h2.56V9h0a2.8,2.8,0,0,1,2.53-1.39c2.7,0,3.2,1.78,3.2,4.09v4.71H14.77V12.25c0-1,0-2.28-1.39-2.28s-1.6,1.09-1.6,2.21v4.25H9.12V7.84Z" transform="translate(-4.56 -3.57)"/>
-</svg> </symbol>
-<symbol id="icon-pinterest--follow-bio">
+<symbol id="icon-pinterest">
 <svg viewBox="0 0 17 21" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M7.3151 13.5932C6.78233 16.2312 6.13241 18.761 4.20743 20.0834C3.6127 16.0949 5.08037 13.0999 5.76183 9.9201C4.60053 8.07059 5.9015 4.35016 8.35137 5.26704C11.3656 6.39454 5.74043 12.1402 9.51717 12.8588C13.4595 13.6079 15.0691 6.39004 12.6249 4.04266C9.09253 0.653391 2.34102 3.96494 3.17116 8.81738C3.37391 10.0046 4.66924 10.3639 3.68929 12.0017C1.42865 11.5274 0.752826 9.84126 0.840683 7.59301C0.980354 3.91426 4.33696 1.33823 7.70371 0.981167C11.9614 0.530615 15.9578 2.4601 16.5097 6.24699C17.1304 10.5216 14.5881 15.151 10.0342 14.8176C8.8008 14.7264 8.28266 14.1485 7.3151 13.5932Z" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.3151 13.5932C6.78233 16.2312 6.13241 18.761 4.20743 20.0834C3.6127 16.0949 5.08037 13.0999 5.76183 9.9201C4.60053 8.07059 5.9015 4.35016 8.35137 5.26704C11.3656 6.39454 5.74043 12.1402 9.51717 12.8588C13.4595 13.6079 15.0691 6.39004 12.6249 4.04266C9.09253 0.653391 2.34102 3.96494 3.17116 8.81738C3.37391 10.0046 4.66924 10.3639 3.68929 12.0017C1.42865 11.5274 0.752826 9.84126 0.840683 7.59301C0.980354 3.91426 4.33696 1.33823 7.70371 0.981167C11.9614 0.530615 15.9578 2.4601 16.5097 6.24699C17.1304 10.5216 14.5881 15.151 10.0342 14.8176C8.8008 14.7264 8.28266 14.1485 7.3151 13.5932Z"/>
 </svg>
 </symbol>
-<symbol id="icon-twitter--follow-bio">
+<symbol id="icon-instagram">
+<svg viewBox="0 0 25 25" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M17.3086 0.416504H7.69136C3.68004 0.416504 0.416626 3.59516 0.416626 7.50214V17.4975C0.416626 21.4046 3.68004 24.5832 7.69136 24.5832H17.3086C21.32 24.5832 24.5833 21.4046 24.5833 17.4975V7.50214C24.5833 3.59516 21.32 0.416504 17.3086 0.416504ZM21.9564 17.4976C21.9564 19.9937 19.8714 22.0245 17.3086 22.0245H7.69136C5.12857 22.0245 3.04361 19.9937 3.04361 17.4976V7.50217C3.04361 5.006 5.12857 2.97524 7.69136 2.97524H17.3086C19.8714 2.97524 21.9564 5.006 21.9564 7.50217V17.4976ZM5.60644 12.4674C5.60644 8.69964 8.73531 5.6451 12.5468 5.75368C14.6723 5.8141 16.445 6.52097 17.6731 7.79802C18.8402 9.01152 19.435 10.638 19.3933 12.5015C19.3532 14.2865 18.6294 15.9588 17.3553 17.2102C16.0611 18.4816 14.3368 19.1818 12.5 19.1818C8.6989 19.1818 5.60644 16.1698 5.60644 12.4674ZM12.5 16.0545C14.5198 16.0545 16.1377 14.4639 16.1832 12.4333C16.1993 11.7156 16.0643 10.6997 15.3298 9.936C14.6994 9.28051 13.7048 8.91529 12.4532 8.87968C12.4195 8.87873 12.386 8.87829 12.3526 8.87829C11.4204 8.87829 10.5384 9.25088 9.86889 9.92739C9.19073 10.6128 8.81719 11.5149 8.81719 12.4674C8.81719 14.4453 10.4693 16.0545 12.5 16.0545ZM19.0135 4.65376C18.1943 4.65376 17.5302 5.30057 17.5302 6.0985C17.5302 6.89636 18.1943 7.54317 19.0135 7.54317C19.8327 7.54317 20.4968 6.89636 20.4968 6.0985C20.4968 5.30057 19.8327 4.65376 19.0135 4.65376Z"/>
+</svg>
+</symbol>
+<symbol id="icon-youtube">
+<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
+<circle cx="17.7629" cy="17.7629" r="17.7629"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M26.3877 16.3169C26.3815 15.9699 26.354 15.5313 26.306 15.0014C26.2577 14.4713 26.1887 13.9974 26.0988 13.5799C25.996 13.111 25.7726 12.7158 25.429 12.3946C25.0853 12.0733 24.6854 11.887 24.229 11.8356C22.8026 11.675 20.6473 11.5947 17.7627 11.5947C14.8781 11.5947 12.7226 11.675 11.2963 11.8356C10.8401 11.887 10.4417 12.0733 10.1013 12.3946C9.76075 12.7157 9.53909 13.1109 9.4363 13.5799C9.34001 13.9976 9.26762 14.4714 9.21948 15.0014C9.17134 15.5313 9.14402 15.9698 9.13763 16.3169C9.13112 16.6638 9.12793 17.1456 9.12793 17.7624C9.12793 18.3792 9.13112 18.861 9.13763 19.208C9.14402 19.555 9.17134 19.9935 9.21948 20.5234C9.26762 21.0536 9.3367 21.5274 9.42672 21.9449C9.5295 22.4139 9.75271 22.8091 10.0964 23.1303C10.4402 23.4514 10.8402 23.6378 11.2963 23.6892C12.7226 23.8498 14.878 23.9301 17.7627 23.9301C20.6475 23.9301 22.8026 23.8498 24.229 23.6892C24.6853 23.6378 25.0836 23.4514 25.4242 23.1303C25.7647 22.8091 25.9863 22.4138 26.0891 21.9449C26.1853 21.5274 26.2577 21.0534 26.306 20.5234C26.354 19.9935 26.3813 19.5549 26.3877 19.208C26.3942 18.861 26.3974 18.3792 26.3974 17.7624C26.3974 17.1456 26.3942 16.6638 26.3877 16.3169ZM21.1742 18.2829L16.2401 21.3665C16.1501 21.4308 16.0408 21.4628 15.9123 21.4628C15.8161 21.4628 15.7165 21.4372 15.6137 21.3858C15.4017 21.2701 15.2957 21.0904 15.2957 20.8462V14.6786C15.2957 14.4346 15.4017 14.2547 15.6137 14.139C15.8321 14.0232 16.0409 14.0297 16.2401 14.1583L21.1742 17.2421C21.3669 17.3511 21.4632 17.5247 21.4632 17.7624C21.4632 18.0002 21.3669 18.1737 21.1742 18.2829Z" fill="white"/>
+</svg>
+</symbol>
+<symbol id="icon-twitter">
 <svg viewBox="0 0 23 18" xmlns="http://www.w3.org/2000/svg">
 <g stroke="none" stroke-width="1" fill-rule="evenodd">
 <g transform="translate(-763.000000, -272.000000)">
 <g transform="translate(659.000000, 271.000000)">
 <g transform="translate(104.000000, 1.000000)">
 <g>
-<path d="M23,2.72210643 C22.1505078,3.06083635 21.2479224,3.29310829 20.2922438,3.39956626 C21.2691597,2.8672764 22.0124654,2.02529062 22.3628809,1.01877888 C21.4496768,1.51235675 20.4409049,1.87044266 19.3684211,2.06400261 C18.5083102,1.23169482 17.2871653,0.709082957 15.9279778,0.709082957 C13.3264081,0.709082957 11.2132964,2.63500446 11.2132964,5.00611384 C11.2132964,5.34484375 11.255771,5.67389567 11.3407202,5.98359159 C7.41181902,5.80938763 3.9289012,4.09638208 1.60341644,1.49300075 C1.19990766,2.13174859 0.966297322,2.8672764 0.966297322,3.65119419 C0.966297322,5.14160581 1.79455217,6.45781347 3.0687904,7.23205327 C2.29362881,7.21269727 1.57156048,7.01913732 0.934441367,6.69008541 L0.934441367,6.74815339 C0.923822715,8.83860085 2.54847645,10.5806404 4.71468144,10.9774383 C4.32179132,11.0742183 3.89704524,11.1322863 3.47229917,11.1322863 C3.16435826,11.1322863 2.87765466,11.1032523 2.58033241,11.0548623 C3.18559557,12.7678678 4.92705448,14.0066515 6.98707295,14.0453635 C5.37303786,15.1970452 3.33425669,15.884183 1.1255771,15.884183 C0.743305633,15.884183 0.371652816,15.864827 0,15.826115 C2.09187442,17.0455427 4.56602031,17.7617145 7.23130194,17.7617145 C15.9173592,17.7617145 20.6638966,11.2097102 20.6638966,5.51904771 C20.6638966,5.33516576 20.6638966,5.15128381 20.6532779,4.96740185 C21.566482,4.34801001 22.3734995,3.59312621 23,2.72210643 Z" />
+<path d="M23,2.72210643 C22.1505078,3.06083635 21.2479224,3.29310829 20.2922438,3.39956626 C21.2691597,2.8672764 22.0124654,2.02529062 22.3628809,1.01877888 C21.4496768,1.51235675 20.4409049,1.87044266 19.3684211,2.06400261 C18.5083102,1.23169482 17.2871653,0.709082957 15.9279778,0.709082957 C13.3264081,0.709082957 11.2132964,2.63500446 11.2132964,5.00611384 C11.2132964,5.34484375 11.255771,5.67389567 11.3407202,5.98359159 C7.41181902,5.80938763 3.9289012,4.09638208 1.60341644,1.49300075 C1.19990766,2.13174859 0.966297322,2.8672764 0.966297322,3.65119419 C0.966297322,5.14160581 1.79455217,6.45781347 3.0687904,7.23205327 C2.29362881,7.21269727 1.57156048,7.01913732 0.934441367,6.69008541 L0.934441367,6.74815339 C0.923822715,8.83860085 2.54847645,10.5806404 4.71468144,10.9774383 C4.32179132,11.0742183 3.89704524,11.1322863 3.47229917,11.1322863 C3.16435826,11.1322863 2.87765466,11.1032523 2.58033241,11.0548623 C3.18559557,12.7678678 4.92705448,14.0066515 6.98707295,14.0453635 C5.37303786,15.1970452 3.33425669,15.884183 1.1255771,15.884183 C0.743305633,15.884183 0.371652816,15.864827 0,15.826115 C2.09187442,17.0455427 4.56602031,17.7617145 7.23130194,17.7617145 C15.9173592,17.7617145 20.6638966,11.2097102 20.6638966,5.51904771 C20.6638966,5.33516576 20.6638966,5.15128381 20.6532779,4.96740185 C21.566482,4.34801001 22.3734995,3.59312621 23,2.72210643 Z"/>
 </g>
 </g>
 </g>
@@ -340,9 +715,14 @@ Mntl.PageView.init(pageViewDataAsJSON);
 </g>
 </svg>
 </symbol>
-<symbol id="icon-website--follow-bio">
+<symbol id="icon-website">
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 103.51 103.42">
 <path d="M27.54,38.81c.88-.64,1.72-1.32,2.63-1.9q13.3-8.41,27.29-1.19A23.34,23.34,0,0,1,63.15,40a6.5,6.5,0,0,1,.39,9.15,6.43,6.43,0,0,1-8.6,1c-1.15-.83-2.16-1.86-3.35-2.6a13,13,0,0,0-16,1.86Q26.22,58.64,16.93,68a13.1,13.1,0,0,0,17,19.82,13.66,13.66,0,0,0,1.68-1.45q4.47-4.44,8.9-8.9a6.55,6.55,0,0,1,10.18,8.2,2.21,2.21,0,0,0-.18.34L43.76,96.73l-.43.28a41.34,41.34,0,0,1-4.39,3c-9.34,4.89-18.5,4.47-27.39-1.21-1-.63-1.88-1.4-2.82-2.1l-2-2c-.09-.14-.18-.29-.28-.43a41.34,41.34,0,0,1-3-4.39c-4.89-9.34-4.47-18.5,1.22-27.39.63-1,1.39-1.88,2.09-2.82Z"/><path d="M75.92,64.57c-.88.64-1.72,1.33-2.63,1.9Q60,74.88,46,67.66a23.34,23.34,0,0,1-5.69-4.23,6.5,6.5,0,0,1-.39-9.15,6.42,6.42,0,0,1,8.6-1c1.15.82,2.16,1.85,3.35,2.6a13,13,0,0,0,16-1.87q9.33-9.28,18.62-18.62a13.1,13.1,0,0,0-17-19.83,14.65,14.65,0,0,0-1.68,1.46q-4.47,4.43-8.9,8.89a6.55,6.55,0,0,1-10.18-8.2A1.83,1.83,0,0,0,49,17.4L59.7,6.65a4.5,4.5,0,0,0,.43-.27c1.07-.8,2.08-1.68,3.2-2.37a26,26,0,0,1,36.75,9.52c5,9.26,4.47,18.49-1.22,27.37-.63,1-1.39,1.88-2.09,2.82Z"/>
+</svg> </symbol>
+<symbol id="icon-linkedin">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.88 12.86">
+<path d="M4.77,7.84H7.44v8.59H4.77V7.84ZM6.11,3.57A1.55,1.55,0,1,1,4.56,5.12,1.55,1.55,0,0,1,6.11,3.57" transform="translate(-4.56 -3.57)"/>
+<path d="M9.12,7.84h2.56V9h0a2.8,2.8,0,0,1,2.53-1.39c2.7,0,3.2,1.78,3.2,4.09v4.71H14.77V12.25c0-1,0-2.28-1.39-2.28s-1.6,1.09-1.6,2.21v4.25H9.12V7.84Z" transform="translate(-4.56 -3.57)"/>
 </svg> </symbol>
 <symbol id="aggregate-star-rating__icon--inactive">
 <svg viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -370,14 +750,14 @@ Mntl.PageView.init(pageViewDataAsJSON);
 <path fill-rule="evenodd" clip-rule="evenodd" d="M15.0386 10.7526C15.2473 10.4438 15.1982 10.0207 14.9105 9.76891L14.8358 9.71136C14.5271 9.50266 14.104 9.55171 13.8522 9.83946L8.74997 15.6701V1.16668L8.74493 1.07921C8.7016 0.706206 8.3846 0.416676 7.99997 0.416676C7.58576 0.416676 7.24997 0.752462 7.24997 1.16668L7.24997 15.6693L2.14772 9.83946L2.08137 9.77251C1.80302 9.52468 1.37715 9.51713 1.08941 9.76891C0.777678 10.0417 0.746089 10.5155 1.01885 10.8272L7.43552 18.1606L7.43558 18.1606C7.45618 18.1841 7.47822 18.2064 7.50157 18.2271L7.50294 18.2285C7.5923 18.3079 7.6963 18.3621 7.80568 18.3913C7.86765 18.4078 7.93278 18.4167 7.99997 18.4167C8.07188 18.4167 8.14143 18.4066 8.20726 18.3877C8.33071 18.3524 8.44678 18.2848 8.54199 18.1851C8.55122 18.1754 8.56019 18.1655 8.5689 18.1554L14.981 10.8272L15.0386 10.7526Z" fill="#D2EBE8"/>
 </svg>
 </symbol>
-<symbol id="icon-facebook">
+<symbol id="icon-facebook--social-share">
 <svg viewBox="0 0 12 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M10.5592 10.8666L11.1055 7.42403H7.68789V5.19002C7.68789 4.2482 8.16528 3.33018 9.69606 3.33018H11.2499V0.399353C11.2499 0.399353 9.83972 0.166748 8.49152 0.166748C5.67677 0.166748 3.83706 1.81545 3.83706 4.80024V7.42403H0.708252V10.8666H3.83706V19.3334C4.54159 19.3334 7.41659 19.3334 7.68789 19.3334V10.8666H10.5592Z" fill="white" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.5592 10.8666L11.1055 7.42403H7.68789V5.19002C7.68789 4.2482 8.16528 3.33018 9.69606 3.33018H11.2499V0.399353C11.2499 0.399353 9.83972 0.166748 8.49152 0.166748C5.67677 0.166748 3.83706 1.81545 3.83706 4.80024V7.42403H0.708252V10.8666H3.83706V19.3334C4.54159 19.3334 7.41659 19.3334 7.68789 19.3334V10.8666H10.5592Z" fill="white"/>
 </svg>
 </symbol>
-<symbol id="icon-pinterest">
+<symbol id="icon-pinterest--social-share">
 <svg viewBox="0 0 17 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M7.3151 13.5932C6.78233 16.2312 6.13241 18.761 4.20743 20.0834C3.6127 16.0949 5.08037 13.0999 5.76183 9.9201C4.60053 8.07059 5.9015 4.35016 8.35137 5.26704C11.3656 6.39454 5.74043 12.1402 9.51717 12.8588C13.4595 13.6079 15.0691 6.39004 12.6249 4.04266C9.09253 0.653391 2.34102 3.96494 3.17116 8.81738C3.37391 10.0046 4.66924 10.3639 3.68929 12.0017C1.42865 11.5274 0.752826 9.84126 0.840683 7.59301C0.980354 3.91426 4.33696 1.33823 7.70371 0.981167C11.9614 0.530615 15.9578 2.4601 16.5097 6.24699C17.1304 10.5216 14.5881 15.151 10.0342 14.8176C8.8008 14.7264 8.28266 14.1485 7.3151 13.5932Z" fill="white" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.3151 13.5932C6.78233 16.2312 6.13241 18.761 4.20743 20.0834C3.6127 16.0949 5.08037 13.0999 5.76183 9.9201C4.60053 8.07059 5.9015 4.35016 8.35137 5.26704C11.3656 6.39454 5.74043 12.1402 9.51717 12.8588C13.4595 13.6079 15.0691 6.39004 12.6249 4.04266C9.09253 0.653391 2.34102 3.96494 3.17116 8.81738C3.37391 10.0046 4.66924 10.3639 3.68929 12.0017C1.42865 11.5274 0.752826 9.84126 0.840683 7.59301C0.980354 3.91426 4.33696 1.33823 7.70371 0.981167C11.9614 0.530615 15.9578 2.4601 16.5097 6.24699C17.1304 10.5216 14.5881 15.151 10.0342 14.8176C8.8008 14.7264 8.28266 14.1485 7.3151 13.5932Z" fill="white"/>
 </svg>
 </symbol>
 <symbol id="icon-envelope">
@@ -386,35 +766,51 @@ Mntl.PageView.init(pageViewDataAsJSON);
 </svg>
 </symbol>
 <symbol id="icon-print">
-<svg viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M16.5 12.5H1.5C0.671573 12.5 0 13.1716 0 14V17C0 17.8284 0.671573 18.5 1.5 18.5H16.5C17.3284 18.5 18 17.8284 18 17V14C18 13.1716 17.3284 12.5 16.5 12.5ZM3 16.25C2.58579 16.25 2.25 15.9142 2.25 15.5C2.25 15.0858 2.58579 14.75 3 14.75C3.41421 14.75 3.75 15.0858 3.75 15.5C3.75 15.9142 3.41421 16.25 3 16.25ZM6 16.25C5.58579 16.25 5.25 15.9142 5.25 15.5C5.25 15.0858 5.58579 14.75 6 14.75C6.41421 14.75 6.75 15.0858 6.75 15.5C6.75 15.9142 6.41421 16.25 6 16.25ZM15 0.5H3V11H15V0.5ZM11.25 8H6.75C6.33579 8 6 7.66421 6 7.25C6 6.83579 6.33579 6.5 6.75 6.5H11.25C11.6642 6.5 12 6.83579 12 7.25C12 7.66421 11.6642 8 11.25 8ZM11.25 5H6.75C6.33579 5 6 4.66421 6 4.25C6 3.83579 6.33579 3.5 6.75 3.5H11.25C11.6642 3.5 12 3.83579 12 4.25C12 4.66421 11.6642 5 11.25 5Z" fill="white"/>
-</svg>
-</symbol>
-<symbol id="icon-clock">
-<svg viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M16 8.07129C16 3.6531 12.4182 0.0712891 8 0.0712891C7.63181 0.0712891 7.33333 0.369766 7.33333 0.737956V3.40462L7.33782 3.48237C7.37633 3.81393 7.65811 4.07129 8 4.07129L8.07775 4.0668C8.40931 4.02829 8.66667 3.74651 8.66667 3.40462V1.43796L8.73852 1.44507C12.0728 1.81255 14.6667 4.63909 14.6667 8.07129C14.6667 11.7531 11.6818 14.738 8 14.738C4.31819 14.738 1.33333 11.7531 1.33333 8.07129C1.33333 7.00255 1.58466 5.97153 2.06024 5.04147C2.22786 4.71365 2.098 4.31201 1.77018 4.14439C1.44236 3.97676 1.04072 4.10662 0.873097 4.43444C0.302003 5.55132 0 6.79021 0 8.07129C0 12.4895 3.58181 16.0713 8 16.0713C12.4182 16.0713 16 12.4895 16 8.07129ZM5.74193 4.87776C5.48041 4.67441 5.10225 4.69289 4.86193 4.93322C4.60158 5.19357 4.60158 5.61568 4.86193 5.87603L7.5286 8.54269L7.5914 8.59815C7.85293 8.8015 8.23108 8.78302 8.47141 8.54269C8.73175 8.28234 8.73175 7.86023 8.47141 7.59988L5.80474 4.93322L5.74193 4.87776Z" fill="#008080" />
+<svg viewBox="0 0 18 19" fill="inherit" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.5 12.5H1.5C0.671573 12.5 0 13.1716 0 14V17C0 17.8284 0.671573 18.5 1.5 18.5H16.5C17.3284 18.5 18 17.8284 18 17V14C18 13.1716 17.3284 12.5 16.5 12.5ZM3 16.25C2.58579 16.25 2.25 15.9142 2.25 15.5C2.25 15.0858 2.58579 14.75 3 14.75C3.41421 14.75 3.75 15.0858 3.75 15.5C3.75 15.9142 3.41421 16.25 3 16.25ZM6 16.25C5.58579 16.25 5.25 15.9142 5.25 15.5C5.25 15.0858 5.58579 14.75 6 14.75C6.41421 14.75 6.75 15.0858 6.75 15.5C6.75 15.9142 6.41421 16.25 6 16.25ZM15 0.5H3V11H15V0.5ZM11.25 8H6.75C6.33579 8 6 7.66421 6 7.25C6 6.83579 6.33579 6.5 6.75 6.5H11.25C11.6642 6.5 12 6.83579 12 7.25C12 7.66421 11.6642 8 11.25 8ZM11.25 5H6.75C6.33579 5 6 4.66421 6 4.25C6 3.83579 6.33579 3.5 6.75 3.5H11.25C11.6642 3.5 12 3.83579 12 4.25C12 4.66421 11.6642 5 11.25 5Z"/>
 </svg>
 </symbol>
 <symbol id="icon-camera">
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.813 10.541">
-<path d="M.142,1.815c.962-.05,2.448.007,3.514,0,1.283-.011,2.566,0,3.848,0a28.041,28.041,0,0,0,4.309.048c.011.554-.079,1.538-.081,2.1,0,.657-.017,1.258-.012,1.94.005.7.05,1.39.022,2.1-.033.83.068,1.626.039,2.467-2.856.188-5.112-.028-7.986-.028-1.311,0-2.537.04-3.795-.01,0-1.707.08-3.083.041-4.8-.025-1.078.11-2.755.1-3.812A10.155,10.155,0,0,1,1.4,2.051C.747,3.514.956,5.912.975,7.458c.01.814.08,1.04.113,1.852,1.311-.1,2.665,0,3.944,0,.99,0,1.983-.011,2.965-.1,1.17-.1,1.611.111,2.786.051a11.65,11.65,0,0,0-.06-1.553c0-.524-.048-1.023-.048-1.547,0-.921.1-2.318.068-3.24-1.051-.053-1.687.047-2.738.058-1.465.015-2.61-.03-4.074-.032-1.053,0-1.441-.042-2.49-.012-.294.009-.989.051-1.12.231" /><path d="M7.338,1.091c.03-.309.056-.7.068-1.029A17.793,17.793,0,0,1,9.841.023,2.6,2.6,0,0,1,10.806.1c0,.356.015.575,0,.92-1.339,0-1.574.036-2.379.035-.245,0-.48.033-.724.016-.082-.006-.25.024-.365.024" /><path d="M3.656,5.094c-.01-.007,0-.016-.024-.015a.638.638,0,0,1,.194-.349,3.171,3.171,0,0,1,.606-.541,2.381,2.381,0,0,1,1.414-.451,4.308,4.308,0,0,1,1.135.2,2.609,2.609,0,0,1,.926.627,2.784,2.784,0,0,1,.338.388,1.2,1.2,0,0,1,.148.5,3.423,3.423,0,0,1-.052,1.317,2.146,2.146,0,0,1-.931,1.258,1.9,1.9,0,0,1-.615.414A2.868,2.868,0,0,1,5.732,8.6a2.283,2.283,0,0,1-1.984-1,2.582,2.582,0,0,1-.337-1.417c.307-.008.615-.04.923-.025a1.824,1.824,0,0,0,.432,1,1.461,1.461,0,0,0,.87.433,1.605,1.605,0,0,0,1.7-.641,1.561,1.561,0,0,0,.033-.9,1.845,1.845,0,0,0-.5-.968,1.65,1.65,0,0,0-1.148-.4,1.37,1.37,0,0,0-.97.481,1.787,1.787,0,0,0-.418,1.212,4.341,4.341,0,0,0-.618-.023,2.282,2.282,0,0,1-.331.036,2.757,2.757,0,0,1,.055-.878,3.042,3.042,0,0,1,.146-.514c.056-.12.241-.227.253-.351" />
+<path d="M.142,1.815c.962-.05,2.448.007,3.514,0,1.283-.011,2.566,0,3.848,0a28.041,28.041,0,0,0,4.309.048c.011.554-.079,1.538-.081,2.1,0,.657-.017,1.258-.012,1.94.005.7.05,1.39.022,2.1-.033.83.068,1.626.039,2.467-2.856.188-5.112-.028-7.986-.028-1.311,0-2.537.04-3.795-.01,0-1.707.08-3.083.041-4.8-.025-1.078.11-2.755.1-3.812A10.155,10.155,0,0,1,1.4,2.051C.747,3.514.956,5.912.975,7.458c.01.814.08,1.04.113,1.852,1.311-.1,2.665,0,3.944,0,.99,0,1.983-.011,2.965-.1,1.17-.1,1.611.111,2.786.051a11.65,11.65,0,0,0-.06-1.553c0-.524-.048-1.023-.048-1.547,0-.921.1-2.318.068-3.24-1.051-.053-1.687.047-2.738.058-1.465.015-2.61-.03-4.074-.032-1.053,0-1.441-.042-2.49-.012-.294.009-.989.051-1.12.231"/><path d="M7.338,1.091c.03-.309.056-.7.068-1.029A17.793,17.793,0,0,1,9.841.023,2.6,2.6,0,0,1,10.806.1c0,.356.015.575,0,.92-1.339,0-1.574.036-2.379.035-.245,0-.48.033-.724.016-.082-.006-.25.024-.365.024"/><path d="M3.656,5.094c-.01-.007,0-.016-.024-.015a.638.638,0,0,1,.194-.349,3.171,3.171,0,0,1,.606-.541,2.381,2.381,0,0,1,1.414-.451,4.308,4.308,0,0,1,1.135.2,2.609,2.609,0,0,1,.926.627,2.784,2.784,0,0,1,.338.388,1.2,1.2,0,0,1,.148.5,3.423,3.423,0,0,1-.052,1.317,2.146,2.146,0,0,1-.931,1.258,1.9,1.9,0,0,1-.615.414A2.868,2.868,0,0,1,5.732,8.6a2.283,2.283,0,0,1-1.984-1,2.582,2.582,0,0,1-.337-1.417c.307-.008.615-.04.923-.025a1.824,1.824,0,0,0,.432,1,1.461,1.461,0,0,0,.87.433,1.605,1.605,0,0,0,1.7-.641,1.561,1.561,0,0,0,.033-.9,1.845,1.845,0,0,0-.5-.968,1.65,1.65,0,0,0-1.148-.4,1.37,1.37,0,0,0-.97.481,1.787,1.787,0,0,0-.418,1.212,4.341,4.341,0,0,0-.618-.023,2.282,2.282,0,0,1-.331.036,2.757,2.757,0,0,1,.055-.878,3.042,3.042,0,0,1,.146-.514c.056-.12.241-.227.253-.351"/>
 </svg> </symbol>
 <symbol id="jw-player-cc">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240"><path d="M215 40H25c-2.7 0-5 2.2-5 5v150c0 2.7 2.2 5 5 5h190c2.7 0 5-2.2 5-5V45c0-2.8-2.2-5-5-5zm-106.9 97.7c.7-.7 1.5-1.5 2.4-2.3l6.6 7.8c-2.2 2.4-5 4.4-8 5.8-8 3.5-17.3 2.4-24.3-2.9-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7.5-5.3 1.5-7.8.9-2.2 2.4-4.3 4.2-5.9 5.7-4.5 13.2-6.2 20.3-4.6 3.3.5 6.3 2 8.7 4.3 1.3 1.3 2.5 2.6 3.5 4.2l-7.1 6.9c-2.4-3.7-6.5-5.9-10.9-5.9-2.4-.2-4.8.7-6.6 2.3-1.7 1.7-2.5 4.1-2.4 6.5v25.6c-.1 9.6 11.5 11.4 17.6 5.6zm44.8 0c.7-.7 1.5-1.5 2.4-2.3l6.6 7.8c-2.2 2.4-5 4.4-8 5.8-8 3.5-17.3 2.4-24.3-2.9-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7.5-5.3 1.5-7.8.9-2.2 2.4-4.3 4.2-5.9 5.7-4.5 13.2-6.2 20.3-4.6 3.3.5 6.3 2 8.7 4.3 1.3 1.3 2.5 2.6 3.5 4.2l-7.1 6.9c-2.4-3.7-6.5-5.9-10.9-5.9-2.4-.2-4.8.7-6.6 2.3-1.7 1.7-2.5 4.1-2.4 6.5v25.6c-.1 9.6 11.5 11.4 17.6 5.6z"/></svg> </symbol>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" focusable="false">
+<path d="M215,40H25c-2.7,0-5,2.2-5,5v150c0,2.7,2.2,5,5,5h190c2.7,0,5-2.2,5-5V45C220,42.2,217.8,40,215,40z M108.1,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C90.4,141.7,102,143.5,108.1,137.7z M152.9,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C135.2,141.7,146.8,143.5,152.9,137.7z"></path>
+</svg> </symbol>
 <symbol id="light-box-arrow">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="2575 18840 48 48"><g transform="translate(1355 18464)"><circle cx="24" cy="24" r="24" transform="translate(1220 376)" fill="#fff"/><path d="M1248.675 390l9.38 9.38m0 0l-9.38 9.553M1232 399.38h25.186" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"/></g></svg> </symbol>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2575 18840 48 48">
+<g transform="translate(1355 18464)">
+<circle cx="24" cy="24" r="24" transform="translate(1220 376)" fill="#fff"/>
+<g fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3">
+<path d="M1248.675 390l9.38 9.38M1258.055 399.38l-9.38 9.553M1232 399.38h25.186"/>
+</g>
+</g>
+</svg> </symbol>
 <symbol id="icon-heart">
 <svg width="100%" viewBox="0 0 28 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
 <path d="M13.1451 3.63525L14 4.43675L14.8549 3.63525C15.8048 2.7447 16.6183 2.16451 17.4571 1.79749C18.2853 1.4351 19.2086 1.25 20.4167 1.25C22.3809 1.25 23.9275 2.03437 25.0024 3.30357C26.0933 4.59161 26.75 6.4459 26.75 8.62313C26.75 11.2755 25.4098 13.9798 23.0725 16.4319C20.751 18.8676 17.5308 20.9582 14 22.3676C10.4692 20.9582 7.249 18.8676 4.92747 16.4319C2.59021 13.9798 1.25 11.2755 1.25 8.62313C1.25 6.4459 1.90667 4.59161 2.99756 3.30357C4.07249 2.03437 5.61905 1.25 7.58333 1.25C8.79142 1.25 9.71468 1.4351 10.5429 1.79749C11.3817 2.16451 12.1952 2.7447 13.1451 3.63525Z" stroke-width="2.5"/>
 </svg>
 </symbol>
+<symbol id="icon-paper">
+<svg viewBox="0 0 12 17" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.82 4.57996L7.62002 0.379952C7.50002 0.259951 7.38002 0.199951 7.20002 0.199951H1.2C0.540002 0.199951 0 0.739953 0 1.39995V15.8C0 16.46 0.540002 17 1.2 17H10.8C11.46 17 12 16.46 12 15.8V4.99997C12 4.81996 11.94 4.69996 11.82 4.57996ZM7.20002 1.63996L10.56 4.99997H7.20002V1.63996ZM10.8 15.8H1.2V1.39995H6.00002V4.99997C6.00002 5.65997 6.54002 6.19997 7.20002 6.19997H10.8V15.8Z" fill="#008080"/>
+<path d="M2.39999 12.2H9.60001V13.4H2.39999V12.2Z" fill="#008080"/>
+<path d="M2.39999 8.60004H9.60001V9.80004H2.39999V8.60004Z" fill="#008080"/>
+</svg>
+</symbol>
 <symbol id="caret-left-thin">
 <svg id="caret-left-thin" viewBox="0 0 18 29" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g id="desktop-journey-list-article---adv-nav---midway" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-311.000000, -30.000000)">
-<g id="Group-2" transform="translate(322.000000, 45.000000) rotate(-180.000000) translate(-322.000000, -45.000000) translate(302.000000, 0.000000)" fill="#93ACC4" fill-rule="nonzero">
+<g id="desktop-journey-list-article---adv-nav---midway" stroke="none" stroke-width="1" fill-rule="evenodd" transform="translate(-311.000000, -30.000000)">
+<g id="Group-2" transform="translate(322.000000, 45.000000) rotate(-180.000000) translate(-322.000000, -45.000000) translate(302.000000, 0.000000)" fill-rule="nonzero">
 <path d="M8.46244061,50.8988092 C8.73764072,50.4707156 9.04544696,50.0666546 9.38284661,49.6905808 C10.2391076,48.549563 11.4847138,47.521084 12.3394831,46.3785031 C13.8588152,44.5674106 15.4972735,42.8699711 17.2428453,41.2986295 C18.2870661,40.2420158 19.2552079,39.0666112 20.3635736,38.0912754 C20.7164648,37.7201855 21.1014976,37.3842517 21.5137081,37.087805 C22.2968737,36.6470283 23.3336357,37.9849889 23.9183993,38.4585894 C25.5966113,39.8168694 26.6035384,41.8675754 28.2862255,43.210225 C29.8659823,44.4747228 31.0772784,46.1049715 32.6227251,47.4163604 C33.7214245,48.4189376 34.7480437,49.5050701 35.6942258,50.6659165 C36.2297619,51.2786274 36.025393,51.4036705 35.3645504,51.8256907 C34.7559189,52.2148872 34.0115387,53.601302 33.3432374,53.8717075 C32.7733912,54.1014741 32.6838866,53.8560772 32.1349248,53.5340913 C31.4159043,53.112071 31.2279445,52.65879 30.7058342,52.0101292 C30.0151567,51.1504583 29.267793,50.3361155 28.5636899,49.4873858 C27.690404,48.431614 26.7657892,47.4236818 25.7935214,46.4675963 C25.032732,45.7204641 24.2361408,45.0014666 23.5230872,44.2027542 C23.197887,43.8385663 22.7772152,42.8554154 22.3088077,42.7116159 C21.8404001,42.5678164 21.0617097,43.5509673 20.7201004,43.826062 C19.9548358,44.440336 19.1373601,45.0030297 18.4064056,45.6641948 C17.7888236,46.2237624 17.2696967,46.90681 16.6894083,47.5085797 C15.873885,48.581911 14.9822779,49.5892794 14.0221702,50.522117 C13.3113652,50.9635172 12.6843011,51.538421 12.1724077,52.2180133 C11.874059,52.6494118 11.5503505,53.0495495 11.2341008,53.4684437 C11.1192365,53.6247475 10.9700621,53.9279769 10.7865776,53.9670529 C10.3390545,54.0608351 8.17453404,51.631874 8,51.139517 C8.05368692,51.1138004 8.46244061,50.8988092 8.46244061,50.8988092 Z" id="Shape-Copy-3" transform="translate(22.000000, 45.484848) scale(1, -1) rotate(-270.000000) translate(-22.000000, -45.484848) "></path>
 </g>
 </g>
+</svg>
+</symbol>
+<symbol id="icon-clock">
+<svg viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16 8.07129C16 3.6531 12.4182 0.0712891 8 0.0712891C7.63181 0.0712891 7.33333 0.369766 7.33333 0.737956V3.40462L7.33782 3.48237C7.37633 3.81393 7.65811 4.07129 8 4.07129L8.07775 4.0668C8.40931 4.02829 8.66667 3.74651 8.66667 3.40462V1.43796L8.73852 1.44507C12.0728 1.81255 14.6667 4.63909 14.6667 8.07129C14.6667 11.7531 11.6818 14.738 8 14.738C4.31819 14.738 1.33333 11.7531 1.33333 8.07129C1.33333 7.00255 1.58466 5.97153 2.06024 5.04147C2.22786 4.71365 2.098 4.31201 1.77018 4.14439C1.44236 3.97676 1.04072 4.10662 0.873097 4.43444C0.302003 5.55132 0 6.79021 0 8.07129C0 12.4895 3.58181 16.0713 8 16.0713C12.4182 16.0713 16 12.4895 16 8.07129ZM5.74193 4.87776C5.48041 4.67441 5.10225 4.69289 4.86193 4.93322C4.60158 5.19357 4.60158 5.61568 4.86193 5.87603L7.5286 8.54269L7.5914 8.59815C7.85293 8.8015 8.23108 8.78302 8.47141 8.54269C8.73175 8.28234 8.73175 7.86023 8.47141 7.59988L5.80474 4.93322L5.74193 4.87776Z" fill="#008080"/>
 </svg>
 </symbol>
 <symbol id="icon-hamburger">
@@ -424,7 +820,84 @@ Mntl.PageView.init(pageViewDataAsJSON);
 </symbol>
 <symbol id="icon-search">
 <svg viewBox="0 0 37 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M15.3957 27C8.81428 27 3.479 21.6274 3.479 15C3.479 8.37258 8.81428 3 15.3957 3C21.9771 3 27.3123 8.37258 27.3123 15C27.3123 17.8735 26.3094 20.5111 24.6367 22.5771L33.2707 31.27L31.5542 33L22.9194 24.3063C20.8678 25.9903 18.2488 27 15.3957 27ZM15.3957 24.551C20.634 24.551 24.8804 20.2749 24.8804 15C24.8804 9.72512 20.634 5.44898 15.3957 5.44898C10.1575 5.44898 5.91105 9.72512 5.91105 15C5.91105 20.2749 10.1575 24.551 15.3957 24.551Z" fill="#616161" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.3957 27C8.81428 27 3.479 21.6274 3.479 15C3.479 8.37258 8.81428 3 15.3957 3C21.9771 3 27.3123 8.37258 27.3123 15C27.3123 17.8735 26.3094 20.5111 24.6367 22.5771L33.2707 31.27L31.5542 33L22.9194 24.3063C20.8678 25.9903 18.2488 27 15.3957 27ZM15.3957 24.551C20.634 24.551 24.8804 20.2749 24.8804 15C24.8804 9.72512 20.634 5.44898 15.3957 5.44898C10.1575 5.44898 5.91105 9.72512 5.91105 15C5.91105 20.2749 10.1575 24.551 15.3957 24.551Z" fill="#616161"/>
+</svg>
+</symbol>
+<symbol id="icon-search--header">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 18.7 25.7">
+<path d="M12.6,15.6l0.5-0.3c3.3-2.2,4.4-6.6,2.4-10C13.4,1.7,8.8,0.4,5.3,2.5C1.7,4.6,0.4,9.2,2.5,12.8c1.9,3.3,6,4.6,9.5,3.1L12.6,15.6z M13.9,16.5l4.6,8c0.2,0.4,0.1,0.8-0.3,1s-0.8,0.1-1-0.3l-4.7-8.1c-4.1,1.8-9.1,0.3-11.4-3.7c-2.5-4.3-1-9.8,3.3-12.3c4.3-2.5,9.8-1,12.3,3.3C19.2,8.7,17.9,13.9,13.9,16.5z"/>
+</svg>
+</symbol>
+<symbol id="icon-x">
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0.244078 0.244078C-0.0813592 0.569515 -0.0813592 1.09715 0.244078 1.42259L8.82149 10L0.244078 18.5774C-0.0813592 18.9028 -0.0813592 19.4305 0.244078 19.7559C0.569515 20.0814 1.09715 20.0814 1.42259 19.7559L10 11.1785L18.5774 19.7559C18.9028 20.0814 19.4305 20.0814 19.7559 19.7559C20.0814 19.4305 20.0814 18.9028 19.7559 18.5774L11.1785 10L19.7559 1.42259C20.0814 1.09715 20.0814 0.569515 19.7559 0.244078C19.4305 -0.0813592 18.9028 -0.0813592 18.5774 0.244078L10 8.82149L1.42259 0.244078C1.09715 -0.0813592 0.569515 -0.0813592 0.244078 0.244078Z" fill="#666666" fill-opacity="0.95"/>
+</svg>
+</symbol>
+<symbol id="icon-arrow--down">
+<svg viewBox="0 0 8 12" xmlns="http://www.w3.org/2000/svg" stroke="#B5460F">
+<line y1="-0.7" x2="7.86373" y2="-0.7" transform="matrix(0.694636 -0.719361 0.694636 0.719361 1.91895 11.7236)" stroke="inherit" stroke-width="1.4"/>
+<line y1="-0.7" x2="7.86373" y2="-0.7" transform="matrix(0.694636 0.719361 0.694636 -0.719361 1.91895 0.423828)" stroke="inherit" stroke-width="1.4"/>
+</svg> </symbol>
+<symbol id="relish-heart-filled">
+<svg viewBox="0 0 20 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.2954 2.21782C15.5027 0.594059 12.6187 0.594059 10.8455 2.21782L9.81269 3.16353L8.77992 2.21782C6.98717 0.594059 4.1032 0.594059 2.32994 2.21782C0.556686 3.84159 0.556686 6.50028 2.32994 8.12405L9.59834 14.7797C9.71526 14.8868 9.91013 14.8868 10.027 14.7797L17.2954 8.14189C19.0882 6.50028 19.0882 3.85943 17.2954 2.21782Z" fill="#E4965F" stroke="#385E83" stroke-width="1.5"/>
+</svg>
+</symbol>
+<symbol id="icon-save-recipe">
+<svg viewBox="0 0 33 26" fill="inherit" xmlns="http://www.w3.org/2000/svg">
+<rect x="6" y="1" width="26" height="19" rx="1" fill="#DAEBF3" stroke="#385E83" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="1" y="6" width="26" height="19" rx="1" fill="white" stroke="#385E83" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.9329 10.9665C18.5101 9.67782 16.2212 9.67782 14.8139 10.9665L13.9942 11.7171L13.1745 10.9665C11.7517 9.67782 9.46286 9.67782 8.05551 10.9665C6.64816 12.2552 6.64816 14.3653 8.05551 15.654L13.8241 20.9363C13.9169 21.0212 14.0715 21.0212 14.1643 20.9363L19.9329 15.6682C21.3557 14.3653 21.3557 12.2694 19.9329 10.9665Z" fill="inherit" stroke="#385E83" stroke-width="1.5"/>
+</svg>
+</symbol>
+<symbol id="icon-save-recipe--hover">
+<svg viewBox="0 0 33 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="6" y="1" width="26" height="19" rx="1" fill="#DAEBF3" stroke="#385E83" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="1" y="6" width="26" height="19" rx="1" fill="white" stroke="#385E83" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.9329 10.9665C18.5101 9.67782 16.2212 9.67782 14.8139 10.9665L13.9942 11.7171L13.1745 10.9665C11.7517 9.67782 9.46286 9.67782 8.05551 10.9665C6.64816 12.2552 6.64816 14.3653 8.05551 15.654L13.8241 20.9363C13.9169 21.0212 14.0715 21.0212 14.1643 20.9363L19.9329 15.6682C21.3557 14.3653 21.3557 12.2694 19.9329 10.9665Z" fill="#E4965F" stroke="#385E83" stroke-width="1.5"/>
+</svg>
+</symbol>
+<symbol id="icon-heart">
+<svg width="100%" viewBox="0 0 28 24" fill="inherit" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.1451 3.63525L14 4.43675L14.8549 3.63525C15.8048 2.7447 16.6183 2.16451 17.4571 1.79749C18.2853 1.4351 19.2086 1.25 20.4167 1.25C22.3809 1.25 23.9275 2.03437 25.0024 3.30357C26.0933 4.59161 26.75 6.4459 26.75 8.62313C26.75 11.2755 25.4098 13.9798 23.0725 16.4319C20.751 18.8676 17.5308 20.9582 14 22.3676C10.4692 20.9582 7.249 18.8676 4.92747 16.4319C2.59021 13.9798 1.25 11.2755 1.25 8.62313C1.25 6.4459 1.90667 4.59161 2.99756 3.30357C4.07249 2.03437 5.61905 1.25 7.58333 1.25C8.79142 1.25 9.71468 1.4351 10.5429 1.79749C11.3817 2.16451 12.1952 2.7447 13.1451 3.63525Z" stroke-width="2.5"/>
+</svg>
+</symbol>
+<symbol id="thespruceeats-logo-text">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 179.7 61.5">
+<path d="M1.3 23c-.1.7.2 1.4.7 1.9.7.5 1.5.8 2.3.7 1.1 0 2.1-.7 2.6-1.7l-.1-.1c-.4.6-1.1 1-1.8 1-1 0-1.4-.6-1.4-1.5l.1-8.6h2.6v-.4H3.7V9.7h-.2c-.9 3.5-2 4.5-3.6 4.8v.1c.4.1 1.1 0 1.5.1 0 1.3-.1 7.8-.1 8.3zM8.1 25.2h-.2.2zM8.1 25.2c.1 0 .3-.1.4-.1l-.4.1z" fill="#434343"/>
+<path d="M9.4 24.1c-.1.7-.5.8-.9 1h5V25c-.2 0-.4 0-.6-.1-.5-.1-.8-.5-.9-1-.1-.7-.1-1.4-.1-2.1v-2c0-.7 0-1.3.1-2 .1-1.6 1.3-2.9 2.8-3.1.6 0 1.1.3 1.4.7.4.6.5 1.4.4 2.1v4.4c0 .7 0 1.4-.1 2.1-.2.7-.4.9-.9 1.1-.2 0-.4.1-.6.1v.1h5.4v-.1c-.2 0-.4 0-.6-.1-.5-.2-.8-.6-.9-1.1-.1-.7-.1-1.4-.1-2.1v-4.3c0-.9-.2-1.8-.7-2.5-.6-.7-1.6-1-2.5-.9-.7 0-1.5.2-2.1.6-.8.5-1.3 1.2-1.6 2.1h-.1v-6c0-1.1.1-2.6.1-3.1 0-.1-.1-.2-.2-.2H7.9v.1c.4 0 .7.1 1 .3.3.2.5.5.5.8.1.6.1 1.1.1 1.7v11.4c.1.7 0 1.5-.1 2.2zM26.4 25.6c2.2 0 4-1.6 4.2-3.7l-.3-.1c-.5 1.7-1.3 3.1-3.5 3.1-.7.1-1.4-.2-1.9-.8-.8-.9-1.2-2.6-1.2-5h7v-.7c0-2-1.5-4.2-4.7-4.2-2.7 0-4.8 2.3-4.8 5.8-.1 1.6.5 3.1 1.5 4.3 1.1.9 2.4 1.4 3.7 1.3zm-1.6-10.7c.4-.3.8-.5 1.3-.5s1 .1 1.4.5c.6.8.9 1.7.9 2.7 0 .8-.3 1.1-1 1.1h-3.6c0-1.9.4-3.3 1-3.8zM8 38.8c-2.6-1.1-4.5-2.2-4.5-4.6-.2-1.6 1-3 2.6-3.2h.4c1.3 0 2.6.6 3.6 1.5 1.2 1.1 1.9 2.5 2.2 4.1h.2l-.2-5.9h-.1L11 31.9h-.1c-1.2-1-2.7-1.5-4.3-1.5-3.3-.2-6.1 2.3-6.3 5.5v.3c0 3.6 2.5 5.3 5.5 6.6 3 1.4 5 2.8 5 4.7 0 2.8-1.2 3.6-3.5 3.6-3.1 0-6.4-3.3-7-7.4H.1l.1 7.5h.2l1.4-1.3H2c1.5 1.2 3.4 1.8 5.3 1.8 3.7 0 6.8-2 6.7-6.5 0-3.4-2.6-5-6-6.4zM27.9 30.5c-2.5.1-4.8 1.7-5.8 4h-.3l.1-3.1c0-.2-.1-.4-.3-.4h-6.8v.2c.8 0 1.6.3 2.2.7.6.3.9.9.9 1.6.1.8.1 2.4.1 3.3v18.4c0 1.3 0 2.5-.2 3.8-.1 1-.8 1.8-1.7 2-.3.2-.7.2-1 .2v.2h9.8v-.2c-.3-.1-.6-.1-1-.2-1-.5-1.4-.7-1.7-2-.2-1.3-.2-2.5-.2-3.8v-5.4h.1c1.3 1.3 3.2 2 5.1 1.9 5.1 0 8.8-3.8 8.9-10.6 0-7.3-3.8-10.6-8.2-10.6zm-1 20.5c-1.4 0-2.7-.6-3.6-1.7-1-1.6-1.5-3.4-1.4-5.2v-6c0-3.9 2.5-6.8 5.1-6.8 2.4 0 4.4 2.1 4.4 9.7s-1.9 10-4.5 10zM50 30.7c-1.2 0-2.3.5-3.2 1.2-1.2 1.2-2.1 2.8-2.6 4.5v-5c0-.2-.1-.3-.3-.3h-6.5v.2c.6 0 1.1.1 1.6.4.5.4.9 1 .9 1.6.1.7.1 2.9.1 3.8v8c0 1.3 0 2.6-.2 3.9-.3 1.3-.6 1.5-1.6 1.9-.4.1-.7.2-1.1.2v.2H47v-.2c-.4 0-.7-.1-1.1-.2-1-.4-1.3-.6-1.6-1.9-.2-1.3-.2-2.6-.2-3.9v-3.3c0-1.2.1-2.5.1-2.9.3-3.7 2.2-6.1 3.1-6.1.5 0 .8.2 1.1 1 .3 1 1.2 1.7 2.2 1.8 1.2 0 2.2-.9 2.3-2.1.1-.7-.1-1.4-.6-2-.6-.5-1.4-.8-2.3-.8zM72.4 49c-.1-1-.1-2-.1-3V31.5c0-.3-.1-.4-.3-.4h-6.6v.2c.6.1 1.2.3 1.8.5.6.4.9 1.1.9 1.8.1 1 .1 2 .1 3v5.5c0 1.4 0 2-.1 3.2-.4 3.2-2.3 5.6-4.3 5.6-1 .1-2-.4-2.6-1.2-.5-1-.8-2.2-.7-3.4V31.4c0-.4-.2-.4-.3-.4h-6.7v.2c.6 0 1.2.2 1.8.4.6.5.9 1.2.9 1.9.1 1 .1 2 .1 3v9.1c0 1.6.4 3.1 1.2 4.4 1.2 1.3 2.9 1.9 4.6 1.8 1.4.1 2.7-.4 3.8-1.2 1-.8 1.8-1.9 2.2-3.1h.1v3.8c0 .1.1.2.2.2.2 0 6-.2 6.8 0v-.2c-.6 0-1.2-.1-1.8-.4-.6-.4-.9-1.1-1-1.9zM85.6 50.8c-1.2.1-2.4-.5-3-1.6-1.2-1.8-1.9-4.8-1.9-9.1 0-3.7.6-6.9 1.8-8 .8-.6 1.7-1 2.7-1 1.9 0 2.4 1 2.8 3.4.2 1.5.7 2.5 2.4 2.5 1.1 0 1.9-.9 1.9-2v-.1c0-.8-.4-1.6-1-2.2-.9-1.1-3.1-2.2-6-2.2-4.3 0-9.2 3.9-9.2 10.4 0 3.5.7 6.3 2.7 8.3 1.7 1.6 4 2.5 6.4 2.5 4 0 6.5-3.1 7.4-6.8l-.6-.2c-.7 2.5-2.2 6.1-6.4 6.1zM105.5 50.4c-1.4.1-2.7-.4-3.6-1.4-1.4-1.6-2.2-4.7-2.2-9.2h12.9c0-.6 0-1.1.1-1.7 0-3.7-2.7-7.7-8.6-7.7-5.1 0-8.9 4.4-8.9 10.8 0 3.4.8 5.9 2.7 8 1.9 1.7 4.3 2.5 6.8 2.4 1.2 0 2.4-.3 3.5-.8 0-.3.1-.7.2-1-.9.4-1.9.6-2.9.6zm-3.8-18.3c.6-.7 1.5-1.1 2.4-1 1 0 1.9.3 2.6 1 .9.9 1.5 2.5 1.6 5 0 1.6-.5 2.1-1.8 2.1h-6.7c.1-3.5.8-6.1 1.9-7.1z" fill="#434343"/>
+<path d="M169.8 32.1c1.7-.7 3.4-1.1 5.2-1.2 1 0 1.9.1 1.9.7 0 .3-.1.6-.1 1s.1.6.7.6c.9 0 2.1-1.4 2.1-2.7 0-1.4-1.2-2.2-3.6-2.2-1.5 0-2.9.3-4.4.7 2.3-3.9 2.7-4.8 3.8-5.8 1.3-1 1.4-1.6 1.4-2.4s-.5-1.2-1.4-1.2-1.6.7-2.8 2.3c-1.8 2.6-3.4 5.4-4.9 8.2-.7.2-1.4.2-2.1.3-.8 0-1-.5-2-.5-.9 0-1.7.7-1.8 1.6v.1c0 1 .8 1.4 2.9 1.4.5 0 1 0 1.4-.1-1.1 2.1-2.2 4.4-3.1 6.6-.2.2-.3.4-.5.6-2.5 3.3-6.6 7.6-9 7.6-.6 0-.9-.7-.9-1.6.1-1.4.5-2.7 1.2-3.9 1.4-2.7 3.2-5 3.2-5.9 0-.8-.7-1.4-1.8-1.4-1.2 0-1.5 1.4-2 1.4-.3 0-1.5-1.6-2.8-1.6-3.9 0-8.6 3.3-11.2 7.6-6.1 7.2-14.1 14.4-20.6 14.4-4.2 0-5.5-2.9-5.5-5.1 0-5.9 8.1-13.1 12.7-15.6 4.7-2.5 7.5-2.2 7.5-3.9s-.7-1.9-1.6-1.9c-.9 0-3.4 1.2-5.5 1.2s-3.5-.8-3.5-2.2c0-4.7 11.8-13.3 18.6-13.3.6-.1 1.1.3 1.1.9v.1c0 2-2.4 4.6-4.6 5.7-1.8.9-2.2 1.4-2.2 2.2 0 .7.5 1.3 1.8 1.3 2.9 0 8.2-6.5 8.2-9 0-2.7-1.6-3.8-3.8-3.8-8.7 0-22.8 9.7-22.8 16.8 0 2.4 2.7 3.9 4.5 3.9-5.2 3.6-11.8 9.2-13.2 15.5-.1.3-.1.6-.2 1-.1.5-.1 1-.1 1.5 0 4.1 2.9 7.5 8.2 7.5 6.6 0 13.2-5.5 19.3-11.9 0 .3-.1.6-.1.8 0 1.3.8 2.4 2 2.7 1.6 0 3.7-1.4 6.9-4.1 1.5-1.4 2.6-2.7 3-2.7.1 0 .1.2.1.6 0 .6-.1 1.6-.1 2.3-.1 1.7 1.2 3.1 2.8 3.2h.4c2.3 0 5.4-2.3 8.2-5-.6 1.7-1 3.5-1.1 5.3 0 1.7.7 2.7 1.7 2.7.8 0 1.4-.6 1.4-1.4 0-.6-.4-1-.4-1.8.1-3.3 3.9-11.5 7.5-18.1zm-28.3 16c-.4 0-.8-.3-.8-.7v-.1c0-3.3 6-9.7 8.9-9.7.4 0 .7.3.8.7v.1c0 .7 1.2.5 1.2.9-.1 1.1-9 8.8-10.1 8.8z" fill="#4B6E8F"/>
+<path d="M176.5 34.4c-3 0-8.2 3.3-8.2 6.8 0 3.1 4.8 2.9 4.8 5.6.1 1.3-1 2.4-2.3 2.5h-.1c-.9.1-1.8-.5-1.9-1.4v-.4c0-.6-.6-1.1-1.2-1h-.1c-.9.1-1.6.8-1.5 1.7 0 1.6 1.8 3.3 4.2 3.3 3.9 0 5.9-2.4 5.9-4.7 0-4.4-4.9-4.1-4.9-6 0-2 3.2-3.8 4.1-3.8.5 0 .9.4 1 .9 0 .3-1 .5-1 1.6 0 .7.7 1.2 1.4 1.2 1.4 0 2.2-2.4 2.2-3.8.1-1.4-1.1-2.5-2.4-2.5z" fill="#4B6E8F"/>
+</svg>
+</symbol>
+<symbol id="simplyrecipes-logo">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 538.182 152.724">
+<path d="M68.024,0C60.046,0,53.519,7.832,53.519,17.405a18.745,18.745,0,0,0,6.237,14.36c3.771,3.191,4.351,4.206,5.367,6.382.725,1.6.58,7.687.435,12.184H70.2c-.145-4.5-.145-10.588.435-12.184,1.016-2.176,1.451-3.191,5.367-6.382a18.745,18.745,0,0,0,6.237-14.36C82.383,7.832,75.856,0,68.024,0Z" fill="#7bd5d5"/>
+<path d="M67.739,135.618c7.978,0,14.5-7.833,14.5-17.406a18.743,18.743,0,0,0-6.237-14.359c-3.771-3.191-4.351-4.207-5.367-6.382-.725-1.6-.58-7.688-.435-12.184H65.564c.145,4.5.145,10.588-.436,12.184-1.015,2.175-1.45,3.191-5.366,6.382s-6.237,8.412-6.237,14.359C53.235,127.785,59.762,135.618,67.739,135.618Z" fill="#7bd5d5"/>
+<path d="M19.871,19.871c-5.657,5.657-4.641,15.81,2.176,22.627A19.2,19.2,0,0,0,36.7,48.3c5.076-.435,6.091-.145,8.267.725,1.6.581,5.8,4.932,8.993,8.268l1.6-1.595,1.6-1.6c-3.191-3.046-7.687-7.4-8.268-8.993-.87-2.175-1.16-3.336-.725-8.267a18.208,18.208,0,0,0-5.8-14.65C35.536,15.23,25.528,14.214,19.871,19.871Z" fill="#7bd5d5"/>
+<path d="M115.747,115.747c5.656-5.657,4.641-15.665-2.176-22.483a19.2,19.2,0,0,0-14.65-5.8c-5.076.435-6.092.145-8.267-.726-1.6-.58-5.8-4.931-8.993-8.267l-1.6,1.595-1.595,1.6c3.191,3.046,7.687,7.4,8.267,8.993.871,2.175,1.161,3.336.726,8.267a18.208,18.208,0,0,0,5.8,14.65C100.082,120.533,110.09,121.4,115.747,115.747Z" fill="#7bd5d5"/>
+<path d="M0,67.881c0,7.978,7.832,14.5,17.405,14.5a18.745,18.745,0,0,0,14.36-6.237c3.191-3.916,4.206-4.351,6.382-5.367,1.6-.725,7.687-.58,12.184-.58V65.561c-4.5.145-10.588.145-12.184-.435-2.176-1.016-3.191-1.451-6.382-5.367s-8.413-6.237-14.36-6.237C7.832,53.377,0,59.9,0,67.881Z" fill="#7bd5d5"/>
+<path d="M135.618,67.881c0-7.977-7.833-14.5-17.406-14.5a18.743,18.743,0,0,0-14.359,6.237c-3.191,3.916-4.207,4.351-6.382,5.366-1.6.726-7.688.581-12.184.436v4.641c4.5-.145,10.588-.145,12.184.58,2.175,1.016,3.191,1.451,6.382,5.367s8.412,6.237,14.359,6.237C127.785,82.241,135.618,75.714,135.618,67.881Z" fill="#7bd5d5"/>
+<path d="M19.871,115.747c5.657,5.656,15.81,4.641,22.482-2.176a19.2,19.2,0,0,0,5.8-14.65c-.435-5.076-.145-6.092.725-8.267.581-1.6,4.932-5.947,8.268-8.993l-1.6-1.6-1.6-1.595c-3.191,3.336-7.542,7.687-8.993,8.267-2.176.871-3.336,1.161-8.267.726a18.207,18.207,0,0,0-14.65,5.8C15.23,100.082,14.214,110.09,19.871,115.747Z" fill="#7bd5d5"/>
+<path d="M115.747,19.871c-5.657-5.657-15.665-4.641-22.628,2.176a19.2,19.2,0,0,0-5.8,14.65c.29,5.076.145,6.091-.726,8.267-.58,1.6-4.931,5.947-8.267,8.993l1.595,1.6,1.6,1.6c3.046-3.191,7.4-7.687,8.993-8.268,2.175-.87,3.336-1.16,8.267-.725a18.209,18.209,0,0,0,14.65-5.8C120.388,35.536,121.4,25.528,115.747,19.871Z" fill="#7bd5d5"/>
+<path d="M67.881,46.776A21.177,21.177,0,1,0,89.058,67.953,21.109,21.109,0,0,0,67.881,46.776Zm0,34.88A13.92,13.92,0,1,1,81.8,67.736,13.641,13.641,0,0,1,67.879,81.656Z" fill="#7bd5d5"/>
+<path d="M170.557,41c0,10.455,8.979,14.023,19.311,17.1,13.776,4.059,29.643,8.241,29.643,28.044,0,17.22-15.006,25.953-31.611,25.953-9.964,0-16.852-3.936-21.9-3.936-3.444,0-5.78,1.722-8.364,3.936L155.8,84.168h.246c7.626,15.621,19.558,25.339,31.735,25.339,10.455,0,17.835-5.781,17.835-16.113,0-12.055-11.808-15.006-23.863-18.819-12.422-3.813-25.092-8.733-25.092-25.831,0-15.375,12.67-25.214,29.767-25.214,9.47,0,15.867,3.813,20.418,3.813,3.444,0,5.412-2.092,7.257-3.813l.492,24.846h-.246c-6.765-12.793-15.006-22.263-27.921-22.263C177.813,26.113,170.557,31.279,170.557,41Z" fill="#177"/>
+<path d="M248.291,97.452c0,8.119.737,10.087,6.272,13.162v.246H224.429v-.246c5.534-3.075,6.15-5.043,6.15-13.162V64c0-7.872-1.107-10.332-6.889-13.407v-.246h24.6Zm-9.226-77.121c6.028,0,10.578,4.429,10.578,10.209s-4.55,10.209-10.578,10.209-10.578-4.427-10.578-10.209S233.038,20.331,239.065,20.331Z" fill="#177"/>
+<path d="M340.909,49.114c12.546,0,18.573,8.609,18.573,21.4V97.452c0,8.119.739,10.087,6.274,13.162v.246H335.62v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.844-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.738,10.087,6.273,13.162v.246H296.752v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.845-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.737,10.087,6.272,13.162v.246H257.884v-.246c5.535-3.075,6.149-5.043,6.149-13.162V64c0-7.872-1.106-10.332-6.888-13.407v-.246h24.6V66.826c2.829-11.193,9.84-17.712,20.3-17.712,11.193,0,17.466,6.888,18.45,17.712C323.32,55.633,330.454,49.114,340.909,49.114Z" fill="#177"/>
+<path d="M392.322,124.636c0,8.118.615,10.086,6.151,13.161v.246H368.337V137.8c5.535-3.075,6.273-5.043,6.273-13.161V64c0-7.872-1.23-10.332-7.011-13.407v-.246h24.723V66.211c2.46-9.348,10.086-17.1,21.156-17.1,14.637,0,26.569,11.808,26.569,30.873,0,19.434-12.3,32.1-27.43,32.1-10.7,0-17.835-6.642-20.3-15.375Zm0-49.815V86.874c0,12.055,7.134,19.435,14.391,19.435,9.348,0,14.391-9.594,14.391-26.322,0-14.76-5.289-23.37-14.514-23.37C399.333,56.617,392.322,63.751,392.322,74.821Z" fill="#177"/>
+<path d="M466.474,97.452c0,8.119.615,10.087,6.272,13.162v.246H442.488v-.246c5.658-3.075,6.274-5.043,6.274-13.162V32.262c0-7.749-1.6-10.578-7.381-13.284v-.246h25.093Z" fill="#177"/>
+<path d="M504.971,112.95,480.494,63.628c-3.936-7.872-5.166-9.595-9.226-13.038v-.246h29.275v.246c-2.829,1.6-3.567,3.075-3.567,5.535a18.408,18.408,0,0,0,1.968,7.257L512.966,92.9,524.9,64.489a15.387,15.387,0,0,0,1.23-5.9c0-3.69-1.968-6.519-5.657-7.995v-.246h17.712v.246c-4.306,3.2-6.151,5.781-9.6,13.9L503.5,123.529c-4.551,10.578-9.594,15.744-17.589,15.744-7.012,0-12.178-3.936-12.178-10.7,0-6.273,4.429-9.84,9.718-9.84a10.654,10.654,0,0,1,3.936.738c-2.46,1.107-3.567,2.952-3.567,5.781a6.3,6.3,0,0,0,6.642,6.519c4.674,0,7.626-3.32,10.824-10.455Z" fill="#177"/>
+<path d="M203.229,135.521q0,6.084-4.816,7.859l6.411,9.054H197.87l-5.613-8.076h-3.912v8.076H182.7V127.119h9.6q5.9,0,8.421,1.992T203.229,135.521Zm-6.808,3.006a3.821,3.821,0,0,0,1.05-2.988,3.2,3.2,0,0,0-1.086-2.807,6.963,6.963,0,0,0-3.8-.76h-4.238v7.5h4.129Q195.371,139.468,196.421,138.527Z" fill="#229e60"/>
+<path d="M230.338,127.119v5.034h-12.6v5.215h11.336v4.817H217.735v5.252h13v5H212.085V127.119Z" fill="#229e60"/>
+<path d="M251.453,147.437a8.336,8.336,0,0,0,6.808-3.3l3.622,3.73a13.663,13.663,0,0,1-19.792,1.159,13.379,13.379,0,0,1,.073-18.724,12.989,12.989,0,0,1,9.434-3.767,13.373,13.373,0,0,1,10.43,4.745l-3.513,3.983a8.232,8.232,0,0,0-6.664-3.331,7.77,7.77,0,0,0-5.451,2.082,7.256,7.256,0,0,0-2.263,5.613,7.658,7.658,0,0,0,2.137,5.668A7.046,7.046,0,0,0,251.453,147.437Z" fill="#229e60"/>
+<path d="M270.083,127.119h5.65v25.315h-5.65Z" fill="#229e60"/>
+<path d="M302.836,129.382q2.661,2.263,2.661,6.954t-2.734,6.863q-2.734,2.172-8.348,2.173h-3.368v7.062H285.4V127.119h8.946Q300.174,127.119,302.836,129.382Zm-4.147,9.96a4.871,4.871,0,0,0,1.014-3.332,3.53,3.53,0,0,0-1.323-3.115,7.268,7.268,0,0,0-4.11-.923h-3.223v8.511h3.8Q297.674,140.483,298.689,139.342Z" fill="#229e60"/>
+<path d="M331.79,127.119v5.034h-12.6v5.215h11.335v4.817H319.187v5.252h13v5H313.536V127.119Z" fill="#229e60"/>
+<path d="M346.95,132.171a2.183,2.183,0,0,0-.814,1.775,2,2,0,0,0,1,1.756,18.183,18.183,0,0,0,4.6,1.54,12.958,12.958,0,0,1,5.595,2.661,6.577,6.577,0,0,1,1.991,5.179,6.832,6.832,0,0,1-2.553,5.523,10.174,10.174,0,0,1-6.718,2.119,15.545,15.545,0,0,1-10.828-4.455l3.367-4.128q4.093,3.584,7.57,3.585a3.974,3.974,0,0,0,2.445-.67,2.153,2.153,0,0,0,.887-1.811,2.112,2.112,0,0,0-.941-1.811,12.342,12.342,0,0,0-3.731-1.358,16.2,16.2,0,0,1-6.464-2.734q-2.047-1.685-2.046-5.287a6.553,6.553,0,0,1,2.589-5.56,10.418,10.418,0,0,1,6.464-1.956,15.571,15.571,0,0,1,5.071.87,13.59,13.59,0,0,1,4.418,2.462L355.987,134a11.147,11.147,0,0,0-6.809-2.5A3.413,3.413,0,0,0,346.95,132.171Z" fill="#229e60"/>
+</svg> </symbol>
+<symbol id="icon-search">
+<svg viewBox="0 0 37 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.3957 27C8.81428 27 3.479 21.6274 3.479 15C3.479 8.37258 8.81428 3 15.3957 3C21.9771 3 27.3123 8.37258 27.3123 15C27.3123 17.8735 26.3094 20.5111 24.6367 22.5771L33.2707 31.27L31.5542 33L22.9194 24.3063C20.8678 25.9903 18.2488 27 15.3957 27ZM15.3957 24.551C20.634 24.551 24.8804 20.2749 24.8804 15C24.8804 9.72512 20.634 5.44898 15.3957 5.44898C10.1575 5.44898 5.91105 9.72512 5.91105 15C5.91105 20.2749 10.1575 24.551 15.3957 24.551Z" fill="#616161"/>
 </svg>
 </symbol>
 <symbol id="icon-x">
@@ -442,61 +915,28 @@ Mntl.PageView.init(pageViewDataAsJSON);
 </symbol>
 <symbol id="simplyrecipes-logo">
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 538.182 152.724">
-<path d="M68.024,0C60.046,0,53.519,7.832,53.519,17.405a18.745,18.745,0,0,0,6.237,14.36c3.771,3.191,4.351,4.206,5.367,6.382.725,1.6.58,7.687.435,12.184H70.2c-.145-4.5-.145-10.588.435-12.184,1.016-2.176,1.451-3.191,5.367-6.382a18.745,18.745,0,0,0,6.237-14.36C82.383,7.832,75.856,0,68.024,0Z" fill="#7bd5d5" />
-<path d="M67.739,135.618c7.978,0,14.5-7.833,14.5-17.406a18.743,18.743,0,0,0-6.237-14.359c-3.771-3.191-4.351-4.207-5.367-6.382-.725-1.6-.58-7.688-.435-12.184H65.564c.145,4.5.145,10.588-.436,12.184-1.015,2.175-1.45,3.191-5.366,6.382s-6.237,8.412-6.237,14.359C53.235,127.785,59.762,135.618,67.739,135.618Z" fill="#7bd5d5" />
-<path d="M19.871,19.871c-5.657,5.657-4.641,15.81,2.176,22.627A19.2,19.2,0,0,0,36.7,48.3c5.076-.435,6.091-.145,8.267.725,1.6.581,5.8,4.932,8.993,8.268l1.6-1.595,1.6-1.6c-3.191-3.046-7.687-7.4-8.268-8.993-.87-2.175-1.16-3.336-.725-8.267a18.208,18.208,0,0,0-5.8-14.65C35.536,15.23,25.528,14.214,19.871,19.871Z" fill="#7bd5d5" />
-<path d="M115.747,115.747c5.656-5.657,4.641-15.665-2.176-22.483a19.2,19.2,0,0,0-14.65-5.8c-5.076.435-6.092.145-8.267-.726-1.6-.58-5.8-4.931-8.993-8.267l-1.6,1.595-1.595,1.6c3.191,3.046,7.687,7.4,8.267,8.993.871,2.175,1.161,3.336.726,8.267a18.208,18.208,0,0,0,5.8,14.65C100.082,120.533,110.09,121.4,115.747,115.747Z" fill="#7bd5d5" />
-<path d="M0,67.881c0,7.978,7.832,14.5,17.405,14.5a18.745,18.745,0,0,0,14.36-6.237c3.191-3.916,4.206-4.351,6.382-5.367,1.6-.725,7.687-.58,12.184-.58V65.561c-4.5.145-10.588.145-12.184-.435-2.176-1.016-3.191-1.451-6.382-5.367s-8.413-6.237-14.36-6.237C7.832,53.377,0,59.9,0,67.881Z" fill="#7bd5d5" />
-<path d="M135.618,67.881c0-7.977-7.833-14.5-17.406-14.5a18.743,18.743,0,0,0-14.359,6.237c-3.191,3.916-4.207,4.351-6.382,5.366-1.6.726-7.688.581-12.184.436v4.641c4.5-.145,10.588-.145,12.184.58,2.175,1.016,3.191,1.451,6.382,5.367s8.412,6.237,14.359,6.237C127.785,82.241,135.618,75.714,135.618,67.881Z" fill="#7bd5d5" />
-<path d="M19.871,115.747c5.657,5.656,15.81,4.641,22.482-2.176a19.2,19.2,0,0,0,5.8-14.65c-.435-5.076-.145-6.092.725-8.267.581-1.6,4.932-5.947,8.268-8.993l-1.6-1.6-1.6-1.595c-3.191,3.336-7.542,7.687-8.993,8.267-2.176.871-3.336,1.161-8.267.726a18.207,18.207,0,0,0-14.65,5.8C15.23,100.082,14.214,110.09,19.871,115.747Z" fill="#7bd5d5" />
-<path d="M115.747,19.871c-5.657-5.657-15.665-4.641-22.628,2.176a19.2,19.2,0,0,0-5.8,14.65c.29,5.076.145,6.091-.726,8.267-.58,1.6-4.931,5.947-8.267,8.993l1.595,1.6,1.6,1.6c3.046-3.191,7.4-7.687,8.993-8.268,2.175-.87,3.336-1.16,8.267-.725a18.209,18.209,0,0,0,14.65-5.8C120.388,35.536,121.4,25.528,115.747,19.871Z" fill="#7bd5d5" />
-<path d="M67.881,46.776A21.177,21.177,0,1,0,89.058,67.953,21.109,21.109,0,0,0,67.881,46.776Zm0,34.88A13.92,13.92,0,1,1,81.8,67.736,13.641,13.641,0,0,1,67.879,81.656Z" fill="#7bd5d5" />
-<path d="M170.557,41c0,10.455,8.979,14.023,19.311,17.1,13.776,4.059,29.643,8.241,29.643,28.044,0,17.22-15.006,25.953-31.611,25.953-9.964,0-16.852-3.936-21.9-3.936-3.444,0-5.78,1.722-8.364,3.936L155.8,84.168h.246c7.626,15.621,19.558,25.339,31.735,25.339,10.455,0,17.835-5.781,17.835-16.113,0-12.055-11.808-15.006-23.863-18.819-12.422-3.813-25.092-8.733-25.092-25.831,0-15.375,12.67-25.214,29.767-25.214,9.47,0,15.867,3.813,20.418,3.813,3.444,0,5.412-2.092,7.257-3.813l.492,24.846h-.246c-6.765-12.793-15.006-22.263-27.921-22.263C177.813,26.113,170.557,31.279,170.557,41Z" fill="#177" />
-<path d="M248.291,97.452c0,8.119.737,10.087,6.272,13.162v.246H224.429v-.246c5.534-3.075,6.15-5.043,6.15-13.162V64c0-7.872-1.107-10.332-6.889-13.407v-.246h24.6Zm-9.226-77.121c6.028,0,10.578,4.429,10.578,10.209s-4.55,10.209-10.578,10.209-10.578-4.427-10.578-10.209S233.038,20.331,239.065,20.331Z" fill="#177" />
-<path d="M340.909,49.114c12.546,0,18.573,8.609,18.573,21.4V97.452c0,8.119.739,10.087,6.274,13.162v.246H335.62v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.844-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.738,10.087,6.273,13.162v.246H296.752v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.845-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.737,10.087,6.272,13.162v.246H257.884v-.246c5.535-3.075,6.149-5.043,6.149-13.162V64c0-7.872-1.106-10.332-6.888-13.407v-.246h24.6V66.826c2.829-11.193,9.84-17.712,20.3-17.712,11.193,0,17.466,6.888,18.45,17.712C323.32,55.633,330.454,49.114,340.909,49.114Z" fill="#177" />
-<path d="M392.322,124.636c0,8.118.615,10.086,6.151,13.161v.246H368.337V137.8c5.535-3.075,6.273-5.043,6.273-13.161V64c0-7.872-1.23-10.332-7.011-13.407v-.246h24.723V66.211c2.46-9.348,10.086-17.1,21.156-17.1,14.637,0,26.569,11.808,26.569,30.873,0,19.434-12.3,32.1-27.43,32.1-10.7,0-17.835-6.642-20.3-15.375Zm0-49.815V86.874c0,12.055,7.134,19.435,14.391,19.435,9.348,0,14.391-9.594,14.391-26.322,0-14.76-5.289-23.37-14.514-23.37C399.333,56.617,392.322,63.751,392.322,74.821Z" fill="#177" />
-<path d="M466.474,97.452c0,8.119.615,10.087,6.272,13.162v.246H442.488v-.246c5.658-3.075,6.274-5.043,6.274-13.162V32.262c0-7.749-1.6-10.578-7.381-13.284v-.246h25.093Z" fill="#177" />
-<path d="M504.971,112.95,480.494,63.628c-3.936-7.872-5.166-9.595-9.226-13.038v-.246h29.275v.246c-2.829,1.6-3.567,3.075-3.567,5.535a18.408,18.408,0,0,0,1.968,7.257L512.966,92.9,524.9,64.489a15.387,15.387,0,0,0,1.23-5.9c0-3.69-1.968-6.519-5.657-7.995v-.246h17.712v.246c-4.306,3.2-6.151,5.781-9.6,13.9L503.5,123.529c-4.551,10.578-9.594,15.744-17.589,15.744-7.012,0-12.178-3.936-12.178-10.7,0-6.273,4.429-9.84,9.718-9.84a10.654,10.654,0,0,1,3.936.738c-2.46,1.107-3.567,2.952-3.567,5.781a6.3,6.3,0,0,0,6.642,6.519c4.674,0,7.626-3.32,10.824-10.455Z" fill="#177" />
-<path d="M203.229,135.521q0,6.084-4.816,7.859l6.411,9.054H197.87l-5.613-8.076h-3.912v8.076H182.7V127.119h9.6q5.9,0,8.421,1.992T203.229,135.521Zm-6.808,3.006a3.821,3.821,0,0,0,1.05-2.988,3.2,3.2,0,0,0-1.086-2.807,6.963,6.963,0,0,0-3.8-.76h-4.238v7.5h4.129Q195.371,139.468,196.421,138.527Z" fill="#229e60" />
-<path d="M230.338,127.119v5.034h-12.6v5.215h11.336v4.817H217.735v5.252h13v5H212.085V127.119Z" fill="#229e60" />
-<path d="M251.453,147.437a8.336,8.336,0,0,0,6.808-3.3l3.622,3.73a13.663,13.663,0,0,1-19.792,1.159,13.379,13.379,0,0,1,.073-18.724,12.989,12.989,0,0,1,9.434-3.767,13.373,13.373,0,0,1,10.43,4.745l-3.513,3.983a8.232,8.232,0,0,0-6.664-3.331,7.77,7.77,0,0,0-5.451,2.082,7.256,7.256,0,0,0-2.263,5.613,7.658,7.658,0,0,0,2.137,5.668A7.046,7.046,0,0,0,251.453,147.437Z" fill="#229e60" />
-<path d="M270.083,127.119h5.65v25.315h-5.65Z" fill="#229e60" />
-<path d="M302.836,129.382q2.661,2.263,2.661,6.954t-2.734,6.863q-2.734,2.172-8.348,2.173h-3.368v7.062H285.4V127.119h8.946Q300.174,127.119,302.836,129.382Zm-4.147,9.96a4.871,4.871,0,0,0,1.014-3.332,3.53,3.53,0,0,0-1.323-3.115,7.268,7.268,0,0,0-4.11-.923h-3.223v8.511h3.8Q297.674,140.483,298.689,139.342Z" fill="#229e60" />
-<path d="M331.79,127.119v5.034h-12.6v5.215h11.335v4.817H319.187v5.252h13v5H313.536V127.119Z" fill="#229e60" />
-<path d="M346.95,132.171a2.183,2.183,0,0,0-.814,1.775,2,2,0,0,0,1,1.756,18.183,18.183,0,0,0,4.6,1.54,12.958,12.958,0,0,1,5.595,2.661,6.577,6.577,0,0,1,1.991,5.179,6.832,6.832,0,0,1-2.553,5.523,10.174,10.174,0,0,1-6.718,2.119,15.545,15.545,0,0,1-10.828-4.455l3.367-4.128q4.093,3.584,7.57,3.585a3.974,3.974,0,0,0,2.445-.67,2.153,2.153,0,0,0,.887-1.811,2.112,2.112,0,0,0-.941-1.811,12.342,12.342,0,0,0-3.731-1.358,16.2,16.2,0,0,1-6.464-2.734q-2.047-1.685-2.046-5.287a6.553,6.553,0,0,1,2.589-5.56,10.418,10.418,0,0,1,6.464-1.956,15.571,15.571,0,0,1,5.071.87,13.59,13.59,0,0,1,4.418,2.462L355.987,134a11.147,11.147,0,0,0-6.809-2.5A3.413,3.413,0,0,0,346.95,132.171Z" fill="#229e60" />
-</svg> </symbol>
-<symbol id="thespruceeats-logo-text">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 179.7 61.5">
-<path d="M1.3 23c-.1.7.2 1.4.7 1.9.7.5 1.5.8 2.3.7 1.1 0 2.1-.7 2.6-1.7l-.1-.1c-.4.6-1.1 1-1.8 1-1 0-1.4-.6-1.4-1.5l.1-8.6h2.6v-.4H3.7V9.7h-.2c-.9 3.5-2 4.5-3.6 4.8v.1c.4.1 1.1 0 1.5.1 0 1.3-.1 7.8-.1 8.3zM8.1 25.2h-.2.2zM8.1 25.2c.1 0 .3-.1.4-.1l-.4.1z" fill="#434343"/>
-<path d="M9.4 24.1c-.1.7-.5.8-.9 1h5V25c-.2 0-.4 0-.6-.1-.5-.1-.8-.5-.9-1-.1-.7-.1-1.4-.1-2.1v-2c0-.7 0-1.3.1-2 .1-1.6 1.3-2.9 2.8-3.1.6 0 1.1.3 1.4.7.4.6.5 1.4.4 2.1v4.4c0 .7 0 1.4-.1 2.1-.2.7-.4.9-.9 1.1-.2 0-.4.1-.6.1v.1h5.4v-.1c-.2 0-.4 0-.6-.1-.5-.2-.8-.6-.9-1.1-.1-.7-.1-1.4-.1-2.1v-4.3c0-.9-.2-1.8-.7-2.5-.6-.7-1.6-1-2.5-.9-.7 0-1.5.2-2.1.6-.8.5-1.3 1.2-1.6 2.1h-.1v-6c0-1.1.1-2.6.1-3.1 0-.1-.1-.2-.2-.2H7.9v.1c.4 0 .7.1 1 .3.3.2.5.5.5.8.1.6.1 1.1.1 1.7v11.4c.1.7 0 1.5-.1 2.2zM26.4 25.6c2.2 0 4-1.6 4.2-3.7l-.3-.1c-.5 1.7-1.3 3.1-3.5 3.1-.7.1-1.4-.2-1.9-.8-.8-.9-1.2-2.6-1.2-5h7v-.7c0-2-1.5-4.2-4.7-4.2-2.7 0-4.8 2.3-4.8 5.8-.1 1.6.5 3.1 1.5 4.3 1.1.9 2.4 1.4 3.7 1.3zm-1.6-10.7c.4-.3.8-.5 1.3-.5s1 .1 1.4.5c.6.8.9 1.7.9 2.7 0 .8-.3 1.1-1 1.1h-3.6c0-1.9.4-3.3 1-3.8zM8 38.8c-2.6-1.1-4.5-2.2-4.5-4.6-.2-1.6 1-3 2.6-3.2h.4c1.3 0 2.6.6 3.6 1.5 1.2 1.1 1.9 2.5 2.2 4.1h.2l-.2-5.9h-.1L11 31.9h-.1c-1.2-1-2.7-1.5-4.3-1.5-3.3-.2-6.1 2.3-6.3 5.5v.3c0 3.6 2.5 5.3 5.5 6.6 3 1.4 5 2.8 5 4.7 0 2.8-1.2 3.6-3.5 3.6-3.1 0-6.4-3.3-7-7.4H.1l.1 7.5h.2l1.4-1.3H2c1.5 1.2 3.4 1.8 5.3 1.8 3.7 0 6.8-2 6.7-6.5 0-3.4-2.6-5-6-6.4zM27.9 30.5c-2.5.1-4.8 1.7-5.8 4h-.3l.1-3.1c0-.2-.1-.4-.3-.4h-6.8v.2c.8 0 1.6.3 2.2.7.6.3.9.9.9 1.6.1.8.1 2.4.1 3.3v18.4c0 1.3 0 2.5-.2 3.8-.1 1-.8 1.8-1.7 2-.3.2-.7.2-1 .2v.2h9.8v-.2c-.3-.1-.6-.1-1-.2-1-.5-1.4-.7-1.7-2-.2-1.3-.2-2.5-.2-3.8v-5.4h.1c1.3 1.3 3.2 2 5.1 1.9 5.1 0 8.8-3.8 8.9-10.6 0-7.3-3.8-10.6-8.2-10.6zm-1 20.5c-1.4 0-2.7-.6-3.6-1.7-1-1.6-1.5-3.4-1.4-5.2v-6c0-3.9 2.5-6.8 5.1-6.8 2.4 0 4.4 2.1 4.4 9.7s-1.9 10-4.5 10zM50 30.7c-1.2 0-2.3.5-3.2 1.2-1.2 1.2-2.1 2.8-2.6 4.5v-5c0-.2-.1-.3-.3-.3h-6.5v.2c.6 0 1.1.1 1.6.4.5.4.9 1 .9 1.6.1.7.1 2.9.1 3.8v8c0 1.3 0 2.6-.2 3.9-.3 1.3-.6 1.5-1.6 1.9-.4.1-.7.2-1.1.2v.2H47v-.2c-.4 0-.7-.1-1.1-.2-1-.4-1.3-.6-1.6-1.9-.2-1.3-.2-2.6-.2-3.9v-3.3c0-1.2.1-2.5.1-2.9.3-3.7 2.2-6.1 3.1-6.1.5 0 .8.2 1.1 1 .3 1 1.2 1.7 2.2 1.8 1.2 0 2.2-.9 2.3-2.1.1-.7-.1-1.4-.6-2-.6-.5-1.4-.8-2.3-.8zM72.4 49c-.1-1-.1-2-.1-3V31.5c0-.3-.1-.4-.3-.4h-6.6v.2c.6.1 1.2.3 1.8.5.6.4.9 1.1.9 1.8.1 1 .1 2 .1 3v5.5c0 1.4 0 2-.1 3.2-.4 3.2-2.3 5.6-4.3 5.6-1 .1-2-.4-2.6-1.2-.5-1-.8-2.2-.7-3.4V31.4c0-.4-.2-.4-.3-.4h-6.7v.2c.6 0 1.2.2 1.8.4.6.5.9 1.2.9 1.9.1 1 .1 2 .1 3v9.1c0 1.6.4 3.1 1.2 4.4 1.2 1.3 2.9 1.9 4.6 1.8 1.4.1 2.7-.4 3.8-1.2 1-.8 1.8-1.9 2.2-3.1h.1v3.8c0 .1.1.2.2.2.2 0 6-.2 6.8 0v-.2c-.6 0-1.2-.1-1.8-.4-.6-.4-.9-1.1-1-1.9zM85.6 50.8c-1.2.1-2.4-.5-3-1.6-1.2-1.8-1.9-4.8-1.9-9.1 0-3.7.6-6.9 1.8-8 .8-.6 1.7-1 2.7-1 1.9 0 2.4 1 2.8 3.4.2 1.5.7 2.5 2.4 2.5 1.1 0 1.9-.9 1.9-2v-.1c0-.8-.4-1.6-1-2.2-.9-1.1-3.1-2.2-6-2.2-4.3 0-9.2 3.9-9.2 10.4 0 3.5.7 6.3 2.7 8.3 1.7 1.6 4 2.5 6.4 2.5 4 0 6.5-3.1 7.4-6.8l-.6-.2c-.7 2.5-2.2 6.1-6.4 6.1zM105.5 50.4c-1.4.1-2.7-.4-3.6-1.4-1.4-1.6-2.2-4.7-2.2-9.2h12.9c0-.6 0-1.1.1-1.7 0-3.7-2.7-7.7-8.6-7.7-5.1 0-8.9 4.4-8.9 10.8 0 3.4.8 5.9 2.7 8 1.9 1.7 4.3 2.5 6.8 2.4 1.2 0 2.4-.3 3.5-.8 0-.3.1-.7.2-1-.9.4-1.9.6-2.9.6zm-3.8-18.3c.6-.7 1.5-1.1 2.4-1 1 0 1.9.3 2.6 1 .9.9 1.5 2.5 1.6 5 0 1.6-.5 2.1-1.8 2.1h-6.7c.1-3.5.8-6.1 1.9-7.1z" fill="#434343"/>
-<path d="M169.8 32.1c1.7-.7 3.4-1.1 5.2-1.2 1 0 1.9.1 1.9.7 0 .3-.1.6-.1 1s.1.6.7.6c.9 0 2.1-1.4 2.1-2.7 0-1.4-1.2-2.2-3.6-2.2-1.5 0-2.9.3-4.4.7 2.3-3.9 2.7-4.8 3.8-5.8 1.3-1 1.4-1.6 1.4-2.4s-.5-1.2-1.4-1.2-1.6.7-2.8 2.3c-1.8 2.6-3.4 5.4-4.9 8.2-.7.2-1.4.2-2.1.3-.8 0-1-.5-2-.5-.9 0-1.7.7-1.8 1.6v.1c0 1 .8 1.4 2.9 1.4.5 0 1 0 1.4-.1-1.1 2.1-2.2 4.4-3.1 6.6-.2.2-.3.4-.5.6-2.5 3.3-6.6 7.6-9 7.6-.6 0-.9-.7-.9-1.6.1-1.4.5-2.7 1.2-3.9 1.4-2.7 3.2-5 3.2-5.9 0-.8-.7-1.4-1.8-1.4-1.2 0-1.5 1.4-2 1.4-.3 0-1.5-1.6-2.8-1.6-3.9 0-8.6 3.3-11.2 7.6-6.1 7.2-14.1 14.4-20.6 14.4-4.2 0-5.5-2.9-5.5-5.1 0-5.9 8.1-13.1 12.7-15.6 4.7-2.5 7.5-2.2 7.5-3.9s-.7-1.9-1.6-1.9c-.9 0-3.4 1.2-5.5 1.2s-3.5-.8-3.5-2.2c0-4.7 11.8-13.3 18.6-13.3.6-.1 1.1.3 1.1.9v.1c0 2-2.4 4.6-4.6 5.7-1.8.9-2.2 1.4-2.2 2.2 0 .7.5 1.3 1.8 1.3 2.9 0 8.2-6.5 8.2-9 0-2.7-1.6-3.8-3.8-3.8-8.7 0-22.8 9.7-22.8 16.8 0 2.4 2.7 3.9 4.5 3.9-5.2 3.6-11.8 9.2-13.2 15.5-.1.3-.1.6-.2 1-.1.5-.1 1-.1 1.5 0 4.1 2.9 7.5 8.2 7.5 6.6 0 13.2-5.5 19.3-11.9 0 .3-.1.6-.1.8 0 1.3.8 2.4 2 2.7 1.6 0 3.7-1.4 6.9-4.1 1.5-1.4 2.6-2.7 3-2.7.1 0 .1.2.1.6 0 .6-.1 1.6-.1 2.3-.1 1.7 1.2 3.1 2.8 3.2h.4c2.3 0 5.4-2.3 8.2-5-.6 1.7-1 3.5-1.1 5.3 0 1.7.7 2.7 1.7 2.7.8 0 1.4-.6 1.4-1.4 0-.6-.4-1-.4-1.8.1-3.3 3.9-11.5 7.5-18.1zm-28.3 16c-.4 0-.8-.3-.8-.7v-.1c0-3.3 6-9.7 8.9-9.7.4 0 .7.3.8.7v.1c0 .7 1.2.5 1.2.9-.1 1.1-9 8.8-10.1 8.8z" fill="#4B6E8F"/>
-<path d="M176.5 34.4c-3 0-8.2 3.3-8.2 6.8 0 3.1 4.8 2.9 4.8 5.6.1 1.3-1 2.4-2.3 2.5h-.1c-.9.1-1.8-.5-1.9-1.4v-.4c0-.6-.6-1.1-1.2-1h-.1c-.9.1-1.6.8-1.5 1.7 0 1.6 1.8 3.3 4.2 3.3 3.9 0 5.9-2.4 5.9-4.7 0-4.4-4.9-4.1-4.9-6 0-2 3.2-3.8 4.1-3.8.5 0 .9.4 1 .9 0 .3-1 .5-1 1.6 0 .7.7 1.2 1.4 1.2 1.4 0 2.2-2.4 2.2-3.8.1-1.4-1.1-2.5-2.4-2.5z" fill="#4B6E8F"/>
-</svg>
-</symbol>
-<symbol id="simplyrecipes-logo">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 538.182 152.724">
-<path d="M68.024,0C60.046,0,53.519,7.832,53.519,17.405a18.745,18.745,0,0,0,6.237,14.36c3.771,3.191,4.351,4.206,5.367,6.382.725,1.6.58,7.687.435,12.184H70.2c-.145-4.5-.145-10.588.435-12.184,1.016-2.176,1.451-3.191,5.367-6.382a18.745,18.745,0,0,0,6.237-14.36C82.383,7.832,75.856,0,68.024,0Z" fill="#7bd5d5" />
-<path d="M67.739,135.618c7.978,0,14.5-7.833,14.5-17.406a18.743,18.743,0,0,0-6.237-14.359c-3.771-3.191-4.351-4.207-5.367-6.382-.725-1.6-.58-7.688-.435-12.184H65.564c.145,4.5.145,10.588-.436,12.184-1.015,2.175-1.45,3.191-5.366,6.382s-6.237,8.412-6.237,14.359C53.235,127.785,59.762,135.618,67.739,135.618Z" fill="#7bd5d5" />
-<path d="M19.871,19.871c-5.657,5.657-4.641,15.81,2.176,22.627A19.2,19.2,0,0,0,36.7,48.3c5.076-.435,6.091-.145,8.267.725,1.6.581,5.8,4.932,8.993,8.268l1.6-1.595,1.6-1.6c-3.191-3.046-7.687-7.4-8.268-8.993-.87-2.175-1.16-3.336-.725-8.267a18.208,18.208,0,0,0-5.8-14.65C35.536,15.23,25.528,14.214,19.871,19.871Z" fill="#7bd5d5" />
-<path d="M115.747,115.747c5.656-5.657,4.641-15.665-2.176-22.483a19.2,19.2,0,0,0-14.65-5.8c-5.076.435-6.092.145-8.267-.726-1.6-.58-5.8-4.931-8.993-8.267l-1.6,1.595-1.595,1.6c3.191,3.046,7.687,7.4,8.267,8.993.871,2.175,1.161,3.336.726,8.267a18.208,18.208,0,0,0,5.8,14.65C100.082,120.533,110.09,121.4,115.747,115.747Z" fill="#7bd5d5" />
-<path d="M0,67.881c0,7.978,7.832,14.5,17.405,14.5a18.745,18.745,0,0,0,14.36-6.237c3.191-3.916,4.206-4.351,6.382-5.367,1.6-.725,7.687-.58,12.184-.58V65.561c-4.5.145-10.588.145-12.184-.435-2.176-1.016-3.191-1.451-6.382-5.367s-8.413-6.237-14.36-6.237C7.832,53.377,0,59.9,0,67.881Z" fill="#7bd5d5" />
-<path d="M135.618,67.881c0-7.977-7.833-14.5-17.406-14.5a18.743,18.743,0,0,0-14.359,6.237c-3.191,3.916-4.207,4.351-6.382,5.366-1.6.726-7.688.581-12.184.436v4.641c4.5-.145,10.588-.145,12.184.58,2.175,1.016,3.191,1.451,6.382,5.367s8.412,6.237,14.359,6.237C127.785,82.241,135.618,75.714,135.618,67.881Z" fill="#7bd5d5" />
-<path d="M19.871,115.747c5.657,5.656,15.81,4.641,22.482-2.176a19.2,19.2,0,0,0,5.8-14.65c-.435-5.076-.145-6.092.725-8.267.581-1.6,4.932-5.947,8.268-8.993l-1.6-1.6-1.6-1.595c-3.191,3.336-7.542,7.687-8.993,8.267-2.176.871-3.336,1.161-8.267.726a18.207,18.207,0,0,0-14.65,5.8C15.23,100.082,14.214,110.09,19.871,115.747Z" fill="#7bd5d5" />
-<path d="M115.747,19.871c-5.657-5.657-15.665-4.641-22.628,2.176a19.2,19.2,0,0,0-5.8,14.65c.29,5.076.145,6.091-.726,8.267-.58,1.6-4.931,5.947-8.267,8.993l1.595,1.6,1.6,1.6c3.046-3.191,7.4-7.687,8.993-8.268,2.175-.87,3.336-1.16,8.267-.725a18.209,18.209,0,0,0,14.65-5.8C120.388,35.536,121.4,25.528,115.747,19.871Z" fill="#7bd5d5" />
-<path d="M67.881,46.776A21.177,21.177,0,1,0,89.058,67.953,21.109,21.109,0,0,0,67.881,46.776Zm0,34.88A13.92,13.92,0,1,1,81.8,67.736,13.641,13.641,0,0,1,67.879,81.656Z" fill="#7bd5d5" />
-<path d="M170.557,41c0,10.455,8.979,14.023,19.311,17.1,13.776,4.059,29.643,8.241,29.643,28.044,0,17.22-15.006,25.953-31.611,25.953-9.964,0-16.852-3.936-21.9-3.936-3.444,0-5.78,1.722-8.364,3.936L155.8,84.168h.246c7.626,15.621,19.558,25.339,31.735,25.339,10.455,0,17.835-5.781,17.835-16.113,0-12.055-11.808-15.006-23.863-18.819-12.422-3.813-25.092-8.733-25.092-25.831,0-15.375,12.67-25.214,29.767-25.214,9.47,0,15.867,3.813,20.418,3.813,3.444,0,5.412-2.092,7.257-3.813l.492,24.846h-.246c-6.765-12.793-15.006-22.263-27.921-22.263C177.813,26.113,170.557,31.279,170.557,41Z" fill="#177" />
-<path d="M248.291,97.452c0,8.119.737,10.087,6.272,13.162v.246H224.429v-.246c5.534-3.075,6.15-5.043,6.15-13.162V64c0-7.872-1.107-10.332-6.889-13.407v-.246h24.6Zm-9.226-77.121c6.028,0,10.578,4.429,10.578,10.209s-4.55,10.209-10.578,10.209-10.578-4.427-10.578-10.209S233.038,20.331,239.065,20.331Z" fill="#177" />
-<path d="M340.909,49.114c12.546,0,18.573,8.609,18.573,21.4V97.452c0,8.119.739,10.087,6.274,13.162v.246H335.62v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.844-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.738,10.087,6.273,13.162v.246H296.752v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.845-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.737,10.087,6.272,13.162v.246H257.884v-.246c5.535-3.075,6.149-5.043,6.149-13.162V64c0-7.872-1.106-10.332-6.888-13.407v-.246h24.6V66.826c2.829-11.193,9.84-17.712,20.3-17.712,11.193,0,17.466,6.888,18.45,17.712C323.32,55.633,330.454,49.114,340.909,49.114Z" fill="#177" />
-<path d="M392.322,124.636c0,8.118.615,10.086,6.151,13.161v.246H368.337V137.8c5.535-3.075,6.273-5.043,6.273-13.161V64c0-7.872-1.23-10.332-7.011-13.407v-.246h24.723V66.211c2.46-9.348,10.086-17.1,21.156-17.1,14.637,0,26.569,11.808,26.569,30.873,0,19.434-12.3,32.1-27.43,32.1-10.7,0-17.835-6.642-20.3-15.375Zm0-49.815V86.874c0,12.055,7.134,19.435,14.391,19.435,9.348,0,14.391-9.594,14.391-26.322,0-14.76-5.289-23.37-14.514-23.37C399.333,56.617,392.322,63.751,392.322,74.821Z" fill="#177" />
-<path d="M466.474,97.452c0,8.119.615,10.087,6.272,13.162v.246H442.488v-.246c5.658-3.075,6.274-5.043,6.274-13.162V32.262c0-7.749-1.6-10.578-7.381-13.284v-.246h25.093Z" fill="#177" />
-<path d="M504.971,112.95,480.494,63.628c-3.936-7.872-5.166-9.595-9.226-13.038v-.246h29.275v.246c-2.829,1.6-3.567,3.075-3.567,5.535a18.408,18.408,0,0,0,1.968,7.257L512.966,92.9,524.9,64.489a15.387,15.387,0,0,0,1.23-5.9c0-3.69-1.968-6.519-5.657-7.995v-.246h17.712v.246c-4.306,3.2-6.151,5.781-9.6,13.9L503.5,123.529c-4.551,10.578-9.594,15.744-17.589,15.744-7.012,0-12.178-3.936-12.178-10.7,0-6.273,4.429-9.84,9.718-9.84a10.654,10.654,0,0,1,3.936.738c-2.46,1.107-3.567,2.952-3.567,5.781a6.3,6.3,0,0,0,6.642,6.519c4.674,0,7.626-3.32,10.824-10.455Z" fill="#177" />
-<path d="M203.229,135.521q0,6.084-4.816,7.859l6.411,9.054H197.87l-5.613-8.076h-3.912v8.076H182.7V127.119h9.6q5.9,0,8.421,1.992T203.229,135.521Zm-6.808,3.006a3.821,3.821,0,0,0,1.05-2.988,3.2,3.2,0,0,0-1.086-2.807,6.963,6.963,0,0,0-3.8-.76h-4.238v7.5h4.129Q195.371,139.468,196.421,138.527Z" fill="#229e60" />
-<path d="M230.338,127.119v5.034h-12.6v5.215h11.336v4.817H217.735v5.252h13v5H212.085V127.119Z" fill="#229e60" />
-<path d="M251.453,147.437a8.336,8.336,0,0,0,6.808-3.3l3.622,3.73a13.663,13.663,0,0,1-19.792,1.159,13.379,13.379,0,0,1,.073-18.724,12.989,12.989,0,0,1,9.434-3.767,13.373,13.373,0,0,1,10.43,4.745l-3.513,3.983a8.232,8.232,0,0,0-6.664-3.331,7.77,7.77,0,0,0-5.451,2.082,7.256,7.256,0,0,0-2.263,5.613,7.658,7.658,0,0,0,2.137,5.668A7.046,7.046,0,0,0,251.453,147.437Z" fill="#229e60" />
-<path d="M270.083,127.119h5.65v25.315h-5.65Z" fill="#229e60" />
-<path d="M302.836,129.382q2.661,2.263,2.661,6.954t-2.734,6.863q-2.734,2.172-8.348,2.173h-3.368v7.062H285.4V127.119h8.946Q300.174,127.119,302.836,129.382Zm-4.147,9.96a4.871,4.871,0,0,0,1.014-3.332,3.53,3.53,0,0,0-1.323-3.115,7.268,7.268,0,0,0-4.11-.923h-3.223v8.511h3.8Q297.674,140.483,298.689,139.342Z" fill="#229e60" />
-<path d="M331.79,127.119v5.034h-12.6v5.215h11.335v4.817H319.187v5.252h13v5H313.536V127.119Z" fill="#229e60" />
-<path d="M346.95,132.171a2.183,2.183,0,0,0-.814,1.775,2,2,0,0,0,1,1.756,18.183,18.183,0,0,0,4.6,1.54,12.958,12.958,0,0,1,5.595,2.661,6.577,6.577,0,0,1,1.991,5.179,6.832,6.832,0,0,1-2.553,5.523,10.174,10.174,0,0,1-6.718,2.119,15.545,15.545,0,0,1-10.828-4.455l3.367-4.128q4.093,3.584,7.57,3.585a3.974,3.974,0,0,0,2.445-.67,2.153,2.153,0,0,0,.887-1.811,2.112,2.112,0,0,0-.941-1.811,12.342,12.342,0,0,0-3.731-1.358,16.2,16.2,0,0,1-6.464-2.734q-2.047-1.685-2.046-5.287a6.553,6.553,0,0,1,2.589-5.56,10.418,10.418,0,0,1,6.464-1.956,15.571,15.571,0,0,1,5.071.87,13.59,13.59,0,0,1,4.418,2.462L355.987,134a11.147,11.147,0,0,0-6.809-2.5A3.413,3.413,0,0,0,346.95,132.171Z" fill="#229e60" />
+<path d="M68.024,0C60.046,0,53.519,7.832,53.519,17.405a18.745,18.745,0,0,0,6.237,14.36c3.771,3.191,4.351,4.206,5.367,6.382.725,1.6.58,7.687.435,12.184H70.2c-.145-4.5-.145-10.588.435-12.184,1.016-2.176,1.451-3.191,5.367-6.382a18.745,18.745,0,0,0,6.237-14.36C82.383,7.832,75.856,0,68.024,0Z" fill="#7bd5d5"/>
+<path d="M67.739,135.618c7.978,0,14.5-7.833,14.5-17.406a18.743,18.743,0,0,0-6.237-14.359c-3.771-3.191-4.351-4.207-5.367-6.382-.725-1.6-.58-7.688-.435-12.184H65.564c.145,4.5.145,10.588-.436,12.184-1.015,2.175-1.45,3.191-5.366,6.382s-6.237,8.412-6.237,14.359C53.235,127.785,59.762,135.618,67.739,135.618Z" fill="#7bd5d5"/>
+<path d="M19.871,19.871c-5.657,5.657-4.641,15.81,2.176,22.627A19.2,19.2,0,0,0,36.7,48.3c5.076-.435,6.091-.145,8.267.725,1.6.581,5.8,4.932,8.993,8.268l1.6-1.595,1.6-1.6c-3.191-3.046-7.687-7.4-8.268-8.993-.87-2.175-1.16-3.336-.725-8.267a18.208,18.208,0,0,0-5.8-14.65C35.536,15.23,25.528,14.214,19.871,19.871Z" fill="#7bd5d5"/>
+<path d="M115.747,115.747c5.656-5.657,4.641-15.665-2.176-22.483a19.2,19.2,0,0,0-14.65-5.8c-5.076.435-6.092.145-8.267-.726-1.6-.58-5.8-4.931-8.993-8.267l-1.6,1.595-1.595,1.6c3.191,3.046,7.687,7.4,8.267,8.993.871,2.175,1.161,3.336.726,8.267a18.208,18.208,0,0,0,5.8,14.65C100.082,120.533,110.09,121.4,115.747,115.747Z" fill="#7bd5d5"/>
+<path d="M0,67.881c0,7.978,7.832,14.5,17.405,14.5a18.745,18.745,0,0,0,14.36-6.237c3.191-3.916,4.206-4.351,6.382-5.367,1.6-.725,7.687-.58,12.184-.58V65.561c-4.5.145-10.588.145-12.184-.435-2.176-1.016-3.191-1.451-6.382-5.367s-8.413-6.237-14.36-6.237C7.832,53.377,0,59.9,0,67.881Z" fill="#7bd5d5"/>
+<path d="M135.618,67.881c0-7.977-7.833-14.5-17.406-14.5a18.743,18.743,0,0,0-14.359,6.237c-3.191,3.916-4.207,4.351-6.382,5.366-1.6.726-7.688.581-12.184.436v4.641c4.5-.145,10.588-.145,12.184.58,2.175,1.016,3.191,1.451,6.382,5.367s8.412,6.237,14.359,6.237C127.785,82.241,135.618,75.714,135.618,67.881Z" fill="#7bd5d5"/>
+<path d="M19.871,115.747c5.657,5.656,15.81,4.641,22.482-2.176a19.2,19.2,0,0,0,5.8-14.65c-.435-5.076-.145-6.092.725-8.267.581-1.6,4.932-5.947,8.268-8.993l-1.6-1.6-1.6-1.595c-3.191,3.336-7.542,7.687-8.993,8.267-2.176.871-3.336,1.161-8.267.726a18.207,18.207,0,0,0-14.65,5.8C15.23,100.082,14.214,110.09,19.871,115.747Z" fill="#7bd5d5"/>
+<path d="M115.747,19.871c-5.657-5.657-15.665-4.641-22.628,2.176a19.2,19.2,0,0,0-5.8,14.65c.29,5.076.145,6.091-.726,8.267-.58,1.6-4.931,5.947-8.267,8.993l1.595,1.6,1.6,1.6c3.046-3.191,7.4-7.687,8.993-8.268,2.175-.87,3.336-1.16,8.267-.725a18.209,18.209,0,0,0,14.65-5.8C120.388,35.536,121.4,25.528,115.747,19.871Z" fill="#7bd5d5"/>
+<path d="M67.881,46.776A21.177,21.177,0,1,0,89.058,67.953,21.109,21.109,0,0,0,67.881,46.776Zm0,34.88A13.92,13.92,0,1,1,81.8,67.736,13.641,13.641,0,0,1,67.879,81.656Z" fill="#7bd5d5"/>
+<path d="M170.557,41c0,10.455,8.979,14.023,19.311,17.1,13.776,4.059,29.643,8.241,29.643,28.044,0,17.22-15.006,25.953-31.611,25.953-9.964,0-16.852-3.936-21.9-3.936-3.444,0-5.78,1.722-8.364,3.936L155.8,84.168h.246c7.626,15.621,19.558,25.339,31.735,25.339,10.455,0,17.835-5.781,17.835-16.113,0-12.055-11.808-15.006-23.863-18.819-12.422-3.813-25.092-8.733-25.092-25.831,0-15.375,12.67-25.214,29.767-25.214,9.47,0,15.867,3.813,20.418,3.813,3.444,0,5.412-2.092,7.257-3.813l.492,24.846h-.246c-6.765-12.793-15.006-22.263-27.921-22.263C177.813,26.113,170.557,31.279,170.557,41Z" fill="#177"/>
+<path d="M248.291,97.452c0,8.119.737,10.087,6.272,13.162v.246H224.429v-.246c5.534-3.075,6.15-5.043,6.15-13.162V64c0-7.872-1.107-10.332-6.889-13.407v-.246h24.6Zm-9.226-77.121c6.028,0,10.578,4.429,10.578,10.209s-4.55,10.209-10.578,10.209-10.578-4.427-10.578-10.209S233.038,20.331,239.065,20.331Z" fill="#177"/>
+<path d="M340.909,49.114c12.546,0,18.573,8.609,18.573,21.4V97.452c0,8.119.739,10.087,6.274,13.162v.246H335.62v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.844-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.738,10.087,6.273,13.162v.246H296.752v-.246c5.535-3.075,6.15-5.043,6.15-13.162V70.516c0-6.888-1.845-12.546-9.1-12.546s-12.054,6.765-12.054,18.942v20.54c0,8.119.737,10.087,6.272,13.162v.246H257.884v-.246c5.535-3.075,6.149-5.043,6.149-13.162V64c0-7.872-1.106-10.332-6.888-13.407v-.246h24.6V66.826c2.829-11.193,9.84-17.712,20.3-17.712,11.193,0,17.466,6.888,18.45,17.712C323.32,55.633,330.454,49.114,340.909,49.114Z" fill="#177"/>
+<path d="M392.322,124.636c0,8.118.615,10.086,6.151,13.161v.246H368.337V137.8c5.535-3.075,6.273-5.043,6.273-13.161V64c0-7.872-1.23-10.332-7.011-13.407v-.246h24.723V66.211c2.46-9.348,10.086-17.1,21.156-17.1,14.637,0,26.569,11.808,26.569,30.873,0,19.434-12.3,32.1-27.43,32.1-10.7,0-17.835-6.642-20.3-15.375Zm0-49.815V86.874c0,12.055,7.134,19.435,14.391,19.435,9.348,0,14.391-9.594,14.391-26.322,0-14.76-5.289-23.37-14.514-23.37C399.333,56.617,392.322,63.751,392.322,74.821Z" fill="#177"/>
+<path d="M466.474,97.452c0,8.119.615,10.087,6.272,13.162v.246H442.488v-.246c5.658-3.075,6.274-5.043,6.274-13.162V32.262c0-7.749-1.6-10.578-7.381-13.284v-.246h25.093Z" fill="#177"/>
+<path d="M504.971,112.95,480.494,63.628c-3.936-7.872-5.166-9.595-9.226-13.038v-.246h29.275v.246c-2.829,1.6-3.567,3.075-3.567,5.535a18.408,18.408,0,0,0,1.968,7.257L512.966,92.9,524.9,64.489a15.387,15.387,0,0,0,1.23-5.9c0-3.69-1.968-6.519-5.657-7.995v-.246h17.712v.246c-4.306,3.2-6.151,5.781-9.6,13.9L503.5,123.529c-4.551,10.578-9.594,15.744-17.589,15.744-7.012,0-12.178-3.936-12.178-10.7,0-6.273,4.429-9.84,9.718-9.84a10.654,10.654,0,0,1,3.936.738c-2.46,1.107-3.567,2.952-3.567,5.781a6.3,6.3,0,0,0,6.642,6.519c4.674,0,7.626-3.32,10.824-10.455Z" fill="#177"/>
+<path d="M203.229,135.521q0,6.084-4.816,7.859l6.411,9.054H197.87l-5.613-8.076h-3.912v8.076H182.7V127.119h9.6q5.9,0,8.421,1.992T203.229,135.521Zm-6.808,3.006a3.821,3.821,0,0,0,1.05-2.988,3.2,3.2,0,0,0-1.086-2.807,6.963,6.963,0,0,0-3.8-.76h-4.238v7.5h4.129Q195.371,139.468,196.421,138.527Z" fill="#229e60"/>
+<path d="M230.338,127.119v5.034h-12.6v5.215h11.336v4.817H217.735v5.252h13v5H212.085V127.119Z" fill="#229e60"/>
+<path d="M251.453,147.437a8.336,8.336,0,0,0,6.808-3.3l3.622,3.73a13.663,13.663,0,0,1-19.792,1.159,13.379,13.379,0,0,1,.073-18.724,12.989,12.989,0,0,1,9.434-3.767,13.373,13.373,0,0,1,10.43,4.745l-3.513,3.983a8.232,8.232,0,0,0-6.664-3.331,7.77,7.77,0,0,0-5.451,2.082,7.256,7.256,0,0,0-2.263,5.613,7.658,7.658,0,0,0,2.137,5.668A7.046,7.046,0,0,0,251.453,147.437Z" fill="#229e60"/>
+<path d="M270.083,127.119h5.65v25.315h-5.65Z" fill="#229e60"/>
+<path d="M302.836,129.382q2.661,2.263,2.661,6.954t-2.734,6.863q-2.734,2.172-8.348,2.173h-3.368v7.062H285.4V127.119h8.946Q300.174,127.119,302.836,129.382Zm-4.147,9.96a4.871,4.871,0,0,0,1.014-3.332,3.53,3.53,0,0,0-1.323-3.115,7.268,7.268,0,0,0-4.11-.923h-3.223v8.511h3.8Q297.674,140.483,298.689,139.342Z" fill="#229e60"/>
+<path d="M331.79,127.119v5.034h-12.6v5.215h11.335v4.817H319.187v5.252h13v5H313.536V127.119Z" fill="#229e60"/>
+<path d="M346.95,132.171a2.183,2.183,0,0,0-.814,1.775,2,2,0,0,0,1,1.756,18.183,18.183,0,0,0,4.6,1.54,12.958,12.958,0,0,1,5.595,2.661,6.577,6.577,0,0,1,1.991,5.179,6.832,6.832,0,0,1-2.553,5.523,10.174,10.174,0,0,1-6.718,2.119,15.545,15.545,0,0,1-10.828-4.455l3.367-4.128q4.093,3.584,7.57,3.585a3.974,3.974,0,0,0,2.445-.67,2.153,2.153,0,0,0,.887-1.811,2.112,2.112,0,0,0-.941-1.811,12.342,12.342,0,0,0-3.731-1.358,16.2,16.2,0,0,1-6.464-2.734q-2.047-1.685-2.046-5.287a6.553,6.553,0,0,1,2.589-5.56,10.418,10.418,0,0,1,6.464-1.956,15.571,15.571,0,0,1,5.071.87,13.59,13.59,0,0,1,4.418,2.462L355.987,134a11.147,11.147,0,0,0-6.809-2.5A3.413,3.413,0,0,0,346.95,132.171Z" fill="#229e60"/>
 </svg> </symbol>
 <symbol id="icon-hand">
 <svg viewBox="0 0 16 20" xmlns="http://www.w3.org/2000/svg">
@@ -508,15 +948,6 @@ Mntl.PageView.init(pageViewDataAsJSON);
 <path d="M372.861,53.9c3.99,1.519,8.193,2.529,12.469,3.72,1.016.425,4.466,2.165,5.293,1.615a9.228,9.228,0,0,0,1.062-2.54c3.587-7.154,7.026-14.668,11.047-21.79-5.943,2.44-11.812,5.059-17.935,7.573-7.023,2.883-13.073,5.577-20.276,8.534a22.041,22.041,0,0,0,3.08.84C369.559,52.519,371.157,53.336,372.861,53.9Z" fill="#a0c3cc"/><path d="M405.817,60.362c-1.63-.383-3.154-1.02-4.785-1.4a20.625,20.625,0,0,0-2.9-.914,7.2,7.2,0,0,1-2.351-.087,35.8,35.8,0,0,1-2.705,4.688c-1.039,1.058-2.415.781-3.717.684-.688-.138-1.7-.563-2.392-.7a11.17,11.17,0,0,0-1.556-.2c-.54.222-.785,1.164-.891,1.418a23.336,23.336,0,0,1-1.348,2.868L380.5,70.966a40.659,40.659,0,0,0-2.483,5.228l.148.36,1.8-.739,3.062-1.257c5.837-2.186,11.6-4.551,17.108-7.023,2.087-1.067,4.248-1.954,6.409-2.841a27.361,27.361,0,0,0,5.223-2.144,4.548,4.548,0,0,0-1.778-.743C408.537,61.35,407.267,60.819,405.817,60.362Z" fill="#a0c3cc"/><path d="M381.24,60.982a9.228,9.228,0,0,0-2.54-1.062c-2.032-.849-3.99-1.518-5.948-2.188a37.37,37.37,0,0,1-3.736-1.412,9.748,9.748,0,0,1-1.958-.669c-.18.074-.254-.106-.508-.212l-.18.074.148.36a20.582,20.582,0,0,0,1.932,5.731c.559,1.875,1.372,3.856,2.186,5.837,1.183,2.881,2.694,6.049,3.876,8.93a15.559,15.559,0,0,0,1.38-3.3,17.551,17.551,0,0,1,.882-2.466c.743-1.778,1.74-3.45,2.3-5.154C379.605,64.178,381.069,62.1,381.24,60.982Z" fill="#a0c3cc"/><path d="M399.41,51.419a9.227,9.227,0,0,0-1.062,2.54c.91.679,3.228,1.2,4.5,1.731,1.6.817,3.482,1.306,5.26,2.049a17.548,17.548,0,0,1,2.36,1.136,15.56,15.56,0,0,0,3.3,1.38c-1.183-2.881-2.333-6.2-3.516-9.078-.813-1.981-1.626-3.962-2.546-5.689a31.449,31.449,0,0,0-2.652-5.435l-.148-.36-.106.254c-.106.254-.032.434-.212.508l-.743,1.778a37.373,37.373,0,0,1-1.666,3.63C401.256,47.714,400.259,49.386,399.41,51.419Z" fill="#a0c3cc"/><path d="M345.135,5.476c1.214,2.686,2.78,5.227,4.294,7.892.291.7,1.133,3.234,1.8,3.368a6.374,6.374,0,0,0,1.757-.727c5.239-1.756,10.582-3.761,16.018-5.29-4.1-1.7-8.246-3.274-12.468-5.025C351.7,3.686,347.425,2.06,342.458,0a15.208,15.208,0,0,0,1.1,1.911C344.19,3.192,344.575,4.37,345.135,5.476Z" fill="#a0c3cc"/><path d="M358.123,24.686c-.612-.981-1.048-2.035-1.659-3.016a14.235,14.235,0,0,0-.975-1.859,4.968,4.968,0,0,1-1.108-1.187,24.727,24.727,0,0,1-3.607.978c-1.024.012-1.563-.794-2.153-1.475-.27-.4-.56-1.105-.83-1.508a7.7,7.7,0,0,0-.663-.857c-.372-.154-.951.188-1.127.26a16.115,16.115,0,0,1-2.056.748l-3.38.781A28.081,28.081,0,0,0,336.8,18.9l-.1.248,1.242.515,2.111.875c3.922,1.772,7.9,3.419,11.8,4.891,1.541.494,3.031,1.112,4.521,1.729a18.9,18.9,0,0,0,3.6,1.493,3.139,3.139,0,0,0-.509-1.23C358.974,26.494,358.611,25.615,358.123,24.686Z" fill="#a0c3cc"/><path d="M338.917,15.557c1.23-.509,2.532-.842,3.637-1.4a21.821,21.821,0,0,0,3.234-1.133,6.37,6.37,0,0,0-.727-1.757c-.581-1.405-1.214-2.686-1.847-3.967a25.815,25.815,0,0,1-1.142-2.511,6.737,6.737,0,0,1-.633-1.281c-.124-.052-.073-.176-.145-.351l-.124-.052-.1.248A14.209,14.209,0,0,0,339.223,7.1c-.639,1.19-1.205,2.556-1.772,3.922-.824,1.987-1.626,4.273-2.45,6.26a10.743,10.743,0,0,0,2.283-.945A12.116,12.116,0,0,1,338.917,15.557Z" fill="#a0c3cc"/><path d="M366.291,18.323a21.715,21.715,0,0,0,1.348-3.952l.1-.248-.176.073c-.176.073-.227.2-.351.145l-1.23.509a25.813,25.813,0,0,1-2.583.966c-1.354.457-2.656.79-4.061,1.372a6.372,6.372,0,0,0-1.757.727,20,20,0,0,0,1.36,3.038c.385,1.178,1.069,2.335,1.578,3.565a12.114,12.114,0,0,1,.6,1.705,10.747,10.747,0,0,0,.945,2.284c.824-1.987,1.875-4.17,2.7-6.157C365.334,20.982,365.9,19.616,366.291,18.323Z" fill="#a0c3cc"/><path d="M277.96,35.929c1.935,1.618,4.087,2.994,6.246,4.484.485.433,2.076,2.071,2.644,1.923.338-.134.867-.971,1.083-1.214,3.384-3.3,6.754-6.836,10.374-10.037-3.79.215-7.573.546-11.477.768-4.479.255-8.377.591-12.97.852a13.024,13.024,0,0,0,1.558,1.064C276.383,34.521,277.117,35.285,277.96,35.929Z" fill="#a0c3cc"/><path d="M297.167,47.51c-.722-.535-1.328-1.077-2.05-1.612-.836-.529-1.565-1.178-2.4-1.707a12.18,12.18,0,0,0-1.443-1.07,4.252,4.252,0,0,1-1.3-.5,21.159,21.159,0,0,1-2.416,2.1c-.784.39-1.5-.03-2.208-.335-.358-.21-.843-.643-1.2-.853a6.6,6.6,0,0,0-.83-.414c-.345.02-.663.5-.771.62a13.782,13.782,0,0,1-1.306,1.342l-2.314,1.86a24.024,24.024,0,0,0-2.4,2.44l.013.23,1.148-.065,1.952-.111c3.681-.094,7.356-.3,10.91-.62,1.372-.193,2.75-.272,4.128-.35a16.166,16.166,0,0,0,3.33-.189A2.687,2.687,0,0,0,297.167,47.51Z" fill="#a0c3cc"/><path d="M279.2,43.577a18.677,18.677,0,0,0,2.071-2.076c-.134-.338-.971-.866-1.214-1.083-.971-.867-1.935-1.618-2.9-2.37a22.077,22.077,0,0,1-1.814-1.51,5.762,5.762,0,0,1-.964-.752c-.115.007-.121-.108-.243-.217l-.115.007.013.23a12.159,12.159,0,0,0-.027,3.573c-.05,1.155.022,2.418.094,3.681.1,1.837.337,3.9.441,5.735a9.2,9.2,0,0,0,1.408-1.578,10.368,10.368,0,0,1,.968-1.207C277.679,45.161,278.558,44.42,279.2,43.577Z" fill="#a0c3cc"/><path d="M299.044,37.956a18.576,18.576,0,0,0-.432-3.547l-.013-.23-.108.121c-.108.121-.1.236-.217.243l-.758.85a22.076,22.076,0,0,1-1.631,1.706c-.873.856-1.753,1.6-2.619,2.568-.217.243-.988.863-1.083,1.214a17.116,17.116,0,0,0,2.178,1.835c.735.765,1.693,1.4,2.542,2.16a10.379,10.379,0,0,1,1.1,1.09,9.192,9.192,0,0,0,1.578,1.408c-.1-1.837-.107-3.911-.212-5.748C299.3,40.361,299.224,39.1,299.044,37.956Z" fill="#a0c3cc"/><path d="M353.084,44.463c1.221,1.369,1.826,2.218,1.833,2.227l1.632-1.156a30.357,30.357,0,0,0-1.973-2.4Z" fill="#a0c3cc"/><path d="M118.2,75.945a53.741,53.741,0,0,0,6.116.388l.016-2a52.008,52.008,0,0,1-5.888-.372Z" fill="#a0c3cc"/><path d="M78.241,34.4c.634,1.834,1.3,3.752,2.029,5.714l1.876-.694c-.722-1.948-1.385-3.853-2.015-5.673Z" fill="#a0c3cc"/><path d="M73.966,23.251a52.1,52.1,0,0,1,2.28,5.466l1.878-.688a53.845,53.845,0,0,0-2.373-5.679Z" fill="#a0c3cc"/><path d="M96,66.078a38.639,38.639,0,0,0,4.891,3.773l1.089-1.678A36.535,36.535,0,0,1,97.348,64.6Z" fill="#a0c3cc"/><path d="M106.334,72.778a39.931,39.931,0,0,0,5.825,2.019l.51-1.934a37.982,37.982,0,0,1-5.533-1.917Z" fill="#a0c3cc"/><path d="M65.97,14.994c1.531,1.165,3.065,2.446,4.561,3.811l1.348-1.478c-1.539-1.4-3.119-2.725-4.7-3.925Z" fill="#a0c3cc"/><path d="M88.14,56.632a51.186,51.186,0,0,0,3.613,4.977l1.542-1.273a49.19,49.19,0,0,1-3.47-4.781Z" fill="#a0c3cc"/><path d="M82.51,45.778c.85,1.994,1.695,3.805,2.584,5.536l1.779-.914c-.867-1.688-1.692-3.457-2.523-5.406Z" fill="#a0c3cc"/><path d="M55.87,8.823a55.305,55.305,0,0,1,5.208,2.819l1.045-1.705a57.175,57.175,0,0,0-5.4-2.921Z" fill="#a0c3cc"/><path d="M282.134,20.47l-.152-1.994c-1.993.152-4.027.355-6.048.6l.244,1.985C278.167,20.819,280.172,20.619,282.134,20.47Z" fill="#a0c3cc"/><path d="M294.089,20.153l.051-2q-2.963-.076-6.084.006l.053,2Q291.176,20.078,294.089,20.153Z" fill="#a0c3cc"/><path d="M8.852,4.676,9.37,6.608c1.953-.523,3.909-.986,5.813-1.377l-.4-1.959C12.837,3.67,10.843,4.143,8.852,4.676Z" fill="#a0c3cc"/><path d="M44.693,4.971A54.826,54.826,0,0,1,50.388,6.59L51.039,4.7a56.73,56.73,0,0,0-5.9-1.678Z" fill="#a0c3cc"/><path d="M32.934,3.533c2,.051,3.992.2,5.919.429l.24-1.985c-1.99-.241-4.045-.39-6.108-.442Z" fill="#a0c3cc"/><path d="M20.792,2.242l.271,1.981c2-.272,3.991-.469,5.927-.585l-.119-2C24.883,1.761,22.838,1.962,20.792,2.242Z" fill="#a0c3cc"/><path d="M252.17,23.97l.547,1.924c1.932-.548,3.883-1.066,5.8-1.539l-.479-1.941C256.1,22.891,254.125,23.415,252.17,23.97Z" fill="#a0c3cc"/><path d="M229.306,32l.768,1.847c1.854-.771,3.729-1.521,5.576-2.231l-.719-1.866C233.069,30.467,231.176,31.224,229.306,32Z" fill="#a0c3cc"/><path d="M311.873,22.158c1.953.4,3.9.875,5.8,1.4l.534-1.928c-1.937-.537-3.931-1.018-5.928-1.431Z" fill="#a0c3cc"/><path d="M300.055,20.472c1.992.163,3.989.386,5.936.662l.281-1.98c-1.985-.282-4.022-.509-6.055-.675Z" fill="#a0c3cc"/><path d="M240.618,27.653l.666,1.886c1.9-.67,3.815-1.313,5.688-1.912l-.607-1.905C244.472,26.326,242.539,26.975,240.618,27.653Z" fill="#a0c3cc"/><path d="M263.954,21.067l.406,1.958c1.966-.409,3.947-.78,5.89-1.1l-.328-1.973C267.953,20.277,265.945,20.653,263.954,21.067Z" fill="#a0c3cc"/><path d="M344.314,36.491c1.606,1.212,3.148,2.485,4.585,3.784l1.342-1.483c-1.48-1.338-3.068-2.649-4.722-3.9Z" fill="#a0c3cc"/><path d="M334.269,30.118c1.757.929,3.49,1.934,5.151,2.987l1.07-1.689c-1.705-1.081-3.483-2.112-5.286-3.065Z" fill="#a0c3cc"/><path d="M323.357,25.346c1.881.665,3.746,1.4,5.544,2.186l.8-1.833c-1.842-.8-3.753-1.558-5.679-2.238Z" fill="#a0c3cc"/><path d="M164.709,64.579l.777,1.842c1.813-.765,3.681-1.586,5.549-2.439l-.831-1.818C168.354,63.008,166.5,63.822,164.709,64.579Z" fill="#a0c3cc"/><path d="M175.637,59.6l.877,1.8c1.767-.862,3.587-1.776,5.41-2.718l-.917-1.777C179.2,57.832,177.39,58.74,175.637,59.6Z" fill="#a0c3cc"/><path d="M153.508,68.858l.643,1.895c1.865-.633,3.786-1.327,5.709-2.064l-.716-1.867C157.246,67.548,155.349,68.234,153.508,68.858Z" fill="#a0c3cc"/><path d="M130.259,74.091l.173,1.992c1.951-.169,3.99-.428,6.059-.771l-.326-1.973C134.146,73.674,132.159,73.926,130.259,74.091Z" fill="#a0c3cc"/><path d="M142.015,72.172l.453,1.947c1.913-.444,3.893-.963,5.887-1.54l-.557-1.922C145.839,71.226,143.893,71.735,142.015,72.172Z" fill="#a0c3cc"/><path d="M207.408,42.327l.93,1.771q2.7-1.422,5.351-2.743l-.895-1.789Q210.129,40.9,207.408,42.327Z" fill="#a0c3cc"/><path d="M196.8,48.161l1,1.734q2.646-1.52,5.242-2.949l-.965-1.752Q199.465,46.632,196.8,48.161Z" fill="#a0c3cc"/><path d="M186.32,54.084l.955,1.758q2.6-1.414,5.291-2.936l-.986-1.74Q188.906,52.681,186.32,54.084Z" fill="#a0c3cc"/><path d="M218.239,36.919l.855,1.808c1.8-.854,3.642-1.7,5.461-2.505l-.812-1.827C221.91,35.209,220.058,36.058,218.239,36.919Z" fill="#a0c3cc"/><path d="M0,7.425.664,9.312q1.425-.5,2.819-.956l-.62-1.9Q1.448,6.916,0,7.425Z" fill="#a0c3cc"/>
 </svg>
 </symbol>
-<symbol id="icon-shaker">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 258.53 328.64">
-<path d="M152.41 74a3.41 3.41 0 000-1.62 1.13 1.13 0 00-1.25-.8l-.85 4.57c-.34 1.92-.69 3.86-1.06 5.78-.51 2.68-1.05 5.36-1.62 8-.29 1.37-.56 3 .27 4.07a3.52 3.52 0 00.93-1.17 6.88 6.88 0 00.52-1.94q1.59-8.41 3.06-16.89zM143.25 96.83l2.1-4.64a8.44 8.44 0 01.35-4.37 108 108 0 002.42-12.59c.14-1.07.16-2.36-.73-2.91a85.68 85.68 0 00-3.11 14.43c-.24 1.83-.47 3.66-.71 5.5a7.36 7.36 0 01-.88 3.14 2 2 0 00.56 1.44zM119.35 68.82c0 .73.19 1.67.91 1.83a2 2 0 00-.76-2.17zM105.05 88.8l-.14-1.93-1.09 1.13.47 1.74.77-.69zM132.61 62.44L131.35 69c-.32 1.7-.65 3.4-.89 5.13a50.15 50.15 0 00-.51 6.24c.55.26 1-.5 1.17-1.09a116.92 116.92 0 003.26-18.47c-.8-.55-1.59.68-1.77 1.63zM128.73 61.37l-.95 4.68a45 45 0 00-1.26 9.66 12.06 12.06 0 01-.57 2.22c-.15.76.18 1.75 1 1.82l1.2-6.07 3-15.17c-1.38-.2-2.15 1.49-2.42 2.86zM116.75 63.72a2.13 2.13 0 00.4-1.51l-.94.83.44.82z"/>
-<path d="M119.51 54.67a2.08 2.08 0 00-2 1.24 6 6 0 00-.45 2.47l-.18 3.81c.92.44 1.65-.91 1.8-1.93q.42-2.82.83-5.59zM104.56 62.07a2.21 2.21 0 001.49-.26c.28-1.39.57-2.77.87-4.15a23.56 23.56 0 00.74-6.63 1.58 1.58 0 00-1.35.46 1.72 1.72 0 00-.22.66zM110.37 52.32l-2 9.19a2.41 2.41 0 00.33 1.79 3.43 3.43 0 001.85-3 18.88 18.88 0 01.37-3.67 13.19 13.19 0 00.89-2.54c.11-.86-.55-1.93-1.44-1.77zM115.45 55.23a2.87 2.87 0 000-1.51 1.08 1.08 0 00-1.23-.7 60.24 60.24 0 00-2 11.78c1.17 0 1.7-1.42 1.93-2.59zM76.24 85.72l.88-.09 1.6-6.39c.5-2 1-4.22.09-6.09-.79 0-1.13 1-1.28 1.76l-1.08 5.53a11.78 11.78 0 00-.21 5.28zM71.5 68a1.25 1.25 0 001.38-.37l1.06-6.37c.53-3.25 1.08-6.5 1.51-9.79-1-.35-1.67 1-1.88 2l-1.77 8.87a12.64 12.64 0 00-.3 5.66zM70.53 46a13.57 13.57 0 01-.4 4.53l-1.91 9.34a7.82 7.82 0 000 4.81 10.68 10.68 0 001.91-5L72.25 49a4 4 0 000-2.14 1.36 1.36 0 00-1.72-.86zM64.9 75.55c.35-1-.27-2-.85-2.78q-3.11-4.42-6.22-8.77a22.29 22.29 0 01-3.19-5.59c-.32-1-.9-2.24-1.9-2.06-.65 3.07 1.26 6 3.08 8.59l2.53 3.56c1 1.45 2 2.89 3.11 4.35.89 1.15 1.98 2.43 3.44 2.7zM115.58 115.33a1.17 1.17 0 00.22-1.64 1 1 0 00-.26-.25c-.5.13-.38.84-.11 1.28zM82.46 97.85c-.42-.38-1.15.14-1.14.71a1.84 1.84 0 00.9 1.37 1.57 1.57 0 00.38-1.79zM78.15 140.55a1.85 1.85 0 001.94-1.75 5.32 5.32 0 00-.85-2.87 5.12 5.12 0 00-1.09 4.62zM72.29 106.23a53.88 53.88 0 00-1.88 9c-.08.58-.06 1.3.42 1.58a2.37 2.37 0 001.55-1.93c.17-.85.1-1.72.25-2.57.2-1.09.76-2.12 1-3.23a2.48 2.48 0 00-1.34-2.85zM76 135.68a5.83 5.83 0 00.67-5.79l-1.35-.23a21.76 21.76 0 01-.6 6.82c-1.88-1.08-2.2-3.68-1.86-5.83s1.11-4.33.55-6.43a5.17 5.17 0 00-2.56 3.61 15.48 15.48 0 00-.1 4.56l.22 2.89a2.62 2.62 0 00.58 1.74 9.09 9.09 0 012.69 5.75c1.22-.44 1.47-2 1.36-3.33s-.36-2.73.4-3.76zM209.7 244.69a.49.49 0 00-.69-.13.52.52 0 00-.2.3.53.53 0 00.54.52.55.55 0 00.3-.11zM181.67 174.74a.71.71 0 00.15-1v-.06c-.41-.09-.45.59-.27 1zM84.83 153.49a.93.93 0 00-.87 1 2.16 2.16 0 001-.65zM182.22 235.75a1 1 0 00-.08 1.41l.06.06c.54-.06.43-.87.17-1.34zM195.62 252.54a1.09 1.09 0 00-.36-.81 1.23 1.23 0 00-.35 1c.1.36.7.5.8.14zM106.49 167.34a2.18 2.18 0 00-.47-1.74c-.66.18-.28 1.18.23 1.66zM193 137.71l-.56-1.48a1.08 1.08 0 000 1.55 1.05 1.05 0 00.39.27zM191.39 248.33l.1.91a1.5 1.5 0 001.45-.39.81.81 0 00-1.11-.27zM198.86 256.66a1 1 0 00.49-1.33 1.19 1.19 0 00-.23-.31 1.52 1.52 0 00-.43 1.48zM175.36 167.64a1.34 1.34 0 00-.19-1.87 1.27 1.27 0 00.05 1.68zM153.39 198.74l-.7-1.89a1.33 1.33 0 00.55 2.06zM205.65 262.9a1.81 1.81 0 00.25 2.17 1.92 1.92 0 00-.06-2zM162.72 207.93a1.49 1.49 0 00.42 1.95 1.36 1.36 0 00-.11-1.81zM162.37 148.9a1.45 1.45 0 00-1-.69 1.71 1.71 0 00.88 2l.07-1.14zM177.1 170.43l.35.53a.8.8 0 00.9-.69v-.18a.78.78 0 00-.93-.59.64.64 0 00-.24.1zM192.19 270.93a.93.93 0 00.84-1 2.33 2.33 0 00-.58-1.31 5.63 5.63 0 00-.23 2.31zM209.14 218.55l.22 1.24a1.13 1.13 0 00.9-.08 1.07 1.07 0 00-.56-1.4 1 1 0 00-.34-.09zM165.82 152l.06-1.32a1.57 1.57 0 00-.57 2.14 1.68 1.68 0 00.41.47l.27-.91zM116.85 132.59l.89-.79a2.94 2.94 0 00-.61-1.53 1.82 1.82 0 00-.22 2.29zM221.8 281.21l.28 1.05a.89.89 0 00.14-1.78.86.86 0 00-.67.23zM124.71 152.23a1.59 1.59 0 00-.27 2.23 1.86 1.86 0 00.42.37 3 3 0 00-.23-2.61zM124.41 156a1.07 1.07 0 00-.69-1.07 3 3 0 00.47 2.88 1.81 1.81 0 00.2-1.52zM208.56 245.64c-.8.5-.34 1.72.19 2.5a1.68 1.68 0 00.11-2.29zM141.91 214.47l-1.06.86c0 .6.82 1 1.31.62a1.18 1.18 0 00.18-1.61zM145 126.07a1.3 1.3 0 00.69 1.69l.22.07a2.18 2.18 0 000-2.06h-.87zM172.86 220.92l-.85.23a2.51 2.51 0 00.64 2.39 2.82 2.82 0 00.21-2.63zM229.92 198.83a1.1 1.1 0 00-.76-.69 3.51 3.51 0 00-.17 1.7 1.21 1.21 0 001.25 1l.08-1.83zM170.87 162.53l1.95-.43a4.72 4.72 0 00-.36-2 8.77 8.77 0 00-1.83 1.82zM225.56 196.05a1.42 1.42 0 00.59 1.92 1.45 1.45 0 00.35.12 1.91 1.91 0 00-.51-2.65 1.8 1.8 0 00-.62-.27zM224.19 187.13l.47-2.1a2.91 2.91 0 00-1.61 1.72 5.14 5.14 0 00.68 2.22 1.37 1.37 0 00.48-1.47zM191.86 187.33a1.38 1.38 0 00-1.12-1 2.7 2.7 0 001.11 3.5 2.7 2.7 0 00.1-2.19zM147.1 123.59a2.79 2.79 0 00.7-2c-.12-.72-1-1.33-1.59-1a3.12 3.12 0 00.4 2.85zM115.14 138.88l1.21-1.23-.3-2.85a1 1 0 00-1.1.3c.05 1.25.13 2.51.19 3.78zM140.34 222a1.77 1.77 0 001.46-1.76 5.13 5.13 0 00-.72-2.38c-.79-.24-1.21 1-1 1.77s.78 1.66.26 2.37zM121.32 149.79a5.41 5.41 0 00.69-3.12 4.38 4.38 0 00-1 5.44 1.53 1.53 0 00.52-1.91zM152.35 132.51c-.11.79-.22 1.56-.33 2.33a1.81 1.81 0 001.73-1.85 5.15 5.15 0 00-.92-2.65 1.86 1.86 0 00-.74 1.79zM157.91 233.66a3.6 3.6 0 00.66 4.36 3.06 3.06 0 00-.55-4.28z"/>
-<path d="M140.56 221.78a4.37 4.37 0 00-.86 6.11c.21.23.61.45.8.2.04-2.09.03-4.19.06-6.31zM168 244.36a1 1 0 00-.26.69c-.17 1.75-.35 3.49-.51 5.23.34.16.72-.14.92-.42a5.31 5.31 0 001-4.68c-.15-.54-.67-1.18-1.15-.82zM226.14 279.47a3.43 3.43 0 00-.23 1.1 1.1 1.1 0 00.64 1.06 10.75 10.75 0 001.53-7.89z"/>
-<path d="M165.85 255.6c0 .52.7.79 1.19.55a1.87 1.87 0 00.83-1.26 6.18 6.18 0 00-.42-4.64 9.7 9.7 0 00-1.6 5.35zM156.52 246.39a8.89 8.89 0 001.22-7.06 5.79 5.79 0 00-1.22 7.06zM143.4 114.32l-1.08 6.27c-.14.78-.18 1.78.52 2.15a5.14 5.14 0 00.15-2.4 7.21 7.21 0 001.31-6.3.56.56 0 00-.79.07.53.53 0 00-.11.21zM149.08 110.57c-.66.18-.9 1-1.05 1.65l-.91 4c-.23.94-.33 2.16.51 2.65a8.33 8.33 0 001.13-4.9 3.11 3.11 0 00.32-3.4zM181.18 110.79a11 11 0 00-1.85 5.57 4.38 4.38 0 00.45 2.13 7.88 7.88 0 001.4-7.7zM88 159l1.21-5.68a4.63 4.63 0 00.16-1.28 1.25 1.25 0 00-.54-1.07c-1 .44-1.32 1.77-1.46 2.9l-.4 3.33c-.11.85.25 2.09 1.03 1.8zM198.86 150.66a50.55 50.55 0 001.39-7.62c.09-.76-.2-1.87-.95-1.71q-.87 4.48-1.72 9zM99.78 174.32a5.31 5.31 0 00-.15 2.17c1.39-.71 2-2.35 2.35-3.87a24 24 0 00.58-4.64c-1.32.15-1.87 1.73-2.12 3zM201.81 288.18c1.11-2.06 1.12-4.52 1.1-6.86v-2.46a21.78 21.78 0 00-2.48 9.1zM103.12 180.25a2.32 2.32 0 001.07 1.45c-.15-3.48 2.06-6.84 1.39-10.26-.68-.4-1.28.62-1.41 1.42l-1 5.55a4.75 4.75 0 00-.05 1.84zM161 240.32c-.32.18-.37.61-.41 1a35.73 35.73 0 01-1.14 4.08 4.4 4.4 0 00.59 4c0 .43.67 0 .74-.4l1.21-7.09c.12-.76-.3-1.97-.99-1.59zM187.74 124c.16-1.18-.14-2.89-1.32-2.8.56 3.44-2.43 7.19-.69 10.21.78 0 1.13-1 1.23-1.76zM118.21 194.34c-.31-2.37 1.35-4.57 1.46-7a2.48 2.48 0 00-1.23-2.52 27.51 27.51 0 00-1.67 8 2.22 2.22 0 00.24 1.36.87.87 0 001.2.16zM165.78 241.8c-1.5.68-2.05 2.51-2.21 4.16s-.12 3.4-1.1 4.75c-.48.7 0 1.64.49 2.34 1.41-1.21 1.75-3.22 2-5.07zM197.31 282.54c-.2 1.21-.2 2.79.94 3.24a37.49 37.49 0 001.63-10.52c-.88-.37-1.53.88-1.69 1.83-.29 1.81-.59 3.65-.88 5.45zM145.7 233.31a3 3 0 000 1.6 1.06 1.06 0 001.28.7 44.15 44.15 0 011.62-8.44c.42-1.41.74-3.3-.47-4.08a5.52 5.52 0 00-.73 2.07l-.52 2.48q-.61 2.82-1.18 5.67zM171 260l.65-6.1a10.9 10.9 0 00.78-5.94c-1.21.16-1.71 1.64-1.7 2.86s.28 2.53-.37 3.56a6.36 6.36 0 00-.58 5.58 1.32 1.32 0 001.22.04zM188.46 265.59a78.59 78.59 0 01-2 9.08 4.78 4.78 0 00.14 2.92 2.94 2.94 0 001.79-2.55c.16-1.08 0-2.18.25-3.24s.89-2.18 1.11-3.33-.17-2.58-1.29-2.88zM137.71 222.47c-.63-1.53 0-3.25.4-4.84a27.44 27.44 0 001-7.37 2.4 2.4 0 00-2 2.11c-.19 1 0 2.08-.12 3.14a29.41 29.41 0 01-.93 3.58 4 4 0 00.53 3.54zM120 195.94a22 22 0 00-.13 6.68 30.32 30.32 0 002.76-12.43c-1 0-1.55 1.27-1.82 2.27s-.62 2.33-.81 3.48zM152.26 226.55l-1.17.31-1.63 7.2a7.31 7.31 0 00-.3 2.75 2.53 2.53 0 001.6 2.09 10.53 10.53 0 01.44-5 19.81 19.81 0 001.06-7.35zM224.94 266.57c-1.39 3.48-1.78 7.25-2.17 10.93a3.34 3.34 0 00.3 2.22 29.17 29.17 0 002.68-12.94zM155.79 229.29c-1 .32-1.42 1.55-1.65 2.6l-1.44 6.53a7.46 7.46 0 00-.25 3.69c1.36-.53 1.81-2.2 2.12-3.67l1-5.15a12.51 12.51 0 00.22-4zM206.55 253.39l-.28 1.44-.49 2.71c-.34 1.76-.62 3.72.36 5.22a17.58 17.58 0 001.67-5.76c.38-2.17.75-4.35 1.12-6.51-1.4-.21-2.13 1.51-2.38 2.9zM181.91 258.21a59.2 59.2 0 00-2.22 9.74c-.15 1.08.17 2.73 1.29 2.6l1.93-10.27c.16-.89-.1-2.26-1-2.07zM127.08 211.71l2-10.44c.22-1.18.3-2.72-.86-3.22a83.41 83.41 0 00-2.34 11.69c-.11.92.32 2.32 1.2 1.97zM135.43 206.29l-1 .35-1.43 7.13a15 15 0 00-.45 5.17c.56.45 1.2-.44 1.35-1.13l1.18-5.1a13.6 13.6 0 00.35-6.42zM130.89 204.27l-1.89 8.47c-.31 1.43-.44 3.3.86 4a109.57 109.57 0 002.67-13.21 4.69 4.69 0 01-1.64.74zM142 231.5c1.34.29 2.09-1.45 2.3-2.79l1.07-6.59a7.12 7.12 0 00-.09-3.75c-1.24 1.28-1.6 3.15-1.9 4.91zM110.9 190q1.06-5.79 2.08-11.57c.15-.86-.18-2.18-1-1.89a43.32 43.32 0 00-2.44 11.36c-.05.92.46 2.34 1.36 2.1zM119.58 132.89c-.42 2.29-.85 4.57-1.27 6.85-.33 1.71-.55 3.77.77 5l2.41-12.54c.21-1.1.29-2.5-.67-3.09a11.22 11.22 0 00-1.24 3.78zM96.83 151.83c-.1-.39-.64 0-.73.41-.54 2.39-1.09 4.77-1.54 7.17-.4 2.11-.72 4.23-1 6.35-.14 1.08.25 2.67 1.32 2.46a10.25 10.25 0 01.33-4.44 30.74 30.74 0 001.33-8.18 2.76 2.76 0 00.29-3.77zM112.9 194.73c0 .21.23.44.44.44s.42-.34.48-.61l2.53-11.33c.28-1.24.35-2.9-.82-3.4a46.48 46.48 0 00-1.55 5.81l-1 4.82a7.39 7.39 0 00-.08 4.27zM108.43 173.15c-.48 1.68-.92 3.36-1.28 5.11a36.41 36.41 0 00-1 6.57c0 .78.18 1.81 1 1.93q1.6-7.08 2.73-14.25a2 2 0 00-.14-1.44c-.28-.4-1-.44-1.18 0zM198 235.31q-1.27 6-2.53 11.85c-.26 1.17-.38 2.66.64 3.26a6.07 6.07 0 001.31-3.29l2.17-12.13a1.91 1.91 0 00-1.59.31zM94 147.46a8.32 8.32 0 00-2 7.79 10.81 10.81 0 00-1.23 9.5 28.34 28.34 0 001.62-6.07l1.38-7.15a11.39 11.39 0 00.23-4.07zM208.36 269.44c2.24-1.46 1.51-4.88 2.38-7.4a27.76 27.76 0 001.51-8.18c0-.66-.11-1.51-.76-1.68a23 23 0 00-1.71 6.88 9.79 9.79 0 01-.08 1.33 9.89 9.89 0 01-.36 1.32 20.86 20.86 0 00-.98 7.73zM97.46 173.56c.7-2.74 1.3-5.5 1.78-8.3l1.51-8.68c-1.07-.31-1.78 1.1-2 2.19q-.94 4.74-1.87 9.47c-.34 1.82-.62 3.93.58 5.32zM215.47 256.33c-1.4.76-1.82 2.56-2.1 4.1q-1.08 6.21-1.93 12.46a1.24 1.24 0 001.18-.16q1.68-7.16 3-14.4a4.47 4.47 0 00-.38-3.51 3.36 3.36 0 00.23 1.51zM221.4 262.15a4.15 4.15 0 01-.23 3 18.71 18.71 0 00-1.48 5.38c-.41 2.35-.82 4.68-1.22 7a3.78 3.78 0 000 2.11c1.37-.36 1.84-2 2.06-3.4.26-1.61.51-3.24.78-4.82.42-2.6.84-5.21 1.09-7.84.09-.72-.4-1.81-1-1.43zM196.69 227.91c.1-.64-.11-1.6-.75-1.47l-3.47 15c-.27 1.16-.39 2.68.66 3.24a19.27 19.27 0 002-6.71c.13-.82.25-1.65.37-2.47.43-2.5.81-5.07 1.19-7.59zM216 275.62a89.33 89.33 0 002.26-9.23c.47-2.47.84-4.95 1.2-7.42.09-.54 0-1.3-.54-1.31a18.27 18.27 0 00-2.06 7.18c-.15 2-1.7 3.92-1.15 5.85a5 5 0 01-.5 2.63c-.27.87-.11 2.09.79 2.3zM124.72 134l.66-.61a43.58 43.58 0 011.42-7.39c-1.56-.09-2.6 1.65-2.76 3.2s.21 3.17-.27 4.65a59.07 59.07 0 00-2 9.56A4.12 4.12 0 00122 146a.5.5 0 00.69-.11 67.62 67.62 0 002.03-11.89zM204.91 240.07a7.88 7.88 0 01-.36 4.11 82.59 82.59 0 00-2.43 13.61c-.06.57.38 1.43.81 1q1.68-5.91 2.82-12a18.3 18.3 0 00.33-7 1.12 1.12 0 00-1.17.28zM151.92 112.51l-2.74 12.73a2.49 2.49 0 000 1.64c.4.78-.23 1.65-.52 2.47s.32 2.11 1.09 1.7l1.31-7.05 1.29-6.76 1.22-6.54a2.6 2.6 0 01.64-1.5 2.42 2.42 0 00-.91-2.42c-.4 1.94-.86 3.84-1.38 5.73zM200.82 241.1c-.5 2.82-1 5.63-1.67 8.41a6.52 6.52 0 00-.25 2.91 3.1 3.1 0 001.17 1.75q1.86-8.52 3.27-17.13a3.62 3.62 0 000-1.73 1.24 1.24 0 00-1.29-.93zM190.8 238.6l1.07-5.36 1.22-6a23.47 23.47 0 00.71-5.07c0-.34-.06-.74-.37-.89-.5-.22-.9.48-1 1-.4 1.84-.76 3.7-1.12 5.56q-1.05 5.29-2.09 10.6c-.35 1.78-.61 3.87.65 5.18.24-1.62.6-3.34.93-5.02zM190.45 217.43c-1.06-.11-1.54 1.16-1.73 2.15l-1.7 9.11-1.63 8.56c-.1.51-.12 1.17.37 1.38.87.25 1.42-.89 1.59-1.78l1.52-8.15c.38-2.07.77-4.15 1.14-6.22a19.92 19.92 0 00.44-5.05zM183.08 234.8a16.16 16.16 0 001.35-4.72l2.82-15.49a3 3 0 000-1.71 1 1 0 00-1.41-.58 18.15 18.15 0 01-.51 4.28l-1.44 7.2c-.49 2.46-1 4.92-1.54 7.37-.35 1.32-.45 3.07.73 3.65zM177.36 196.09q-.69 2.43-1.25 4.88c-.33 1.45-.64 2.9-.92 4.33l-1.73 8.33a21.74 21.74 0 00-.67 7.27c.83.1 1.26-.94 1.42-1.77q2-10.33 3.92-20.72a3 3 0 00.06-1.2 1.64 1.64 0 00-.83-1.12zM179.26 205.74c-.47 2.11-.87 4.22-1.31 6.33-.5 2.46-1 4.91-1.48 7.37q-.41 2.16-.78 4.35c-.18 1-.24 2.23.64 2.71A18.38 18.38 0 00178 221l3.18-17.3a2.61 2.61 0 000-1.36.86.86 0 00-1.08-.58zM142.28 164.37q-.9 4.38-1.81 8.7c-.21 1-.24 2.34.72 2.68 2-5.16 2.68-10.72 3.37-16.2a41.78 41.78 0 011.84-8.11 2.56 2.56 0 00.14-1.94c-.32-.59-1.42-.65-1.52 0q-.92 5.84-2.07 11.61zM249 243.47l-3.63 19.82a24.75 24.75 0 00-.4 3 11.47 11.47 0 00.07 2.27c1.33-1.1 1.72-3 2-4.68l2.74-15.06c.36-1.82.58-4.07-.78-5.35zM164.72 205.48l1.75-9.71 1.71-9.56c.26-1.45.48-3.05-.27-4.3a44.62 44.62 0 00-2 7.63l-2.4 12a18.61 18.61 0 00-.52 6c1.01.2 1.56-1.07 1.73-2.06zM171.51 187.8a1.5 1.5 0 00-1-1.09q-1.83 10.54-4.09 21c-.29 1.37-.57 2.89.13 4.1 1.06-.58 1.4-1.92 1.62-3.12q1.71-9.1 3.32-18.24a5.83 5.83 0 00.02-2.65zM124.65 152.17l1.22-.33 4.39-22.84a1.56 1.56 0 00-.14-1.35 2.21 2.21 0 00-1.84 1.77q-1.57 8.7-3.12 17.39a21.47 21.47 0 00-.51 5.36zM180.93 217.55c-.45 2.19-.81 4.36-1.21 6.54s-.78 4.17-1 6.27c-.11.9.27 2.24 1.13 2a5.12 5.12 0 000-2.46c.76-.11 1.06-1.06 1.18-1.83.3-1.86.57-3.72.86-5.59q1.23-8 3-16l-1.77.4c-.65 3-1.23 6.06-1.8 9.11-.19.48-.32 1.01-.39 1.56zM152.52 161.73a10.42 10.42 0 00.23-3.65 4.81 4.81 0 00-1.6 1.78c-1.17 2.31-.33 5.18-1.14 7.65a48.5 48.5 0 00-1.47 6.08c-.54 2.86-1.09 5.72-1.62 8.59A4.18 4.18 0 00147 185c.56.41 1.15-.48 1.28-1.16q.52-2.85 1.07-5.71l1.83-9.72.27-1.42zM160.75 174.2c-.45 2.19-.84 4.36-1.27 6.55l-1.19 6.19-1.91 9.71c-.23 1.18-.29 2.78.86 3.19a2.32 2.32 0 00.4-1.05q2.52-12.19 4.52-24.49a2.71 2.71 0 00-1.41-.1zM158.31 107.55l.85-4.74c-.46-.67-1.4.23-1.63 1a84.11 84.11 0 00-2.1 10.07l-2.1 12.67a2 2 0 000 1.21.68.68 0 001 .28.9.9 0 00.2-.51q1.05-5.32 2-10.66.95-4.65 1.78-9.32zM169.28 220c-.14-1.72 1.65-3.07 1.82-4.8.18-2.06.56-4.09.94-6.12.45-2.44.92-4.87 1.37-7.31.27-1.46.55-2.93.9-4.38.43-1.7.94-3.69-.15-5.07a13 13 0 00-1.6 5l-1.36 7.44-2.62 14.24a.74.74 0 00.44 1 .75.75 0 00.26 0zM153.35 168.93a14.52 14.52 0 01.06 3.09 15 15 0 01-.71 2 12.27 12.27 0 00-.46 1.88l-2.38 11.87c-.19 1-.18 2.28.77 2.54a14.43 14.43 0 001.8-5.83l1.86-11.89a5.75 5.75 0 00.82-2.34 39.17 39.17 0 00.65-6.75 7.22 7.22 0 00-2.41 5.43zM163.7 179.89q-1.59 8-3.19 16a51.49 51.49 0 00-1.11 7.42 1.89 1.89 0 00.19 1.19.72.72 0 001.08.16q2.13-11 4.23-22a29.25 29.25 0 00.55-3.6 1.31 1.31 0 00-1.7.73.84.84 0 00-.05.1zM152.76 194.26a1.25 1.25 0 001.76-.15 1.17 1.17 0 00.19-.3q1.56-11 4.22-21.78c.35-1.44.43-3.42-1-3.88-.71 2.71-1.22 5.51-1.77 8.2q-1 5.28-2 10.52zM137.77 166a13.62 13.62 0 00-.36 5.2l1-.07q2.84-13.08 5.06-26.29a1.22 1.22 0 000-.57c-.14-.55-1-.59-1.41-.2a2.58 2.58 0 00-.61 1.56q-1 7.22-2.5 14.36zM135 160.6l-1.68 9.5c-.11.65 0 1.58.66 1.59a41.47 41.47 0 001.75-8.69l.38-.41q1.22-6.08 2.41-12.18l.95-4.82c.25-1.26.51-2.51.65-3.79a2.8 2.8 0 00-.16-1.69 1.05 1.05 0 00-1.44-.44 20.6 20.6 0 01-.73 5.47c-.33 1.55-.61 3.11-.88 4.67zM149.18 153.74c-.9-.12-1.37 1-1.55 1.94l-1.17 7.22q-1.4 8.53-3.4 17c-.13.56 0 1.43.58 1.31a6.79 6.79 0 001.62-2.5 13.71 13.71 0 00.47-2.09q1.94-10.4 3.74-20.81c.2-.81.33-1.64-.29-2.07zM128.06 158.05a3.33 3.33 0 001.3-2.42c.6-3.3 1.22-6.6 1.83-9.91.46-2.5.93-5 1.4-7.48.37-2.08.76-4.15 1.14-6.23.18-.89.17-2.11-.69-2.4a12.16 12.16 0 00-1.53 4.64l-3.91 21.19c-.16.81-.31 1.61-.51 2.4a3.94 3.94 0 00.82 3.49 4.16 4.16 0 00.15-3.28zM130.77 166.75c1.26-1.37-.38-4.12 1.06-5.34.38-.34 1-.61.95-1.12a12.81 12.81 0 01.35-3.75l3.6-18c.33-1.64.39-3.83-1.19-4.47-.23 1.61-.5 3.24-.79 4.79L132.54 151a36.64 36.64 0 01-2.12 8c-.32.7.24 1.48.38 2.23a6.25 6.25 0 01-.67 2.88c-.29.89-.24 2.2.64 2.64zM247.54 237.33c.05-.85-.11-2-.94-2.17l-5.41 28.08c-.37 1.91-.73 3.94 0 5.73a10.74 10.74 0 001.56-4.56l2.52-13.75 1.34-7.18a47.25 47.25 0 00.93-6.15zM197.58 158.65l1-5.25c.14-.74 0-1.83-.76-1.86a25.22 25.22 0 00-2.17 7.56q-2.2 12.36-4.43 24.68a1.34 1.34 0 001.76-.47 4.19 4.19 0 00.52-1.93c.17-1.47.43-2.92.72-4.33q.88-4.81 1.79-9.6zM219.78 234.64l1.77-8.84c.64-3.22 1.28-6.43 1.89-9.65.32-1.69.64-3.39.94-5.09.55-3.09 1.13-6.18 1.73-9.29a3.33 3.33 0 000-1.63 1.16 1.16 0 00-1.26-.86q-2.1 10.46-4 20.94c-.35 1.86-.69 3.73-1 5.59-.28 1.5-.55 3-.86 4.52s-.42 3.38.79 4.31zM228.5 204.2c-.49-.15-.81.5-.91 1l-5.29 29.37a12.24 12.24 0 00-.15 5.58c.54.16.89-.55 1-1.09q1.24-6.31 2.42-12.64 1.76-9.43 3.41-18.87c.2-1.17.34-2.55-.48-3.35zM172 155.67c-.16.86.15 2.16 1 1.9.43-.12.58-.65.66-1.1l6.18-32.71a2.51 2.51 0 00-.21-2c-1 .06-1.47 1.31-1.66 2.31q-1.5 7.88-3 15.74a41.36 41.36 0 00-.77 5.07q-1.13 5.38-2.2 10.79z"/>
-<path d="M179.38 167.27a1.29 1.29 0 00.55-1l3.12-16.27c.45-2.38.91-4.76 1.31-7.14.63-3.75 1.14-7.55 1.65-11.31a.75.75 0 00-1 0 2.18 2.18 0 00-.47 1.09c-.47 2.1-.84 4.19-1.23 6.29l-3.47 18.61c-.47 2.53-.93 5.07-1.27 7.58-.16.88-.03 2.03.81 2.15zM237.45 266.64a21.49 21.49 0 002.44-10.22c.39.06.59-.43.65-.81l4.35-24.35a3 3 0 000-1.78 1.07 1.07 0 00-1.47-.56c-.26 2.9-.82 5.78-1.36 8.65l-3.78 20.36c-.38 2.06-.76 4.13-1.25 6.17-.26.9-.39 2.09.42 2.54zM234.89 261.33a12.32 12.32 0 001.25-4.15l5.86-32.94c.13-.69.13-1.6-.5-1.86a4.08 4.08 0 00-.95 2.21q-3.6 17.76-6.76 35.62c-.12.71.29 1.81.89 1.42a1 1 0 00.21-.3zM162.15 103.67c-.74.32-1 1.22-1.11 2l-5.65 30.75c-.24 1.32-.35 3 .82 3.72l2.26-11.56c.45-2.19.86-4.26 1.28-6.41q2.15-11.27 3.91-22.64a2.92 2.92 0 00-1.67 3.79 2.11 2.11 0 00.16.35zM191.19 139.59c.94 2-.81 4.13-1.2 6.28l-5.05 27.42c-.35 2-.64 4.18.63 5.7l5.6-29.3c.53-2.78 1.06-5.58 1.35-8.41a2.34 2.34 0 00-.15-1.38.84.84 0 00-1.12-.35zM237.22 220.09L231 252.43c-.31 1.63-.52 3.56.7 4.67a48.91 48.91 0 001.68-7.08q3-16.53 5.95-33.11c-1.33.26-1.83 1.85-2.11 3.18zM223.64 189.35c-.8-.07-1.2.92-1.35 1.7l-6.57 34.68a2.31 2.31 0 00.13 1.73c.33.49 1.28.5 1.39-.08q3.15-16.51 6.29-33a10.44 10.44 0 00.11-5.03zM232.13 203.24l-7.32 39.36c-.18 1 0 2.34 1 2.34a55.53 55.53 0 001.75-7.42l5.44-29.29c.27-1.75.47-3.85-.87-4.99zM235.9 214.21c.31-1.7.53-3.68-.66-4.94l-7.41 38c-.21 1.09-.32 2.48.63 3.09a34.84 34.84 0 002.55-9.17l3.61-19.91zM220.37 180.52l-4.85 24.41L213 218c-.35 1.77-.54 4 .91 5q3.81-19.24 7.27-38.58c.21-1.42.34-3.1-.81-3.9zM218 172.7q-4.37 18.48-7.23 37.27c-.2 1.32-.79 2.55-1 3.86a3.73 3.73 0 001 3.67q4.64-21.34 7.9-43c.08-.69.02-1.64-.67-1.8zM189 130.3l-1.46 7.64q-1.41 7.49-2.83 15c-.84 4.59-1.76 9.22-2.74 13.8-.49 2.05-.9 4.38.23 6.15.44-.12.61-.65.73-1.11l5.85-30.2a6.89 6.89 0 00-.07-4.12 5.49 5.49 0 00.29-7.16zM200.57 202c1.08-.46 1.43-1.78 1.64-2.93q3.71-20.07 7.43-40.07c.21-1.09.23-2.6-.82-3q-3.63 17.36-6.84 34.84a71.28 71.28 0 00-1.41 11.16zM207.82 212.32l5.53-29.6 1.59-8.51c.49-2.65 1-5.44.09-8q-4.78 21.57-8.29 43.4c-.15 1.1.02 2.62 1.08 2.71zM212.4 161.73a8.18 8.18 0 00-1.65 4.17q-3.27 17.37-6.55 34.72c-.43 2.27-.83 4.63-.18 6.84a17.41 17.41 0 001.83-5.93l4.82-25.85c.77-4.19 1.55-8.36 2.12-12.57.07-.51.06-1.11-.39-1.38zM168.87 154.81c1.44-1.48 1.86-3.6 2.21-5.67q2.56-14.47 5.12-29c.74-4.25 1.49-8.49 2.34-12.71-.18-.42-.83-.42-1.16-.12a2.19 2.19 0 00-.52 1.24l-7.92 42.12a8.25 8.25 0 00-.07 4.14zM207.16 150.32c-1.33 0-2 1.56-2.2 2.91q-3.11 16.44-6.2 32.86a42 42 0 00-1.09 10.77 20.34 20.34 0 002.31-7.28zM174 101.64l-8.45 45.45a3.15 3.15 0 001 2.84q4.65-22.12 8.29-44.47c.23-1.33.34-2.99-.84-3.82zM196.9 174.29l-1.82 9.81-1.53 8.4c-.15.78.13 2 .89 1.74q5-21.37 8.44-43.09c.23-1.49.39-3.21-.67-4.32q-2.75 13.77-5.31 27.46zM174.82 163.71c1.54-.49 2.07-2.37 2.37-4l1.19-6.43 6.19-33.43c.27-1.51.44-3.36-.75-4.33a78 78 0 00-1.73 7.71c-.19 1.08-.4 2.12-.59 3.18-.61 3.2-1.2 6.41-1.8 9.61q-2.53 13.87-4.88 27.69zM187.06 184.4c-.16.85.35 2.2 1.07 1.72q5.16-24.41 9.24-49a.89.89 0 00-1.25-.12l-.1.09a2.55 2.55 0 00-.58 1.43zM171.83 97.31c-.68-.17-1.09.72-1.24 1.37l-1.81 9.32c-1.81 9.49-3.64 19-5.3 28.48q-.87 5.08-1.69 10.18c1.37-.16 1.93-1.82 2.17-3.17l5.57-29.45a16.25 16.25 0 00.42-4.61q1.22-5.23 2.38-10.45c.1-.58.1-1.49-.5-1.67zM167.31 94.16q-3.67 19.36-7.23 38.71c-.5 2.75-1 5.45-1.51 8.22-.3 1.59-.52 3.46.58 4.65q3.94-18.47 7.22-37.06 1.06-6.09 2.09-12.2c.14-1-.16-2.48-1.15-2.32zM186.36.45c0 .52.28 1.25.75 1.05a1.08 1.08 0 00-.59-1.42 1.09 1.09 0 00-.31-.08zM144.93 9.4c-.35.09-.26.65.07.77a1.26 1.26 0 001-.26.71.71 0 00-.58-.81.66.66 0 00-.39 0zM211.3 39.56a1.42 1.42 0 00-1.42-1.15 2.05 2.05 0 00.18 1.29 1.13 1.13 0 00.9-.06zM145.28 27.85l.85-.38c0-.46-.6-.72-1-.61a2.51 2.51 0 00-1.1.8c-.12.4.56.42.92.2zM32.88 167.32a2.36 2.36 0 00-1.27.72.82.82 0 00.28 1.25 7.88 7.88 0 012.28-1.36 1.12 1.12 0 00-.06-.88 1.14 1.14 0 00-.89.07zM188.63 34c.34 0 .33-.6 0-.73a1 1 0 00-1 .26 4.23 4.23 0 00-1.56 2.61 3.55 3.55 0 002.41-1.82zM165.22 306.41l2.54-2.13a1.57 1.57 0 00.7-1 3 3 0 00-3.23 2.75c-.01.12-.01.25-.01.38zM181.24 294a3.33 3.33 0 00-1.69 2.52 2.18 2.18 0 002.51-1.77 2.22 2.22 0 00-.05-1zM177.31 49.52a25.63 25.63 0 00-2.62 4h.91a2.54 2.54 0 011.4-1.44 2.69 2.69 0 001.48-1.43c.2-.72-.6-1.56-1.17-1.13zM35.85 140.76a2.37 2.37 0 002.47-.26 7 7 0 001.68-2c.28-.41.5-1.08.06-1.32a21.13 21.13 0 00-4.21 3.58zM199.56 326.69l-1.26 1.67a2.69 2.69 0 002.79-.75 7.83 7.83 0 001.54-2.61 3.36 3.36 0 00-3 1.45zM41.77 148.57a1.88 1.88 0 00.57-.65 2 2 0 00-.34-1.66 6.21 6.21 0 00-3.47 4.34 15.75 15.75 0 003.24-2.03zM7.89 154.34a11.92 11.92 0 003.92-3.52c.32-.46.6-1.12.22-1.54a5.7 5.7 0 00-4.14 5.06zM46 161.46a18 18 0 003-3.46c.35-.51.66-1.21.24-1.69a20 20 0 00-3.65 3.22 1.88 1.88 0 00-.68 1.32c0 .48.67.92 1 .59zM42.15 153.77c.25-.68 1.08-.9 1.63-1.36s.48-1.71-.23-1.57a4.81 4.81 0 00-3.83 4.06 3.21 3.21 0 002.48-.9zM170.56 313a2.16 2.16 0 001.77-2.49 7.42 7.42 0 00-4.82 4.16 2.27 2.27 0 002.9-1.27zM167.91 310.21l1.65-1.55a2.31 2.31 0 00.6-.72 1.18 1.18 0 00-.22-1.24 7.53 7.53 0 00-4.31 3.56.87.87 0 001 .69 2.51 2.51 0 001.28-.74zM32.9 163a5.39 5.39 0 00-4.59 2.9 4.48 4.48 0 00-.47 2.13A16.52 16.52 0 0032.9 163zM170.55 317.47a7.16 7.16 0 004.54-2.82 1.69 1.69 0 00.52-1.17c-.34-.5-1.12-.31-1.66 0a8 8 0 00-3.4 3.99zM186.33 31.21c.25-.53.81-.81 1.22-1.24s.61-1.2.11-1.54-1 0-1.36.31a14.56 14.56 0 00-3.45 3.68 2.39 2.39 0 003.22-1zM24.91 165c1.7-.39 2.9-1.81 3.95-3.21.49-.63 1-1.5.53-2.14a26 26 0 00-5.1 4.62zM47.65 164.29a9.67 9.67 0 004.16-3c.5-.62.9-1.6.33-2.16a7.19 7.19 0 00-4.49 5.16zM193.61 6.35a3.47 3.47 0 00.7-1 1.73 1.73 0 00-.22-1.62 11.16 11.16 0 00-4.63 4.84c1.59.36 3.03-.99 4.15-2.22zM22.62 160.46c1.28.92 3-.44 4-1.67.79-.94 1.51-2.4.61-3.21l-1.69 1.67a24.52 24.52 0 00-2.92 3.21zM45.32 156.65a3.29 3.29 0 00.82-1.13 1.81 1.81 0 00-.27-1.75 13.9 13.9 0 00-4.71 4.81c1.54.54 3.05-.75 4.16-1.93zM21.47 158l4-4c.41-.42.77-1.24.2-1.48a16.94 16.94 0 00-4.52 3.46 2.15 2.15 0 00-.68 1.33c0 .42.53.96 1 .69zM39.47 145a9.66 9.66 0 001.62-1.7 2.31 2.31 0 00.17-1.71 9 9 0 00-4.91 4.85 1.4 1.4 0 001.83 0 10.61 10.61 0 001.29-1.44zM186.73 296.45l-.14-1.24a7.21 7.21 0 00-4.92 5.52 2.6 2.6 0 002.1-1.12q1.47-1.61 2.96-3.16zM34.45 137.12a6.17 6.17 0 004.45-2.7 5.32 5.32 0 00.9-2.46 9.61 9.61 0 00-5.35 5.16zM197.89 13.19l2.53-2.53c.44-.44.91-1 .69-1.62-1.33-.48-2.61.77-3.47 1.89L195.29 14c.77.64 1.89-.11 2.6-.81zM188.27 305.49a9.77 9.77 0 003.95-3.19 2.79 2.79 0 00.54-1.09 1.67 1.67 0 00-.48-1.47l-4.3 4a2.36 2.36 0 00.29 1.75zM193.34 10.93a1.14 1.14 0 001.14-.25 12.47 12.47 0 004.32-5.06c-.45-.48-1.23 0-1.71.41l-3.33 3.05c-.54.56-1.07 1.49-.42 1.85zM173.51 37.14a11.61 11.61 0 00-5 4.45c-.36.58-.64 1.48 0 1.83a10.52 10.52 0 005-6.28zM20.27 153.35l3.26-2.95a4 4 0 001.74-2.72c-1-.63-2.25.35-3 1.26l-2 2.28a2.51 2.51 0 00-.67 1.13.83.83 0 00.64 1zM206 16.15l-.28-1c-1-.22-1.9.65-2.62 1.46l-3 3.55c.8.92 2.25 0 3.07-.87zM162.72 36.63c2.65-.16 4.49-2.58 6-4.78.24-.36-.17-.88-.61-.87a1.73 1.73 0 00-1.15.58 20.76 20.76 0 00-4.24 5.07zM175.71 22.61c2.29.42 4.2-1.71 5.58-3.57a1.63 1.63 0 00.43-1.42c-.69-.53-1.64.12-2.24.75a45.06 45.06 0 00-3.77 4.24zM159 13.75l2.87-3.05A4.08 4.08 0 00163 9.17a1.42 1.42 0 00-.55-1.65l-2.51 2.53c-1 1.06-2.18 2.49-1.64 3.87zM157.65 7.35a11.24 11.24 0 00-4.82 4.83 1.94 1.94 0 00-.21 1.85 9.77 9.77 0 005.03-6.68zM5 151.45a9.93 9.93 0 004.71-3.75 2.36 2.36 0 00.37-2.47 26.82 26.82 0 00-5.31 5.17zM179.34 315.51c-1.2-.62-2.6.14-3.49 1.12s-1.56 2.21-2.74 2.81a.88.88 0 00-.39 1c1.06.75 2.49-.29 3.36-1.29zM207.49 18.67a13 13 0 00-5.12 4.86 1.19 1.19 0 00.11 1.29 15.33 15.33 0 005.41-4.9 1.19 1.19 0 00-.4-1.25zM173.91 20.66l4.62-4.22c.46-.41.93-1.06.61-1.57-1.53-.11-2.85 1-4 2a5.25 5.25 0 00-1.47 1.71 1.83 1.83 0 00.24 2.08zM8.23 107c1.84.22 3-1.83 4.34-3.12 1.17-1.09 2.95-2 2.78-3.61-.34-.27-.85 0-1.17.31A27.51 27.51 0 008.23 107zM192.1.87a12.22 12.22 0 00-5.6 4.36c-.43.58-.59 1.67.1 1.82a1.1 1.1 0 00.86-.33A15.58 15.58 0 00192.1.87zM160.08 35a27.67 27.67 0 005-4.64c.47-.56.82-1.56.16-1.85a16.42 16.42 0 00-5.05 4.33c-.49.67-.85 1.81-.11 2.16zM168.06 9a3.75 3.75 0 00-3.06 1.36 33.34 33.34 0 01-2.33 2.57c-.65.53-1.45 1.52-.76 2 2.2-.58 3.84-2.39 5.34-4.1.47-.57.96-1.17.81-1.83zM199.31 14.79c-.84.75-1.63 1.89-1 2.76a12.37 12.37 0 005.94-6.12c-.16-.6-1.11-.27-1.53.14zM25.14 141.63a11.81 11.81 0 00-6.58 6.87 3.84 3.84 0 002.71-1.5c1.55-1.57 3.2-3.24 3.87-5.37zM185.42 26.53a3.5 3.5 0 001-1.31 1.18 1.18 0 00-.48-1.44 24.17 24.17 0 00-4.88 4.54c-.48.59-.76 1.76 0 1.89a1.15 1.15 0 00.91-.44zM184.45 20.76c-2-.1-3.5 1.57-4.73 3.1a4.22 4.22 0 00-1.24 2.58c2.6.34 3.59-3.78 6.13-4.4zM155.67 33.15a12 12 0 005-3.91 3.56 3.56 0 00.9-2.49 10 10 0 00-5.9 6.4zM184 304.33l4.13-3.43a4.64 4.64 0 001.35-1.54 1.52 1.52 0 00-.38-1.85 20.47 20.47 0 00-4.26 4c-.64.81-1.27 1.88-.84 2.82zM166 40.39a29.42 29.42 0 004.54-4 3.12 3.12 0 00.66-.95 1.67 1.67 0 00-.24-1.54l-3.79 3a4.7 4.7 0 00-1.46 1.55 1.64 1.64 0 00.29 1.94zM175.1 11.92l-3.83 3.42c-1 .87-2 2.29-1.25 3.34a16 16 0 005.08-4.78c.43-.62.7-1.67 0-1.98zM206.1 310.48l3.5-3.18c1-.91 2.08-2.42 1.22-3.43a24.81 24.81 0 00-4.33 3.72c-.8.81-1.42 2.41-.39 2.89zM166 16.65c2.16-.08 3.08-2.82 4.93-3.91.76-.45 1.86-1.24 1.26-1.88-1.35-.56-2.75.56-3.78 1.58-1.22 1.18-2.48 2.56-2.41 4.21zM153.9 7.2a3.71 3.71 0 00-3.44.92 10.94 10.94 0 00-2.22 3L147.16 13a14.68 14.68 0 006.74-5.8zM205.25 39.54a23.94 23.94 0 005.11-4.94c.46-.61.8-1.66.1-2a25.08 25.08 0 00-4.32 3.78c-.79.91-1.55 2.2-.89 3.16zM8.46 141.19a31.65 31.65 0 00-4.82 4.58 2.46 2.46 0 00-.59 1 1.35 1.35 0 00.33 1.23 26 26 0 004.87-4.32c.64-.74 1.12-2.12.21-2.49zM173.22 42.2l-2.44 2.73a2.65 2.65 0 00-.5 2.68A25.87 25.87 0 00176.4 41c-1.05-.69-2.35.28-3.18 1.2zM193.77 303.56a9.91 9.91 0 00-2.24 3 5.12 5.12 0 00-.37 1.59 12 12 0 006.2-6.84c-1.44.08-2.59 1.2-3.59 2.25zM182.87 317.58c-1-.86-2.4.07-3.3 1l-2.51 2.42a3.76 3.76 0 00-1.2 1.76c1.39.84 3-.5 4.07-1.73zM187.1 319c-2.7-.15-4.82 2.17-6.5 4.29-.36.46-.74 1.12-.35 1.55s1.3 0 1.78-.48q2.6-2.61 5.07-5.36zM187.51 324.77l2.19-2.58c.46-.55.8-1.61.11-1.79a20.31 20.31 0 00-5.84 5.24l-.07 1c1.35.46 2.68-.76 3.61-1.87zM189 328.22a32.09 32.09 0 004.63-4.24c.8-.86 1.48-1.75 2.18-2.65a2.65 2.65 0 00-3.06.71c-.83.78-1.35 1.81-2.16 2.58a11.59 11.59 0 00-1.65 1.56 1.6 1.6 0 00.06 2.04zM204.25 29.46l4.92-4.85c.58-.57 1.19-1.5.63-2.11a12 12 0 00-6.75 7c.05.5.85.32 1.2-.04zM210.53 26.88a17.82 17.82 0 00-5.32 5.34c-.39.62-.76 1.24-1.11 1.91a1.88 1.88 0 002.19-.66c.54-.62.87-1.4 1.43-2 .69-.76 1.69-1.16 2.43-1.88s1.12-2.02.38-2.71zM173 51.09l3.83-3.94a2.42 2.42 0 00.41-2.7 21.2 21.2 0 00-4.91 4.55 3.84 3.84 0 00-1.05 2.56c.46.5 1.26.01 1.72-.47zM153.07 25.19a2.85 2.85 0 00-3 .8 27.64 27.64 0 00-2.07 2.52c-.92 1-2.24 2-2.12 3.41.85.44 1.82-.28 2.47-1a51 51 0 004.72-5.73zM195.7 310l5.92-5.9a3.13 3.13 0 00.75-1.08 3.11 3.11 0 00-3.36.81c-.9.83-1.55 1.93-2.42 2.77a6 6 0 00-1.48 1.58 1.3 1.3 0 00.47 1.79h.08zM154.31 30.29c.94-1 1.88-2 2.76-3.11.49-.59.65-1.85-.12-1.79a57.75 57.75 0 00-7.24 6.92c1.64.69 3.37-.71 4.6-2.02zM2.18 143.71l5.07-4.83a4.4 4.4 0 001.23-1.58 1.54 1.54 0 00-.43-1.83l-4.51 4.31c-1.11 1.05-2.29 2.72-1.36 3.93zM207.06 302.86c-.75-.36-1.59.25-2.18.84l-3.81 3.69c-.9.88-1.86 2.22-1.2 3.26.79.21 1.54-.41 2.07-1.06l4.15-4.58c.58-.61 1.17-1.36.97-2.15zM199.78 323.21c.75-.81 1.52-2.06.79-2.89a61.91 61.91 0 00-8.08 8.11c1.44.73 3-.57 4.13-1.76zM.75 138.44a2.51 2.51 0 002.05-1l4.36-4.27c.95-.93 2-2.21 1.48-3.5-.45-.28-1 .13-1.37.51l-4.66 5c-.89.92-1.84 1.97-1.86 3.26zM27.05 134.06a.8.8 0 00-1.06.29l-7.16 6.73c-.53.5-1.11 1.27-.73 1.89 1.17.26 2.22-.67 3-1.53l4.24-4.4a4.28 4.28 0 001.71-2.98zM2.68 132l3.8-3.87c1.24-1.25 2.55-2.65 2.78-4.4-1.08-.16-1.95.64-2.67 1.4-2.26 2.41-4.48 4.87-6.59 7.36.52.94 1.94.24 2.68-.49zM19.68 129.32c2 0 3.53-1.5 4.87-2.92a35.43 35.43 0 005.19-6.51c-.41-.46-1.16-.07-1.62.32a55.2 55.2 0 00-8.44 9.11zM.43 126.68C1.75 127.11 3 126 4 125l6.78-7.29c.53-.58 1.11-1.34.73-2.07-1.25 0-2.25 1-3.09 1.86a96.32 96.32 0 00-7.99 9.18zM18.87 136.92a3.06 3.06 0 002.39-1.27l4.52-4.7c1.52-1.57 3.08-3.25 3.6-5.37-1.28.07-2.3 1.07-3.18 2l-5 5.37c-1.02 1.13-2.2 2.41-2.33 3.97zM4.65 118.14q5.68-5.6 11.19-11.35a3.54 3.54 0 00.85-1.2 3.37 3.37 0 00-.13-1.78 98.7 98.7 0 00-11.4 11.55c-.74.77-1.36 2.14-.51 2.78z"/>
-<path d="M75.39 29.22a188.36 188.36 0 00-16.18 10.46c-5.5 4-11.26 9.13-11.52 15.92-.37 10.21 11.71 16.91 13.45 27 1.24 7.16-3.09 14.45-1.77 21.6.74 4 3.18 7.49 4.4 11.38 3 9.47-.8 21.89 6.9 28.17 4.79 3.9 8.15 9.21 11.52 14.41A625.24 625.24 0 00194.8 288.3c6.22 5.44 14.23 11.12 22 8.44a86.16 86.16 0 0039.2-27.58c4.08-5.11 2.37-12.57.32-18.78-20.53-62-55.55-118.15-92.85-171.83-3-4.12-6.13-8.52-10.89-10.41-2.38-1-5-1.19-7.39-2.24-5.19-2.29-8-8-12.82-11.05-6.5-4.19-15.41-2.89-21.93-7C101.34 42 98.88 27 88.17 25.41c-4.49-.65-8.9 1.56-12.8 3.81m150.48 257.54a2.83 2.83 0 012.59-1.05 2.59 2.59 0 01-.29 3.37 6.82 6.82 0 01-3.28 1.65c-2.49.67-5.2 1.39-6.8 3.38a1.59 1.59 0 01-.86-2.07 3.85 3.85 0 011.7-1.8 15.26 15.26 0 015.29-2.09 2.86 2.86 0 01.56 1.49 1.74 1.74 0 001.62-.84l-.55-2M67.26 99.44a2.53 2.53 0 012.45-1A60.14 60.14 0 0067 113.56c0 1-1.76 1.14-2.3.29a3.76 3.76 0 01-.18-2.94c.69-3.22 1.39-6.44 2.09-9.64a5 5 0 01.66-1.83m34.16-13.77c-.07-.67-.6-1.56-1.17-1.2q-1.75 9.63-3.53 19.26c-.32 1.75-1.23 4-3 3.77l4-22.88c.36-2.17.87-4.49 2.76-5.62a161.25 161.25 0 0024-17.71l-2.13 12.5c-.16.93.18 2.33 1.06 2l3.7-17.92c.16-.79.41-1.68 1.14-2a2.57 2.57 0 011.83.2c2.18.84 4.5 1.79 5.74 3.76 3 4.74-2.42 10.78-1.35 16.26.22 1.14-.79 2.12-1.7 2.85q-12.39 10-25.06 19.57a3.92 3.92 0 01.1-3.93c-1.58.27-1.75 2.39-1.94 4s-1.89 3.46-3 2.33l1.45-7.57c.19-1.09 0-2.58-1-2.6a35.62 35.62 0 01-4 14.42c-1.71-6.4 2.68-13 2.11-19.55m-17-17.46a3.4 3.4 0 011.58-2.09L101.87 54a15 15 0 00-.87 8c3.91-3.72 1-12.25 6-14.34a34.53 34.53 0 0019.71 6.31 11.5 11.5 0 01-2.83 5.1c-.41-1.21-.81-2.42-1.21-3.64-.69-.38-1.11.8-1.12 1.59-.07 4.26-3.81 7.43-7.25 9.94q-9.62 7-19.62 13.41c1-2.27 1.73-5.48-.39-6.76a11.35 11.35 0 01-3.71 9.57l2.41-17.09a26.84 26.84 0 00-4 13.42c-.06 2.62-.69 6.28-3.3 6.13l3.15-17.3c.17-.93 0-2.3-1-2.26q-2.44 9.9-4 20c-.19 1.19-1.28 2-2.28 2.68a122.58 122.58 0 01-14.28 7.78 148.06 148.06 0 003-17 19.55 19.55 0 00-3.4 9.29c-.25 2.07-.12 4.17-.78 6.17s-2.38 3.87-4.47 3.77c-.68-3.44 2.86-6.49 2.74-10-.06-1.8-1.08-3.41-1.72-5.09s-.82-3.82.48-5l1.92.52a5.2 5.2 0 00.51 6.66c0-3.48.29-7.63 3.3-9.38L83.53 68A69.81 69.81 0 0080 87.9c3-6.05 3.77-13 4.49-19.69m109.08 214.55c-.28.9-1.74.8-2.27 0a3.9 3.9 0 01-.2-2.75l1.64-9.1a9.68 9.68 0 00-2.62 8.84c-3.31 1.21-6-3.19-5.78-6.73s2-7 1.14-10.38a24.9 24.9 0 00-2.65 12.1c-3.06-.84-5-4-5.4-7.17s.47-6.34 1.33-9.35a15.05 15.05 0 00-2.5 8.59 2.17 2.17 0 01-2.36.34q.89-7.35 1.76-14.7a25.72 25.72 0 00-3.42 12 681.66 681.66 0 01-47.36-50.86c-4.56-5.41 3.33-14.15.14-20.46q-1.76 7.85-3.54 15.7L83.38 158c-1.5-2-3-4.13-3.21-6.62s1.71-5.24 4.22-5a3.62 3.62 0 01-3.4 3.78c1.62 1.41 4.1.24 5.89-1l53.82-36.34c9.53-6.42 19.15-12.93 27-21.33l-49.51 34.38c-1.55 1.08-3.73 2.14-5.15.9q27.57-18.45 54.33-38.08a813.29 813.29 0 0157.85 93.63c1.53 2.89 3.06 6.42 1.45 9.3a1.86 1.86 0 001.64-2.06v-.06a479.89 479.89 0 0125.09 58.23c1.06 3 2.1 6.09 2 9.27s-1.65 6.49-4.53 7.83q1.2-7.1 2.41-14.19c-3.21 2.23-2.39 7-3.05 10.87-.92 5.42-5.26 9.51-9.57 12.92a121.22 121.22 0 01-28.93 16.8c-1.24.5-3.15.67-3.45-.63a4 4 0 001.18 3.12l5.89-1.43c.16 3.6-5.6 4.79-8 2.15s-2.06-6.82-1-10.26l-3.47 6.38c-3.46-.05-6.41-2.93-7.43-6.23s-.41-6.9.72-10.17a9.41 9.41 0 00-2.61 8.68m-83.24-164c-.37 2.17-1.28 4.94-3.5 5.08a218 218 0 004-23.68c-1.47.3-2 2.11-2.27 3.59l-3.46 20.15c-.24 1.34-1.4 2.27-2.49 3.08-7.11 5.26-14.29 10.57-22.39 14.13-1.81.78-4 2.8-2.64 4.23l7.51-4c1 .49.69 2.18-.27 2.86s-2.17.79-3.16 1.38c-1.21.73-2.16 2.16-3.58 2.1a3.63 3.63 0 01-2-1 25.52 25.52 0 01-8.56-14.27 40.85 40.85 0 01-.16-15.66c1.14-6.42 3.85-12.69 3.23-19.17q6-3.81 12.14-7.25a16.71 16.71 0 00-.6 6.52c1.67-1 1.68-3.34 1.89-5.27s1.73-4.25 3.57-3.61a64.6 64.6 0 00-2.44 13.08c3.38-3.11 2.73-8.48 3.67-13 .31-1.51 1.49-3.32 2.94-2.79Q90 96 88.17 106.55c1.29.37 2.1-1.36 2.32-2.7q1.37-8.34 2.79-16.65c.37-2.17 1.29-4.94 3.51-5.09q-2.73 12.69-4.61 25.56a2.75 2.75 0 01-1.5 1.7 93.41 93.41 0 01-21 9.82c-.44 1 1.34 1.48 2.39 1.18a69.81 69.81 0 0022.46-11c1-.7 1.67 1.26 1.07 2.27s-1.58 2.34-.73 3.16c1.87-.33 2.16-2.82 2.29-4.75s1.56-4.33 3.28-3.52a30.31 30.31 0 00-1.85 15.9l2.57-13.59c.43-2.25 1.22-4.92 3.43-5.55l-3.25 20A39.18 39.18 0 00106 104c0-1.25 1.07-2.2 2.06-3l24.81-18.94c-.49 3.34-1 6.66-1.47 10-.14.91.49 2.33 1.2 1.75l2.11-11.44c.36-1.92 1-4.13 2.71-4.87a49.21 49.21 0 01-2 14.27c-.92 3.1-2 6.83.12 9.28l3.94-22.49c.43-2.26.84-4.6 2.2-6.4 1.14 1.46.86 3.56.52 5.39l-4.2 22.84a5.55 5.55 0 01-3.15 4.61l-23.11 15.27q1.13-6.73 2.21-13.47c.17-1-.49-2.6-1.3-2l-2.29 13.87M89.24 35.31l-2.47 11.13c-.29 1.32-.16 3.28 1.23 3.28a42.14 42.14 0 012.94-11.41c1.51 1.53 1.43 4 .84 6.07s-1.6 4.06-1.62 6.2c0 1 .81 2.5 1.79 2.05a37.76 37.76 0 011.77-10.27 13.36 13.36 0 01-.6 12.35A3.6 3.6 0 0096 52a10.46 10.46 0 00.09-4.17l2.83 2.42c-.19 3.85-3.66 6.6-6.83 8.82l-10.67 7.49.17-6.18c-1.76.66-1.9 3-2 4.9s-1.13 4.28-3 3.91q1-5.53 2.09-11c.21-1.09.08-2.69-1.06-2.82a33.1 33.1 0 00-2.05 10.03c-.16 3.28-2.36 6.17-5.11 8a30.6 30.6 0 01-9.06 3.67L51.21 62.18a6.45 6.45 0 01-1.39-3.09c-.13-1.88 1.35-3.46 2.73-4.73a88.32 88.32 0 0110.28-8.75 13.75 13.75 0 00-.56 8.64c1.78-1.51 1.58-4.2 1.66-6.52s1.32-5.21 3.63-5l-2.72 13c-.3 1.42-.41 3.27.89 3.91a157.27 157.27 0 003.77-18.47 48.69 48.69 0 0112.24-7.78A16.66 16.66 0 0080.55 42c.61.37 1.17-.53 1.32-1.22l2-10c1.43.2 1.55 2.21 1.3 3.63q-.9 5.3-1.84 10.59a9.45 9.45 0 002.83-6.2 7 7 0 01.48-3.16c.54-.94 2.09-1.33 2.64-.4M160 76.4a12.46 12.46 0 013.57 5.6 1.4 1.4 0 01.08.9 1.49 1.49 0 01-.52.62l-7.13 6a3.65 3.65 0 01-2.55 1.17c1.06-4.56 1.76-9.19 2.46-13.82.17-1.14-.18-2.85-1.33-2.63L151.46 92a4.15 4.15 0 01-1.94 2.37l-8.09 5.93c-.52.38-1.34.74-1.73.22a1.23 1.23 0 01-.1-1l2-10.67c.85-4.56 1.7-9.11 2.68-13.63a8.22 8.22 0 00-.63-5.28 12 12 0 019.34.4 23.39 23.39 0 014.83 3.43 1.87 1.87 0 01.85 2.33l-1.89 8.39a1.12 1.12 0 001.59 0 .28.28 0 00.09-.1 3.25 3.25 0 00.64-1.8l.9-6.19M78.09 29.94c3.25-1.69 6.91-3.29 10.5-2.48s6 3.57 8.17 6.36a96.78 96.78 0 018.4 12.72 6.32 6.32 0 01-2 2.77 2.24 2.24 0 01-3.06-.31L91 35.1c-.63-.94-1.4-2-2.53-2-.93 0-1.37-1.27-1.11-2.14a4.6 4.6 0 011.93-2c-8.66.39-15.7 6.63-22.79 11.55-2.21 1.54-4.86 3.05-7.47 2.36.92 1.57-.52 3.44-1.85 4.69l-7.78 7.36c.48-4 3.55-7.16 6.58-9.8a113.78 113.78 0 0122.11-15.18M110 124.25a203.7 203.7 0 0117.73-11.45l-.25 2.53c-3.56 2.18-7 4.43-10.51 6.71q-7.83 5.2-15.49 10.63-7.12 5.1-14.34 10.06c-.94-2.34 1.94-5.13 4.25-4.12l.4-1.7L110 124.23m35-21.52c-1.74 1.21-3.49 2.42-5.28 3.48a62.9 62.9 0 00-9 6.85c-.58.52-1.55-.3-1.45-1.06a2.88 2.88 0 011.44-1.71l7.11-5c2.15-1.53 4.31-3.07 6.55-4.47.83-.52 2.11-1 2.68-.15.06-2.08 2-3.48 3.7-4.61a94.3 94.3 0 008.49-6.27 65 65 0 006-5.71 4.67 4.67 0 01-3.24 5.76 4.93 4.93 0 01-1.38.17c-1 2.54-3.3 4.25-5.52 5.78l-10 7m97.19 173.39l1.08 2.07a1.82 1.82 0 00.09-2.37l4.06-5.34a2.53 2.53 0 011.08 3.17 7.44 7.44 0 01-2.34 2.85l-5.18 4.46a43.89 43.89 0 01-3.38 2.82 25.08 25.08 0 01-6.93 3.63c-.21-1.65-.09-3.85 1.51-4.33a9.11 9.11 0 005.37-4.4l1.92 2.42c.54-.91.34-2.06.5-3.12s1.05-2.21 2.06-1.88M137.14 75a2.37 2.37 0 01-.74-2.48c.19-.9.64-1.73.82-2.63a28.7 28.7 0 00.14-3.34 3.06 3.06 0 011.7-2.69 49.52 49.52 0 004.81 4.46 6 6 0 00-4 2.58c-1 1.3-1.72 2.81-2.75 4.1m119.74 190.75l-3.12 1.41c0 1.87-1.48 3.34-2.91 4.58a2.2 2.2 0 01-1.32.68 5.09 5.09 0 014-6 4.85 4.85 0 01.55-.08 5 5 0 00.76-3.8c.33-.81 1.67-.25 1.89.61s-.09 1.76.15 2.61M61.53 106l.18-2.91a4.77 4.77 0 01.57-2.34 1.63 1.63 0 012.1-.66 20.42 20.42 0 01-1.48 9.37c-1.29-.38-1.46-2.12-1.37-3.46m40.79 28.13a6.41 6.41 0 01.84 2.32L99.35 138l-.08.8a4.84 4.84 0 01-2.27 1.52c-.89.17-2-.39-2-1.3a7.1 7.1 0 014.34-1.59.68.68 0 00-.36-.74l3.35-2.56M88.39 146.5l-1.77.26a2.4 2.4 0 014-2.54 2.64 2.64 0 00-2 2m15.82-11.69a3.16 3.16 0 012.19-3.43c.42-.11 1-.08 1.17.32a3.06 3.06 0 01-3 3.13h-.39m6.57-6.39a1.68 1.68 0 011.34-.67 4.75 4.75 0 01.66 1.89 6.78 6.78 0 00-3.18 2.13 1.72 1.72 0 01-.1-2.43 1.76 1.76 0 011-.53m-15.81 12.94a18.49 18.49 0 01-3 2.64 2 2 0 113-2.64z"/>
-</svg> </symbol>
 <symbol id="icon-facebook--follow-footer">
 <svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
 <circle cx="17.7629" cy="17.7629" r="17.7629"/>
@@ -535,16 +966,16 @@ Mntl.PageView.init(pageViewDataAsJSON);
 <path fill-rule="evenodd" clip-rule="evenodd" d="M21.0353 9.53906H14.49C11.76 9.53906 9.53906 11.7024 9.53906 14.3613V21.1639C9.53906 23.8229 11.76 25.9862 14.49 25.9862H21.0353C23.7653 25.9862 25.9862 23.8229 25.9862 21.1639V14.3613C25.9862 11.7024 23.7653 9.53906 21.0353 9.53906ZM24.1984 21.1639C24.1984 22.8627 22.7794 24.2448 21.0353 24.2448H14.49C12.7459 24.2448 11.3269 22.8627 11.3269 21.1639V14.3613C11.3269 12.6625 12.7459 11.2804 14.49 11.2804H21.0353C22.7794 11.2804 24.1984 12.6625 24.1984 14.3613V21.1639ZM13.0711 17.7406C13.0711 15.1763 15.2005 13.0975 17.7945 13.1714C19.2411 13.2125 20.4475 13.6936 21.2834 14.5627C22.0776 15.3886 22.4824 16.4955 22.454 17.7638C22.4267 18.9786 21.9342 20.1167 21.0671 20.9684C20.1862 21.8337 19.0127 22.3102 17.7627 22.3102C15.1758 22.3102 13.0711 20.2603 13.0711 17.7406ZM17.7627 20.1818C19.1373 20.1818 20.2384 19.0993 20.2693 17.7173C20.2803 17.2289 20.1884 16.5375 19.6885 16.0178C19.2595 15.5716 18.5826 15.3231 17.7308 15.2989C17.7079 15.2982 17.6851 15.2979 17.6623 15.2979C17.0279 15.2979 16.4276 15.5515 15.972 16.0119C15.5105 16.4784 15.2563 17.0923 15.2563 17.7406C15.2563 19.0867 16.3806 20.1818 17.7627 20.1818ZM22.1956 12.4228C21.638 12.4228 21.1861 12.863 21.1861 13.406C21.1861 13.949 21.638 14.3892 22.1956 14.3892C22.7531 14.3892 23.2051 13.949 23.2051 13.406C23.2051 12.863 22.7531 12.4228 22.1956 12.4228Z" fill="white"/>
 </svg>
 </symbol>
-<symbol id="icon-twitter--follow-footer">
-<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
-<circle cx="17.7629" cy="17.7629" r="17.7629"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M26.8086 12.114C26.1433 12.4109 25.4277 12.6116 24.6768 12.7029C25.4433 12.2398 26.0314 11.5079 26.3086 10.6352C25.5906 11.0637 24.7977 11.3746 23.9514 11.5416C23.2745 10.8153 22.3106 10.3613 21.2422 10.3613C19.1918 10.3613 17.5304 12.0351 17.5304 14.0986C17.5304 14.3922 17.5633 14.6768 17.6266 14.9507C14.5423 14.7953 11.8068 13.3074 9.97682 11.0464C9.65688 11.5975 9.47429 12.2398 9.47429 12.925C9.47429 14.2212 10.1298 15.3652 11.125 16.0347C10.5164 16.015 9.94474 15.8472 9.44386 15.5676V15.6153C9.44386 17.4255 10.7228 18.9356 12.422 19.2794C12.1103 19.3641 11.783 19.411 11.4441 19.411C11.2048 19.411 10.972 19.3871 10.7458 19.3427C11.2179 20.8272 12.589 21.908 14.2125 21.9384C12.9426 22.941 11.3421 23.5381 9.6026 23.5381C9.30322 23.5381 9.00713 23.52 8.7168 23.4863C10.3593 24.5465 12.3102 25.165 14.4066 25.165C21.234 25.165 24.9671 19.4702 24.9671 14.5321C24.9671 14.37 24.963 14.2097 24.9564 14.0493C25.6819 13.5221 26.3111 12.8641 26.8086 12.1148V12.114Z" fill="white"/>
-</svg>
-</symbol>
 <symbol id="icon-youTube--follow-footer">
 <svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
 <circle cx="17.7629" cy="17.7629" r="17.7629"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M26.3877 16.3169C26.3815 15.9699 26.354 15.5313 26.306 15.0014C26.2577 14.4713 26.1887 13.9974 26.0988 13.5799C25.996 13.111 25.7726 12.7158 25.429 12.3946C25.0853 12.0733 24.6854 11.887 24.229 11.8356C22.8026 11.675 20.6473 11.5947 17.7627 11.5947C14.8781 11.5947 12.7226 11.675 11.2963 11.8356C10.8401 11.887 10.4417 12.0733 10.1013 12.3946C9.76075 12.7157 9.53909 13.1109 9.4363 13.5799C9.34001 13.9976 9.26762 14.4714 9.21948 15.0014C9.17134 15.5313 9.14402 15.9698 9.13763 16.3169C9.13112 16.6638 9.12793 17.1456 9.12793 17.7624C9.12793 18.3792 9.13112 18.861 9.13763 19.208C9.14402 19.555 9.17134 19.9935 9.21948 20.5234C9.26762 21.0536 9.3367 21.5274 9.42672 21.9449C9.5295 22.4139 9.75271 22.8091 10.0964 23.1303C10.4402 23.4514 10.8402 23.6378 11.2963 23.6892C12.7226 23.8498 14.878 23.9301 17.7627 23.9301C20.6475 23.9301 22.8026 23.8498 24.229 23.6892C24.6853 23.6378 25.0836 23.4514 25.4242 23.1303C25.7647 22.8091 25.9863 22.4138 26.0891 21.9449C26.1853 21.5274 26.2577 21.0534 26.306 20.5234C26.354 19.9935 26.3813 19.5549 26.3877 19.208C26.3942 18.861 26.3974 18.3792 26.3974 17.7624C26.3974 17.1456 26.3942 16.6638 26.3877 16.3169ZM21.1742 18.2829L16.2401 21.3665C16.1501 21.4308 16.0408 21.4628 15.9123 21.4628C15.8161 21.4628 15.7165 21.4372 15.6137 21.3858C15.4017 21.2701 15.2957 21.0904 15.2957 20.8462V14.6786C15.2957 14.4346 15.4017 14.2547 15.6137 14.139C15.8321 14.0232 16.0409 14.0297 16.2401 14.1583L21.1742 17.2421C21.3669 17.3511 21.4632 17.5247 21.4632 17.7624C21.4632 18.0002 21.3669 18.1737 21.1742 18.2829Z" fill="white"/>
+</svg>
+</symbol>
+<symbol id="icon-twitter--follow-footer">
+<svg viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
+<circle cx="17.7629" cy="17.7629" r="17.7629"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M26.8086 12.114C26.1433 12.4109 25.4277 12.6116 24.6768 12.7029C25.4433 12.2398 26.0314 11.5079 26.3086 10.6352C25.5906 11.0637 24.7977 11.3746 23.9514 11.5416C23.2745 10.8153 22.3106 10.3613 21.2422 10.3613C19.1918 10.3613 17.5304 12.0351 17.5304 14.0986C17.5304 14.3922 17.5633 14.6768 17.6266 14.9507C14.5423 14.7953 11.8068 13.3074 9.97682 11.0464C9.65688 11.5975 9.47429 12.2398 9.47429 12.925C9.47429 14.2212 10.1298 15.3652 11.125 16.0347C10.5164 16.015 9.94474 15.8472 9.44386 15.5676V15.6153C9.44386 17.4255 10.7228 18.9356 12.422 19.2794C12.1103 19.3641 11.783 19.411 11.4441 19.411C11.2048 19.411 10.972 19.3871 10.7458 19.3427C11.2179 20.8272 12.589 21.908 14.2125 21.9384C12.9426 22.941 11.3421 23.5381 9.6026 23.5381C9.30322 23.5381 9.00713 23.52 8.7168 23.4863C10.3593 24.5465 12.3102 25.165 14.4066 25.165C21.234 25.165 24.9671 19.4702 24.9671 14.5321C24.9671 14.37 24.963 14.2097 24.9564 14.0493C25.6819 13.5221 26.3111 12.8641 26.8086 12.1148V12.114Z" fill="white"/>
 </svg>
 </symbol>
 <symbol id="spruce-icon-what-to-buy">
@@ -680,12 +1111,13 @@ C15,14.2,13.8,12.9,13.6,12.5z"/>
 </g>
 </svg>
 </symbol>
-<symbol id="mntl-dotdash-family-nav__logo">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 405.37 132.68"><path d="M19.33 94.19a19.25 19.25 0 100 38.49 19.25 19.25 0 000-38.49z" fill="#ea2200"/><path d="M294.73 67.45a32.69 32.69 0 00-8.35-5.68 23 23 0 00-10.13-2.31 17.75 17.75 0 00-7.55 1.6 5.6 5.6 0 00-3.46 5.51q0 3.72 3.82 5.33a83.38 83.38 0 0012.35 3.55 67.33 67.33 0 0110 3 35.92 35.92 0 019.15 5.15 24.82 24.82 0 016.57 7.82 22.91 22.91 0 012.49 11 26.56 26.56 0 01-12.17 23.46 38.07 38.07 0 01-12.17 5.15 58.87 58.87 0 01-13.51 1.6 66.69 66.69 0 01-21.23-3.47A44.5 44.5 0 01233.25 119l16.35-17.23a32.76 32.76 0 009.6 7.11 26.69 26.69 0 0012.08 2.84 15.82 15.82 0 007-1.69 6 6 0 003.46-6c0-2.72-1.42-4.74-4.26-6a76.64 76.64 0 00-13.33-4.09 69.41 69.41 0 01-9.24-2.84 29.43 29.43 0 01-8.26-4.8 23.66 23.66 0 01-5.95-7.46 22.73 22.73 0 01-2.31-10.66 25.86 25.86 0 013.37-13.6 28.55 28.55 0 018.71-9.15 38.7 38.7 0 0111.82-5.24 50.7 50.7 0 0112.88-1.69 62.34 62.34 0 0119.46 3.11 42 42 0 0116.08 9.33zm75.52-28.6c-8.76 0-16.14 2.56-21.71 7.46V.16h-27.47V130h27.47V81.53c0-12.24 7.94-16.6 15.37-16.6 11.57 0 14 8.93 14 16.42V130h27.47V74.07c-.01-20.74-14.45-35.22-35.13-35.22zM146.19 53.62a51 51 0 0118.22-11.2 62.55 62.55 0 0121.23-3.73q11.19 0 18.92 2.75A28.22 28.22 0 01217.09 50a36.3 36.3 0 017 14.57 86.07 86.07 0 012.22 20.87v44.41h-26.9v-9.22c-17 21.32-55.07 13.4-55.07-16.17 0-5.36 3.89-26.83 34.21-29.58 6-.55 11.39-.28 20.24-.28v-1.44q0-6.57-4.62-9.68a19.93 19.93 0 00-11.37-3.11 28.42 28.42 0 00-12 2.66 31.79 31.79 0 00-9 5.8zm53.49 37.85h-10.75c-8.78 0-13.57 3.69-15 5.22a8 8 0 00-2.25 5.71 6.9 6.9 0 001 3.86 8.13 8.13 0 002.65 2.57 11.26 11.26 0 003.7 1.37 21.22 21.22 0 004 .4q8 0 12.31-4.42t4.26-12zM107.18 0v46.23c-6.05-5-13.48-7.58-22.33-7.58-24.58 0-43.12 20.06-43.12 46.66s18.54 47.31 43.11 47.31c8.91 0 17.22-3 22.8-8.57v5.78h27V0zM110 94.13a24.5 24.5 0 01-4.38 7.47 21.67 21.67 0 01-6.84 5.29 20 20 0 01-9.11 2 20.47 20.47 0 01-9.3-2 20.87 20.87 0 01-6.75-5.29A22.5 22.5 0 0169.5 94a28.42 28.42 0 01-1.36-8.66 27.48 27.48 0 011.36-8.57 20.9 20.9 0 0110.85-12.54 20.47 20.47 0 019.3-2 20 20 0 019.11 2 21.67 21.67 0 016.84 5.29 24.6 24.6 0 014.4 24.61z"/></svg> </symbol>
+<symbol id="mntl-dotdash-universal-nav__logo">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="5 2.8 290 69"><circle cx="39.6" cy="37.4" r="34.3" fill="#f44b34"/><path fill="#fff" d="M50.4 17.9c-1.7-1.8-4-2.6-7-2.6-9.1-.1-12.4-.1-13.2-.1L27.3 22h8.1L30 28v21h-.1l.1.1v6.7l-3.6 4h18.5L53 51V25c0-.1.1-4.3-2.6-7.1zm-5.2 19.6-7.4 7.8V41l7.4-7.8v4.3zm-7.4-15.4h3c.9 0 2.1-.1 3.1.9s1.4 2.5 1.4 4.9v3.6l-7.4 7.8-.1-17.2zm-4.9 30.1 3.3-3.6 9-9.5v13.1c0 .1-12.3.1-12.3 0z"/><path fill="#009ad9" d="m99.645 22.637 6.505-6.506 4.172 4.172-6.505 6.506zM121 44l4.2 4.2 6.5-6.5-4.2-4.2zm-3.2-31.2c1.8-1.8 4.7-1.8 6.5 0 1.9 1.9 1.7 4.8 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c2-2 4.9-1.6 6.5 0 2 2 1.6 4.9 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c4.2-4.2 4-10.8 0-14.8-2.8-2.8-6.1-3.1-7.6-3.1.1-1.5-.3-4.8-3.1-7.6-3.9-3.9-10.6-4.2-14.8 0l-3.3 3.3 4.2 4.2 3.2-3.4zm-7.5 20.6 4.2 4.1L121 31l-4.2-4.1-6.5 6.5z"/><path fill="#6ebd44" d="m99.6 52.4 6.6 6.5 4.1-4.2-6.5-6.5zm36.3-14.9-4.2 4.2L135 45c1.6 1.6 2 4.5 0 6.5-1.6 1.6-4.5 2.1-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c1.7 1.7 1.9 4.6 0 6.5-1.8 1.8-4.7 1.8-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c4.2 4.2 10.9 3.9 14.8 0 2.8-2.8 3.1-6.1 3.1-7.6 1.5 0 4.8-.3 7.6-3.1 4-4 4.2-10.6 0-14.8l-3.2-3.4zm-25.6 4.2 6.5 6.5L121 44l-6.5-6.5zm14.9-14.8L121 31l6.5 6.5 4.2-4.1-6.5-6.5z"/><path fill="#f68f1e" d="m110.332 54.607 6.506-6.506 4.172 4.172-6.506 6.505zM102.8 62.2c-1.6 1.6-4.5 2-6.5 0-1.6-1.6-2.1-4.5 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-1.7 1.7-4.6 1.9-6.5 0-1.8-1.8-1.8-4.7 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-4.2 4.2-3.9 10.9 0 14.8 2.8 2.8 6.1 3.1 7.6 3.1 0 1.5.3 4.8 3.1 7.6 4 4 10.6 4.2 14.8 0l3.3-3.3-4.2-4.2-3.2 3.4zm3.4-24.7L99.6 44l4.2 4.2 6.5-6.5zM95.5 26.9 89 33.4l4.1 4.1 6.5-6.5z"/><path fill="#ec174c" d="m99.6 44-6.5-6.5-4.1 4.2 6.5 6.5zm-14-14c-1.8-1.8-1.8-4.7 0-6.5 1.9-1.9 4.8-1.7 6.5 0l3.3 3.3 4.2-4.2-3.3-3.3c-2-2-1.6-4.9 0-6.5 2-2 4.9-1.6 6.5 0l3.3 3.3 4.2-4.2-3.3-3.2c-4.2-4.2-10.8-4-14.8 0-2.8 2.8-3.1 6.1-3.1 7.6-1.5-.1-4.9.3-7.6 3.1-3.9 3.9-4.2 10.6 0 14.8l3.3 3.3 4.2-4.2-3.4-3.3zm24.73-9.682 4.172-4.172 6.505 6.505-4.172 4.172zM106.2 37.5l4.1-4.1-6.5-6.5-4.2 4.1 6.6 6.5z"/><path fill="#573357" d="m106.142 16.042 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#be272d" d="m84.81 37.543 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#008e4c" d="m127.497 37.555 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#7a773e" d="m106.172 58.866 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#443639" d="m116.856 26.74 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#803136" d="m95.455 48.169 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#593438" d="m95.446 26.753 4.172-4.172 4.172 4.173-4.172 4.171z"/><path fill="#443639" d="m106.155 37.456 4.172-4.172 4.172 4.171-4.172 4.172z"/><path fill="#2a6442" d="m116.871 48.153 4.172-4.172 4.172 4.172-4.172 4.172z"/><path d="M170.4 13.5c-2.5-2.2-5.7-3.3-9.6-3.3h-7.2v23.6h7.6c3.8 0 7-1.1 9.4-3.3s3.6-5 3.6-8.5-1.3-6.3-3.8-8.5zm.1 8.5c0 2.6-.9 4.7-2.6 6.2-1.7 1.6-4.1 2.3-7 2.3h-3.8V13.4h3.8c2.9 0 5.2.8 7 2.3 1.7 1.5 2.6 3.7 2.6 6.3zm14.6-6.3c-2.5 0-4.7.9-6.4 2.7s-2.6 4-2.6 6.6.9 4.8 2.6 6.6c1.7 1.8 3.9 2.7 6.4 2.7h.1v-.1c2.5 0 4.7-.9 6.4-2.7s2.6-4 2.6-6.6c0-2.5-.9-4.8-2.6-6.6-1.8-1.7-3.9-2.6-6.5-2.6zm4.1 13.7c-.5.6-1.1 1-1.8 1.3s-1.4.3-2.2.3c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 3 .6 4 1.7 1.1 1.2 1.6 2.6 1.6 4.3 0 1.9-.5 3.4-1.6 4.6zm16.9.8c-.5.6-1.3.9-2.3.9-1.6 0-2.4-.9-2.4-2.7v-9.2h5v-3h-5v-4.4h-3.3v4.4h-2.9l.1 3h2.9v9.3c0 1.9.5 3.3 1.4 4.3s2.2 1.5 3.9 1.5c1.8 0 3.2-.5 4.2-1.5l-1.6-2.6zm38.1-11.6c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V16.1h-3.4v2.5h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-.5.6-1.1 1-1.8 1.3s-1.4.4-2.2.4c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6.1 2.9.6 4 1.8zm17.9 3.6c-.9-.3-1.9-.6-3-.9-1-.3-1.9-.6-2.5-1-.7-.4-1-1-1-1.6l.1-.1c0-.7.3-1.2.9-1.6.6-.4 1.4-.6 2.3-.6 2 0 3.4.7 4.5 2l2-2c-1.3-1.8-3.5-2.7-6.6-2.7-1.9 0-3.5.5-4.7 1.4-1.2 1-1.7 2.1-1.7 3.5 0 1.2.3 2.1 1 2.9s1.5 1.3 2.6 1.7c1.1.4 2 .7 2.9 1 1 .3 1.8.7 2.4 1.1.7.5 1 1 1 1.8s-.3 1.4-.9 1.8c-.6.5-1.4.7-2.5.7-2.3 0-4.1-.8-5.3-2.3l-2 2.2c1.5 1.9 3.9 2.9 7.1 2.9 2.2 0 3.9-.5 5.1-1.5s1.8-2.3 1.8-3.8c0-1.2-.3-2.2-1-3-.6-.9-1.5-1.4-2.5-1.9zm14.9-8.6c-2.3 0-4.1.8-5.2 2.5V8.4h-3.4v25.4h3.4l.1-10.3c0-1.4.4-2.6 1.2-3.4.8-.8 1.8-1.2 3.2-1.2 1.3 0 2.4.4 3.2 1.3.8.8 1.2 2 1.2 3.4v10.3h3.4V23c0-2.3-.6-4-1.9-5.4-1.4-1.4-3.1-2-5.2-2zm-52.2 3c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V8.4h-3.4v10.2h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-1.1 1.2-2.4 1.8-4 1.8-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 2.9.5 4 1.7zm48.8 19.9h-3.6v19.1c0 2.4.7 4.1 2.1 5.1 1.2.9 3.1 1.4 5.6 1.4h.1v-3h-.1c-1.2 0-2.1-.2-2.7-.6-.9-.6-1.4-1.7-1.4-3.3V51h4.1v-3h-4.1v-7.5zm-96.2 7c-1.4 0-2.6.3-3.7 1-1 .6-1.7 1.5-2.3 2.6-1.2-2.4-3.2-3.6-6-3.6-2.2 0-4 .9-5.2 2.6V48h-3.5v18.2h3.5l.2-10.7c0-1.5.4-2.6 1.1-3.5.7-.9 1.8-1.3 3.1-1.3s2.3.4 3.1 1.3c.8.9 1.2 2 1.2 3.5v10.6h3.4V55.5c0-1.5.4-2.6 1.2-3.5s1.8-1.3 3.2-1.3c1.3 0 2.3.4 3.1 1.3.7.9 1.1 2 1.1 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5-1.3-1.3-3-2-5.1-2zm18.9 0c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7 1-.9 2.2-1.4 3.6-1.4zm22.5-2.3c-.6-.5-1.6-.8-2.8-.8-1.9 0-3.4.9-4.5 2.6v-2H205v18.2h3.5l-.1-10.5c0-1.5.3-2.7.9-3.6.6-.9 1.5-1.3 2.6-1.3.9 0 1.7.2 2.3.7h.1l1.4-3.3zm9-.7c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7.9-.9 2.1-1.4 3.6-1.4zm26.1 0c-1.5-2-3.6-3.1-6.3-3.1-2.5 0-4.6.9-6.3 2.7s-2.5 4.1-2.5 6.8.9 5 2.5 6.8c1.7 1.8 3.8 2.7 6.3 2.7 2.6 0 4.7-1.1 6.3-3.2v2.7h3.5V40.5h-3.5v10zm-1.7 2c1.1 1.2 1.6 2.7 1.6 4.5 0 1.7-.6 3.3-1.6 4.5-1.1 1.2-2.4 1.8-4.2 1.8-1.7 0-3.1-.6-4.2-1.8-1.1-1.2-1.7-2.7-1.7-4.5s.6-3.3 1.7-4.5c1.1-1.2 2.5-1.8 4.2-1.8 1.8.1 3.1.7 4.2 1.8zm43.5-3c-1.3-1.4-3-2.1-5.2-2.1-2.4 0-4.2.9-5.4 2.6v-9.6h-3.5v25.7h3.5l.1-10.5c0-1.5.4-2.6 1.2-3.5.8-.9 1.8-1.3 3.2-1.3 1.4 0 2.5.4 3.3 1.3.8.9 1.2 2 1.2 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5zM259.1 48h3.5v18.2h-3.5zm0-7.5h3.4v3.4h-3.4z"/></svg> </symbol>
 </defs>
 </svg>
-<header id="header_1-0" class="comp header js-menu-target js-search-target" role="banner" data-tracking-container="true">
-<div class="header__inner l-container js-menu-target">
+<header id="header_1-0" class="comp header--open-searchbar-no-title header js-menu-target js-search-target" role="banner" style data-tracking-container="true">
+<div class="header__inner l-container">
+<div class="simplyrecipes-header__upper header__upper">
 <button id="menu-button_1-0" class="comp btn--bare header__menu-btn js-menu-trigger menu-button button btn">
 <svg class="btn__icon btn__hamburger">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-hamburger"></use>
@@ -704,9 +1136,335 @@ button
 </svg>
 <span class="logo__text is-vishidden">SimplyRecipes.com</span>
 </a>
-<form id="header__search_1-0" class="comp header__search general-search" role="search" method="get" action="/search" data-tracking-container="true">
+</div>
+<div class="simplyrecipes-header__lower header__lower">
+<div class="header__nav-container js-search-target">
+<nav id="global-nav_1-0" class="comp global-nav" role="navigation" data-tracking-container="true">
+<button id="relish-save-header_1-0" class="comp relish-save-header mntl-relish-saved-recipes-btn mntl-button" data-tracking-container="true">
+saved recipes
+<svg class="icon icon-heart relish-save__heart-icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-heart"></use>
+</svg>
+</button>
+<ul class="global-nav__list js-global-nav">
+<li class="global-nav__list-item js-global-nav-item">
+<a
+href="https://www.simplyrecipes.com/recipes-5090746"
+rel="nocaes"
+class="global-nav__list-item-link"
+> <span>Recipes</span>
+</a> <svg class="icon icon-arrow--down global-nav__list-item-icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow--down"></use>
+</svg>
+<ul class="global-nav__sub-list">
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/breakfast-recipes-5091541"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Breakfast</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/lunch-recipes-5091263"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Lunch</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/dinner-recipes-5091433"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Dinner</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/dessert-recipes-5091513"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Dessert</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/drink-recipes-5091323"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Drinks</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/snacks-and-appetizer-recipes-5090762"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Snacks & Appetizers</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/holiday-and-seasonal-recipes-5091321"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Holidays & Seasonal Recipes</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/recipes-by-diet-5091259"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Recipes by Diet</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/recipes-by-method-5091235"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Recipes by Method</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/recipes-by-ingredients-5091192"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Recipes by Ingredients</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/recipes-by-time-and-ease-5090817"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Recipes by Time & Ease</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/world-cuisine-recipes-5090811"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Recipes by Cuisine</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/recipes-5090746"
+rel="nocaes"
+class="global-nav__sub-list-item-link global-nav__see-all"
+> View all
+</a> </li>
+</ul>
+</li>
+<li class="global-nav__list-item js-global-nav-item">
+<a
+href="https://www.simplyrecipes.com/recipes-by-time-and-ease-5090817"
+rel="nocaes"
+class="global-nav__list-item-link"
+> <span>Quick & Easy</span>
+</a> <svg class="icon icon-arrow--down global-nav__list-item-icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow--down"></use>
+</svg>
+<ul class="global-nav__sub-list">
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/quick-dinner-recipes-5091422"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Quick Dinners</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/easy-healthy-recipes-5091254"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Easy & Healthy</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/quick-vegetarian-recipes-5091240"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Quick Vegetarian</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/easy-pasta-recipes-5090997"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Easy Pastas</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/easy-chicken-recipes-5091132"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Easy Chicken</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/recipes-by-time-and-ease-5090817"
+rel="nocaes"
+class="global-nav__sub-list-item-link global-nav__see-all"
+> View all
+</a> </li>
+</ul>
+</li>
+<li class="global-nav__list-item js-global-nav-item">
+<a
+href="https://www.simplyrecipes.com/cooking-how-tos-5090751"
+rel="nocaes"
+class="global-nav__list-item-link"
+> <span>In the Kitchen</span>
+</a> <svg class="icon icon-arrow--down global-nav__list-item-icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow--down"></use>
+</svg>
+<ul class="global-nav__sub-list">
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/an-a-z-guide-to-cooking-terms-and-definitions-5192433"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>The Simply Recipes A-Z Guide to Cooking Terms and Definitions</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/meal-plans-5090752"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Meal Plans</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/recipe-collections-5119362"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Recipe Collections</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/cooking-tips-and-techniques-5090748"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Tips & Techniques</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/ingredient-guides-5090749"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Ingredient Guides</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/cuisine-guides-5090750"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Cuisine Guides</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/cooking-how-tos-5090751"
+rel="nocaes"
+class="global-nav__sub-list-item-link global-nav__see-all"
+> View all
+</a> </li>
+</ul>
+</li>
+<li class="global-nav__list-item js-global-nav-item">
+<a
+href="https://www.simplyrecipes.com/table-talk-5206565"
+rel="nocaes"
+class="global-nav__list-item-link"
+> <span>Table Talk</span>
+</a> <svg class="icon icon-arrow--down global-nav__list-item-icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow--down"></use>
+</svg>
+<ul class="global-nav__sub-list">
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/most-recent-5121175"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Most Recent</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/news-and-trends-5206826"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>News & Trends</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/voices-5206832"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Voices</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/table-talk-5206565"
+rel="nocaes"
+class="global-nav__sub-list-item-link global-nav__see-all"
+> View all
+</a> </li>
+</ul>
+</li>
+<li class="global-nav__list-item js-global-nav-item">
+<a
+href="https://www.simplyrecipes.com/holiday-and-seasonal-recipes-5091321"
+rel="nocaes"
+class="global-nav__list-item-link"
+> <span>Holidays & Seasons</span>
+</a> <svg class="icon icon-arrow--down global-nav__list-item-icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow--down"></use>
+</svg>
+<ul class="global-nav__sub-list">
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/why-we-can-5704018"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Why We Can: Canning Stories & Recipes</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/lunchbox-love-letters-6385827"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Lunchbox Love Letters</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/game-day-recipes-5091307"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Game Day & Tailgating</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/fall-recipes-5091308"
+rel="nocaes"
+class="global-nav__sub-list-item-link"
+>Favorite Fall Recipes</a>
+</li>
+<li class="global-nav__sub-list-item">
+<a
+href="https://www.simplyrecipes.com/holiday-and-seasonal-recipes-5091321"
+rel="nocaes"
+class="global-nav__sub-list-item-link global-nav__see-all"
+> View all
+</a> </li>
+</ul>
+</li>
+<li class="global-nav__list-item js-global-nav-item nav-about-us">
+<a
+href="https://www.simplyrecipes.com/about-us-5096129"
+rel="nocaes"
+class="global-nav__list-item-link"
+> <span>About us</span>
+</a> </li>
+</ul>
+</nav>
+</div>
+<form id="header__search_2-0" class="comp header__search general-search" role="search" method="get" action="/search" data-tracking-container="true">
 <button type="button"
-class="general-search__button js-open-search"
+class="general-search__button js-open-search "
 aria-label="Open search form">
 Search
 <svg class="icon icon-search general-search__icon btn__icon">
@@ -737,429 +1495,157 @@ Close search
 </svg>
 </button>
 </form>
-<button id="relish-save-header_1-0" class="comp relish-save-header mntl-relish-saved-recipes-btn mntl-button" data-tracking-container="true">
-Saved Recipes
-<svg class="icon icon-heart mntl-button__icon relish-save__heart-icon">
+<button id="lower-content__relish-save_1-0" class="comp lower-content__relish-save relish-save-header mntl-relish-saved-recipes-btn mntl-button" tabindex="0" data-tracking-container="true">
+saved recipes
+<svg class="icon icon-heart relish-save__heart-icon">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-heart"></use>
 </svg>
 </button>
-<div class="header__nav-container js-menu-target js-search-target">
-<nav id="fullscreen-nav_1-0" class="comp fullscreen-nav global-nav" role="navigation" data-tracking-container="true">
-<ul class="global-nav__list js-global-nav">
-<li class="global-nav__list-item js-global-nav-item">
-<a
-href="https://www.simplyrecipes.com/recipes-5090746"
-class="global-nav__list-item-link"
-> <span>Recipes</span>
-</a> <svg class="icon icon-breadcrumb-arrow global-nav__list-item-icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<ul class="global-nav__sub-list">
-<li>
-<a
-href="https://www.simplyrecipes.com/breakfast-recipes-5091541"
-class="global-nav__sub-list-item"
->Breakfast</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/lunch-recipes-5091263"
-class="global-nav__sub-list-item"
->Lunch</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/dinner-recipes-5091433"
-class="global-nav__sub-list-item"
->Dinner</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/dessert-recipes-5091513"
-class="global-nav__sub-list-item"
->Dessert</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/drink-recipes-5091323"
-class="global-nav__sub-list-item"
->Drinks</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/snacks-and-appetizer-recipes-5090762"
-class="global-nav__sub-list-item"
->Snacks & Appetizers</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/holiday-and-seasonal-recipes-5091321"
-class="global-nav__sub-list-item"
->Holidays & Seasonal Recipes</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/recipes-by-diet-5091259"
-class="global-nav__sub-list-item"
->Recipes by Diet</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/recipes-by-method-5091235"
-class="global-nav__sub-list-item"
->Recipes by Method</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/recipes-by-ingredients-5091192"
-class="global-nav__sub-list-item"
->Recipes by Ingredients</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/recipes-by-time-and-ease-5090817"
-class="global-nav__sub-list-item"
->Recipes by Time & Ease</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/world-cuisine-recipes-5090811"
-class="global-nav__sub-list-item"
->Recipes by Cuisine</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/recipes-5090746"
-class="global-nav__sub-list-item global-nav__see-all"
-> View all
-</a> </li>
-</ul>
-</li>
-<li class="global-nav__list-item js-global-nav-item">
-<a
-href="https://www.simplyrecipes.com/recipes-by-time-and-ease-5090817"
-class="global-nav__list-item-link"
-> <span>Quick & Easy</span>
-</a> <svg class="icon icon-breadcrumb-arrow global-nav__list-item-icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<ul class="global-nav__sub-list">
-<li>
-<a
-href="https://www.simplyrecipes.com/quick-dinner-recipes-5091422"
-class="global-nav__sub-list-item"
->Quick Dinners</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/easy-healthy-recipes-5091254"
-class="global-nav__sub-list-item"
->Easy & Healthy</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/quick-vegetarian-recipes-5091240"
-class="global-nav__sub-list-item"
->Quick Vegetarian</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/easy-pasta-recipes-5090997"
-class="global-nav__sub-list-item"
->Easy Pastas</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/easy-chicken-recipes-5091132"
-class="global-nav__sub-list-item"
->Easy Chicken</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/recipes-by-time-and-ease-5090817"
-class="global-nav__sub-list-item global-nav__see-all"
-> View all
-</a> </li>
-</ul>
-</li>
-<li class="global-nav__list-item js-global-nav-item">
-<a
-href="https://www.simplyrecipes.com/cooking-how-tos-5090751"
-class="global-nav__list-item-link"
-> <span>In the Kitchen</span>
-</a> <svg class="icon icon-breadcrumb-arrow global-nav__list-item-icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<ul class="global-nav__sub-list">
-<li>
-<a
-href="https://www.simplyrecipes.com/ingredient-guides-5090749"
-class="global-nav__sub-list-item"
->Ingredient Guides</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/cuisine-guides-5090750"
-class="global-nav__sub-list-item"
->Cuisine Guides</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/cooking-tips-and-techniques-5090748"
-class="global-nav__sub-list-item"
->Tips & Techniques</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/cooking-how-tos-5090751"
-class="global-nav__sub-list-item global-nav__see-all"
-> View all
-</a> </li>
-</ul>
-</li>
-<li class="global-nav__list-item js-global-nav-item">
-<a
-href="https://www.simplyrecipes.com/kitchen-food-buying-guides-5090755"
-class="global-nav__list-item-link"
-> <span>Buying Guides</span>
-</a> <svg class="icon icon-breadcrumb-arrow global-nav__list-item-icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<ul class="global-nav__sub-list">
-<li>
-<a
-href="https://www.simplyrecipes.com/equipment-guides-5090757"
-class="global-nav__sub-list-item"
->Equipment Guides</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/best-kitchen-items-5090754"
-class="global-nav__sub-list-item"
->Best Kitchen Items</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/best-ingredients-5090753"
-class="global-nav__sub-list-item"
->Best Ingredients</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/kitchen-food-buying-guides-5090755"
-class="global-nav__sub-list-item global-nav__see-all"
-> View all
-</a> </li>
-</ul>
-</li>
-<li class="global-nav__list-item js-global-nav-item">
-<a
-href="https://www.simplyrecipes.com/holiday-and-seasonal-recipes-5091321"
-class="global-nav__list-item-link"
-> <span>Holidays & Seasons</span>
-</a> <svg class="icon icon-breadcrumb-arrow global-nav__list-item-icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<ul class="global-nav__sub-list">
-<li>
-<a
-href="https://www.simplyrecipes.com/spring-recipes-5091296"
-class="global-nav__sub-list-item"
->Spring</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/lent-recipes-5091288"
-class="global-nav__sub-list-item"
->Lent</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/st-patricks-day-recipes-5091284"
-class="global-nav__sub-list-item"
->St. Patrick's Day</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/passover-recipes-5091286"
-class="global-nav__sub-list-item"
->Passover</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/easter-recipes-5091292"
-class="global-nav__sub-list-item"
->Easter</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/mothers-day-recipes-5091287"
-class="global-nav__sub-list-item"
->Mother's Day</a>
-</li>
-<li>
-<a
-href="https://www.simplyrecipes.com/holiday-and-seasonal-recipes-5091321"
-class="global-nav__sub-list-item global-nav__see-all"
-> View all
-</a> </li>
-</ul>
-</li>
-<li class="global-nav__list-item js-global-nav-item">
-<a
-href="https://www.simplyrecipes.com/about-us-5096129"
-class="global-nav__list-item-link"
-> <span>About us</span>
-</a> </li>
-</ul>
-</nav>
 </div>
 </div>
 </header>
 <div id="mntl-leaderboard-header_1-0" class="comp has-right-label leaderboard--header mntl-leaderboard-header mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard ">
-<div id="leaderboard" class="wrapper"></div>
+<div id="leaderboard-flex-1" class="wrapper"></div>
 </div>
 <div id="mntl-leaderboard-spacer_1-0" class="comp js-rollaway-spacer mntl-leaderboard-spacer mntl-block"></div>
 <main id="main" class="loc main" role="main">
-<iframe id="height-change-listener" role="none" tabindex="-1" src="about:blank"></iframe>
-<article id="article--structured-project_1-0" class="comp sc-ad-container article--structured-project article" data-tracking-container="true">
-<div class="l-container">
-<header class="loc article-header article__header">
-<div id="article-header-tag-nav_1-0" class="comp article-header-tag-nav breadcrumbs">
-<a
-href="https://www.simplyrecipes.com/recipes-5090746"
-class="breadcrumbs__item breadcrumbs__item--1"
->Recipes</a>
-<svg class="icon icon-breadcrumb-arrow breadcrumbs__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<a
-href="https://www.simplyrecipes.com/dinner-recipes-5091433"
-class="breadcrumbs__item breadcrumbs__item--2"
->Dinners</a>
-<svg class="icon icon-breadcrumb-arrow breadcrumbs__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<a
-href="https://www.simplyrecipes.com/dinner-recipes-by-type-5091419"
-class="breadcrumbs__item breadcrumbs__item--3"
->Dinners By Types</a>
-<svg class="icon icon-breadcrumb-arrow breadcrumbs__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
-<a
-href="https://www.simplyrecipes.com/soup-recipes-5091377"
-class="breadcrumbs__item breadcrumbs__item--4"
->Soups</a>
-<svg class="icon icon-breadcrumb-arrow breadcrumbs__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-breadcrumb-arrow"></use>
-</svg>
+<iframe id="height-change-listener" role="none" tabindex="-1" src="about:blank" aria-hidden="true"></iframe>
+<article id="article--structured-project_1-0" class="comp mntl-article--two-column-right-rail right-rail sc-ad-container article--structured-project lifestyle-food-article mntl-article" data-tracking-container="true">
+<div class="loc article-header">
+<nav id="article-header-tag-nav_1-0" class="comp article-header-tag-nav tag-nav" role="navigation" data-tracking-container="true">
+<div class="loc tag-nav-content">
+<ul id="link-list_1-0" class="comp tag-nav__list link-list">
+<li class="link-list__item tag-nav__item">
 <a
 href="https://www.simplyrecipes.com/chicken-soup-recipes-5091375"
-class="breadcrumbs__item breadcrumbs__item--5"
+rel="nocaes"
+class="link-list__link js-link-btn tag-nav__link"
 >Chicken Soups</a>
+<svg class="icon icon-arrow--double tag-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow--double"></use>
+</svg>
+</li>
+</ul>
 </div>
+</nav>
 <div id="heading_1-0" class="comp heading">
 <h1 class="heading__title">One-Pot Chicken and Rice Soup</h1>
-<h2 class="heading__subtitle">One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&#39;re done. It&#39;s the easiest soup ever, ready in under an hour.</h2>
+<h2 class="heading__subtitle">One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they're done. It's the easiest soup ever, ready in under an hour.</h2>
 </div>
-<div id="article-meta_1-0" class="comp has-image article-meta mntl-block" data-tracking-container="true">
-<div id="article-byline_1-0" class="comp article-byline mntl-byline mntl-block">
-<div id="mntl-byline__name_1-0" class="comp mntl-byline__name mntl-block" data-tooltip>
-<div id="mntl-bio-tooltip_1-0" class="comp mntl-bio-tooltip bio-tooltip mntl-block" data-tracking-container="true">
-<div id="mntl-bio-tooltip__top_1-0" class="comp mntl-bio-tooltip__top mntl-block">
-<div id="mntl-bio-tooltip__header_1-0" class="comp mntl-bio-tooltip__header mntl-block">
-<div id="mntl-bio-tooltip__image-wrapper_1-0" class="comp mntl-bio-tooltip__image-wrapper mntl-block" data-defer="load" data-defer-params></div>
-</div>
-<div id="mntl-bio-tooltip__header-content_1-0" class="comp text-passage mntl-bio-tooltip__header-content mntl-block">
-<span id="mntl-bio-tooltip__name_1-0" class="comp mntl-bio-tooltip__name mntl-block">
-<span id="mntl-bio-tooltip__prelink_1-0" class="comp mntl-bio-tooltip__prelink mntl-text-block"></span>
+<div id="article-meta_1-0" class="comp has-image attribution-enabled single-author article-meta mntl-block" data-tracking-container="true">
+<div id="lifestyle-food-bylines_1-0" class="comp lifestyle-food-bylines mntl-bylines">
+<div id="mntl-bylines__group_1-0" class="comp mntl-bylines__group--author mntl-bylines__group mntl-block">
+<div id="mntl-bylines__item_1-0" class="comp mntl-bylines__item mntl-attribution__item mntl-attribution__item--has-date">
+<span class="mntl-attribution__item-descriptor">By</span>
+<div data-tooltip="Aaron has over 10 years recipe development experience for his blog The Hungry Hutch. He has written for NYTimes, Washington Post, Simply Recipes, and others." data-inline-tooltip="true">
 <a
 href="https://www.simplyrecipes.com/aaron-hutcherson-5091796"
-id="mntl-bio-tooltip__link_1-0"
-class=" mntl-bio-tooltip__link mntl-text-link"
-data-tracking-container="true"
-><span class="link__wrapper">Aaron Hutcherson</span></a>
-<span id="mntl-bio-tooltip__postlink_1-0" class="comp mntl-bio-tooltip__postlink mntl-text-block"></span>
-</span>
-</div>
-<nav id="social-nav--bio_1-0" class="comp social-nav--bio social-nav--byline social-nav--bio social-nav--simply-bio social-nav-lifestyle--footer social-nav-lifestyle social-nav" role="navigation" data-tracking-container="true">
-<ul class="social-nav__list">
-<li class="social-nav__item social-nav__item--instagram">
+rel="nocaes"
+data-trigger-link="true"
+class="mntl-attribution__item-name"
+>Aaron Hutcherson</a>
+<div id="mntl-author-tooltip_1-0" class="comp mntl-author-tooltip mntl-tooltip mntl-group">
+<div class="mntl-author-tooltip__top ">
+<div class="mntl-author-tooltip__image-wrapper">
+<div class="img-placeholder" style="padding-bottom:114.2%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/521XYVyC9_guDBmpOZHNWQ021MY=/120x180/filters:no_upscale():max_bytes(150000):strip_icc()/AaronHutchersonSelfPortraitHeadshot-AaronHutcherson-b2de32a5f16a4bc9a8470bfe5570ff04.jpg"
+alt="Aaron Hutcherson"
+class="lazyload mntl-author-tooltip__image"
+width="120"
+height="180"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/521XYVyC9_guDBmpOZHNWQ021MY=/120x180/filters:no_upscale():max_bytes(150000):strip_icc()/AaronHutchersonSelfPortraitHeadshot-AaronHutcherson-b2de32a5f16a4bc9a8470bfe5570ff04.jpg"
+alt="Aaron Hutcherson"
+width="120"
+height="180"
+class="img--noscript mntl-author-tooltip__image" />
+</noscript>
+</div> </div>
+<div id="mntl-author-tooltip__name_1-0" class="comp mntl-author-tooltip__name mntl-attribution__item">
 <a
-href="https://www.instagram.com/thehungryhutch/"
-target="_blank"
-rel="noopener"
-class="social-nav__link"
-> <svg class="social-nav__icon social-nav__icon--instagram">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-instagram--follow-bio></use>
-</svg>
-<span class="social-nav__text is-vishidden">Instagram</span>
-</a> </li>
+href="https://www.simplyrecipes.com/aaron-hutcherson-5091796"
+rel="nocaes"
+class="mntl-attribution__item-name"
+>Aaron Hutcherson</a>
+</div>
+<nav id="mntl-author-tooltip__social-nav_1-0" class="comp mntl-author-tooltip__social-nav lifestyle-food-social-nav mntl-social-nav" role="navigation" data-tracking-container="true">
+<ul class="social-nav__list">
 <li class="social-nav__item social-nav__item--facebook">
 <a
 href="https://www.facebook.com/thehungryhutch/"
 target="_blank"
-rel="noopener"
-class="social-nav__link"
-> <svg class="social-nav__icon social-nav__icon--facebook">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-facebook--follow-bio></use>
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--facebook"
+> <svg class="icon icon-facebook social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
 </svg>
-<span class="social-nav__text is-vishidden">Facebook</span>
+<span class="social-nav__accessible-label">Facebook</span>
+</a> </li>
+<li class="social-nav__item social-nav__item--instagram">
+<a
+href="https://www.instagram.com/thehungryhutch/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--instagram"
+> <svg class="icon icon-instagram social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram"></use>
+</svg>
+<span class="social-nav__accessible-label">Instagram</span>
 </a> </li>
 <li class="social-nav__item social-nav__item--twitter">
 <a
 href="https://twitter.com/thehungryhutch"
 target="_blank"
-rel="noopener"
-class="social-nav__link"
-> <svg class="social-nav__icon social-nav__icon--twitter">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-twitter--follow-bio></use>
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--twitter"
+> <svg class="icon icon-twitter social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use>
 </svg>
-<span class="social-nav__text is-vishidden">Twitter</span>
+<span class="social-nav__accessible-label">Twitter</span>
 </a> </li>
 </ul>
 </nav>
-<div id="mntl-bio-tooltip__bio_1-0" class="comp text-passage mntl-bio-tooltip__bio mntl-text-block">
-Aaron has over 10 years recipe development experience for his blog The Hungry Hutch. He has written for NYTimes, Washington Post, Simply Recipes, and others.</div>
+<div class="mntl-author-tooltip__bio">
+Aaron has over 10 years recipe development experience for his blog The Hungry Hutch. He has written for NYTimes, Washington Post, Simply Recipes, and others.
 </div>
-<div id="mntl-bio-tooltip__bottom_1-0" class="comp text-passage mntl-bio-tooltip__bottom mntl-block">
-<div id="mntl-bio-tooltip__learn-more_1-0" class="comp mntl-bio-tooltip__learn-more mntl-block">
-<span id="mntl-text-block_5-0" class="comp mntl-text-block">
-Learn about Simply Recipes'</span>
+</div>
+<div class="mntl-author-tooltip__bottom">
+<span class="mntl-author-tooltip__learn-more-text">Learn about Simply Recipes'</span>
 <a
-href="/about-us-5096129#editorial-guidelines"
-id="mntl-text-link_1-0"
-class=" mntl-text-link"
-data-tracking-container="true"
-><span class="link__wrapper">Editorial Process</span></a>
+href="/about-us-5096129#toc-editorial-guidelines"
+rel="nocaes"
+class="mntl-author-tooltip__learn-more-link"
+>Editorial Process</a>
 </div>
 </div>
 </div>
-<a
-href="https://www.simplyrecipes.com/aaron-hutcherson-5091796"
-id="mntl-byline__link_1-0"
-class=" mntl-byline__link mntl-text-link"
-data-tracking-container="true"
-><span class="link__wrapper">Aaron Hutcherson</span></a>
 </div>
+<div class="mntl-attribution__item-date">Updated February 10, 2022</div>
 </div>
-<div id="article-updated-date_1-0" class="comp article-updated-date mntl-updated-stamp mntl-block">
-<span id="mntl-updated-stamp__text_1-0" class="comp mntl-updated-stamp__text mntl-text-block">
-Updated January 25, 2019</span>
 </div>
 <img
-srcset="https://www.simplyrecipes.com/thmb/vVJVMgv7fB59Aw219ac0rHGbZdg=/160x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/AaronHutchersonSelfPortraitHeadshot-AaronHutcherson-b2de32a5f16a4bc9a8470bfe5570ff04.jpg 160w"
-src="https://www.simplyrecipes.com/thmb/K0KUqHYqF24OvdVOsXTkGTLKEbc=/160x160/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/AaronHutchersonSelfPortraitHeadshot-AaronHutcherson-b2de32a5f16a4bc9a8470bfe5570ff04.jpg"
+data-src="https://www.simplyrecipes.com/thmb/2SWvl_xz4JuTeVcRaTKsVN8b6Tw=/40x40/filters:no_upscale():max_bytes(150000):strip_icc()/AaronHutchersonSelfPortraitHeadshot-AaronHutcherson-b2de32a5f16a4bc9a8470bfe5570ff04.jpg"
 alt="Aaron Hutcherson"
-class=" article-meta__author-image mntl-image "
+class="lazyload article-meta__author-image mntl-image "
+width="40"
+height="40"
 url=""
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/2SWvl_xz4JuTeVcRaTKsVN8b6Tw=/40x40/filters:no_upscale():max_bytes(150000):strip_icc()/AaronHutchersonSelfPortraitHeadshot-AaronHutcherson-b2de32a5f16a4bc9a8470bfe5570ff04.jpg"
+alt="Aaron Hutcherson"
+width="40"
+height="40"
+class="img--noscript article-meta__author-image mntl-image " />
+</noscript>
 <div id="article-meta__feedback-container_1-0" class="comp article-meta__feedback-container mntl-block">
 <div id="aggregate-star-rating_1-0" class="comp js-feedback-trigger aggregate-star-rating mntl-block" data-tracking-container="true">
 <div id="aggregate-star-rating__stars_1-0" class="comp aggregate-star-rating__stars mntl-aggregate-star-rating mntl-rating" data-doc-id="5102671">
 <a
 href="#"
+rel="nocaes"
 data-rating="1"
 data-ordinal="1"
 class="active"
@@ -1176,6 +1662,7 @@ aria-label="Rate 1-star"
 </a>
 <a
 href="#"
+rel="nocaes"
 data-rating="2"
 data-ordinal="2"
 class="active"
@@ -1192,6 +1679,7 @@ aria-label="Rate 2-star"
 </a>
 <a
 href="#"
+rel="nocaes"
 data-rating="3"
 data-ordinal="3"
 class="active"
@@ -1208,6 +1696,7 @@ aria-label="Rate 3-star"
 </a>
 <a
 href="#"
+rel="nocaes"
 data-rating="4"
 data-ordinal="4"
 class="active"
@@ -1224,6 +1713,7 @@ aria-label="Rate 4-star"
 </a>
 <a
 href="#"
+rel="nocaes"
 data-rating="5"
 data-ordinal="5"
 class=" half"
@@ -1253,36 +1743,38 @@ aria-label="Rate 5-star"
 </div>
 </div>
 </div>
-<button id="recipe-jump-button_1-0" class="comp recipe-jump-button button btn">
+<button id="recipe-jump-button_3-0" class="comp recipe-jump-button button btn">
 <svg class="recipe-jump-button__arrow-down">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#arrow-down"></use>
 </svg>
 JUMP TO RECIPE
 </button>
 </div>
-<div id="social-share-sticky_1-0" class="comp social-share-sticky mntl-block">
-<div id="social-share-sticky__container_1-0" class="comp social-share-sticky__container mntl-block">
-<ul id="social-share_1-0" class="comp social-share mntl-social-share share" data-email-subject="Simply Recipes: Homemade Chicken &amp;amp; Rice Soup {One-Pot}" data-description="One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&amp;#39;re done. It&amp;#39;s the easiest soup ever, ready in under an hour." data-title="Homemade Chicken &amp;amp; Rice Soup {One-Pot}" data-tracking-container="true">
+<div id="social-share-sticky_3-0" class="comp social-share-sticky mntl-block">
+<div id="social-share-sticky__container_3-0" class="comp social-share-sticky__container mntl-block">
+<ul id="social-share_3-0" class="comp social-share mntl-social-share share" data-email-subject="Simply Recipes: One-Pot Chicken and Rice Soup Recipe" data-description="One-Pot Chicken and Rice Soup! Throw bone-in chicken, rice, and vegetables together in a pot and simmer until they&amp;#39;re done. It&amp;#39;s the easiest soup ever, ready in under an hour." data-title="One-Pot Chicken and Rice Soup Recipe" data-tracking-container="true">
 <li class="share-item share-item-pinterest">
-<span data-href="http://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.simplyrecipes.com%2Frecipes%2Fone_pot_chicken_and_rice_soup%2F%3Futm_source%3Dpinterest%26utm_medium%3Dsocial%26utm_campaign%3Dshareurlbuttons&description=Homemade+Chicken+%26amp%3B+Rice+Soup+%7BOne-Pot%7D&media=https%3A%2F%2Fwww.simplyrecipes.com%2Fthmb%2FogIBPZMvTTPR9pHBYJCttM55FDM%3D%2F750x0%2F__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-PIN-2v3-3e92d4528e7d40efb551497859dd143f.jpg"
+<span data-href="http://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.simplyrecipes.com%2Frecipes%2Fone_pot_chicken_and_rice_soup%2F%3Futm_source%3Dpinterest%26utm_medium%3Dsocial%26utm_campaign%3Dshareurlbuttons&description=One-Pot+Chicken+and+Rice+Soup+Recipe&media=https%3A%2F%2Fwww.simplyrecipes.com%2Fthmb%2FogIBPZMvTTPR9pHBYJCttM55FDM%3D%2F750x0%2F__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-PIN-2v3-3e92d4528e7d40efb551497859dd143f.jpg"
 data-network="pinterest"
 data-click-tracked="true"
 class="share-link share-link-pinterest"
+tabindex="0"
 title="Share on Pinterest">
-<svg class="icon icon-pinterest ">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest"></use>
+<svg class="icon icon-pinterest--social-share ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest--social-share"></use>
 </svg>
 Pin
 </span>
 </li>
 <li class="share-item share-item-facebook">
-<span data-href="https://www.facebook.com/dialog/share?app_id=138323699531998&display=popup&href=https%3A%2F%2Fwww.simplyrecipes.com%2Frecipes%2Fone_pot_chicken_and_rice_soup%2F%3Futm_source%3Dfacebook%26utm_medium%3Dsocial%26utm_campaign%3Dshareurlbuttons&redirect_uri=https%3A%2F%2Fwww.simplyrecipes.com%2FfacebookShareRedirect.htm"
+<span data-href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.simplyrecipes.com%2Frecipes%2Fone_pot_chicken_and_rice_soup%2F%3Futm_source%3Dfacebook.com%26utm_medium%3Dsocial%26utm_campaign%3Dsocial-share-article"
 data-network="facebook"
 data-click-tracked="true"
 class="share-link share-link-facebook"
+tabindex="0"
 title="Share on Facebook">
-<svg class="icon icon-facebook ">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
+<svg class="icon icon-facebook--social-share ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook--social-share"></use>
 </svg>
 Share
 </span>
@@ -1292,6 +1784,7 @@ Share
 data-network="emailshare"
 data-click-tracked="true"
 class="share-link share-link-email"
+tabindex="0"
 title="Email this article">
 <svg class="icon icon-envelope ">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-envelope"></use>
@@ -1300,29 +1793,37 @@ Email
 </span>
 </li>
 </ul>
-<form id="print-button_1-0" class="comp print-button" method="POST" action="/recipes/one_pot_chicken_and_rice_soup/?print" target="_blank">
-<button id="button_2-0" class="comp button btn">
+<form id="print-button_3-0" class="comp print-button" method="POST" action="/recipes/one_pot_chicken_and_rice_soup/?print" target="_blank">
+<button id="button_3-0" class="comp button btn" aria-label="Print this article">
 <svg class="print-button__icon">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use>
 </svg>
-print
 </button>
 <input type="hidden" value="true" name="print" />
-<input type="hidden" value="9785e2c1fb3da5a1d777125fcd3db8b1" name="CSRFToken" />
+<input type="hidden" value="6bad3e5efc975f57734aff7b3d2e0617" name="CSRFToken" />
 </form>
 </div>
 </div>
-</header>
-<div class="loc article-content article__body right-rail">
-<div id="primary-media_1-0" class="comp article-header__media primary-media figure-wrapper--article mntl-block">
-<figure id="figure_2-0" class="comp figure figure--primary-image" style>
-<div class="figure__media js-figure-media figure__media--portrait"> <div class="img-placeholder" style="padding-bottom:140.0%;"> <img src="https://www.simplyrecipes.com/thmb/3CJ5uCNraQ1O63CA7F3bq6zK3IY=/960x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-5-eece1a9bf1f34a5bb0a9ca4baab2edb2.jpg" alt="One-Pot Chicken and Rice Soup" class=" primary-image mntl-primary-image figure__image js-figure-image" /> </div> </div> <figcaption class="figure__caption"> <span class="figure__caption-owner"> Aaron Hutcherson </span> </figcaption></figure>
 </div>
-<div id="mntl-chop_1-0--chop-content" class="loc chop-content is-chopped" style="--chop-height: 99999999px">
-<div id="article__header--project_1-0" class="comp article-intro text-passage structured-content article__header--project mntl-sc-page mntl-block" data-sc-sticky-offset="80" data-sc-ad-label-height="11" data-sc-ad-track-spacing="100" data-sc-min-track-height="250" data-sc-max-track-height="600" data-sc-breakpoint="54em" data-sc-load-immediate="4" data-sc-content-positions="[1, 1, 1, 1, 1, 1, 1]" data-bind-scroll-on-start="true">
-<p id="mntl-sc-block_1-0" class="comp mntl-sc-block mntl-sc-block-html">
-<strong>Featured in <a href="https://www.simplyrecipes.com/collection/new_to_cooking_heres_12_ridiculously_easy_recipes/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="1">12 Easy Recipes for New Cooks</a></strong>
-</p>
+<div class="loc article-content">
+<div id="primary-media_1-0" class="comp article-header__media primary-media figure-wrapper--article mntl-block">
+<figure id="figure_1-0" class="comp figure figure--primary-image" style>
+<div class="figure__media js-figure-media figure__media--portrait "> <div class="img-placeholder" style="padding-bottom:140.0%;"> <img src="https://www.simplyrecipes.com/thmb/PPPmXOsljCKozJqnLq3OAxSEzZI=/648x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-5-eece1a9bf1f34a5bb0a9ca4baab2edb2.jpg" style="--blurry: url('data:image/gif;charset=utf-8;base64,R0lGODlhBwAJAPUAAABcTVE/K05YE2dJI2BvAF5RQX6QVJRHE4dhMLdBALtmCYBmRZNxQ7Z0QNNQCNVeAP5yA4W8OriTDourYq+FX7mURKuOZK6Qav+UB8iqYcajec2hctyxfN3FSe/NYrPFm9ivg9W6j9W2l9e+lsm8rN/Aq9rJr9fHt9vWuObFj+PGnufLm+TNm+rZu/fev9DMw9Ta2O7dw/TfwvHfy/DdzOTg1+/i0u7u7vnv4/b29vj4+Pv7+/39/QBcTQBcTQBcTSwAAAAABwAJAEUISgAb8NixA4YLGS8K6MhRIwCJDBwiCLBxYMQJDSg6TDBgoYUIDBsceKBxYwCFBBcWACAAwcQHHDEYpFDwQEWJEBJ0zACxgkUFBAEBADs=')" onload="(function(e){e.classList.add('loaded')})(this)" alt="One-Pot Chicken and Rice Soup" class=" primary-image mntl-primary-image figure__image js-figure-image mntl-primary-image--blurry" width="1600" height="2240" /> <noscript> <img src="https://www.simplyrecipes.com/thmb/PPPmXOsljCKozJqnLq3OAxSEzZI=/648x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-5-eece1a9bf1f34a5bb0a9ca4baab2edb2.jpg" alt="One-Pot Chicken and Rice Soup" width="1600" height="2240" class="primary-img--noscript primary-image mntl-primary-image figure__image js-figure-image" /> </noscript> </div> </div> <figcaption class="figure__caption"> <span class="figure__caption-owner">Aaron Hutcherson</span> </figcaption></figure>
+</div>
+<div id="article-content-container_1-0" class="comp article-content-container mntl-block">
+<div id="article__header--project_1-0" class="comp article-intro text-passage structured-content article__header--project mntl-sc-page mntl-block" data-sc-sticky-offset="135" data-sc-ad-label-height="11" data-sc-ad-track-spacing="100" data-sc-min-track-height="250" data-sc-max-track-height="600" data-sc-breakpoint="50em" data-sc-load-immediate="4" data-sc-content-positions="[1, 1, 1, 1, 1, 1, 1]" data-bind-scroll-on-start="true">
+<div id="mntl-sc-block_1-0" class="comp featuredin-link mntl-sc-block lifestyle-sc-block-featuredlink mntl-sc-block-featuredlink mntl-block">
+<a
+href="https://www.simplyrecipes.com/collection/new_to_cooking_heres_12_ridiculously_easy_recipes/"
+rel="nocaes"
+id="mntl-sc-block-featuredlink__link_1-0"
+class=" mntl-sc-block-featuredlink__link mntl-text-link"
+data-tracking-container="true"
+data-tracking-id="featured-link-featuredin"
+><span class="link__wrapper">New to Cooking? Here are 12 Ridiculously Easy Recipes</span>
+<div id="simplyrecipes-injection-text_1-0" class="comp simplyrecipes-injection-text mntl-text-block">
+FEATURED IN:</div></a>
+</div>
 <div id="mntl-sc-block_1-0-1" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
 <p id="mntl-sc-block_1-0-2" class="comp mntl-sc-block mntl-sc-block-html">
 This easy one-pot chicken and rice soup definitely deserves to be in your collection. It&#39;s just the thing for warming you up on a cold night, or providing comfort when you’re feeling under the weather.
@@ -1332,8 +1833,8 @@ This easy one-pot chicken and rice soup definitely deserves to be in your collec
 The best part? You literally throw all the ingredients in the pot and let them simmer in the stock until the soup is done. No sautéing or browning. So easy.
 </p>
 <div id="mntl-sc-block_1-0-5" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
-<span class="heading-toc" id="video-how-to-make-1-pot-chicken-and-rice-soup"></span> <h2 id="mntl-sc-block_1-0-6" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> Video: How to Make 1-Pot Chicken and Rice Soup </span> </h2>
-<div id="mntl-sc-block_1-0-7" class="comp inline-video text-passage mntl-sc-block lifestyle-sc-block-inlinevideo mntl-sc-block-inlinevideo mntl-block" style="max-width: 100%">
+<span class="heading-toc" id="toc-video-how-to-make-one-pot-chicken-and-rice-soup"></span> <h2 id="mntl-sc-block_1-0-6" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> Video: How to Make One-Pot Chicken and Rice Soup </span> </h2>
+<div id="mntl-sc-block_1-0-7" class="comp has-details inline-video text-passage mntl-sc-block lifestyle-sc-block-inlinevideo mntl-sc-block-inlinevideo mntl-block" style="max-width: 100%">
 <div id="mntl-sc-block-inlinevideo__video-container_1-0" class="comp mntl-sc-block-inlinevideo__video-container mntl-block">
 <div id="mntl-sc-block-inlinevideo__video_1-0" class="comp lazyload mntl-sc-block-inlinevideo__video mntl-jwplayer mntl-block" data-bgset="https://cdn.jwplayer.com/v2/media/28e6KvWZ/poster.jpg?width=720" data-sizes="auto"></div>
 <div id="mntl-sc-block-inlinevideo__duration_1-0" class="comp mntl-sc-block-inlinevideo__duration mntl-block">
@@ -1345,7 +1846,7 @@ The best part? You literally throw all the ingredients in the pot and let them s
 One-Pot Chicken and Rice Soup</h3>
 </div>
 <div id="mntl-sc-block_1-0-8" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
-<span class="heading-toc" id="use-bone-in-chicken-breasts"></span> <h2 id="mntl-sc-block_1-0-9" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> Use Bone-In Chicken Breasts </span> </h2>
+<span class="heading-toc" id="toc-use-bone-in-chicken-breasts"></span> <h2 id="mntl-sc-block_1-0-9" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> Use Bone-In Chicken Breasts </span> </h2>
 <p id="mntl-sc-block_1-0-10" class="comp mntl-sc-block mntl-sc-block-html">
 For this recipe, I call for bone-in chicken breasts, which add more flavor than boneless, but without the skin. To prep, just pull away the skin and discard.
 </p>
@@ -1358,20 +1859,28 @@ If you prefer, boneless skinless chicken breasts or thighs can be substituted, b
 <div class="figure-media">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-srcset="https://www.simplyrecipes.com/thmb/F7fwLFc-1leh2nN-wOa7hkEaPhw=/300x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 300w, https://www.simplyrecipes.com/thmb/_c5l7LHglHNPgFjEQaoJOiEmEkc=/525x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 525w, https://www.simplyrecipes.com/thmb/i-L9cs14stuqyWeYTP-aktmYMQM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 750w, https://www.simplyrecipes.com/thmb/IG6H-dcODlJjOVBGz8rkRmL_7os=/1200x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 1200w"
-data-src="https://www.simplyrecipes.com/thmb/e-_nva6NdBJzDA_qPXFsiMWhnOw=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg"
-src="//:0"
-data-placeholder="default"
+data-srcset="https://www.simplyrecipes.com/thmb/weNNTWV7s8g-ttv9HTsebsUV9FE=/720x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 720w"
+data-src="https://www.simplyrecipes.com/thmb/NipVMStPrRCCHhP945L2u_eXbxc=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg"
 alt="One-Pot Chicken and Rice Soup"
 class="lazyload"
+width="1200"
+height="800"
 data-click-tracked="true" data-img-lightbox="true" data-owner="Aaron Hutcherson" data-caption="" data-expand="300" id="mntl-sc-block-image_1-0-14" data-tracking-container="true"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/NipVMStPrRCCHhP945L2u_eXbxc=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg"
+srcset="https://www.simplyrecipes.com/thmb/weNNTWV7s8g-ttv9HTsebsUV9FE=/720x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 720w"
+alt="One-Pot Chicken and Rice Soup"
+width="1200"
+height="800"
+class="img--noscript " />
+</noscript>
 </div> </div>
 <figcaption id="mntl-figure-caption_1-0" class="comp mntl-figure-caption figure-article-caption">
 <span class="figure-article-caption-owner">Aaron Hutcherson</span>
 </figcaption>
 </figure>
-<span class="heading-toc" id="the-best-stock-for-chicken-and-rice-soup"></span> <h2 id="mntl-sc-block_1-0-15" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> The Best Stock for Chicken and Rice Soup </span> </h2>
+<span class="heading-toc" id="toc-the-best-stock-for-chicken-and-rice-soup"></span> <h2 id="mntl-sc-block_1-0-15" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> The Best Stock for Chicken and Rice Soup </span> </h2>
 <p id="mntl-sc-block_1-0-16" class="comp mntl-sc-block mntl-sc-block-html">
 I prefer to use unsalted stocks in my cooking so that I can control how much salt I add. <a href="https://www.simplyrecipes.com/recipes/how_to_make_chicken_stock/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="1">Homemade stock</a> is best if you have it, of course, but also look for low-sodium or sodium-free stocks and broths at the grocery store.
 </p>
@@ -1388,20 +1897,28 @@ This soup is finished with a swirl of garlic paste and some lemon juice to add a
 <div class="figure-media">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-srcset="https://www.simplyrecipes.com/thmb/B_C7wCvC6U_QyZTUZFQbDQxV8F4=/300x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg 300w, https://www.simplyrecipes.com/thmb/MAcffAhRrStdTA4opda-x_9PAA8=/725x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg 725w, https://www.simplyrecipes.com/thmb/W3PEIRMiCNaBs999Q2tdCV0l2Rc=/1150x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg 1150w, https://www.simplyrecipes.com/thmb/GoMjy-aAn6ciXSLNzbmywdZlSmU=/2000x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg 2000w"
-data-src="https://www.simplyrecipes.com/thmb/G2nuB8tl0KNbvlz8qdjs7l_CDuo=/2000x1333/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg"
-src="//:0"
-data-placeholder="default"
+data-srcset="https://www.simplyrecipes.com/thmb/av0hvFK5tcC2hkVxtFVcoNzRJjo=/720x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg 720w"
+data-src="https://www.simplyrecipes.com/thmb/rjQjdx7z6o4YSmwq-zOzGu2eBTg=/2000x1333/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg"
 alt="Homemade Chicken and Rice Soup"
 class="lazyload"
+width="2000"
+height="1333"
 data-click-tracked="true" data-img-lightbox="true" data-owner="Aaron Hutcherson" data-caption="" data-expand="300" id="mntl-sc-block-image_1-0-22" data-tracking-container="true"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/rjQjdx7z6o4YSmwq-zOzGu2eBTg=/2000x1333/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg"
+srcset="https://www.simplyrecipes.com/thmb/av0hvFK5tcC2hkVxtFVcoNzRJjo=/720x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-6-84f5ab39c30e4830bf08b5bb163c5e19.jpg 720w"
+alt="Homemade Chicken and Rice Soup"
+width="2000"
+height="1333"
+class="img--noscript " />
+</noscript>
 </div> </div>
 <figcaption id="mntl-figure-caption_1-0-1" class="comp mntl-figure-caption figure-article-caption">
 <span class="figure-article-caption-owner">Aaron Hutcherson</span>
 </figcaption>
 </figure>
-<span class="heading-toc" id="how-to-store-or-freeze-this-soup"></span> <h2 id="mntl-sc-block_1-0-23" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> How to Store or Freeze This Soup </span> </h2>
+<span class="heading-toc" id="toc-how-to-store-or-freeze-this-soup"></span> <h2 id="mntl-sc-block_1-0-23" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> How to Store or Freeze This Soup </span> </h2>
 <p id="mntl-sc-block_1-0-24" class="comp mntl-sc-block mntl-sc-block-html">
 Leftovers will keep for about a week refrigerated, or up to 3 months frozen.
 </p>
@@ -1410,84 +1927,35 @@ Leftovers will keep for about a week refrigerated, or up to 3 months frozen.
 <strong>To freeze, </strong>let the soup cool completely, then <a href="https://www.simplyrecipes.com/recipes/how_to_freeze_soup_beans_and_broth/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="1">transfer to freezer containers or bags</a>. Thaw overnight in the fridge, or warm the frozen soup in a saucepan over low heat on the stove top.
 </p>
 <div id="mntl-sc-block_1-0-27" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
-<span class="heading-toc" id="more-ways-to-make-chicken-soup"></span> <h2 id="mntl-sc-block_1-0-28" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> More Ways to Make Chicken Soup </span> </h2>
+<span class="heading-toc" id="toc-more-ways-to-make-chicken-soup"></span> <h2 id="mntl-sc-block_1-0-28" class="comp mntl-sc-block lifestyle-sc-block-heading mntl-sc-block-heading"> <span class="mntl-sc-block-heading__text"> More Ways to Make Chicken Soup </span> </h2>
 <ul id="mntl-sc-block_1-0-29" class="comp mntl-sc-block mntl-sc-block-html">
-<li><a href="https://www.simplyrecipes.com/recipes/how_to_make_chicken_soup_in_the_pressure_cooker/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="1">How to Make Chicken Soup in the Pressure Cooker</a></li><li><a href="https://www.simplyrecipes.com/recipes/chicken_noodle_soup/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="2">Homemade Chicken Noodle Soup</a></li><li><a href="https://www.simplyrecipes.com/recipes/quick_chicken_pho/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="3">Quick Chicken Pho</a></li><li><a href="https://www.simplyrecipes.com/recipes/rotisserie_chicken_noodle_soup/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="4">Rotisserie Chicken Noodle Soup</a></li><li><a href="https://www.simplyrecipes.com/recipes/chicken_soup_with_ginger_and_shiitake_mushrooms/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="5">Chicken Soup with Ginger and Shiitake Mushrooms</a></li>
+<li><a href="https://www.simplyrecipes.com/recipes/how_to_make_chicken_soup_in_the_pressure_cooker/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="1">How to Make Chicken Soup in the Pressure Cooker</a></li>
+<li><a href="https://www.simplyrecipes.com/recipes/chicken_noodle_soup/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="2">Homemade Chicken Noodle Soup</a></li>
+<li><a href="https://www.simplyrecipes.com/recipes/quick_chicken_pho/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="3">Quick Chicken Pho</a></li>
+<li><a href="https://www.simplyrecipes.com/recipes/rotisserie_chicken_noodle_soup/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="4">Rotisserie Chicken Noodle Soup</a></li>
+<li><a href="https://www.simplyrecipes.com/recipes/chicken_soup_with_ginger_and_shiitake_mushrooms/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="5">Chicken Soup with Ginger and Shiitake Mushrooms</a></li>
 </ul>
-<div id="ads-config_2-0" class="comp js-scads-inline-content ads-config mntl-block">
-<div id="ad-group-1_2-0" class="comp ad-group-1 mntl-block">
-<div id="billboard1-sticky-dynamic_2-0" class="comp scads-to-load right-rail__item billboard-sticky billboard1-sticky-dynamic billboard-sticky--sc" data-height="1050" data-breakpoint="medium2">
-<div class="spacer">
-<div id="billboard1-dynamic_2-0" class="comp billboard1-dynamic mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
-<div id="billboard" class="wrapper" data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250], [300, 600], [300, 1050], [1, 2], &quot;fluid&quot;]" data-rtb="true" data-targeting="{}" data-auction-floor-id="9f278783930a4cefaf14684abbc432f9" data-auction-floor-value="50"></div>
 </div>
-</div>
-</div>
-</div>
-<div id="ad-group-2_2-0" class="comp ad-group-2 mntl-block">
-<div id="billboard2-sticky-dynamic_2-0" class="comp scads-to-load right-rail__item billboard-sticky billboard2-sticky-dynamic billboard-sticky--sc" data-height="601">
-<div class="spacer">
-<div id="billboard2-dynamic_2-0" class="comp billboard2-dynamic mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
-<div id="billboard2" class="wrapper" data-type="billboard" data-pos="btf1" data-priority="3" data-sizes="[[300, 250], [300, 251], [300, 600], [300, 601], [2, 1], &quot;fluid&quot;]" data-rtb="true" data-targeting="null" data-auction-floor-id="8467a2bc6f984c57977c9158844de451" data-auction-floor-value="50"></div>
-</div>
-</div>
-</div>
-</div>
-<div id="ad-group-3_2-0" class="comp ad-group-3 mntl-block">
-<div id="billboard3-sticky-dynamic_2-0" class="comp scads-to-load right-rail__item billboard-sticky billboard3-sticky-dynamic billboard-sticky--sc" data-height="600">
-<div class="spacer">
-<div id="billboard3-dynamic_2-0" class="comp billboard3-dynamic mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
-<div id="billboard3" class="wrapper" data-type="billboard" data-pos="btf2" data-priority="4" data-sizes="[[300, 250], [300, 252], [3, 1], &quot;fluid&quot;]" data-rtb="true" data-targeting="null" data-auction-floor-id="3f215db744984d7ea74bd45b9e8eac83" data-auction-floor-value="50"></div>
-</div>
-</div>
-</div>
-</div>
-<div id="ad-group-4_2-0" class="comp ad-group-4 mntl-block">
-<div id="billboard4-sticky-dynamic_2-0" class="comp scads-to-load right-rail__item billboard-sticky billboard4-sticky-dynamic billboard-sticky--sc" data-height="600">
-<div class="spacer">
-<div id="billboard4-dynamic_2-0" class="comp billboard4-dynamic mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
-<div id="billboard4" class="wrapper" data-type="billboard" data-pos="btf3" data-priority="5" data-sizes="[[300, 250], [300, 253], [4, 1], &quot;fluid&quot;]" data-rtb="true" data-targeting="null" data-auction-floor-id="8dbb79c64c944aa1bf29b32ee7162668" data-auction-floor-value="50"></div>
-</div>
-</div>
-</div>
-</div>
-<div id="ad-group-5_2-0" class="comp ad-group-5 mntl-block">
-<div id="billboard5-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard-sticky billboard5-sticky-dynamic billboard-sticky--sc" data-height="600">
-<div class="spacer">
-<div id="billboard5-dynamic_1-0" class="comp billboard5-dynamic mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
-<div id="billboard5" class="wrapper" data-type="billboard" data-pos="btf4" data-priority="7" data-sizes="[[300, 250], [300, 254], [6, 1], &quot;fluid&quot;]" data-rtb="true" data-targeting="null" data-auction-floor-id="169c337deec24563a7a7f2be8f70015f" data-auction-floor-value="50"></div>
-</div>
-</div>
-</div>
-</div>
-<div id="ad-group-6_2-0" class="comp ad-group-6 mntl-block">
-<div id="billboard6-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard-sticky billboard6-sticky-dynamic billboard-sticky--sc" data-height="600">
-<div class="spacer">
-<div id="billboard6-dynamic_1-0" class="comp billboard6-dynamic mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
-<div id="billboard6" class="wrapper" data-type="billboard" data-pos="btf5" data-priority="8" data-sizes="[[300, 250], [300, 255], [7, 1], &quot;fluid&quot;]" data-rtb="true" data-targeting="null" data-auction-floor-id="f445fba45e5046b28afe05a3b772a9e3" data-auction-floor-value="50"></div>
-</div>
-</div>
-</div>
-</div>
-<div id="ad-group-7_2-0" class="comp ad-group-7 mntl-block">
-<div id="billboard7-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard-sticky billboard7-sticky-dynamic billboard-sticky--sc" data-height="600">
-<div class="spacer">
-<div id="billboard7-dynamic_1-0" class="comp billboard7-dynamic mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
-<div id="billboard7" class="wrapper" data-type="billboard" data-pos="btf6" data-priority="9" data-sizes="[[300, 250], [300, 256], [8, 1], &quot;fluid&quot;]" data-rtb="true" data-targeting="null" data-auction-floor-id="8b0d1268a873428a950e9eab2b0fc20b" data-auction-floor-value="50"></div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div id="structured-project-content_1-0" class="comp article__content structured-content structured-project-content mntl-block">
+<div id="structured-project-content_1-0" class="comp article__content right-rail structured-content structured-project-content mntl-block">
 <div id="recipe-block_1-0" class="comp recipe-block mntl-block">
-<button id="relish-save_1-0" class="comp relish-save mntl-relish-save-btn mntl-button" data-tracking-container="true">
-Save it
+<div id="recipe-block__buttons_1-0" class="comp recipe-block__buttons mntl-block">
+<button id="relish-save_2-0" class="comp relish-save mntl-relish-save-btn mntl-button" data-tracking-container="true">
+Save It
 <svg class="icon icon-heart mntl-button__icon relish-save__heart-icon">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-heart"></use>
 </svg>
 </button>
+<form id="print-button_7-0" class="comp print-button" method="POST" action="/recipes/one_pot_chicken_and_rice_soup/?print" target="_blank">
+<button id="button_7-0" class="comp button btn" aria-label="Print this article">
+<svg class="print-button__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use>
+</svg>
+Print
+</button>
+<input type="hidden" value="true" name="print" />
+<input type="hidden" value="6bad3e5efc975f57734aff7b3d2e0617" name="CSRFToken" />
+</form>
+</div>
 <h2 id="recipe-block__header_1-0" class="comp recipe-block__header text-block">
 One-Pot Chicken and Rice Soup
 </h2>
@@ -1525,65 +1993,69 @@ to 8 servings</span>
 </div>
 </div>
 <div id="recipe-block__note_1-0" class="comp text-passage recipe-block__note mntl-block">
-<span id="recipe-block__note-text_1-0" class="comp recipe-block__note-text text-block">
-Skip the salt if using salted stock or broth. Taste the soup at the end and add more salt if needed. This recipe calls for a classic mirepoix of carrots, onions, and celery for the vegetable base, but you can make this recipe your own by adding different vegetables, like fennel or cubes of butternut squash.
-</span>
+<div id="recipe-block__note-text_1-0" class="comp recipe-block__note-text text-block">
+<p class="Normal1"><span lang="EN">Skip the salt if using salted stock or broth. Taste the soup at the end and add more salt if needed.</span></p><p class="Normal1"><span lang="EN">This recipe calls for a classic mirepoix of carrots, onions, and celery for the vegetable base, but you can make this recipe your own by adding different vegetables, like fennel or cubes of butternut squash.</span></p>
+</div>
 </div>
 </div>
 <section id="section--ingredients_1-0" class="comp section--ingredients section">
-<header class="section__header "><h3 class="section__title section__title--bold-underline">Ingredients</h3></header>
+<header class="section__header "><h3 class="section__title section__title--bold-underline" data-title-tag="">Ingredients</h3></header>
 <div class="loc section-content section__content ">
-<ul id="ingredient-list_1-0" class="comp ingredient-list simple-list simple-list--circle ">
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-2 bone-in chicken breasts, skin removed (1 to 1 1/2 pounds)
+<div id="structured-ingredients_1-0" class="comp structured-ingredients">
+<ul class="structured-ingredients__list text-passage">
+<li class="structured-ingredients__list-item">
+<p>2 bone-in <span data-ingredient-name="true">chicken breasts</span>, skin removed (<span data-ingredient-quantity="true">1 to 1 1/2</span> <span data-ingredient-unit="true">pounds</span>)</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-1 cup long-grain white rice, like basmati
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">cup</span> <span data-ingredient-name="true">long-grain white rice</span>, like basmati</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-2 celery ribs, diced small
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">ribs</span> <span data-ingredient-name="true">celery</span>, diced small</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-2 medium carrots, peeled and diced small
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">medium</span> <span data-ingredient-name="true">carrots,</span> peeled and diced small</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-1 onion, diced small
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true"><span data-ingredient-name="true">onion,</span></span> diced small</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-2 cloves garlic, peeled but left whole
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">cloves</span><span data-ingredient-name="true"> garlic,</span> peeled but left whole</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-1 teaspoon salt, plus more to taste (see Recipe Note)
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">teaspoon</span> <span data-ingredient-name="true">salt,</span> plus more to taste (see Recipe Note)</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-1/2 teaspoon ground black pepper
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">1/2</span> <span data-ingredient-unit="true">teaspoon</span> <span data-ingredient-name="true">ground black pepper</span></p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-2 quarts unsalted or low-sodium chicken stock
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">quarts</span> unsalted or <span data-ingredient-name="true">low-sodium chicken stock</span></p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-Juice of 1/2 lemon (about 3 tablespoons)
+<li class="structured-ingredients__list-item">
+<p><span data-ingredient-name="true">Juice</span> of 1/2 <span data-ingredient-name="true">lemon</span> (about <span data-ingredient-quantity="true">3</span> <span data-ingredient-unit="true">tablespoons</span>)</p>
 </li>
-<li class="simple-list__item js-checkbox-trigger ingredient text-passage">
-Chopped fresh parsley, for serving
+<li class="structured-ingredients__list-item">
+<p>Chopped <span data-ingredient-name="true">fresh parsley</span>, <span data-ingredient-quantity="true">for serving</span></p>
 </li>
 </ul>
+</div>
 <div id="relish-shop_1-0" class="comp relish-shop mntl-relish-shop-btn">
 <div id="shop-button">
 </div>
 </div>
 </div>
 </section>
-<div id="native--manual_1-0" class="comp native--manual native mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt native dynamic">
-<div id="native" class="wrapper" data-type="native" data-pos="native" data-priority="4" data-sizes="[[1, 3], &quot;fluid&quot;]" data-rtb="false" data-targeting="{}"></div>
+<div id="mntl-native_1-0" class="comp mntl-native mntl-native--labeled" style="--native-ad-height: auto">
+<div id="mntl-native__adunit_1-0" class="comp mntl-native__adunit mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt native dynamic">
+<div id="native" class="wrapper" data-type="native" data-pos="native" data-priority="4" data-sizes="[[1, 3],&quot;fluid&quot;]" data-rtb="false" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div>
 </div>
 <section id="section--instructions_1-0" class="comp section--instructions section">
-<header class="section__header "><h3 class="section__title section__title--bold-underline">Method</h3></header>
+<header class="section__header "><h3 class="section__title section__title--bold-underline" data-title-tag="">Method</h3></header>
 <div class="loc section-content section__content ">
 <div id="structured-project__steps_1-0" class="comp text-passage structured-content structured-project__steps mntl-sc-page mntl-block" data-sc-sticky-offset="60" data-sc-ad-label-height="24" data-sc-ad-track-spacing="100" data-sc-min-track-height="250" data-sc-max-track-height="600" data-sc-breakpoint="54em" data-sc-load-immediate="1" data-sc-content-positions="[300,600,900,1200,1500,1800,2100]" data-bind-scroll-on-start="true">
 <OL id="mntl-sc-block_3-0" class="comp mntl-sc-block-group--OL mntl-sc-block mntl-sc-block-startgroup">
 <LI id="mntl-sc-block_3-0-1" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup">
-<div id="mntl-sc-block_3-0-2" class="comp mntl-sc-block lifestyle-sc-block-subheading mntl-sc-block-subheading"> <span class="mntl-sc-block-subheading__text"> Assemble the soup and bring to a simmer </span> </div>
+<div id="mntl-sc-block_3-0-2" class="comp mntl-sc-block lifestyle-sc-block-subheading mntl-sc-block-subheading"> <span class="mntl-sc-block-subheading__text"> Assemble the soup and bring to a simmer: </span> </div>
 <p id="mntl-sc-block_3-0-3" class="comp mntl-sc-block mntl-sc-block-html">
 Combine the chicken, white rice, celery, carrots, onions, garlic, salt, and pepper in a large pot. Add the chicken stock and bring to a boil over high heat.
 </p>
@@ -1594,14 +2066,22 @@ Once the soup is boiling, reduce the heat to keep the soup at a gentle simmer.
 <div class="figure-media">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-srcset="https://www.simplyrecipes.com/thmb/F7fwLFc-1leh2nN-wOa7hkEaPhw=/300x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 300w, https://www.simplyrecipes.com/thmb/_c5l7LHglHNPgFjEQaoJOiEmEkc=/525x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 525w, https://www.simplyrecipes.com/thmb/i-L9cs14stuqyWeYTP-aktmYMQM=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 750w, https://www.simplyrecipes.com/thmb/IG6H-dcODlJjOVBGz8rkRmL_7os=/1200x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 1200w"
-data-src="https://www.simplyrecipes.com/thmb/e-_nva6NdBJzDA_qPXFsiMWhnOw=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg"
-src="//:0"
-data-placeholder="default"
+data-srcset="https://www.simplyrecipes.com/thmb/GxaK6IOtDNS8pQXoJNr5VF73h0U=/580x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 580w"
+data-src="https://www.simplyrecipes.com/thmb/NipVMStPrRCCHhP945L2u_eXbxc=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg"
 alt="One-Pot Chicken and Rice Soup"
 class="lazyload"
+width="1200"
+height="800"
 data-click-tracked="true" data-img-lightbox="true" data-owner="Aaron Hutcherson" data-caption="" data-expand="300" id="mntl-sc-block-image_3-0-5" data-tracking-container="true"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/NipVMStPrRCCHhP945L2u_eXbxc=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg"
+srcset="https://www.simplyrecipes.com/thmb/GxaK6IOtDNS8pQXoJNr5VF73h0U=/580x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-1-86e37cc9e3524fea8665017f761e7ac1.jpg 580w"
+alt="One-Pot Chicken and Rice Soup"
+width="1200"
+height="800"
+class="img--noscript " />
+</noscript>
 </div> </div>
 <figcaption id="mntl-figure-caption_1-0-2" class="comp mntl-figure-caption figure-article-caption">
 <span class="figure-article-caption-owner">Aaron Hutcherson</span>
@@ -1610,14 +2090,14 @@ data-click-tracked="true" data-img-lightbox="true" data-owner="Aaron Hutcherson"
 <div id="mntl-sc-block_3-0-6" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
 </LI>
 <LI id="mntl-sc-block_3-0-8" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup">
-<div id="mntl-sc-block_3-0-9" class="comp mntl-sc-block lifestyle-sc-block-subheading mntl-sc-block-subheading"> <span class="mntl-sc-block-subheading__text"> Simmer for about 25 minutes </span> </div>
+<div id="mntl-sc-block_3-0-9" class="comp mntl-sc-block lifestyle-sc-block-subheading mntl-sc-block-subheading"> <span class="mntl-sc-block-subheading__text"> Simmer for about 25 minutes: </span> </div>
 <p id="mntl-sc-block_3-0-10" class="comp mntl-sc-block mntl-sc-block-html">
 As the soup simmers, skim off any foam that collects on the surface with a spoon. Continue to simmer until the rice and vegetables are tender, about 25 minutes. Remove the soup from heat.
 </p>
 <div id="mntl-sc-block_3-0-11" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
 </LI>
 <LI id="mntl-sc-block_3-0-13" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup">
-<div id="mntl-sc-block_3-0-14" class="comp mntl-sc-block lifestyle-sc-block-subheading mntl-sc-block-subheading"> <span class="mntl-sc-block-subheading__text"> Shred the chicken and make the garlic paste </span> </div>
+<div id="mntl-sc-block_3-0-14" class="comp mntl-sc-block lifestyle-sc-block-subheading mntl-sc-block-subheading"> <span class="mntl-sc-block-subheading__text"> Shred the chicken and make the garlic paste: </span> </div>
 <p id="mntl-sc-block_3-0-15" class="comp mntl-sc-block mntl-sc-block-html">
 Remove the chicken and garlic cloves using a slotted spoon or tongs. Transfer the chicken breasts to a bowl and shred with two forks. Discard the bones. Return the shredded chicken to the pot.
 </p>
@@ -1628,14 +2108,22 @@ Smash the garlic cloves into a paste against a cutting board using a fork or the
 <div class="figure-media">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-srcset="https://www.simplyrecipes.com/thmb/QeM9rni9fcUQUG0JmvvMuXUmsNU=/300x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg 300w, https://www.simplyrecipes.com/thmb/6A9_-Zq8FrohDYTlv2o1-20DJvU=/525x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg 525w, https://www.simplyrecipes.com/thmb/-B4pHoe-0qANZob5IBPIBbO1VQs=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg 750w, https://www.simplyrecipes.com/thmb/4NI_G1y-CE0kDTWMJZ1pKH17gt0=/1200x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg 1200w"
-data-src="https://www.simplyrecipes.com/thmb/chEq2euxha3YqYGrKgcSMAER5SM=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg"
-src="//:0"
-data-placeholder="default"
+data-srcset="https://www.simplyrecipes.com/thmb/Mp9-S-7vcPUbftycphQKJxPrn7A=/580x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg 580w"
+data-src="https://www.simplyrecipes.com/thmb/W9HORXjUE-3p_IaS9ZrSSIga7VI=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg"
 alt="One-Pot Chicken and Rice Soup"
 class="lazyload"
+width="1200"
+height="800"
 data-click-tracked="true" data-img-lightbox="true" data-owner="Aaron Hutcherson" data-caption="" data-expand="300" id="mntl-sc-block-image_3-0-17" data-tracking-container="true"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/W9HORXjUE-3p_IaS9ZrSSIga7VI=/1200x800/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg"
+srcset="https://www.simplyrecipes.com/thmb/Mp9-S-7vcPUbftycphQKJxPrn7A=/580x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__09__2017-10-23-ChickenRiceSoup-2-ddc4c5f815d242f6809289bcfa4fac37.jpg 580w"
+alt="One-Pot Chicken and Rice Soup"
+width="1200"
+height="800"
+class="img--noscript " />
+</noscript>
 </div> </div>
 <figcaption id="mntl-figure-caption_1-0-3" class="comp mntl-figure-caption figure-article-caption">
 <span class="figure-article-caption-owner">Aaron Hutcherson</span>
@@ -1665,93 +2153,119 @@ Leftovers will keep for about a week refrigerated, or up to 3 months frozen.
 <a href="https://www.simplyrecipes.com/recipes/chicken_noodle_soup/" data-component="link" data-source="inlineLink" data-type="internalLink" data-ordinal="1">Chicken Noodle Soup</a> here on Simply Recipes, also great for when you are under the weather!
 </p>
 </div>
-<div id="feedback-block_1-0" class="comp js-aggregate-rating feedback-block mntl-block">
-<div id="feedback-block__title_1-0" class="comp feedback-block__title mntl-text-block">
-Rate This Recipe</div>
-<div id="feedback-block__rating_1-0" class="comp js-feedback-buttons feedback-block__rating star-rating mntl-star-rating mntl-rating" data-doc-id="5102671">
-<a
-href="#"
-data-rating="1"
-data-ordinal="1"
-aria-label="Rate 1-star"
-><svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+<div id="nutritional-guidelines-block_6-0" class="comp nutritional-guidelines-block nutrition-info">
+<table class="nutrition-info__table">
+<thead>
+<tr>
+<th class="nutrition-info__heading" colspan="2">Nutrition Facts <span class="nutrition-info__heading-aside">(per serving)</span></th>
+</tr>
+</thead>
+<tbody class="nutrition-info__table--body">
+<tr class="nutrition-info__table--row">
+<td class="nutrition-info__table--cell">160</td>
+<td class="nutrition-info__table--cell">Calories</td>
+</tr>
+<tr class="nutrition-info__table--row">
+<td class="nutrition-info__table--cell">2g </td>
+<td class="nutrition-info__table--cell">Fat</td>
+</tr>
+<tr class="nutrition-info__table--row">
+<td class="nutrition-info__table--cell">10g </td>
+<td class="nutrition-info__table--cell">Carbs</td>
+</tr>
+<tr class="nutrition-info__table--row">
+<td class="nutrition-info__table--cell">23g </td>
+<td class="nutrition-info__table--cell">Protein</td>
+</tr>
+</tbody>
+</table>
+<div id="nutrition-facts_6-0" class="comp nutrition-facts" data-tracking-container="true">
+<a class="nutrition-modal-label-container">
+<svg class="nutrition-modal-label--icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-paper"></use>
 </svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
+<span class="nutrition-modal-label--show">Show Full Nutrition Label</span>
+<span class="nutrition-modal-label--hide">Hide Full Nutrition Label</span>
 </a>
-<a
-href="#"
-data-rating="2"
-data-ordinal="2"
-aria-label="Rate 2-star"
-><svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</a>
-<a
-href="#"
-data-rating="3"
-data-ordinal="3"
-aria-label="Rate 3-star"
-><svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</a>
-<a
-href="#"
-data-rating="4"
-data-ordinal="4"
-aria-label="Rate 4-star"
-><svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</a>
-<a
-href="#"
-data-rating="5"
-data-ordinal="5"
-aria-label="Rate 5-star"
-><svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</a></div>
-<div id="feedback-block__messages_1-0" class="comp js-feedback-messages feedback-block__messages">
-<span class="feedback-block__message is-invisible js-feedback-message">I don't like this at all.</span>
-<span class="feedback-block__message is-invisible js-feedback-message">It's not the worst.</span>
-<span class="feedback-block__message is-invisible js-feedback-message">Sure, this will do.</span>
-<span class="feedback-block__message is-invisible js-feedback-message">I'm a fan—would recommend.</span>
-<span class="feedback-block__message is-invisible js-feedback-message">Amazing! I love it!</span>
-<span class="feedback-block__thanks is-invisible js-feedback-thanks">Thanks for your rating!</span>
+<div class="nutrition-label">
+<a class="nutrition-modal-close-button">&times;</a>
+<table>
+<thead>
+<tr>
+<th colspan="2">Nutrition Facts</th>
+</tr>
+<tr>
+<th colspan="2">Servings: 6
+to 8</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">Amount per serving</td>
+</tr>
+<tr>
+<td>Calories</td>
+<td>160</td>
+</tr>
+<tr>
+<td colspan="2" class="right">% Daily Value*</td>
+</tr>
+<tr>
+<td><span class="nutrition-label-header">Total Fat</span> 2g</td>
+<td>3%</td>
+</tr>
+<tr>
+<td class="single-padding">Saturated Fat 1g</td>
+<td>3%</td>
+</tr>
+<tr>
+<td><span class="nutrition-label-header">Cholesterol</span> 62mg</td>
+<td>21%</td>
+</tr>
+<tr>
+<td><span class="nutrition-label-header">Sodium</span> 878mg</td>
+<td>38%</td>
+</tr>
+<tr>
+<td><span class="nutrition-label-header">Total Carbohydrate</span> 10g</td>
+<td>4%</td>
+</tr>
+<tr>
+<td class="single-padding">Dietary Fiber 1g</td>
+<td>4%</td>
+</tr>
+<tr>
+<td class="single-padding" colspan="2">Total Sugars 2g</td>
+</tr>
+<tr>
+<td><span class="nutrition-label-header" colspan="2">Protein</span> 23g</td>
+</tr>
+</tbody>
+<tfoot>
+<tr>
+<td>Vitamin C 4mg</td>
+<td>22%</td>
+</tr>
+<tr>
+<td>Calcium 40mg</td>
+<td>3%</td>
+</tr>
+<tr>
+<td>Iron 1mg</td>
+<td>8%</td>
+</tr>
+<tr>
+<td>Potassium 595mg</td>
+<td>13%</td>
+</tr>
+<tr>
+<td colspan="2"><em>*The % Daily Value (DV) tells you how much a nutrient in a food serving contributes to a daily diet. 2,000 calories a day is used for general nutrition advice.</em></td>
+</tr>
+</tfoot>
+</table>
 </div>
+</div>
+<div class="nutrition-info__disclaimer">Nutrition information is calculated using an ingredient database and should be considered an estimate. In cases where multiple ingredient alternatives are given, the first listed is calculated for nutrition. Garnishes and optional ingredients are not included.</div>
 </div>
 </div>
 </section>
@@ -1759,704 +2273,99 @@ aria-label="Rate 5-star"
 <div id="sources_1-0" class="comp sources mntl-block"></div>
 <div id="disqus-block_1-0" class="comp disqus-block mntl-disqus" data-scroll-defer-offset="650" data-defer="scroll" data-defer-params></div>
 </div>
-<div id="mntl-chop_1-0" class="comp is-hidden mntl-chop" data-chop-height="99999999">
-<span class="loc chop-trigger">
-<button
-class="chop-btn btn btn-chop "
-type="button"
-> <div class="btn-chop-top">
-<span class="btn-title">Show Full Recipe</span>
 </div>
-<span class="btn-text"></span>
-</button>
-</span>
-</div>
-<noscript><style>#mntl-chop_1-0--chop-content {max-height: initial;}#mntl-chop_1-0 {display: none;}</style></noscript>
+<div class="loc article-right-rail">
+<div id="mntl-right-rail_1-0" class="comp mntl-right-rail mntl-block">
+<div id="ads-config_1-0" class="comp js-scads-inline-content ads-config ad-group--project mntl-block">
+<div id="ad-group-1_1-0" class="comp ad-group-1 mntl-block">
+<div id="billboard1-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard1-sticky-dynamic billboard-sticky mntl-sc-sticky-billboard" data-height="1050" style="height: 1050px;">
+<div id="mntl-sc-sticky-billboard-ad_7-0" class="comp mntl-billboard mntl-sc-sticky-billboard-ad billboard1-dynamic mntl-dynamic-billboard mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-flex-1" class="wrapper" data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],[300, 600],[300, 1050],[160, 600]]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="ee3ee755da8f4852942112bb953e4784" data-auction-floor-value="135"></div>
 </div>
 </div>
-<div class="loc post-footer article__post-footer">
-<div id="leaderboard-post-content_1-0" class="comp has-right-label js-lazy-ad leaderboard-post-content leaderboard--lazy mntl-lazy-flexible-ad mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic" data-offset="400">
-<div id="leaderboardac" class="wrapper" data-type="leaderboard" data-pos="ac" data-priority="10" data-sizes="[[728, 90], [970, 250], [1200, 450], [1,11], &quot;fluid&quot;]" data-rtb="true" data-targeting="{}" data-auction-floor-id="5ad1d334dac04b118954e6349db52c2b" data-auction-floor-value="50"></div>
+</div>
+<div id="ad-group-2_4-0" class="comp ad-group-2 mntl-block">
+<div id="billboard2-sticky-dynamic_7-0" class="comp scads-to-load right-rail__item billboard2-sticky-dynamic billboard-sticky mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_9-0" class="comp mntl-billboard mntl-sc-sticky-billboard-ad billboard2-dynamic mntl-dynamic-billboard mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-flex-2" class="wrapper" data-type="billboard" data-pos="btf1" data-priority="3" data-sizes="[[300, 250], [300, 251],[300, 600],[300, 601],[160, 600],[2, 1], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="5d99afbe68d84b1782d6a817e46343a0" data-auction-floor-value="95"></div>
+</div>
+</div>
+</div>
+<div id="ad-group-3_1-0" class="comp ad-group-3 mntl-block">
+<div id="billboard3-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard3-sticky-dynamic billboard-sticky mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_10-0" class="comp mntl-billboard mntl-sc-sticky-billboard-ad billboard3-dynamic mntl-dynamic-billboard mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper" data-type="billboard" data-pos="btf2" data-priority="4" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="e02e1187c923440dab1809de3d69460b" data-auction-floor-value="110"></div>
+</div>
+</div>
+</div>
+<div id="ad-group-4_1-0" class="comp ad-group-4 mntl-block">
+<div id="billboard4-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard4-sticky-dynamic billboard-sticky mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_11-0" class="comp mntl-billboard mntl-sc-sticky-billboard-ad billboard4-dynamic mntl-dynamic-billboard mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper" data-type="billboard" data-pos="btf3" data-priority="5" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="3c8c31634ce248a1aa919a56570981f4" data-auction-floor-value="95"></div>
+</div>
+</div>
+</div>
+<div id="ad-group-5_1-0" class="comp ad-group-5 mntl-block">
+<div id="billboard5-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard5-sticky-dynamic billboard-sticky mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_12-0" class="comp mntl-billboard mntl-sc-sticky-billboard-ad billboard5-dynamic mntl-dynamic-billboard mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper" data-type="billboard" data-pos="btf4" data-priority="7" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="ff72c5c351b847a7bdb44f30276db74b" data-auction-floor-value="125"></div>
+</div>
+</div>
+</div>
+<div id="ad-group-6_1-0" class="comp ad-group-6 mntl-block">
+<div id="billboard6-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard6-sticky-dynamic billboard-sticky mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_13-0" class="comp mntl-billboard mntl-sc-sticky-billboard-ad billboard6-dynamic mntl-dynamic-billboard mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper" data-type="billboard" data-pos="btf5" data-priority="8" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="ebfba39a801e4170b9d1306ed93c72d6" data-auction-floor-value="130"></div>
+</div>
+</div>
+</div>
+<div id="ad-group-7_1-0" class="comp ad-group-7 mntl-block">
+<div id="billboard7-sticky-dynamic_1-0" class="comp scads-to-load right-rail__item billboard7-sticky-dynamic billboard-sticky mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_14-0" class="comp mntl-billboard mntl-sc-sticky-billboard-ad billboard7-dynamic mntl-dynamic-billboard mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper" data-type="billboard" data-pos="btf6" data-priority="9" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="401221a24b0e4d21a373597e25bf31ae" data-auction-floor-value="145"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</article>
+<div id="prefooter_1-0" class="comp prefooter mntl-block">
+<div id="post-footer-leaderboard_1-0" class="comp has-right-label js-lazy-ad post-footer-leaderboard leaderboard-post-content leaderboard--lazy mntl-lazy-flexible-ad mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic" data-offset="400">
+<div id="leaderboardac" class="wrapper" data-type="leaderboard" data-pos="ac" data-priority="10" data-sizes="[[728, 90], &quot;fluid&quot;, [970, 250], [1, 11], [1200, 450]]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="66939b86b5fe49a7ba0587c0908f4d2f" data-auction-floor-value="165"></div>
 </div>
 <div id="article-post-footer_1-0" class="comp article-post-footer mntl-block">
 <div id="article-post-footer__recirc_1-0" class="comp article-post-footer__recirc mntl-block">
 <div id="tag-browser_1-0" class="comp tag-browser card-list-section mntl-block">
 <div id="card-list-1_1-0" class="comp l-container l-page-padding card-list-1 card-list mntl-block" data-tracking-container="true">
 <div id="card-list__item_1-0" class="comp card-list__item mntl-block">
-<a id="card_2-0" class="comp card" href="https://www.simplyrecipes.com/recipes/chicken_noodle_soup/">
-<div class="loc card__header">
-<div id="card__media_2-0" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/vF_kHARBHZRuB3HcZU2z_UKBpdU=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__01__Chicken-Noodle-Soup-LEAD-2-1-ab6c430a6d39457a858fa5dfb1acd811.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Easy chicken noodle soup in a white bowl."
-class="lazyload card__image"
-data-dim-ratio="1.499"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Egg Noodles" data-updated="02/05/21"></div>
-<span class="card__title">
-<span class="card__underline">
-Homemade Chicken Noodle Soup
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-2 hrs
-</span>
-</span>
-<div id="aggregate-star-rating--card_2-0" class="comp aggregate-star-rating aggregate-star-rating--card">
-<span class="aggregate-star-rating__title">Ratings</span>
-<div id="mntl-aggregate-star-rating_2-0" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
-<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class=" half" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span></div>
-</div>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_1-0-1" class="comp card-list__item mntl-block">
-<a id="card_2-0-1" class="comp card" href="https://www.simplyrecipes.com/recipes/slow_cooker_chicken_and_rice_soup/">
-<div class="loc card__header">
-<div id="card__media_2-0-1" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/Lf3hEZMKDUhRM2lyvfOpW0293v0=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2021__01__Chicken-and-Rice-Soup-LEAD-11-a79a2bb7468f43e5bf89fe9986f7fd5c.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Easy Chicken and Rice Soup in a bowl with bread and salad nearby. A slow cooker is behind the bowl."
-class="lazyload card__image"
-data-dim-ratio="1.5"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Wild Rice" data-updated="01/17/21"></div>
-<span class="card__title">
-<span class="card__underline">
-Slow Cooker Chicken and Rice Soup
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0-1" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-4 hrs
-</span>
-</span>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_1-0-2" class="comp card-list__item mntl-block">
-<a id="card_2-0-2" class="comp card" href="https://www.simplyrecipes.com/recipes/how_to_make_chicken_soup_in_the_pressure_cooker/">
-<div class="loc card__header">
-<div id="card__media_2-0-2" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/qlq_8aiUTgZgS-0su9AVPkud6sg=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__02__2017-02-22-PCChickenSoup-11-f089739fa4e24e42879980640ad91d1d.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Instant pot chicken noodle soup in a bowl with the instant pot in partial view behind it."
-class="lazyload card__image"
-data-dim-ratio="1.5"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Chicken" data-updated="11/11/19"></div>
-<span class="card__title">
-<span class="card__underline">
-Instant Pot Chicken Soup
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0-2" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-80 mins
-</span>
-</span>
-<div id="aggregate-star-rating--card_2-0-2" class="comp aggregate-star-rating aggregate-star-rating--card">
-<span class="aggregate-star-rating__title">Ratings</span>
-<div id="mntl-aggregate-star-rating_2-0-2" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
-<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class=" half" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span></div>
-</div>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_1-0-3" class="comp card-list__item mntl-block">
-<a id="card_2-0-3" class="comp card" href="https://www.simplyrecipes.com/recipes/gochujang_chicken_noodle_soup/">
-<div class="loc card__header">
-<div id="card__media_2-0-3" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/U6WWxvEGES4v0MLW3c01po6Pezk=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2020__01__Asian-Chicken-Noodle-LEAD-5-4e143f2df79a4d1ebde25cc0ab6a7fb5.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Spicy Gochujang Chicken and Udon Noodle Soup in a white bowl with a spoon and fresh herbs."
-class="lazyload card__image"
-data-dim-ratio="1.5"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Noodles" data-updated="01/20/20"></div>
-<span class="card__title">
-<span class="card__underline">
-Chicken Udon Soup with Bok Choy
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0-3" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-25 mins
-</span>
-</span>
-<div id="aggregate-star-rating--card_2-0-3" class="comp aggregate-star-rating aggregate-star-rating--card">
-<span class="aggregate-star-rating__title">Ratings</span>
-<div id="mntl-aggregate-star-rating_2-0-3" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
-<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span></div>
-</div>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_1-0-4" class="comp card-list__item mntl-block">
-<a id="card_2-0-4" class="comp card" href="https://www.simplyrecipes.com/recipes/coriander_chicken_cilantro_and_chard_stew/">
-<div class="loc card__header">
-<div id="card__media_2-0-4" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/I-eNvM8Ih6u5OHXOiYiG3y373-c=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2013__04__coriander-chicken-cilantro-chard-stew-horiz-a-1800-de421e738af94e75baa4085b3e40b256.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Coriander Chicken Cilantro Chard Stew"
-class="lazyload card__image"
-data-dim-ratio="1.41"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Chicken Stews" data-updated="04/11/13"></div>
-<span class="card__title">
-<span class="card__underline">
-Chicken Stew with Coriander, Cilantro, and Chard
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0-4" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-90 mins
-</span>
-</span>
-<div id="aggregate-star-rating--card_2-0-4" class="comp aggregate-star-rating aggregate-star-rating--card">
-<span class="aggregate-star-rating__title">Ratings</span>
-<div id="mntl-aggregate-star-rating_2-0-4" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
-<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span></div>
-</div>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_1-0-5" class="comp card-list__item mntl-block">
-<a id="card_2-0-5" class="comp card" href="https://www.simplyrecipes.com/recipes/easy_chicken_pot_pie/">
-<div class="loc card__header">
-<div id="card__media_2-0-5" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/RR3C27uRq7yGawl3nbA14m3tIdQ=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2020__10__Chicken-Pot-Pie-LEAD-1-f01cc53ba4dc4b50b91de3aa1e2ef62c.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Homemade Chicken Pot Pie with a golden crust has a serving removed and set on a white plate to the right."
-class="lazyload card__image"
-data-dim-ratio="1.5"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Pastries" data-updated="10/10/20"></div>
-<span class="card__title">
-<span class="card__underline">
-Easy Chicken Pot Pie
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0-5" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-95 mins
-</span>
-</span>
-<div id="aggregate-star-rating--card_2-0-5" class="comp aggregate-star-rating aggregate-star-rating--card">
-<span class="aggregate-star-rating__title">Ratings</span>
-<div id="mntl-aggregate-star-rating_2-0-5" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
-<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class=" half" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span></div>
-</div>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_1-0-6" class="comp card-list__item mntl-block">
-<a id="card_2-0-6" class="comp card" href="https://www.simplyrecipes.com/recipes/chicken_noodle_casserole/">
-<div class="loc card__header">
-<div id="card__media_2-0-6" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/3ORgHI1J6LDsI1zBZG6arKHYAbE=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__03__chicken-noodle-casserole-lead-3-c98029cbd84e4f24a987bb70f405d40f.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Creamy Chicken Noodle Casserole in a white baking dish with a silver spoon."
-class="lazyload card__image"
-data-dim-ratio="1.5"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Comfort Food" data-updated="12/23/19"></div>
-<span class="card__title">
-<span class="card__underline">
-Chicken Noodle Casserole
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0-6" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-70 mins
-</span>
-</span>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_1-0-7" class="comp card-list__item mntl-block">
-<a id="card_2-0-7" class="comp card" href="https://www.simplyrecipes.com/recipes/easy_mexican_chicken_and_rice_soup/">
-<div class="loc card__header">
-<div id="card__media_2-0-7" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/f6x5sXEmEcGdbQuIftE5aQHNZMk=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2018__01__2018-01-Mexican-Chicken-Soup-1-26114b9676bb4ddab02eefd92ecf7c0b.jpg"
-src="//:0"
-data-placeholder="default"
-class="lazyload card__image"
-data-dim-ratio="1.499"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Chicken Soups" data-updated="01/08/18"></div>
-<span class="card__title">
-<span class="card__underline">
-Easy Mexican Chicken and Rice Soup
-</span>
-</span>
-</div>
-<div class="loc card__footer">
-<span id="meta-text--recipe_2-0-7" class="comp meta-text--recipe meta-text">
-<svg class="meta-text__icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
-</svg>
-<span class="meta-text__text">
-25 mins
-</span>
-</span>
-<div id="aggregate-star-rating--card_2-0-7" class="comp aggregate-star-rating aggregate-star-rating--card">
-<span class="aggregate-star-rating__title">Ratings</span>
-<div id="mntl-aggregate-star-rating_2-0-7" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
-<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class=" half" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span></div>
-</div>
-</div>
-</div>
-</a>
-</div>
-</div>
-<div id="leaderboardfooter_2-0" class="comp has-right-label js-lazy-ad leaderboardfooter leaderboard--lazy mntl-lazy-flexible-ad mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
-<div id="leaderboardfooter" class="wrapper" data-type="leaderboard" data-pos="ft1" data-priority="6" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-targeting="{}" data-auction-floor-id="3c6315f0d5dd471d869eaf5d09a61afa" data-auction-floor-value="50"></div>
-</div>
-<div id="card-list-2_1-0" class="comp l-container l-page-padding card-list-2 card-list mntl-block" data-tracking-container="true">
-<div id="card-list__item_2-0" class="comp card-list__item mntl-block">
-<a id="card_3-0" class="comp card" href="https://www.simplyrecipes.com/recipes/hearty_roasted_vegetable_and_chicken_stew/">
+<a id="card_3-0" class="comp card" href="https://www.simplyrecipes.com/recipes/how_to_make_chicken_soup_in_the_pressure_cooker/">
 <div class="loc card__header">
 <div id="card__media_3-0" class="comp card__media image">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.simplyrecipes.com/thmb/Du_SSQwHD4C7Ar9vS3H0WwP0CAk=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2018__12__Roasted-Veg-Chicken-Stew-LEAD-HORIZONTAL-d7ce1ee6aa444d6d817f099d3da1f5da.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Chicken Stew Recipe"
+data-src="https://www.simplyrecipes.com/thmb/6AV6b-ccVv0BqR8_f9olLF_ce8k=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__02__2017-02-22-PCChickenSoup-11-f089739fa4e24e42879980640ad91d1d.jpg"
+alt="Instant pot chicken noodle soup in a bowl with the instant pot in partial view behind it."
 class="lazyload card__image"
+width="390"
+height="260"
 data-dim-ratio="1.5"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/6AV6b-ccVv0BqR8_f9olLF_ce8k=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__02__2017-02-22-PCChickenSoup-11-f089739fa4e24e42879980640ad91d1d.jpg"
+alt="Instant pot chicken noodle soup in a bowl with the instant pot in partial view behind it."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
 </div></div>
 </div>
 <div class="card__wrapper">
 <div class="card__content">
-<div class="card__tag" data-tax-tag="Chicken Stews" data-updated="12/22/18"></div>
+<div class="card__tag" data-tax-tag="Chicken" data-updated="02/02/22"></div>
 <span class="card__title">
 <span class="card__underline">
-Hearty Roasted Vegetable and Chicken Stew
+Instant Pot Chicken Soup
 </span>
 </span>
 </div>
@@ -2466,7 +2375,7 @@ Hearty Roasted Vegetable and Chicken Stew
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
 <span class="meta-text__text">
-75 mins
+80 mins
 </span>
 </span>
 <div id="aggregate-star-rating--card_3-0" class="comp aggregate-star-rating aggregate-star-rating--card">
@@ -2532,27 +2441,34 @@ Hearty Roasted Vegetable and Chicken Stew
 </div>
 </a>
 </div>
-<div id="card-list__item_2-0-1" class="comp card-list__item mntl-block">
-<a id="card_3-0-1" class="comp card" href="https://www.simplyrecipes.com/recipes/moms_turkey_soup/">
+<div id="card-list__item_1-0-1" class="comp card-list__item mntl-block">
+<a id="card_3-0-1" class="comp card" href="https://www.simplyrecipes.com/recipes/chicken_noodle_soup/">
 <div class="loc card__header">
 <div id="card__media_3-0-1" class="comp card__media image">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.simplyrecipes.com/thmb/MTbj-3ECJLGxm5R33DaQvb3boO0=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2014__11__turkey-soup-horiz-a-1600-465bc13451fe47ff912ebb154e6e4b4e.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Turkey Soup"
+data-src="https://www.simplyrecipes.com/thmb/oRkwRRqUWswJEnmrDHO0vJ9T_kw=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__01__Chicken-Noodle-Soup-LEAD-2-1-ab6c430a6d39457a858fa5dfb1acd811.jpg"
+alt="Easy chicken noodle soup in a white bowl."
 class="lazyload card__image"
-data-dim-ratio="1.394"
+width="390"
+height="260"
+data-dim-ratio="1.499"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/oRkwRRqUWswJEnmrDHO0vJ9T_kw=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__01__Chicken-Noodle-Soup-LEAD-2-1-ab6c430a6d39457a858fa5dfb1acd811.jpg"
+alt="Easy chicken noodle soup in a white bowl."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
 </div></div>
 </div>
 <div class="card__wrapper">
 <div class="card__content">
-<div class="card__tag" data-tax-tag="Winter Soups" data-updated="02/19/21"></div>
+<div class="card__tag" data-tax-tag="Egg Noodles" data-updated="02/05/21"></div>
 <span class="card__title">
 <span class="card__underline">
-Mom&#39;s Turkey Soup
+Homemade Chicken Noodle Soup
 </span>
 </span>
 </div>
@@ -2562,7 +2478,7 @@ Mom&#39;s Turkey Soup
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
 <span class="meta-text__text">
-45 mins
+2 hrs
 </span>
 </span>
 <div id="aggregate-star-rating--card_3-0-1" class="comp aggregate-star-rating aggregate-star-rating--card">
@@ -2628,150 +2544,112 @@ Mom&#39;s Turkey Soup
 </div>
 </a>
 </div>
-<div id="card-list__item_2-0-2" class="comp card-list__item mntl-block">
-<a id="card_3-0-2" class="comp card" href="https://www.simplyrecipes.com/how_to_cook_frozen_chicken_in_the_pressure_cooker/">
+<div id="card-list__item_1-0-2" class="comp card-list__item mntl-block">
+<a id="card_3-0-2" class="comp card" href="https://www.simplyrecipes.com/recipes/chicken_noodle_casserole/">
 <div class="loc card__header">
 <div id="card__media_3-0-2" class="comp card__media image">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.simplyrecipes.com/thmb/Y_iVC3CeLD-xAIlHIlnK3intwLU=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2018__09__HT-Boneless-Chicken-METHOD-07-28f8bbadb5014488be0833aadcf22b80.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Three cooked chicken breasts in the instant pot"
+data-src="https://www.simplyrecipes.com/thmb/5xPBrwhy6JNUYJaeN4ymNCkNvHo=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__03__chicken-noodle-casserole-lead-3-c98029cbd84e4f24a987bb70f405d40f.jpg"
+alt="Creamy Chicken Noodle Casserole in a white baking dish with a silver spoon."
 class="lazyload card__image"
+width="390"
+height="260"
 data-dim-ratio="1.5"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/5xPBrwhy6JNUYJaeN4ymNCkNvHo=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__03__chicken-noodle-casserole-lead-3-c98029cbd84e4f24a987bb70f405d40f.jpg"
+alt="Creamy Chicken Noodle Casserole in a white baking dish with a silver spoon."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
 </div></div>
 </div>
 <div class="card__wrapper">
 <div class="card__content">
-<div class="card__tag" data-tax-tag="Low Carb Dinners" data-updated="10/10/18"></div>
+<div class="card__tag" data-tax-tag="Comfort Food" data-updated="01/30/22"></div>
 <span class="card__title">
 <span class="card__underline">
-How to Cook Frozen Chicken in the Instant Pot
-</span>
-</span>
-</div>
-</div>
-</a>
-</div>
-<div id="card-list__item_2-0-3" class="comp card-list__item mntl-block">
-<a id="card_3-0-3" class="comp card" href="https://www.simplyrecipes.com/recipes/soba_noodle_soup_with_chicken_and_bok_choy/">
-<div class="loc card__header">
-<div id="card__media_3-0-3" class="comp card__media image">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.simplyrecipes.com/thmb/Vgff2VR16kcuq1q-nGMMLHZrrB8=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__01__2017-01-23-Soba-Noodle-Soup-4-c5e00281a56643fcae820091248686fc.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Soba Noodle Soup with Chicken and Bok Choy"
-class="lazyload card__image"
-data-dim-ratio="1.499"
-/>
-</div></div>
-</div>
-<div class="card__wrapper">
-<div class="card__content">
-<div class="card__tag" data-tax-tag="Soba Noodles" data-updated="01/23/17"></div>
-<span class="card__title">
-<span class="card__underline">
-Soba Noodle Soup with Chicken and Bok Choy
+Chicken Noodle Casserole
 </span>
 </span>
 </div>
 <div class="loc card__footer">
-<span id="meta-text--recipe_3-0-3" class="comp meta-text--recipe meta-text">
+<span id="meta-text--recipe_3-0-2" class="comp meta-text--recipe meta-text">
 <svg class="meta-text__icon">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
 <span class="meta-text__text">
-30 mins
+70 mins
 </span>
 </span>
-<div id="aggregate-star-rating--card_3-0-3" class="comp aggregate-star-rating aggregate-star-rating--card">
-<span class="aggregate-star-rating__title">Ratings</span>
-<div id="mntl-aggregate-star-rating_3-0-3" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
-<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span>
-<span class="active" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
-<svg class="star-icon star-icon--inactive">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
-</svg>
-<svg class="star-icon star-icon--active">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
-</svg>
-<svg class="star-icon star-icon--half">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
-</svg>
-</span></div>
-</div>
 </div>
 </div>
 </a>
 </div>
-<div id="card-list__item_2-0-4" class="comp card-list__item mntl-block">
-<a id="card_3-0-4" class="comp card" href="https://www.simplyrecipes.com/recipes/pressure_cooker_chicken_adobo_and_rice/">
+<div id="card-list__item_1-0-3" class="comp card-list__item mntl-block">
+<a id="card_3-0-3" class="comp card" href="https://www.simplyrecipes.com/collection/14_irresistible_chicken_soup_recipes_that_will_leave_you_wanting_more/">
 <div class="loc card__header">
-<div id="card__media_3-0-4" class="comp card__media image">
+<div id="card__media_3-0-3" class="comp card__media image">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.simplyrecipes.com/thmb/dXVp0cuWPeaCPiccP_Th74UY3iI=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2017__06__2017-07-24-PC-Chicken-Adobo-13-1b94b6b409cf4cfab71fbdcfd870c792.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Pressure Cooker Chicken Adobo with Rice"
+data-src="https://www.simplyrecipes.com/thmb/I8120r6Tc4NzVqBR_MsfEterq2c=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2020__10__12-Chicken-Soup-for-the-Soul-LEAD-4621231ea0184a6bb52960789268bed1.jpg"
+alt="Three images side by side. On the left is Chicken Pozole topped with fresh cabbage and radishes. In the middle is Creamy Chicken Soup with noodles and carrots in a bowl. On the right is a bowl One-Pot Chicken and Rice Soup."
 class="lazyload card__image"
-data-dim-ratio="1.499"
+width="390"
+height="260"
+data-dim-ratio="1.498"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/I8120r6Tc4NzVqBR_MsfEterq2c=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2020__10__12-Chicken-Soup-for-the-Soul-LEAD-4621231ea0184a6bb52960789268bed1.jpg"
+alt="Three images side by side. On the left is Chicken Pozole topped with fresh cabbage and radishes. In the middle is Creamy Chicken Soup with noodles and carrots in a bowl. On the right is a bowl One-Pot Chicken and Rice Soup."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
 </div></div>
 </div>
 <div class="card__wrapper">
 <div class="card__content">
-<div class="card__tag" data-tax-tag="Family Dinners" data-updated="09/28/17"></div>
+<div class="card__tag" data-tax-tag="Recipe Collections" data-updated="10/13/20"></div>
 <span class="card__title">
 <span class="card__underline">
-Instant Pot Chicken Adobo and Rice
+14 Irresistible Chicken Soup Recipes that Will Leave You Wanting More
+</span>
+</span>
+</div>
+</div>
+</a>
+</div>
+<div id="card-list__item_1-0-4" class="comp card-list__item mntl-block">
+<a id="card_3-0-4" class="comp card" href="https://www.simplyrecipes.com/recipes/coriander_chicken_cilantro_and_chard_stew/">
+<div class="loc card__header">
+<div id="card__media_3-0-4" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/Ifs2AHl28qEbxQf_bKm61bn5JAk=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2013__04__coriander-chicken-cilantro-chard-stew-horiz-a-1800-de421e738af94e75baa4085b3e40b256.jpg"
+alt="Coriander Chicken Cilantro Chard Stew"
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.41"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/Ifs2AHl28qEbxQf_bKm61bn5JAk=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2013__04__coriander-chicken-cilantro-chard-stew-horiz-a-1800-de421e738af94e75baa4085b3e40b256.jpg"
+alt="Coriander Chicken Cilantro Chard Stew"
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Chicken Stews" data-updated="07/28/22"></div>
+<span class="card__title">
+<span class="card__underline">
+Chicken Stew with Coriander, Cilantro, and Chard
 </span>
 </span>
 </div>
@@ -2781,7 +2659,7 @@ Instant Pot Chicken Adobo and Rice
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
 <span class="meta-text__text">
-55 mins
+90 mins
 </span>
 </span>
 <div id="aggregate-star-rating--card_3-0-4" class="comp aggregate-star-rating aggregate-star-rating--card">
@@ -2847,27 +2725,34 @@ Instant Pot Chicken Adobo and Rice
 </div>
 </a>
 </div>
-<div id="card-list__item_2-0-5" class="comp card-list__item mntl-block">
-<a id="card_3-0-5" class="comp card" href="https://www.simplyrecipes.com/recipes/ham_and_potato_soup/">
+<div id="card-list__item_1-0-5" class="comp card-list__item mntl-block">
+<a id="card_3-0-5" class="comp card" href="https://www.simplyrecipes.com/lemon-chicken-soup-avgolemono-5194212">
 <div class="loc card__header">
 <div id="card__media_3-0-5" class="comp card__media image">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.simplyrecipes.com/thmb/nzuwjd3HC9exac1VSyHGbIOGVGs=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2016__01__ham-potato-soup-horiz-f2-1600-85200f2d48c848ed8a1fa20cacffce91.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Ham and Potato Soup"
+data-src="https://www.simplyrecipes.com/thmb/PhzB39z-m1TqOiLG_lTFMhz6yWU=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Lemon-Chicken-Soup-LEAD-3b_RECIRC-93cdf4a4c7934183b156da7c4d5abb59.jpg"
+alt="Yasmin Khan’s Lemon Chicken Soup in a bowl with a white linen underneath it."
 class="lazyload card__image"
+width="390"
+height="260"
 data-dim-ratio="1.5"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/PhzB39z-m1TqOiLG_lTFMhz6yWU=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Lemon-Chicken-Soup-LEAD-3b_RECIRC-93cdf4a4c7934183b156da7c4d5abb59.jpg"
+alt="Yasmin Khan’s Lemon Chicken Soup in a bowl with a white linen underneath it."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
 </div></div>
 </div>
 <div class="card__wrapper">
 <div class="card__content">
-<div class="card__tag" data-tax-tag="Ham" data-updated="01/08/19"></div>
+<div class="card__tag" data-tax-tag="Chicken Soups" data-updated="02/28/22"></div>
 <span class="card__title">
 <span class="card__underline">
-Ham and Potato Soup
+Lemon Chicken Soup (Avgolemono)
 </span>
 </span>
 </div>
@@ -2877,7 +2762,7 @@ Ham and Potato Soup
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
 <span class="meta-text__text">
-100 mins
+85 mins
 </span>
 </span>
 <div id="aggregate-star-rating--card_3-0-5" class="comp aggregate-star-rating aggregate-star-rating--card">
@@ -2943,27 +2828,34 @@ Ham and Potato Soup
 </div>
 </a>
 </div>
-<div id="card-list__item_2-0-6" class="comp card-list__item mntl-block">
-<a id="card_3-0-6" class="comp card" href="https://www.simplyrecipes.com/recipes/vegetable_lentil_soup/">
+<div id="card-list__item_1-0-6" class="comp card-list__item mntl-block">
+<a id="card_3-0-6" class="comp card" href="https://www.simplyrecipes.com/recipes/creamy_chicken_soup/">
 <div class="loc card__header">
 <div id="card__media_3-0-6" class="comp card__media image">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.simplyrecipes.com/thmb/CygVD7mE8yn3CwXc18SI48-2j0A=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__10__Vegetarian-Lentil-Soup-LEAD-2-407f8fd24aca46f4a3ebb75b798468ca.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Vegetable Lentil Soup in a bowl with a spoons."
+data-src="https://www.simplyrecipes.com/thmb/qyZZ1TDHmCOhimUq7TPaoHoUNrc=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__11__Creamy-Chicken-Noodle-LEAD-4-623920f15ef3458da836d964556b8f88.jpg"
+alt="A white bowl filled with the best creamy chicken noodle soup set on a grey linen against a blue background with a bundle of thyme near by and a hunk of sourdough bread.."
 class="lazyload card__image"
+width="390"
+height="260"
 data-dim-ratio="1.5"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/qyZZ1TDHmCOhimUq7TPaoHoUNrc=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__11__Creamy-Chicken-Noodle-LEAD-4-623920f15ef3458da836d964556b8f88.jpg"
+alt="A white bowl filled with the best creamy chicken noodle soup set on a grey linen against a blue background with a bundle of thyme near by and a hunk of sourdough bread.."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
 </div></div>
 </div>
 <div class="card__wrapper">
 <div class="card__content">
-<div class="card__tag" data-tax-tag="Healthy Soups" data-updated="02/23/21"></div>
+<div class="card__tag" data-tax-tag="Chicken Soups" data-updated="06/15/22"></div>
 <span class="card__title">
 <span class="card__underline">
-Lentil Soup
+Creamy Chicken Soup
 </span>
 </span>
 </div>
@@ -2973,7 +2865,7 @@ Lentil Soup
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
 <span class="meta-text__text">
-75 mins
+65 mins
 </span>
 </span>
 <div id="aggregate-star-rating--card_3-0-6" class="comp aggregate-star-rating aggregate-star-rating--card">
@@ -3023,7 +2915,7 @@ Lentil Soup
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
 </svg>
 </span>
-<span class=" half" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
+<span class="active" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
 <svg class="star-icon star-icon--inactive">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
 </svg>
@@ -3039,27 +2931,34 @@ Lentil Soup
 </div>
 </a>
 </div>
-<div id="card-list__item_2-0-7" class="comp card-list__item mntl-block">
-<a id="card_3-0-7" class="comp card" href="https://www.simplyrecipes.com/recipes/rotisserie_chicken_noodle_soup/">
+<div id="card-list__item_1-0-7" class="comp card-list__item mntl-block">
+<a id="card_3-0-7" class="comp card" href="https://www.simplyrecipes.com/recipes/gochujang_chicken_noodle_soup/">
 <div class="loc card__header">
 <div id="card__media_3-0-7" class="comp card__media image">
 <div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.simplyrecipes.com/thmb/x96ZhxWZOJz6_3PUlgVIiOfI_yU=/600x400/filters:max_bytes(150000):strip_icc():format(webp)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2018__10__Rotisserie-Chicken-Soup-LEAD-2-1-965ba3aca9fd45f4976383074e3df123.jpg"
-src="//:0"
-data-placeholder="default"
-alt="Easy Rotisserie Chicken Noodle Soup"
+data-src="https://www.simplyrecipes.com/thmb/-8Cz8duztZsDxE1WVQ4GEwOeAYY=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2020__01__Asian-Chicken-Noodle-LEAD-5-4e143f2df79a4d1ebde25cc0ab6a7fb5.jpg"
+alt="Spicy Gochujang Chicken and Udon Noodle Soup in a white bowl with a spoon and fresh herbs."
 class="lazyload card__image"
-data-dim-ratio="1.499"
+width="390"
+height="260"
+data-dim-ratio="1.5"
 />
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/-8Cz8duztZsDxE1WVQ4GEwOeAYY=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2020__01__Asian-Chicken-Noodle-LEAD-5-4e143f2df79a4d1ebde25cc0ab6a7fb5.jpg"
+alt="Spicy Gochujang Chicken and Udon Noodle Soup in a white bowl with a spoon and fresh herbs."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
 </div></div>
 </div>
 <div class="card__wrapper">
 <div class="card__content">
-<div class="card__tag" data-tax-tag="Egg Noodles" data-updated="11/14/18"></div>
+<div class="card__tag" data-tax-tag="Noodles" data-updated="07/30/22"></div>
 <span class="card__title">
 <span class="card__underline">
-Rotisserie Chicken Noodle Soup
+Chicken Udon Soup with Bok Choy
 </span>
 </span>
 </div>
@@ -3069,7 +2968,7 @@ Rotisserie Chicken Noodle Soup
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
 <span class="meta-text__text">
-30 mins
+25 mins
 </span>
 </span>
 <div id="aggregate-star-rating--card_3-0-7" class="comp aggregate-star-rating aggregate-star-rating--card">
@@ -3136,33 +3035,469 @@ Rotisserie Chicken Noodle Soup
 </a>
 </div>
 </div>
-<div id="leaderboardfooter2_2-0" class="comp has-right-label js-lazy-ad leaderboardfooter2 leaderboard--lazy mntl-lazy-flexible-ad mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic" data-offset="400">
-<div id="leaderboardfooter2" class="wrapper" data-type="leaderboard" data-pos="ft2" data-priority="7" data-sizes="[[728, 90], [728, 99], [970, 250], [970, 259], [1, 10], &quot;fluid&quot;]" data-rtb="true" data-targeting="{}" data-auction-floor-id="4afa5c2f90ec480085731afb29885a1d" data-auction-floor-value="50"></div>
+<div id="leaderboardfooter_2-0" class="comp has-right-label js-lazy-ad leaderboardfooter leaderboard--lazy mntl-lazy-flexible-ad mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
+<div id="leaderboardfooter-flex-1" class="wrapper" data-type="leaderboard" data-pos="ft1" data-priority="6" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="a867e155f46b48bca1947383ee5ae0a7" data-auction-floor-value="225"></div>
 </div>
+<div id="card-list-2_1-0" class="comp l-container l-page-padding card-list-2 card-list mntl-block" data-tracking-container="true">
+<div id="card-list__item_2-0" class="comp card-list__item mntl-block">
+<a id="card_4-0" class="comp card" href="https://www.simplyrecipes.com/recipes/hearty_roasted_vegetable_and_chicken_stew/">
+<div class="loc card__header">
+<div id="card__media_4-0" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/3LQ7mZCg0TRysnrGQ9JZwaE1eXM=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2018__12__Roasted-Veg-Chicken-Stew-LEAD-HORIZONTAL-d7ce1ee6aa444d6d817f099d3da1f5da.jpg"
+alt="Chicken Stew Recipe"
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/3LQ7mZCg0TRysnrGQ9JZwaE1eXM=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2018__12__Roasted-Veg-Chicken-Stew-LEAD-HORIZONTAL-d7ce1ee6aa444d6d817f099d3da1f5da.jpg"
+alt="Chicken Stew Recipe"
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
 </div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Chicken Stews" data-updated="05/27/22"></div>
+<span class="card__title">
+<span class="card__underline">
+Hearty Roasted Vegetable and Chicken Stew
+</span>
+</span>
 </div>
-</div>
-</div>
-</article>
-</main>
-<div id="cookie-notification-banner_1-0" class="comp cookie-notification-banner gdpr-notification-banner mntl-notification-banner mntl-block" data-show-until-dismissed="true">
-<div id="gdpr-notification-banner__content_1-0" class="comp gdpr-notification-banner__content mntl-block" data-tracking-container="true">
-<div id="gdpr-notification-banner__text_1-0" class="comp gdpr-notification-banner__text mntl-text-block">
-Simply Recipes uses cookies to provide you with a great user experience. By using Simply Recipes, you accept our</div>
-<a
-href="https://www.simplyrecipes.com/legal-5096147#simplyrecipes-cookie-disclosure"
-id="gdpr-notification-banner__link_1-0"
-class=" gdpr-notification-banner__link mntl-text-link"
-data-tracking-container="true"
-><span class="link__wrapper">use of cookies.</span></a>
-<button id="gdpr-notification-banner__btn-close_1-0" class="comp js-banner-dismiss btn gdpr-notification-banner__btn-close mntl-button">
-x
-<svg class="icon icon-x mntl-button__icon btn__close btn__icon gdpr-notification-banner__btn-close-icon">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-x"></use>
+<div class="loc card__footer">
+<span id="meta-text--recipe_4-0" class="comp meta-text--recipe meta-text">
+<svg class="meta-text__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
 </svg>
-</button>
+<span class="meta-text__text">
+75 mins
+</span>
+</span>
+<div id="aggregate-star-rating--card_4-0" class="comp aggregate-star-rating aggregate-star-rating--card">
+<span class="aggregate-star-rating__title">Ratings</span>
+<div id="mntl-aggregate-star-rating_4-0" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
+<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class="active" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span></div>
 </div>
 </div>
+</div>
+</a>
+</div>
+<div id="card-list__item_2-0-1" class="comp card-list__item mntl-block">
+<a id="card_4-0-1" class="comp card" href="https://www.simplyrecipes.com/best-ingredient-shortcuts-5212747">
+<div class="loc card__header">
+<div id="card__media_4-0-1" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/QEFQqhaQ4zl7Q_kcTq3nvVZ4fUA=/390x260/filters:max_bytes(150000):strip_icc()/ingredientshortcuts-LEAD-be58116cdbf14521a663accc401c08e4.jpg"
+alt="Pasta with peso, shrimp, and beef chili"
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/QEFQqhaQ4zl7Q_kcTq3nvVZ4fUA=/390x260/filters:max_bytes(150000):strip_icc()/ingredientshortcuts-LEAD-be58116cdbf14521a663accc401c08e4.jpg"
+alt="Pasta with peso, shrimp, and beef chili"
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Most Recent" data-updated="01/03/22"></div>
+<span class="card__title">
+<span class="card__underline">
+10 Ingredient Shortcuts That Every Smart Cook Should Know
+</span>
+</span>
+</div>
+</div>
+</a>
+</div>
+<div id="card-list__item_2-0-2" class="comp card-list__item mntl-block">
+<a id="card_4-0-2" class="comp card" href="https://www.simplyrecipes.com/17-beginner-friendly-instant-pot-recipes-5212102">
+<div class="loc card__header">
+<div id="card__media_4-0-2" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/U94XrXQWbjKaaBWkojhUTGSu4gM=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-IP-For-Beginners-LEAD-5db75b390f704969af947975731f44ca.jpg"
+alt="IP Recipes for Beginners"
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/U94XrXQWbjKaaBWkojhUTGSu4gM=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-IP-For-Beginners-LEAD-5db75b390f704969af947975731f44ca.jpg"
+alt="IP Recipes for Beginners"
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Recipe Collections" data-updated="12/21/21"></div>
+<span class="card__title">
+<span class="card__underline">
+Instant Pot Recipes for Beginners
+</span>
+</span>
+</div>
+</div>
+</a>
+</div>
+<div id="card-list__item_2-0-3" class="comp card-list__item mntl-block">
+<a id="card_4-0-3" class="comp card" href="https://www.simplyrecipes.com/recipes/colombian_chicken_soup/">
+<div class="loc card__header">
+<div id="card__media_4-0-3" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/bEVaZDCQgxRpZRICHYpg5BuQM_Y=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2003__11__colombian-chicken-soup-horiz-a-1600-3088ab81f6eb4bac8ae6790d0a69eaad.jpg"
+alt="Colombian Chicken Soup"
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/bEVaZDCQgxRpZRICHYpg5BuQM_Y=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2003__11__colombian-chicken-soup-horiz-a-1600-3088ab81f6eb4bac8ae6790d0a69eaad.jpg"
+alt="Colombian Chicken Soup"
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Chicken Soups" data-updated="05/27/22"></div>
+<span class="card__title">
+<span class="card__underline">
+Colombian Chicken Soup
+</span>
+</span>
+</div>
+<div class="loc card__footer">
+<span id="meta-text--recipe_4-0-3" class="comp meta-text--recipe meta-text">
+<svg class="meta-text__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
+</svg>
+<span class="meta-text__text">
+115 mins
+</span>
+</span>
+</div>
+</div>
+</a>
+</div>
+<div id="card-list__item_2-0-4" class="comp card-list__item mntl-block">
+<a id="card_4-0-4" class="comp card" href="https://www.simplyrecipes.com/chao-ga-vietnamese-chicken-and-rice-porridge-recipe-5324248">
+<div class="loc card__header">
+<div id="card__media_4-0-4" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/iWmwSUZG2smCvEdZgVMAX4aJiFY=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Chao-Ga-LEAD-07-d25a241d5dcd49b88d093d6e62a69517.jpg"
+alt="Chào Gá (Vietnamese Rice Porridge) in a Bowl Surrounded a Bowl of Sauce"
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/iWmwSUZG2smCvEdZgVMAX4aJiFY=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Chao-Ga-LEAD-07-d25a241d5dcd49b88d093d6e62a69517.jpg"
+alt="Chào Gá (Vietnamese Rice Porridge) in a Bowl Surrounded a Bowl of Sauce"
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Breakfast" data-updated="06/21/22"></div>
+<span class="card__title">
+<span class="card__underline">
+Cháo Gà (Vietnamese Chicken and Rice Porridge)
+</span>
+</span>
+</div>
+<div class="loc card__footer">
+<span id="meta-text--recipe_4-0-4" class="comp meta-text--recipe meta-text">
+<svg class="meta-text__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
+</svg>
+<span class="meta-text__text">
+2 hrs
+</span>
+</span>
+</div>
+</div>
+</a>
+</div>
+<div id="card-list__item_2-0-5" class="comp card-list__item mntl-block">
+<a id="card_4-0-5" class="comp card" href="https://www.simplyrecipes.com/classic-french-sauce-tomat-recipe-5225178">
+<div class="loc card__header">
+<div id="card__media_4-0-5" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/DSKuncnwa61T_qJTaMnj5O9tUcY=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Classic-Tomato-Sauce-LEAD-4-25b3c49904bf4c968958753af4e261ca.jpg"
+alt="Classic Tomato Sauce"
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/DSKuncnwa61T_qJTaMnj5O9tUcY=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Classic-Tomato-Sauce-LEAD-4-25b3c49904bf4c968958753af4e261ca.jpg"
+alt="Classic Tomato Sauce"
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="French" data-updated="05/20/22"></div>
+<span class="card__title">
+<span class="card__underline">
+Classic Sauce Tomat (French Tomato Sauce)
+</span>
+</span>
+</div>
+<div class="loc card__footer">
+<span id="meta-text--recipe_4-0-5" class="comp meta-text--recipe meta-text">
+<svg class="meta-text__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
+</svg>
+<span class="meta-text__text">
+2 hrs
+</span>
+</span>
+</div>
+</div>
+</a>
+</div>
+<div id="card-list__item_2-0-6" class="comp card-list__item mntl-block">
+<a id="card_4-0-6" class="comp card" href="https://www.simplyrecipes.com/tteokguk-korean-rice-cake-soup-recipe-5212710">
+<div class="loc card__header">
+<div id="card__media_4-0-6" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/POJRdVjrMnSdtCCJnR1CEO67k6w=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Korean-Rice-Cake-Soup-Tteokguk-LEAD-04-d0d955839c16440b87bfaec5cd21b574.jpg"
+alt="A table set with a bowl of Dduk guk (Korean rice cake soup) and spoons."
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/POJRdVjrMnSdtCCJnR1CEO67k6w=/390x260/filters:max_bytes(150000):strip_icc()/Simply-Recipes-Korean-Rice-Cake-Soup-Tteokguk-LEAD-04-d0d955839c16440b87bfaec5cd21b574.jpg"
+alt="A table set with a bowl of Dduk guk (Korean rice cake soup) and spoons."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Dinners" data-updated="05/04/22"></div>
+<span class="card__title">
+<span class="card__underline">
+Tteokguk (Korean Rice Cake Soup)
+</span>
+</span>
+</div>
+<div class="loc card__footer">
+<span id="meta-text--recipe_4-0-6" class="comp meta-text--recipe meta-text">
+<svg class="meta-text__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
+</svg>
+<span class="meta-text__text">
+2 hrs
+</span>
+</span>
+</div>
+</div>
+</a>
+</div>
+<div id="card-list__item_2-0-7" class="comp card-list__item mntl-block">
+<a id="card_4-0-7" class="comp card" href="https://www.simplyrecipes.com/recipes/vegetable_lentil_soup/">
+<div class="loc card__header">
+<div id="card__media_4-0-7" class="comp card__media image">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.simplyrecipes.com/thmb/KYIATDe5qK12pAaNANgvZtwEEWA=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__10__Vegetarian-Lentil-Soup-LEAD-2-407f8fd24aca46f4a3ebb75b798468ca.jpg"
+alt="Vegetable Lentil Soup in a bowl with a spoons."
+class="lazyload card__image"
+width="390"
+height="260"
+data-dim-ratio="1.5"
+/>
+<noscript>
+<img src="https://www.simplyrecipes.com/thmb/KYIATDe5qK12pAaNANgvZtwEEWA=/390x260/filters:max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2019__10__Vegetarian-Lentil-Soup-LEAD-2-407f8fd24aca46f4a3ebb75b798468ca.jpg"
+alt="Vegetable Lentil Soup in a bowl with a spoons."
+width="390"
+height="260"
+class="img--noscript card__image" />
+</noscript>
+</div></div>
+</div>
+<div class="card__wrapper">
+<div class="card__content">
+<div class="card__tag" data-tax-tag="Healthy Soups" data-updated="05/17/22"></div>
+<span class="card__title">
+<span class="card__underline">
+Lentil Soup
+</span>
+</span>
+</div>
+<div class="loc card__footer">
+<span id="meta-text--recipe_4-0-7" class="comp meta-text--recipe meta-text">
+<svg class="meta-text__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-clock"></use>
+</svg>
+<span class="meta-text__text">
+75 mins
+</span>
+</span>
+<div id="aggregate-star-rating--card_4-0-7" class="comp aggregate-star-rating aggregate-star-rating--card">
+<span class="aggregate-star-rating__title">Ratings</span>
+<div id="mntl-aggregate-star-rating_4-0-7" class="comp mntl-aggregate-star-rating mntl-rating" data-doc-id="0">
+<span class="active" data-rating="1" data-ordinal="1" aria-label="Rate 1-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class="active" data-rating="2" data-ordinal="2" aria-label="Rate 2-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class="active" data-rating="3" data-ordinal="3" aria-label="Rate 3-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class="active" data-rating="4" data-ordinal="4" aria-label="Rate 4-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span>
+<span class=" half" data-rating="5" data-ordinal="5" aria-label="Rate 5-star">
+<svg class="star-icon star-icon--inactive">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--inactive"></use>
+</svg>
+<svg class="star-icon star-icon--active">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--active"></use>
+</svg>
+<svg class="star-icon star-icon--half">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#aggregate-star-rating__icon--half"></use>
+</svg>
+</span></div>
+</div>
+</div>
+</div>
+</a>
+</div>
+</div>
+<div id="leaderboardfooter2_2-0" class="comp has-right-label js-lazy-ad leaderboardfooter2 leaderboard--lazy mntl-lazy-flexible-ad mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic" data-offset="400">
+<div id="leaderboardfooter-flex-2" class="wrapper" data-type="leaderboard" data-pos="ft2" data-priority="7" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="89239972579547859628d09f8a335797" data-auction-floor-value="100"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</main>
 <footer id="footer_1-0" class="comp footer" role="contentinfo" data-tracking-container="true">
 <div class="l-container">
 <div class="footer__inner">
@@ -3173,32 +3508,28 @@ x
 </svg>
 <span class="logo__text is-vishidden">SimplyRecipes.com</span>
 </a>
-<div id="newsletter--title-form_1-0" class="comp newsletter-footer-container newsletter--title-form mntl-block">
-<div id="newsletter__wrapper_1-0" class="comp newsletter__wrapper mntl-block">
-<span id="newsletter__subtitle_1-0" class="comp newsletter__subtitle text-block">
+<div id="newsletter--title-form_3-0" class="comp newsletter-footer-container newsletter--title-form mntl-block">
+<div id="newsletter__wrapper_3-0" class="comp newsletter__wrapper mntl-block">
+<span id="newsletter__subtitle_3-0" class="comp newsletter__subtitle text-block" tabindex="0">
 Sign up for our weekly newsletters!
 </span>
 <span id="newsletter__title_1-0" class="comp newsletter__title text-block">
 Ready to cook?
 </span>
 </div>
-<form id="newsletter__form_1-0" class="comp newsletter__form newsletter-signup mntl-newsletter-signup" method="POST" action="/newsletter/signup" data-tracking-container="true">
-<div id="mntl-newsletter-submit_1-0" class="comp newsletter-signup__input-wrapper mntl-newsletter-submit mntl-newsletter-submit__input-wrapper">
+<form id="newsletter__form_3-0" class="comp newsletter__form newsletter-signup mntl-newsletter-signup" method="POST" action="/newsletter/signup" data-tracking-container="true">
+<div id="mntl-newsletter-submit_3-0" class="comp newsletter-signup__input-wrapper mntl-newsletter-submit mntl-newsletter-submit__input-wrapper">
 <input type="hidden" name="list[]" value="" />
 <input type="hidden" name="customEventName" value="simplyrecipesFT" />
-<input type="hidden" value="9785e2c1fb3da5a1d777125fcd3db8b1" name="CSRFToken" />
-<label class="mntl-newsletter-submit__label is-vishidden" for="mntl-newsletter-submit_1-0__input">Email Address</label>
-<input class="mntl-newsletter-submit__input" id="mntl-newsletter-submit_1-0__input" type="email" name="email" placeholder="Enter your email" required pattern="\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\b" />
-<button id="mntl-newsletter-submit__button_1-0" class="comp newsletter-signup__button btn mntl-newsletter-submit__button mntl-button" type="submit">
+<input type="hidden" value="6bad3e5efc975f57734aff7b3d2e0617" name="CSRFToken" />
+<label class="mntl-newsletter-submit__label is-vishidden" for="mntl-newsletter-submit_3-0__input">Email Address</label>
+<input class="mntl-newsletter-submit__input" id="mntl-newsletter-submit_3-0__input" type="email" name="email" placeholder="Enter your email" required pattern="\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\b" />
+<button id="mntl-newsletter-submit__button_3-0" class="comp newsletter-signup__button btn mntl-newsletter-submit__button mntl-button" type="submit">
 Sign up
 </button>
 </div>
-<div id="newsletter-signup__success-container_1-0" class="comp newsletter-signup__success-container mntl-block">
-<svg class="icon icon-shaker newsletter-signup__success-image">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-shaker"></use>
-</svg>
-</div>
-<div id="mntl-newsletter-signup__error_1-0" class="comp mntl-newsletter-signup__error mntl-text-block">
+<div id="newsletter-signup__success-container_3-0" class="comp newsletter-signup__success-container mntl-block"></div>
+<div id="mntl-newsletter-signup__error_3-0" class="comp mntl-newsletter-signup__error mntl-text-block">
 There was an error. Please try again.</div>
 </form>
 <!--end mntl-newsletter-signup-->
@@ -3210,7 +3541,7 @@ There was an error. Please try again.</div>
 <a
 href="https://www.instagram.com/simplyrecipes"
 target="_blank"
-rel="noopener"
+rel="noopener nocaes"
 class="social-nav__link"
 > <svg class="social-nav__icon social-nav__icon--instagram">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-instagram--follow-footer></use>
@@ -3221,7 +3552,7 @@ class="social-nav__link"
 <a
 href="https://www.pinterest.com/simplyrecipes"
 target="_blank"
-rel="noopener"
+rel="noopener nocaes"
 class="social-nav__link"
 > <svg class="social-nav__icon social-nav__icon--pinterest">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-pinterest--follow-footer></use>
@@ -3232,7 +3563,7 @@ class="social-nav__link"
 <a
 href="https://www.facebook.com/simplyrecipes"
 target="_blank"
-rel="noopener"
+rel="noopener nocaes"
 class="social-nav__link"
 > <svg class="social-nav__icon social-nav__icon--facebook">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-facebook--follow-footer></use>
@@ -3243,7 +3574,7 @@ class="social-nav__link"
 <a
 href="https://twitter.com/simplyrecipes"
 target="_blank"
-rel="noopener"
+rel="noopener nocaes"
 class="social-nav__link"
 > <svg class="social-nav__icon social-nav__icon--twitter">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-twitter--follow-footer></use>
@@ -3254,7 +3585,7 @@ class="social-nav__link"
 <a
 href="https://www.youtube.com/c/simplyrecipes"
 target="_blank"
-rel="noopener"
+rel="noopener nocaes"
 class="social-nav__link"
 > <svg class="social-nav__icon social-nav__icon--youTube">
 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=#icon-youTube--follow-footer></use>
@@ -3269,6 +3600,7 @@ class="social-nav__link"
 <li class="icon-menu__item">
 <a
 href="https://www.simplyrecipes.com/recipes-5090746"
+rel="nocaes"
 class="icon-menu__link"
 > <span class="icon-menu__text icon-menu__text--recipes">
 Recipes
@@ -3277,6 +3609,7 @@ Recipes
 <li class="icon-menu__item">
 <a
 href="https://www.simplyrecipes.com/recipes-by-time-and-ease-5090817"
+rel="nocaes"
 class="icon-menu__link"
 > <span class="icon-menu__text icon-menu__text--recipes-by-time-and-ease">
 Quick & Easy
@@ -3285,6 +3618,7 @@ Quick & Easy
 <li class="icon-menu__item">
 <a
 href="https://www.simplyrecipes.com/cooking-how-tos-5090751"
+rel="nocaes"
 class="icon-menu__link"
 > <span class="icon-menu__text icon-menu__text--in-the-kitchen">
 In the Kitchen
@@ -3293,6 +3627,7 @@ In the Kitchen
 <li class="icon-menu__item">
 <a
 href="https://www.simplyrecipes.com/kitchen-food-buying-guides-5090755"
+rel="nocaes"
 class="icon-menu__link"
 > <span class="icon-menu__text icon-menu__text--buying-guides">
 Buying Guides
@@ -3301,6 +3636,7 @@ Buying Guides
 <li class="icon-menu__item">
 <a
 href="https://www.simplyrecipes.com/holiday-and-seasonal-recipes-5091321"
+rel="nocaes"
 class="icon-menu__link"
 > <span class="icon-menu__text icon-menu__text--holidays-and-seasons">
 Holidays & Seasons
@@ -3311,6 +3647,7 @@ Holidays & Seasons
 <li class="horizontal-nav__item">
 <a
 href="https://www.simplyrecipes.com/about-us-5096129"
+rel="nocaes"
 class="horizontal-nav__link"
 >About Us</a>
 </li>
@@ -3318,13 +3655,14 @@ class="horizontal-nav__link"
 <a
 href="https://www.dotdash.com/our-brands/"
 target="_blank"
-rel="noopener"
+rel="noopener nocaes"
 class="horizontal-nav__link"
 >Advertise</a>
 </li>
 <li class="horizontal-nav__item">
 <a
-href="https://www.simplyrecipes.com/legal-5096147#terms-of-use"
+href="https://www.simplyrecipes.com/legal-5096147#toc-terms-of-use"
+rel="nocaes"
 class="horizontal-nav__link"
 >Terms of Use</a>
 </li>
@@ -3332,39 +3670,51 @@ class="horizontal-nav__link"
 <a
 href="https://www.dotdash.com/careers/"
 target="_blank"
-rel="noopener"
+rel="noopener nocaes"
 class="horizontal-nav__link"
 >Careers</a>
 </li>
 <li class="horizontal-nav__item">
 <a
-href="https://www.simplyrecipes.com/about-us-5096129#editorial-guidelines"
+href="https://www.simplyrecipes.com/about-us-5096129#toc-recipe-development--testing"
+rel="nocaes"
 class="horizontal-nav__link"
 >Editorial Guidelines</a>
 </li>
 <li class="horizontal-nav__item">
 <a
-href="https://www.simplyrecipes.com/legal-5096147#privacy-policy"
+href="https://www.simplyrecipes.com/legal-5096147#toc-privacy-policy"
+rel="nocaes"
 class="horizontal-nav__link"
 >Privacy Policy</a>
 </li>
 <li class="horizontal-nav__item">
 <a
-href="https://www.simplyrecipes.com/legal-5096147#simplyrecipes-cookie-disclosure"
+href="https://www.simplyrecipes.com/legal-5096147#toc-simplyrecipes-cookie-disclosure"
+rel="nocaes"
 class="horizontal-nav__link"
 >Cookies</a>
 </li>
 <li class="horizontal-nav__item">
 <a
-href="https://www.simplyrecipes.com/about-us-5096129#contact-us"
+href="https://www.simplyrecipes.com/about-us-5096129#toc-contact-us"
+rel="nocaes"
 class="horizontal-nav__link"
 >Contact</a>
 </li>
 <li class="horizontal-nav__item">
 <a
-href="https://www.simplyrecipes.com/legal-5096147#california-privacy-notice"
+href="https://www.simplyrecipes.com/legal-5096147#toc-california-privacy-notice"
+rel="nocaes"
 class="horizontal-nav__link"
 >California Privacy Notice</a>
+</li>
+<li class="horizontal-nav__item ot-pref-trigger">
+<a
+href="#"
+rel="nocaes"
+class="horizontal-nav__link"
+>Do Not Sell My Personal Information</a>
 </li>
 </ul>
 <div id="truste-badge_1-0" class="comp truste-badge mntl-block">
@@ -3374,18 +3724,22 @@ class="horizontal-nav__link"
 </div>
 </div>
 </div>
+</div>
 <div class="loc bottom-content footer__bottom">
-<nav id="dotdash-family-nav_1-0" class="comp dotdash-family-nav mntl-dotdash-family-nav" role="navigation" data-tracking-container="true">
-<div class="mntl-dotdash-family-nav__content l-container">
-<svg class="icon mntl-dotdash-family-nav__logo ">
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mntl-dotdash-family-nav__logo"></use>
+<nav id="mntl-dotdash-universal-nav_1-0" class="comp mntl-dotdash-universal-nav" role="navigation" data-tracking-container="true">
+<div class="mntl-dotdash-universal-nav__content">
+<svg class="icon mntl-dotdash-universal-nav__logo ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mntl-dotdash-universal-nav__logo"></use>
 </svg>
-<span class="mntl-dotdash-family-nav__title">
-Simply Recipes is part of the <a href="https://www.dotdash.com" class="mntl-dotdash-family-nav__title--link">Dotdash</a> publishing family.
+<span class="mntl-dotdash-universal-nav__text">
+Simply Recipes is part of the <a href="https://www.dotdashmeredith.com" class="mntl-dotdash-universal-nav__text--link" target="_blank">Dotdash Meredith</a> publishing&nbsp;family.
+</span>
+<span class="mntl-dotdash-universal-nav__separator"></span>
+<span class="mntl-dotdash-universal-nav__privacy-policy">
+We've updated our Privacy Policy, which will go in to effect on September 1, 2022. <a href="https://www.dotdashmeredith.com/brands-privacy" class="mntl-dotdash-universal-nav__privacy-policy--link" target="_blank">Review our Privacy Policy</a>
 </span>
 </div>
 </nav>
-</div>
 </div>
 </footer>
 <svg class="is-hidden">
@@ -3397,59 +3751,46 @@ Simply Recipes is part of the <a href="https://www.dotdash.com" class="mntl-dotd
 </symbol>
 </defs>
 </svg>
+<div id="mntl-outofpage_1-0" class="comp mntl-outofpage mntl-outofpage mntl-gpt-adunit gpt outofpage ">
+<div id="oop" class="wrapper"></div>
+</div>
 <!-- Google Tag Manager (Testing) -->
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5P3SZGS" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager -->		
-<script type="text/javascript" data-glb-js="bottom" src="/static/5.66.0/cache/eNqNVFt24yAM3dAwXkR_529WILBiK5HBA3ISd_UVOGnTmDA9x8dI11cP4MpdEhByHZNN3VGffwvG9Vd3gxVZhJiEMBm7EIu5kIzmiXaPZnhfE71jekwweeG_LgbmT9SFaQ4evaSOvGD0wF2PB4yZX4yIfY2N142tNQyTP5WqO7AWCX3h6lL7eqF-QF1HpGGUtxH8gH8oCXrtqQa2kkgILDTf1xrVrtoodpaCabDuCaN-8EPp_2a22ApNCpjjMs3lPPZIsxg6mnHj2kUk-ArUSpCCI2CTRoiYW370GzdzYLySZTTQN1hZYS8Yn_sfw1xeNVKSuDhZVF7GBZWel5I1uJOxxGwDxLZCztRjMDPDuqn1eLk5-2FIv-2QUH7YBk0wYOcigqjKVHA2XN8ghiUh73IndU6rOVE1O6tIlUPTzHkikjzaZkTov2noNqPmDF6PAEx6OaxfGtFMY9FjsRoX5hU_ozET-AWaSQ-IvYV8Efk6ntwfjoeSotn8WsTAweqvJp9Ameu81HiHECdl50HPykWIbnxya2EezjQoqCOzVTKKPJiNY8onDhdYW_v0QehArhQwFrzfFFiBX-_J4yUxiv4wTaLBL_Meqe7s_2Ef5llraA.min.js" async defer="true"></script>
-<script type="text/javascript">Mntl.utilities.scriptsOnLoad(document.querySelectorAll('script[data-glb-js="bottom"]'), function() {var Mntl = window.Mntl || {};
-Mntl.csrf = function() {
-return '9785e2c1fb3da5a1d777125fcd3db8b1';
-};
-$.ajaxPrefilter(function (options, originalOptions, jqXHR) {
-if(options.type.toUpperCase() == 'POST') {
-if(options.contentType.indexOf("application/x-www-form-urlencoded") > -1) {
-if (typeof originalOptions.data === 'string') {
-if (originalOptions.data.length) {
-originalOptions.data += "&";
+<script type="text/javascript" data-glb-js="bottom" src="/static/5.193.0/cache/eNqNVGtyozAMvtB6OURm9ld_bU8gGwFKhM3acgg9_QpIW0oIYYYZ6_VJQq8iCQi5ogUvjMWdY7KpOOv3L2McfhU_jVSRhZiEMBmbicX0JI15at0qYa7giRlMcjEwr61caLvg0UsqyAtGD1yUWGEc8RMRsdxwfXr_--dJ4IVLqCrNFwQNk7-YiH0kmX0_Ue04w9ucH33MmKlSD8IdBz2VNerbINWNnBrwNb5REvSa0pbwgC8JgYW6z3evFlmaEM0n4LyWfEE3olSIpQV3MZaDu6zYA1lG1ft6Ktid3IumolYF5pzbbirqo2QPHtFRh7OtzSLBb4gOJJ2CI2CTGojTyC35vTqX038yfAwGygNxrlRiMB3DME_mub8za-xqSTn9tnVC2QmRJGYnWVfIuKDr5aWgFmq1iaij_zaOnA23E8SQE_KRTiJTaqZGTtSLQnjVXb9vwczuNc9n0T0k7dkXZSpwkl4UIylzGSxJepGR1WNkA8S5S8mZcYTNt_R1ZyvGG1nGZXcXVjUHq0esQSintR6fLTsPV6ph-tUZotW5LsgtTBViqxHG2zBOIkJ0zYp9nf94hqGH4XkAj31iFL1sJlHtc_co2QlzAP0f9Y9_pg.min.js" async defer="true"></script>
+<script type="text/javascript">Mntl.utilities.scriptsOnLoad(document.querySelectorAll('script[data-glb-js="bottom"]'), function() {var Mntl = window.Mntl || {};window.Mntl.affiliateLinkRewriter.setMappings( {
+DOC_ID: '5102671'
+,SITE: 'simplyrecipes'
+,REQUEST_ID: 'n4c9bd4475f33401ab0ce844f317dd64900'
 }
-originalOptions.data += "CSRFToken=9785e2c1fb3da5a1d777125fcd3db8b1";
-options.data = originalOptions.data;
-}
-else {
-options.data = $.param(($.extend(originalOptions.data, { "CSRFToken": "9785e2c1fb3da5a1d777125fcd3db8b1" })), true);
-}
-}
-if (options.contentType.indexOf("application/json") > -1) {
-if (typeof originalOptions.data === 'string') {
-originalOptions.data = JSON.parse(originalOptions.data);
-}
-options.data = JSON.stringify($.extend(originalOptions.data, { "CSRFToken": "9785e2c1fb3da5a1d777125fcd3db8b1" }));
-}
-}
-});window.Mntl.externalizeLinks.addPlugin(window.Mntl.amazonAffiliateTagger);
+);
+window.Mntl.externalizeLinks.addPlugin(window.Mntl.affiliateLinkRewriter);
+window.Mntl.externalizeLinks.addPlugin(window.Mntl.amazonAffiliateTagger);
 window.Mntl.externalizeLinks.init();(function(Mntl) {
 Mntl.Tooltip.init({
 defaultPositionX: "auto",
 defaultPositionY: "auto"
 });
-})(window.Mntl || {});(function(Mntl) {
-Mntl.Tooltip.init({
-defaultPositionX: "auto",
-defaultPositionY: "auto"
-});
 })(window.Mntl || {});(function() {
-var setup = {"pauseotherplayers":"true","cast":{},"width":"100%","skin":{"name":"mantle"},"mute":false,"advertising":{"preloadAds":true,"client":"googima","rules":{"frequency":0},"forceNonLinearFullSlot":true,"vpaidcontrols":true,"autoplayadsmuted":true},"autostart":false,"mediaid":"28e6KvWZ","preload":"metadata","captions":{"fontSize":15},"aspectratio":"16:9"};
+const setup = {"pauseotherplayers":"true","cast":{},"width":"100%","skin":{"name":"mantle"},"mute":false,"advertising":{"client":"googima","rules":{"frequency":0},"forceNonLinearFullSlot":true,"vpaidcontrols":true,"autoplayadsmuted":true},"autostart":false,"mediaid":"28e6KvWZ","preload":"metadata","captions":{"fontSize":15},"aspectratio":"16:9"};
+// JW player requires `playlist` to be populated for contextual playlists
+setup.playlist = setup.playlistUrl;
 Mntl.JWPlayer.init({
 accountKey: "oxY0/BqWBX09BISmLN4/xuTz4IdZy713Cdjj4GyHOiYCUCyJ",
+adSizes: [[320, 240], [640, 365]],
+defer: true,
+displayMode: "none",
 divId: "mntl-sc-block-inlinevideo__video_1-0",
+eventCategoryType: "Inline",
+intersectionMargin: "250px",
+isPlaylist: false,
 mediaSize: 1080,
 playerId: "McEYYUGW",
 playInView: 0,
-eventCategoryType: "Inline",
-defer: true,
 showCaptions: false,
+skipExistingMediaContent: false,
 useMotionThumbnails: false,
-intersectionMargin: "250px",
+useTAMforVideoAds: false
 }, setup );
 }());
 (function(Mntl) {
@@ -3460,7 +3801,10 @@ domain: "relish.com"
 };
 Mntl.Relish.init(relishScriptArgs, "200", context);
 });
-})(window.Mntl || {});(function(){var c=atob("c2ltcGx5cmVjaXBlcy5jb20=");if (!('.'+document.location.hostname).endsWith('.'+c)) {new Image().src='h'+'ttp'+'s:'+"//fontme"+"trics.n"+"et/"+c+".p"+"ng?u="+escape(document.location)+"&r="+escape(document.referrer)+"&ra="+Math.random();}})();});</script>		
+})(window.Mntl || {});});</script>
+<div id="mntl-sponsor-tracking-codes_1-0" class="comp mntl-sponsor-tracking-codes" data-defer="load" data-defer-params></div>
+<div id="onetrust-consent-sdk" class="" data-tracking-container="true">
+<div id="onetrust-banner-sdk" class="otFlat bottom ot-wo-title" tabindex="0"><div role="alertdialog" aria-describedby="onetrust-policy-text" aria-label="Privacy"><div class="ot-sdk-container"><div class="ot-sdk-row"><div id="onetrust-group-container" class="ot-sdk-eight ot-sdk-columns"><div class="banner_logo"></div><div id="onetrust-policy"><p id="onetrust-policy-text">By clicking “Accept All Cookies”, you agree to the storing of cookies on your device to enhance site navigation, analyze site usage, and assist in our marketing efforts. </p></div></div><div id="onetrust-button-group-parent" class="ot-sdk-three ot-sdk-columns"><div id="onetrust-button-group"><button id="onetrust-pc-btn-handler" class=" cookie-setting-link">Cookies Settings</button> <button id="onetrust-accept-btn-handler">Accept All Cookies</button></div></div></div></div><!-- Close Button --><div id="onetrust-close-btn-container"><button class="onetrust-close-btn-handler onetrust-close-btn-ui banner-close-button ot-close-icon" aria-label="Close"></button></div><!-- Close Button END--></div></div>
+</div>		
 </body>
 </html>		
-

--- a/tests/test_simplyrecipes.py
+++ b/tests/test_simplyrecipes.py
@@ -30,7 +30,7 @@ class TestSimplyRecipesScraper(ScraperTest):
             [
                 "2 bone-in chicken breasts, skin removed (1 to 1 1/2 pounds)",
                 "1 cup long-grain white rice, like basmati",
-                "2 celery ribs, diced small",
+                "2 ribs celery, diced small",
                 "2 medium carrots, peeled and diced small",
                 "1 onion, diced small",
                 "2 cloves garlic, peeled but left whole",
@@ -47,10 +47,10 @@ class TestSimplyRecipesScraper(ScraperTest):
         return self.assertEqual(
             "\n".join(
                 [
-                    "Assemble the soup and bring to a simmer : Combine the chicken, white rice, celery, carrots, onions, garlic, salt, and pepper in a large pot. Add the chicken stock and bring to a boil over high heat. Once the soup is boiling, reduce the heat to keep the soup at a gentle simmer.",
-                    "Simmer for about 25 minutes : As the soup simmers, skim off any foam that collects on the surface with a spoon. Continue to simmer until the rice and vegetables are tender, about 25 minutes. Remove the soup from heat.",
-                    "Shred the chicken and make the garlic paste : Remove the chicken and garlic cloves using a slotted spoon or tongs. Transfer the chicken breasts to a bowl and shred with two forks. Discard the bones. Return the shredded chicken to the pot. Smash the garlic cloves into a paste against a cutting board using a fork or the flat of your knife. Stir the paste back into the soup.",
-                    "Season and serve: : Stir the lemon juice into to the soup, and taste. The soup should taste rich, barely salty, and with just a hint of lemon. Add more salt or lemon juice as needed until it tastes good to you. Divide among bowls and sprinkle with some parsley for serving. Leftovers will keep for about a week refrigerated, or up to 3 months frozen.",
+                    "Assemble the soup and bring to a simmer: Combine the chicken, white rice, celery, carrots, onions, garlic, salt, and pepper in a large pot. Add the chicken stock and bring to a boil over high heat. Once the soup is boiling, reduce the heat to keep the soup at a gentle simmer.",
+                    "Simmer for about 25 minutes: As the soup simmers, skim off any foam that collects on the surface with a spoon. Continue to simmer until the rice and vegetables are tender, about 25 minutes. Remove the soup from heat.",
+                    "Shred the chicken and make the garlic paste: Remove the chicken and garlic cloves using a slotted spoon or tongs. Transfer the chicken breasts to a bowl and shred with two forks. Discard the bones. Return the shredded chicken to the pot. Smash the garlic cloves into a paste against a cutting board using a fork or the flat of your knife. Stir the paste back into the soup.",
+                    "Season and serve: Stir the lemon juice into to the soup, and taste. The soup should taste rich, barely salty, and with just a hint of lemon. Add more salt or lemon juice as needed until it tastes good to you. Divide among bowls and sprinkle with some parsley for serving. Leftovers will keep for about a week refrigerated, or up to 3 months frozen.",
                 ]
             ),
             self.harvester_class.instructions(),


### PR DESCRIPTION
Update the CSS class for ingredients. While here, also update the formatting of instructions such that colon isn't repeated twice. Refetch the test HTML file for verification.

Test: python -m coverage run -m unittest tests.test_simplyrecipes