### PR TITLE
Maintenance: update bs4 string searches to use 'string' parameter instead of 'text'

### DIFF
--- a/recipe_scrapers/cookstr.py
+++ b/recipe_scrapers/cookstr.py
@@ -17,7 +17,7 @@ class Cookstr(AbstractScraper):
         sections = self.soup.findAll("div", {"class": "articleAttrSection"})
         total_time = 0
         for section in sections:
-            time = section.find(text="Total Time")
+            time = section.find(string="Total Time")
             if time:
                 total_time += get_minutes(time.parent.parent)
         return total_time
@@ -25,7 +25,7 @@ class Cookstr(AbstractScraper):
     def yields(self):
         sections = self.soup.findAll("span", {"class": "attrLabel"})
         for section in sections:
-            serves = section.find(text="Serves")
+            serves = section.find(string="Serves")
             if serves:
                 return get_yields(serves.parent.parent)
         raise Exception("Servings amount not found")

--- a/recipe_scrapers/cucchiaio.py
+++ b/recipe_scrapers/cucchiaio.py
@@ -21,7 +21,7 @@ class Cucchiaio(AbstractScraper):
         return 0
 
     def yields(self):
-        header = self.soup.find("td", text="PORZIONI")
+        header = self.soup.find("td", string="PORZIONI")
         if header:
             value = header.find_next("td")
             return get_yields(value)

--- a/recipe_scrapers/nutritionbynathalie.py
+++ b/recipe_scrapers/nutritionbynathalie.py
@@ -31,7 +31,7 @@ class NutritionByNathalie(AbstractScraper):
     def ingredients(self):
         ingredients = []
 
-        elements = self.soup.find_all(text=self.ingredientMatch)
+        elements = self.soup.find_all(string=self.ingredientMatch)
         for outerElement in elements:
             title = outerElement.find_parent("p")
             if not title:
@@ -47,7 +47,7 @@ class NutritionByNathalie(AbstractScraper):
         return ingredients
 
     def instructions(self):
-        title = self.soup.find(text="Directions:").find_parent("p")
+        title = self.soup.find(string="Directions:").find_parent("p")
 
         instructions = []
         for child in title.nextSibling.find_all("li"):

--- a/recipe_scrapers/popsugar.py
+++ b/recipe_scrapers/popsugar.py
@@ -13,12 +13,12 @@ class PopSugar(AbstractScraper):
         return normalize_string(title)
 
     def total_time(self):
-        anchor = self._context().find(text="Total Time")
+        anchor = self._context().find(string="Total Time")
         time = anchor.parent.findNext("dd").get_text()
         return get_minutes(time)
 
     def yields(self):
-        anchor = self._context().find(text="Yield")
+        anchor = self._context().find(string="Yield")
         serves = anchor.parent.findNext("dd").get_text()
         return get_yields(serves)
 
@@ -29,7 +29,7 @@ class PopSugar(AbstractScraper):
         return article
 
     def ingredients(self):
-        container = self._context().find("h3", text="Ingredients").parent
+        container = self._context().find("h3", string="Ingredients").parent
         entries = container.findAll("li")
 
         ingredients = []
@@ -51,7 +51,7 @@ class PopSugar(AbstractScraper):
         return ingredients
 
     def instructions(self):
-        container = self._context().find("h3", text="Directions").parent
+        container = self._context().find("h3", string="Directions").parent
         return "\n".join([entry.get_text() for entry in container.findAll("li")])
 
     def _context(self):

--- a/recipe_scrapers/thespruceeats.py
+++ b/recipe_scrapers/thespruceeats.py
@@ -13,14 +13,14 @@ class TheSpruceEats(AbstractScraper):
 
     def total_time(self):
         return get_minutes(
-            self.soup.find("span", text="Total: ").find_next_sibling(
+            self.soup.find("span", string="Total: ").find_next_sibling(
                 "span", {"class": "meta-text__data"}
             )
         )
 
     def yields(self):
         return (
-            self.soup.find("span", text="Servings: ")
+            self.soup.find("span", string="Servings: ")
             .find_next_sibling("span", {"class": "meta-text__data"})
             .get_text()
         )


### PR DESCRIPTION
The 'text' parameter is still provided by `bs4` but is deprecated; see https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG#L546.