### PR TITLE
Consolidate linting configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.982
+    hooks:
+    - id: mypy
+      additional_dependencies: [types-beautifulsoup4, types-requests]

--- a/README.rst
+++ b/README.rst
@@ -342,7 +342,6 @@ Assuming you have ``>=python3.7`` installed, navigate to the directory where you
     python3 -m venv .venv &&
     source .venv/bin/activate &&
     pip install -r requirements-dev.txt &&
-    pre-commit install &&
     python -m unittest
 
 In case you want to run a single unittest for a newly developed scraper

--- a/generate.py
+++ b/generate.py
@@ -1,3 +1,5 @@
+# mypy: allow-untyped-defs
+
 # generate generates a new recipe scraper.
 import ast
 import sys

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,7 @@ disallow_any_expr=False
 disallow_any_decorated=False
 disallow_any_explicit=False
 disallow_any_generics=True
-disallow_subclassing_any=True
+disallow_subclassing_any=False  # note: currently only required for templates/scraper.py
 
 disallow_untyped_calls=False
 disallow_untyped_defs=True

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -1,9 +1,10 @@
 # mypy: disallow_untyped_defs=False
 
 import html
-import isodate
 import math
 import re
+
+import isodate
 
 from ._exceptions import ElementNotFoundInHtml
 

--- a/recipe_scrapers/bettybossi.py
+++ b/recipe_scrapers/bettybossi.py
@@ -1,8 +1,9 @@
 # mypy: disallow_untyped_defs=False
-from typing import Optional, Union, Tuple, Dict
+from typing import Dict, Optional, Tuple, Union
+
 from requests import Session
 
-from ._abstract import AbstractScraper, HEADERS
+from ._abstract import HEADERS, AbstractScraper
 
 
 class BettyBossi(AbstractScraper):

--- a/recipe_scrapers/goustojson.py
+++ b/recipe_scrapers/goustojson.py
@@ -1,7 +1,7 @@
 # mypy: disallow_untyped_defs=False
 import requests
 
-from ._abstract import AbstractScraper, HEADERS
+from ._abstract import HEADERS, AbstractScraper
 from ._utils import get_minutes, get_yields, normalize_string, url_path_to_dict
 
 

--- a/recipe_scrapers/marleyspoon.py
+++ b/recipe_scrapers/marleyspoon.py
@@ -1,9 +1,10 @@
 # mypy: disallow_untyped_defs=False
 import json
 import re
+
 import requests
 
-from ._abstract import AbstractScraper, HEADERS
+from ._abstract import HEADERS, AbstractScraper
 from ._exceptions import ElementNotFoundInHtml
 from ._utils import normalize_string
 

--- a/recipe_scrapers/woolworths.py
+++ b/recipe_scrapers/woolworths.py
@@ -1,7 +1,7 @@
 # mypy: disallow_untyped_defs=False
 import requests
 
-from ._abstract import AbstractScraper, HEADERS
+from ._abstract import HEADERS, AbstractScraper
 from ._schemaorg import SchemaOrg
 from ._utils import url_path_to_dict
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,5 @@
 -e .
-black>=22.3.0
 coverage>=4.5.1
-flake8>=3.8.3
-flake8-printf-formatting>=1.1.0
-pre-commit>=2.6.0
 responses>=0.21.0
-mypy>=0.971
 # language-tags>=1.0.0
 # tld>=0.12.3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 import os
-from typing import Any, Iterator, Optional, Tuple
 import unittest
+from typing import Any, Iterator, Optional, Tuple
 
 import responses
 

--- a/tests/test_foodnetwork.py
+++ b/tests/test_foodnetwork.py
@@ -1,7 +1,6 @@
 from responses import GET
 
 from recipe_scrapers.foodnetwork import FoodNetwork
-
 from tests import ScraperTest
 
 

--- a/tests/test_gousto.py
+++ b/tests/test_gousto.py
@@ -1,7 +1,6 @@
 from responses import GET
 
 from recipe_scrapers.gousto import Gousto
-
 from tests import ScraperTest
 
 

--- a/tests/test_goustojson.py
+++ b/tests/test_goustojson.py
@@ -1,4 +1,5 @@
 from responses import GET
+
 from recipe_scrapers.goustojson import GoustoJson
 from tests import ScraperTest
 

--- a/tests/test_marleyspoon.py
+++ b/tests/test_marleyspoon.py
@@ -1,7 +1,6 @@
 import responses
 
 from recipe_scrapers.marleyspoon import MarleySpoon
-
 from tests import ScraperTest
 
 

--- a/tests/test_woolworths.py
+++ b/tests/test_woolworths.py
@@ -1,4 +1,5 @@
 from responses import GET
+
 from recipe_scrapers.woolworths import Woolworths
 from tests import ScraperTest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,6 @@
 [testenv]
-deps =
-    coverage >= 4.5.1
-    responses >= 0.21.0
-commands =
-    coverage run -m unittest
+deps = -r{toxinidir}/requirements-dev.txt
+commands = coverage run -m unittest
 
 # The system-provided libxml2 on MacOS is typically outdated and this can lead to lxml parsing issues
 # Using PyPi-provided binary wheels instead resolves this

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,5 @@ install_command =
 
 [testenv:lint]
 skip_install = true
-deps =
-    pre-commit >= 2.20.0
-commands =
-    pre-commit run --all-files
+deps = pre-commit >= 2.20.0
+commands = pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,6 @@ install_command =
 [testenv:lint]
 skip_install = true
 deps =
-    black >= 22.3.0
-    flake8 >= 3.8.3
-    flake8-printf-formatting >= 1.1.0
-    mypy >= 0.971
-    types-beautifulsoup4 >= 4.11.6
-    types-requests >= 2.28.10
+    pre-commit >= 2.20.0
 commands =
-    black --check .
-    flake8 --count .
-    mypy recipe_scrapers tests
+    pre-commit run --all-files


### PR DESCRIPTION
- Use `pre-commit` to perform both `tox`-based and git-hook-based linting
- Add `mypy` to the `pre-commit` lint configuration