### PR TITLE
Maintenance: update bs4 string searches to use 'string' parameter instead of 'text'

### DIFF
--- a/recipe_scrapers/farmhousedelivery.py
+++ b/recipe_scrapers/farmhousedelivery.py
@@ -22,7 +22,7 @@ class FarmhouseDelivery(AbstractScraper):
 
     def ingredients(self):
         # Style 1
-        ingredients_marker = self.soup.find("p", text=re.compile(r"Ingredients:"))
+        ingredients_marker = self.soup.find("p", string=re.compile(r"Ingredients:"))
         if ingredients_marker is not None:
             ingredients_marker_siblings = ingredients_marker.next_siblings
             for ingredients_marker_sibling in ingredients_marker_siblings:
@@ -37,7 +37,7 @@ class FarmhouseDelivery(AbstractScraper):
                     ]
 
         # Style 2
-        ingredients_marker = self.soup.find("p", text=re.compile(r"Ingredients"))
+        ingredients_marker = self.soup.find("p", string=re.compile(r"Ingredients"))
         if ingredients_marker is not None:
             ingredients = []
             ingredients_marker_siblings = ingredients_marker.next_siblings
@@ -58,7 +58,7 @@ class FarmhouseDelivery(AbstractScraper):
 
     def _instructions_list(self):
         # Style 1
-        instructions_marker = self.soup.find("p", text=re.compile(r"Instructions:"))
+        instructions_marker = self.soup.find("p", string=re.compile(r"Instructions:"))
         if instructions_marker is not None:
             instructions_marker_siblings = instructions_marker.next_siblings
             for instructions_marker_sibling in instructions_marker_siblings:
@@ -74,7 +74,7 @@ class FarmhouseDelivery(AbstractScraper):
                     ]
 
         # Style 2
-        instructions_marker = self.soup.find("p", text=re.compile(r"Instructions"))
+        instructions_marker = self.soup.find("p", string=re.compile(r"Instructions"))
         if instructions_marker is not None:
             instructions = []
             instructions_marker_siblings = instructions_marker.next_siblings

--- a/recipe_scrapers/fredriksfikaallas.py
+++ b/recipe_scrapers/fredriksfikaallas.py
@@ -29,7 +29,7 @@ class FredriksFikaAllas(AbstractScraper):
 
     def ingredients(self):
         ingredients = []
-        content = self.soup.find("strong", text=re.compile("Ingredienser"))
+        content = self.soup.find("strong", string=re.compile("Ingredienser"))
 
         contentRows = content.parent.text.split("\n")
 
@@ -43,7 +43,7 @@ class FredriksFikaAllas(AbstractScraper):
 
     def instructions(self):
         instructions = []
-        content = self.soup.find("strong", text=re.compile("Gör så här"))
+        content = self.soup.find("strong", string=re.compile("Gör så här"))
 
         contentRows = content.parent.text.split("\n")
 

--- a/recipe_scrapers/mykitchen101.py
+++ b/recipe_scrapers/mykitchen101.py
@@ -19,7 +19,7 @@ class MyKitchen101(AbstractScraper):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()
 
     def yields(self):
-        return get_yields(self.soup.find("p", text=re.compile("分量：")).get_text())
+        return get_yields(self.soup.find("p", string=re.compile("分量：")).get_text())
 
     def image(self):
         return self.schema.image()
@@ -27,13 +27,13 @@ class MyKitchen101(AbstractScraper):
     def ingredients(self):
         soup = BeautifulSoup(str(self.soup), features="html.parser")
         ingredients = (
-            soup.find(name="p", text=re.compile("材料：")).find_next("ul").find_all("li")
+            soup.find(name="p", string=re.compile("材料：")).find_next("ul").find_all("li")
         )
         return [normalize_string(ingredient.get_text()) for ingredient in ingredients]
 
     def instructions(self):
         soup = BeautifulSoup(str(self.soup), features="html.parser")
-        instructions = soup.find(name="p", text=re.compile("做法：")).find_all_next("p")
+        instructions = soup.find(name="p", string=re.compile("做法：")).find_all_next("p")
         return "\n".join(
             [
                 normalize_string(instruction.get_text())

--- a/recipe_scrapers/mykitchen101en.py
+++ b/recipe_scrapers/mykitchen101en.py
@@ -19,7 +19,7 @@ class MyKitchen101en(AbstractScraper):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()
 
     def yields(self):
-        return get_yields(self.soup.find("p", text=re.compile("Yields: ")).get_text())
+        return get_yields(self.soup.find("p", string=re.compile("Yields: ")).get_text())
 
     def image(self):
         return self.schema.image()
@@ -27,7 +27,7 @@ class MyKitchen101en(AbstractScraper):
     def ingredients(self):
         soup = BeautifulSoup(str(self.soup), features="html.parser")
         ingredients = (
-            soup.find(name="p", text=re.compile("Ingredients:"))
+            soup.find(name="p", string=re.compile("Ingredients:"))
             .find_next("ul")
             .find_all("li")
         )
@@ -36,7 +36,7 @@ class MyKitchen101en(AbstractScraper):
     def instructions(self):
         soup = BeautifulSoup(str(self.soup), features="html.parser")
         instructions = soup.find(
-            name="p", text=re.compile("Directions:")
+            name="p", string=re.compile("Directions:")
         ).find_all_next("p")
         return "\n".join(
             [

--- a/recipe_scrapers/sunbasket.py
+++ b/recipe_scrapers/sunbasket.py
@@ -14,11 +14,11 @@ class SunBasket(AbstractScraper):
         return self.soup.find("h1").get_text()
 
     def total_time(self):
-        minutes_tag = self.soup.find("span", text=re.compile(r"Minutes"))
+        minutes_tag = self.soup.find("span", string=re.compile(r"Minutes"))
         return get_minutes(minutes_tag.parent.get_text())
 
     def yields(self):
-        yields_tag = self.soup.find("span", text=re.compile(r"Servings,"))
+        yields_tag = self.soup.find("span", string=re.compile(r"Servings,"))
         return get_yields(yields_tag.parent.get_text())
 
     def ingredients(self):


### PR DESCRIPTION
Continues #632 for searches that use compiled regular expressions.

The 'text' parameter is still provided by `bs4` but is deprecated; see https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG?start_revid=642#L546.