### PR TITLE
Reduce the amount of wording in the GitHub 'new issue' templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_scraper.md
+++ b/.github/ISSUE_TEMPLATE/new_scraper.md
@@ -7,14 +7,7 @@ assignees: ''
 
 ---
 
-We always enjoy adding support for new websites to the library!
-
-To help us out, please check that recipes published on the website you're requesting are public (we can't currently scrape recipes that require an account login) and add sample recipe URL(s) below:
+Please check that recipes published on the website you're requesting are public (we can't currently scrape recipes that require an account login), and add sample recipe URL(s) below:
 
 - https:// ...
-
-Can you write Python and would you like to help add the scraper yourself?  We'd be glad for your assistance!  We can provide you with guidance and code review in return.  If so, tick any of the relevant boxes below:
-
-- [ ] I'd like to try adding this scraper myself
-- [ ] I'd like guidance to help me develop a scraper
-- [ ] I'd prefer if the `recipe-scrapers` community try to add this
+- https:// ...

--- a/.github/ISSUE_TEMPLATE/scraper_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/scraper_bug_report.md
@@ -7,12 +7,6 @@ assignees: ''
 
 ---
 
-Thanks for filing a bug report with us!
-
-If your request is about a website that is not supported, please open a 'new scraper' issue request instead.
-
-To help get the issue fixed, please fill in the information below.
-
 **Pre-filing checks**
 
 - [ ] I have searched for open issues that report the same problem
@@ -21,12 +15,6 @@ To help get the issue fixed, please fill in the information below.
 **The URL of the recipe(s) that are not being scraped correctly**
 
 - https:// ...
-
-**The version of Python you're using**
-
-...
-
-**The operating system of your environment**
 
 ...
 
@@ -37,9 +25,3 @@ To help get the issue fixed, please fill in the information below.
 **The results (including any Python error messages) that you are seeing**
 
 ...
-
-Can you write Python and would you like to help fix the scraper yourself?  We'd be glad for your assistance!  We can provide you with guidance and code review in return.  If so, tick any of the relevant boxes below:
-
-- [ ] I'd like to try fixing this scraper myself
-- [ ] I'd like guidance to help me develop a fix
-- [ ] I'd prefer if the `recipe-scrapers` team try to fix this


### PR DESCRIPTION
Relates to https://github.com/hhursev/recipe-scrapers/issues/617#issuecomment-1280024742.

Edit: link to specific commit instead of issue number.