### PR TITLE
Remove unittest-parallel dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,7 +343,7 @@ Assuming you have ``>=python3.7`` installed, navigate to the directory where you
     source .venv/bin/activate &&
     pip install -r requirements-dev.txt &&
     pre-commit install &&
-    python run_tests.py
+    python -m unittest
 
 In case you want to run a single unittest for a newly developed scraper
 

--- a/README.rst
+++ b/README.rst
@@ -349,7 +349,7 @@ In case you want to run a single unittest for a newly developed scraper
 
 .. code:: shell
 
-    python -m coverage run -m unittest tests.test_myscraper
+    python -m unittest tests.test_myscraper
 
 FAQ
 ---

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ flake8>=3.8.3
 flake8-printf-formatting>=1.1.0
 pre-commit>=2.6.0
 responses>=0.21.0
-unittest-parallel>=1.5.0
 mypy>=0.971
 # language-tags>=1.0.0
 # tld>=0.12.3

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,0 @@
-import subprocess
-
-if __name__ == "__main__":
-    run_tests_command = (
-        "unittest-parallel -t . -s tests --coverage --coverage-rcfile .coveragerc"
-    )
-    subprocess.run(run_tests_command.split(" "), check=True, text=True)


### PR DESCRIPTION
Given the number of tests we run, this feels like it _should_ be useful in some circumstances.  But as part of #617 I'd like to try to reduce, clean up and modernize some of our dependencies, and then re-add complexity only where it proves valuable.

#648 was a sorta half-hearted attempt to discover continuous integration performance changes as a result of running tests in serial - it didn't really prove anything for/against though.

On the principle of simplification, I plan to move ahead with this - and if & when anyone disagrees, happy to restore it, although preferably with some supporting (and ideally ongoing) information to show that it's working.