### PR TITLE
Continuous integration: re-enable coveralls test coverage upload

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -43,5 +43,7 @@ jobs:
       - name: Unittest and Coverage Report
         run: |
           python run_tests.py
-      - name: coveralls.io
+      # Provide code coverage reports on Linux
+      - if: ${{ matrix.os == 'ubuntu-latest' }}
+        name: coveralls.io
         uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -47,3 +47,6 @@ jobs:
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: coveralls.io
         uses: AndreMiras/coveralls-python-action@develop
+        with:
+          # coveralls repo token
+          github-token: "SmlfzlVJy4ow55rduU7IU5GmmFCfAdGeq"

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -43,3 +43,5 @@ jobs:
       - name: Unittest and Coverage Report
         run: |
           python run_tests.py
+      - name: coveralls.io
+        uses: AndreMiras/coveralls-python-action@develop


### PR DESCRIPTION
I had disabled Coveralls during #628 (a bugfix to make our continuous integration run as we intend on multiple operating systems) because I noticed that it looked like a token value was exposed.

This pull request re-enables coveralls - I'll also check whether it makes sense to enable parallel mode at the same time.