### PR TITLE
Fixup: remove overwrite of schema.org data with 'mainEntity' contents during schema.org processing

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -52,8 +52,6 @@ class SchemaOrg:
                 if in_context and item_type.lower() in low_schema:
                     self.format = syntax
                     self.data = item
-                    if item_type.lower() == "webpage":
-                        self.data = self.data.get("mainEntity")
                     return
                 elif in_context and "@graph" in item:
                     for graph_item in item.get("@graph", ""):
@@ -63,10 +61,7 @@ class SchemaOrg:
                         if graph_item_type.lower() in low_schema:
                             in_graph = SCHEMA_ORG_HOST in graph_item.get("@context", "")
                             self.format = syntax
-                            if graph_item_type.lower() == "webpage" and in_graph:
-                                self.data = self.data.get("mainEntity")
-                                return
-                            elif graph_item_type.lower() == "recipe":
+                            if graph_item_type.lower() == "recipe":
                                 self.data = graph_item
                                 return
 

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -59,7 +59,6 @@ class SchemaOrg:
                         if not isinstance(graph_item_type, str):
                             continue
                         if graph_item_type.lower() in low_schema:
-                            in_graph = SCHEMA_ORG_HOST in graph_item.get("@context", "")
                             self.format = syntax
                             if graph_item_type.lower() == "recipe":
                                 self.data = graph_item

--- a/recipe_scrapers/sallysblog.py
+++ b/recipe_scrapers/sallysblog.py
@@ -41,3 +41,7 @@ class SallysBlog(AbstractScraper):
                 for instruction in instructions
             ]
         )
+
+    def image(self):
+        image = self.soup.find("meta", {"property", "og:image"})
+        return image["content"] if image else None


### PR DESCRIPTION
While refactoring some of the `schema.org` metadata handling, I found a couple of situations where we were overwriting the `data` attribute on `SchemaOrg` object instances with empty/falsy data.