### PR TITLE
Provide migration path from SchemaOrgFillPlugin to schemaorg_fallback decorator

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -84,7 +84,7 @@ from .gonnawantseconds import GonnaWantSeconds
 from .goustojson import GoustoJson
 from .greatbritishchefs import GreatBritishChefs
 from .halfbakedharvest import HalfBakedHarvest
-from .hassenchef import Hassanchef
+from .hassanchef import HassanChef
 from .headbangerskitchen import HeadbangersKitchen
 from .heb import HEB
 from .heinzbrasil import HeinzBrasil
@@ -301,7 +301,7 @@ SCRAPERS = {
     GreatBritishChefs.host(): GreatBritishChefs,
     HEB.host(): HEB,
     HalfBakedHarvest.host(): HalfBakedHarvest,
-    Hassanchef.host(): Hassanchef,
+    HassanChef.host(): HassanChef,
     HeadbangersKitchen.host(): HeadbangersKitchen,
     HeinzBrasil.host(): HeinzBrasil,
     HelloFresh.host(): HelloFresh,

--- a/recipe_scrapers/abril.py
+++ b/recipe_scrapers/abril.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Abril(AbstractScraper):
@@ -11,6 +11,10 @@ class Abril(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/acouplecooks.py
+++ b/recipe_scrapers/acouplecooks.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class ACoupleCooks(AbstractScraper):
@@ -11,6 +11,10 @@ class ACoupleCooks(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/amazingribs.py
+++ b/recipe_scrapers/amazingribs.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class AmazingRibs(AbstractScraper):
@@ -11,6 +11,10 @@ class AmazingRibs(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/ambitiouskitchen.py
+++ b/recipe_scrapers/ambitiouskitchen.py
@@ -1,13 +1,17 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class AmbitiousKitchen(AbstractScraper):
     @classmethod
     def host(cls):
         return "ambitiouskitchen.com"
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/archanaskitchen.py
+++ b/recipe_scrapers/archanaskitchen.py
@@ -1,13 +1,17 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class ArchanasKitchen(AbstractScraper):
     @classmethod
     def host(cls):
         return "archanaskitchen.com"
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/atelierdeschefs.py
+++ b/recipe_scrapers/atelierdeschefs.py
@@ -9,6 +9,10 @@ class AtelierDesChefs(AbstractScraper):
     def host(cls):
         return "atelierdeschefs.fr"
 
+    @schemaorg_fallback
+    def author(self):
+        pass
+
     def title(self):
         return self.schema.title()
 

--- a/recipe_scrapers/averiecooks.py
+++ b/recipe_scrapers/averiecooks.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class AverieCooks(AbstractScraper):
@@ -11,6 +11,10 @@ class AverieCooks(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/bakingsense.py
+++ b/recipe_scrapers/bakingsense.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class BakingSense(AbstractScraper):
@@ -11,6 +11,10 @@ class BakingSense(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/bbcgoodfood.py
+++ b/recipe_scrapers/bbcgoodfood.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class BBCGoodFood(AbstractScraper):
@@ -11,6 +11,10 @@ class BBCGoodFood(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/bettycrocker.py
+++ b/recipe_scrapers/bettycrocker.py
@@ -8,7 +8,7 @@
 
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class BettyCrocker(AbstractScraper):
@@ -18,6 +18,10 @@ class BettyCrocker(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/bigoven.py
+++ b/recipe_scrapers/bigoven.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class BigOven(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/blueapron.py
+++ b/recipe_scrapers/blueapron.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class BlueApron(AbstractScraper):
@@ -11,6 +11,10 @@ class BlueApron(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/bonappetit.py
+++ b/recipe_scrapers/bonappetit.py
@@ -12,6 +12,10 @@ class BonAppetit(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    @schemaorg_fallback
+    def author(self):
+        pass
+
     def total_time(self):
         return None
 

--- a/recipe_scrapers/bowlofdelicious.py
+++ b/recipe_scrapers/bowlofdelicious.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class BowlOfDelicious(AbstractScraper):
@@ -11,6 +11,10 @@ class BowlOfDelicious(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/budgetbytes.py
+++ b/recipe_scrapers/budgetbytes.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class BudgetBytes(AbstractScraper):
@@ -11,6 +11,10 @@ class BudgetBytes(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/castironketo.py
+++ b/recipe_scrapers/castironketo.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class CastIronKeto(AbstractScraper):
@@ -11,6 +11,10 @@ class CastIronKeto(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/cdkitchen.py
+++ b/recipe_scrapers/cdkitchen.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class CdKitchen(AbstractScraper):
@@ -11,6 +11,10 @@ class CdKitchen(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/chefkoch.py
+++ b/recipe_scrapers/chefkoch.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Chefkoch(AbstractScraper):
@@ -11,6 +11,10 @@ class Chefkoch(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def description(self):
         return self.schema.description()

--- a/recipe_scrapers/closetcooking.py
+++ b/recipe_scrapers/closetcooking.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -14,6 +14,10 @@ class ClosetCooking(AbstractScraper):
         return normalize_string(
             self.soup.find("h1", {"class": "entry-title"}).get_text()
         )
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find(itemprop="totalTime").parent)

--- a/recipe_scrapers/cookeatshare.py
+++ b/recipe_scrapers/cookeatshare.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 
 
 class CookEatShare(AbstractScraper):
@@ -9,6 +11,10 @@ class CookEatShare(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return None

--- a/recipe_scrapers/cookieandkate.py
+++ b/recipe_scrapers/cookieandkate.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class CookieAndKate(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/cookinglight.py
+++ b/recipe_scrapers/cookinglight.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class CookingLight(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/cookpad.py
+++ b/recipe_scrapers/cookpad.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class CookPad(AbstractScraper):
@@ -11,6 +11,10 @@ class CookPad(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/cookstr.py
+++ b/recipe_scrapers/cookstr.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -14,6 +14,10 @@ class Cookstr(AbstractScraper):
         return normalize_string(
             self.soup.find("h1", {"class": "articleHeadline"}).get_text()
         )
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         sections = self.soup.findAll("div", {"class": "articleAttrSection"})

--- a/recipe_scrapers/coop.py
+++ b/recipe_scrapers/coop.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Coop(AbstractScraper):
@@ -20,6 +20,10 @@ class Coop(AbstractScraper):
 
     def cook_time(self):
         return self.schema.cook_time()
+
+    @schemaorg_fallback
+    def total_time(self):
+        pass
 
     def yields(self):
         return self.schema.yields()

--- a/recipe_scrapers/copykat.py
+++ b/recipe_scrapers/copykat.py
@@ -8,7 +8,7 @@
 
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import normalize_string
 
 
@@ -19,6 +19,10 @@ class CopyKat(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/countryliving.py
+++ b/recipe_scrapers/countryliving.py
@@ -13,6 +13,9 @@ class CountryLiving(AbstractScraper):
     def title(self):
         return self.soup.find("h1", {"class": "content-hed recipe-hed"}).get_text()
 
+    def author(self):
+        return self.soup.find("span", {"rel": "author"}).get_text()
+
     def total_time(self):
         return get_minutes(
             self.soup.find("span", {"class": "total-time-amount"}).parent

--- a/recipe_scrapers/cuisineaz.py
+++ b/recipe_scrapers/cuisineaz.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class CuisineAZ(AbstractScraper):
@@ -11,6 +11,10 @@ class CuisineAZ(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/cybercook.py
+++ b/recipe_scrapers/cybercook.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Cybercook(AbstractScraper):
@@ -11,6 +11,10 @@ class Cybercook(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/delish.py
+++ b/recipe_scrapers/delish.py
@@ -8,7 +8,7 @@
 
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -19,6 +19,10 @@ class Delish(AbstractScraper):
 
     def title(self):
         return normalize_string(self.soup.find("h1").get_text())
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     # Return total time to complete dish in minutes (includes prep time)
     def total_time(self):

--- a/recipe_scrapers/ditchthecarbs.py
+++ b/recipe_scrapers/ditchthecarbs.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class DitchTheCarbs(AbstractScraper):
@@ -11,6 +11,10 @@ class DitchTheCarbs(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/domesticateme.py
+++ b/recipe_scrapers/domesticateme.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class DomesticateMe(AbstractScraper):
@@ -11,6 +11,10 @@ class DomesticateMe(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/dr.py
+++ b/recipe_scrapers/dr.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Dr(AbstractScraper):
@@ -11,6 +11,10 @@ class Dr(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/eatingwell.py
+++ b/recipe_scrapers/eatingwell.py
@@ -13,6 +13,9 @@ class EatingWell(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    def author(self):
+        return self.soup.find("span", {"class": "author-name"}).get_text()
+
     @opengraph_fallback
     def image(self):
         return self.schema.image()

--- a/recipe_scrapers/eatsmarter.py
+++ b/recipe_scrapers/eatsmarter.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Eatsmarter(AbstractScraper):
@@ -11,6 +11,10 @@ class Eatsmarter(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/eatwhattonight.py
+++ b/recipe_scrapers/eatwhattonight.py
@@ -1,13 +1,17 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class EatWhatTonight(AbstractScraper):
     @classmethod
     def host(cls):
         return "eatwhattonight.com"
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/epicurious.py
+++ b/recipe_scrapers/epicurious.py
@@ -12,6 +12,9 @@ class Epicurious(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    def author(self):
+        return self.soup.find("a", {"itemprop": "author"}).get_text()
+
     def total_time(self):
         return self.schema.total_time()
 

--- a/recipe_scrapers/farmhousedelivery.py
+++ b/recipe_scrapers/farmhousedelivery.py
@@ -5,7 +5,7 @@ import re
 from bs4 import Tag
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import normalize_string
 
 """
@@ -21,6 +21,10 @@ class FarmhouseDelivery(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "entry-title"}).get_text(strip=True)
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def ingredients(self):
         # Style 1

--- a/recipe_scrapers/fifteenspatulas.py
+++ b/recipe_scrapers/fifteenspatulas.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class FifteenSpatulas(AbstractScraper):
@@ -11,6 +11,10 @@ class FifteenSpatulas(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/finedininglovers.py
+++ b/recipe_scrapers/finedininglovers.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,12 @@ class FineDiningLovers(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "recipe-full-class"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        container = self.soup.find("div", {"class": "author-name"})
+        if container:
+            return container.find("a").get_text()
 
     def total_time(self):
         return get_minutes(self.soup.find("div", {"class": "timing"}))

--- a/recipe_scrapers/fitmencook.py
+++ b/recipe_scrapers/fitmencook.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -16,6 +16,10 @@ class FitMenCook(AbstractScraper):
         title = title.replace("\n", "")
 
         return title
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("span", {"class": "total-time"}))

--- a/recipe_scrapers/food.py
+++ b/recipe_scrapers/food.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Food(AbstractScraper):
@@ -27,3 +27,7 @@ class Food(AbstractScraper):
 
     def instructions(self):
         return self.schema.instructions()
+
+    @schemaorg_fallback
+    def ratings(self):
+        pass

--- a/recipe_scrapers/food.py
+++ b/recipe_scrapers/food.py
@@ -12,6 +12,10 @@ class Food(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    @schemaorg_fallback
+    def author(self):
+        pass
+
     def total_time(self):
         return self.schema.total_time()
 

--- a/recipe_scrapers/food52.py
+++ b/recipe_scrapers/food52.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from recipe_scrapers._abstract import AbstractScraper
-from recipe_scrapers._decorators import opengraph_fallback
+from recipe_scrapers._decorators import opengraph_fallback, schemaorg_fallback
 from recipe_scrapers._utils import get_minutes, normalize_string
 
 
@@ -12,6 +12,10 @@ class Food52(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         ul = self.soup.find("ul", {"class": "recipe__details"})

--- a/recipe_scrapers/foodandwine.py
+++ b/recipe_scrapers/foodandwine.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class FoodAndWine(AbstractScraper):
@@ -11,6 +11,10 @@ class FoodAndWine(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/foodrepublic.py
+++ b/recipe_scrapers/foodrepublic.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class FoodRepublic(AbstractScraper):
 
     def title(self):
         return self.soup.find("h3", {"class": "recipe-title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return sum(

--- a/recipe_scrapers/g750g.py
+++ b/recipe_scrapers/g750g.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class G750g(AbstractScraper):
@@ -11,6 +11,10 @@ class G750g(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/geniuskitchen.py
+++ b/recipe_scrapers/geniuskitchen.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -14,6 +14,10 @@ class GeniusKitchen(AbstractScraper):
         return (
             self.soup.find("title").get_text().replace(" Recipe - Genius Kitchen", "")
         )
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("td", {"class": "time"}))

--- a/recipe_scrapers/giallozafferano.py
+++ b/recipe_scrapers/giallozafferano.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class GialloZafferano(AbstractScraper):
@@ -11,6 +11,10 @@ class GialloZafferano(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/gimmesomeoven.py
+++ b/recipe_scrapers/gimmesomeoven.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class GimmeSomeOven(AbstractScraper):
@@ -11,6 +11,10 @@ class GimmeSomeOven(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/globo.py
+++ b/recipe_scrapers/globo.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Globo(AbstractScraper):
@@ -11,6 +11,10 @@ class Globo(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/gonnawantseconds.py
+++ b/recipe_scrapers/gonnawantseconds.py
@@ -8,7 +8,7 @@
 
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -19,6 +19,10 @@ class GonnaWantSeconds(AbstractScraper):
 
     def title(self):
         return normalize_string(self.soup.find("h1").get_text())
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         total_time = 0

--- a/recipe_scrapers/gousto.py
+++ b/recipe_scrapers/gousto.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 # TODO: Remove? Switching over to GoustoJson 2022-08-01
@@ -12,6 +12,10 @@ class Gousto(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/goustojson.py
+++ b/recipe_scrapers/goustojson.py
@@ -1,7 +1,9 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 import requests
 
 from ._abstract import HEADERS, AbstractScraper
+from ._decorators import schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string, url_path_to_dict
 
 
@@ -35,6 +37,10 @@ class GoustoJson(AbstractScraper):
 
     def title(self):
         return self.data.get("title")
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(sorted(self.data.get("prep_times").values())[-1])

--- a/recipe_scrapers/greatbritishchefs.py
+++ b/recipe_scrapers/greatbritishchefs.py
@@ -8,7 +8,7 @@
 
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -19,6 +19,10 @@ class GreatBritishChefs(AbstractScraper):
 
     def title(self):
         return normalize_string(self.soup.find("h1").get_text())
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         total_time = 0

--- a/recipe_scrapers/halfbakedharvest.py
+++ b/recipe_scrapers/halfbakedharvest.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class HalfBakedHarvest(AbstractScraper):
@@ -11,6 +11,10 @@ class HalfBakedHarvest(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/hassanchef.py
+++ b/recipe_scrapers/hassanchef.py
@@ -4,13 +4,16 @@ from ._abstract import AbstractScraper
 from ._decorators import opengraph_fallback
 
 
-class Hassanchef(AbstractScraper):
+class HassanChef(AbstractScraper):
     @classmethod
     def host(cls):
         return "hassanchef.com"
 
     def title(self):
         return self.schema.title()
+
+    def author(self):
+        return self.schema.author().title()
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/heb.py
+++ b/recipe_scrapers/heb.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class HEB(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         minutes_tag = self.soup.find("div", {"itemprop": "totalTime"})

--- a/recipe_scrapers/heinzbrasil.py
+++ b/recipe_scrapers/heinzbrasil.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import normalize_string
 
 
@@ -12,6 +12,10 @@ class HeinzBrasil(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "krRDPrecName"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return 0

--- a/recipe_scrapers/hellofresh.py
+++ b/recipe_scrapers/hellofresh.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class HelloFresh(AbstractScraper):
@@ -11,6 +11,10 @@ class HelloFresh(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/hostthetoast.py
+++ b/recipe_scrapers/hostthetoast.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Hostthetoast(AbstractScraper):
@@ -11,6 +11,10 @@ class Hostthetoast(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/hundredandonecookbooks.py
+++ b/recipe_scrapers/hundredandonecookbooks.py
@@ -13,6 +13,10 @@ class HundredAndOneCookbooks(AbstractScraper):
     def title(self):
         return self.soup.find("h1").get_text()
 
+    @schemaorg_fallback
+    def author(self):
+        pass
+
     def total_time(self):
         return get_minutes(
             self.soup.findAll("div", {"class": "wprm-recipe-time"})[-1].get_text()

--- a/recipe_scrapers/ig.py
+++ b/recipe_scrapers/ig.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_yields, normalize_string
 
 
@@ -12,6 +12,14 @@ class IG(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2", {"itemprop": "name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        nav = self.soup.find("nav", {"class": "nav-mais-receitas"})
+        if nav:
+            first = nav.find("li", {"class": "first"})
+            if first:
+                return first.find("a").get_text()
 
     def total_time(self):
         container = self.soup.find("div", {"class": "box-info-preparacao"})

--- a/recipe_scrapers/innit.py
+++ b/recipe_scrapers/innit.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 """
     Note that innit hosts recipes for several companies.  I found it while looking at centralmarket.com
@@ -15,6 +15,10 @@ class Innit(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/inspiralized.py
+++ b/recipe_scrapers/inspiralized.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,13 @@ class Inspiralized(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2").get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        if type(self.page_data) == bytes and b"Ali Maffucci" in self.page_data:
+            return "Ali Maffucci"
+        if type(self.page_data) == str and "Ali Maffucci" in self.page_data:
+            return "Ali Maffucci"
 
     def total_time(self):
         return get_minutes(self.soup.find("span", {"itemprop": "totalTime"}))

--- a/recipe_scrapers/jamieoliver.py
+++ b/recipe_scrapers/jamieoliver.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class JamieOliver(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1").get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("div", {"class": "time"}))

--- a/recipe_scrapers/justataste.py
+++ b/recipe_scrapers/justataste.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class JustATaste(AbstractScraper):
@@ -11,6 +11,10 @@ class JustATaste(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/justbento.py
+++ b/recipe_scrapers/justbento.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -12,6 +14,10 @@ class JustBento(AbstractScraper):
         expected_prefix = "Recipe: "
         title = self.soup.find("meta", {"property": "og:title", "content": True})
         return title.get("content").replace(expected_prefix, "")
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         time = self.soup.find(

--- a/recipe_scrapers/kennymcgovern.py
+++ b/recipe_scrapers/kennymcgovern.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class KennyMcGovern(AbstractScraper):
 
     def title(self):
         return self.soup.find("div", {"class": "wprm-recipe-name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/kingarthur.py
+++ b/recipe_scrapers/kingarthur.py
@@ -3,7 +3,7 @@
 from bs4 import BeautifulSoup
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import normalize_string
 
 
@@ -14,6 +14,10 @@ class KingArthur(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/kochbar.py
+++ b/recipe_scrapers/kochbar.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Kochbar(AbstractScraper):
@@ -11,6 +11,10 @@ class Kochbar(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/kuchniadomowa.py
+++ b/recipe_scrapers/kuchniadomowa.py
@@ -13,6 +13,10 @@ class KuchniaDomowa(AbstractScraper):
         return self.soup.find("h2").get_text().strip()
 
     @schemaorg_fallback
+    def author(self):
+        pass
+
+    @schemaorg_fallback
     def total_time(self):
         pass
 

--- a/recipe_scrapers/kuchniadomowa.py
+++ b/recipe_scrapers/kuchniadomowa.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class KuchniaDomowa(AbstractScraper):
@@ -12,10 +12,22 @@ class KuchniaDomowa(AbstractScraper):
     def title(self):
         return self.soup.find("h2").get_text().strip()
 
+    @schemaorg_fallback
+    def total_time(self):
+        pass
+
+    @schemaorg_fallback
+    def yields(self):
+        pass
+
     @opengraph_fallback
     def image(self):
         urls = self.soup.findAll("img", {"class": "article-img", "id": "article-img-1"})
         return f"https:{urls[1]['src']}"
+
+    @schemaorg_fallback
+    def ingredients(self):
+        pass
 
     def instructions(self):
         instructions = self.soup.find("div", {"id": "recipe-instructions"}).findAll(

--- a/recipe_scrapers/latelierderoxane.py
+++ b/recipe_scrapers/latelierderoxane.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -20,6 +20,10 @@ class LAtelierDeRoxane(AbstractScraper):
     def title(self):
         div = self.soup.find("div", {"class": "bloc_titreh1 bloc_blog"})
         return div.find("h1").get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def description(self):
         div = self.soup.find("div", {"class": "bloc_chapeau bloc_blog"})

--- a/recipe_scrapers/lecremedelacrumb.py
+++ b/recipe_scrapers/lecremedelacrumb.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class LeCremeDeLaCrumb(AbstractScraper):
@@ -11,6 +11,10 @@ class LeCremeDeLaCrumb(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/littlespicejar.py
+++ b/recipe_scrapers/littlespicejar.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class LittleSpiceJar(AbstractScraper):
@@ -11,6 +11,10 @@ class LittleSpiceJar(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/livelytable.py
+++ b/recipe_scrapers/livelytable.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class LivelyTable(AbstractScraper):
@@ -11,6 +11,10 @@ class LivelyTable(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/lovingitvegan.py
+++ b/recipe_scrapers/lovingitvegan.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Lovingitvegan(AbstractScraper):
@@ -11,6 +11,10 @@ class Lovingitvegan(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/marmiton.py
+++ b/recipe_scrapers/marmiton.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 
 
 class Marmiton(AbstractScraper):
@@ -9,6 +11,10 @@ class Marmiton(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/marthastewart.py
+++ b/recipe_scrapers/marthastewart.py
@@ -13,6 +13,10 @@ class MarthaStewart(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    @schemaorg_fallback
+    def author(self):
+        pass
+
     def total_time(self):
         s = (
             self.soup.findAll("div", {"class": "two-subcol-content-wrapper"})[0]

--- a/recipe_scrapers/matprat.py
+++ b/recipe_scrapers/matprat.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class Matprat(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1").get_text().strip()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         total_time = 0

--- a/recipe_scrapers/melskitchencafe.py
+++ b/recipe_scrapers/melskitchencafe.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class MelsKitchenCafe(AbstractScraper):
@@ -11,6 +11,10 @@ class MelsKitchenCafe(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/mindmegette.py
+++ b/recipe_scrapers/mindmegette.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class Mindmegette(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         item_sibling = self.soup.find("span", {"class": "spriteTime"})

--- a/recipe_scrapers/minimalistbaker.py
+++ b/recipe_scrapers/minimalistbaker.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Minimalistbaker(AbstractScraper):
@@ -11,6 +11,10 @@ class Minimalistbaker(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/misya.py
+++ b/recipe_scrapers/misya.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Misya(AbstractScraper):
@@ -11,6 +11,10 @@ class Misya(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/momswithcrockpots.py
+++ b/recipe_scrapers/momswithcrockpots.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class MomsWithCrockPots(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2", {"class": "wprm-recipe-name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/motherthyme.py
+++ b/recipe_scrapers/motherthyme.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class MotherThyme(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2", {"class": "wprm-recipe-name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/mybakingaddiction.py
+++ b/recipe_scrapers/mybakingaddiction.py
@@ -13,6 +13,10 @@ class MyBakingAddiction(AbstractScraper):
     def title(self):
         return self.soup.find("h1").get_text()
 
+    @schemaorg_fallback
+    def author(self):
+        pass
+
     def total_time(self):
         return get_minutes(
             self.soup.find("div", {"class": "mv-create-time-total"}).get_text()

--- a/recipe_scrapers/myrecipes.py
+++ b/recipe_scrapers/myrecipes.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class MyRecipes(AbstractScraper):
@@ -11,6 +11,10 @@ class MyRecipes(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -1,8 +1,10 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from dataclasses import dataclass
 from typing import List, Optional
 
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 from ._exceptions import ElementNotFoundInHtml
 from ._utils import get_minutes, get_yields, normalize_string
 
@@ -23,6 +25,10 @@ class NIHHealthyEating(AbstractScraper):
     def title(self):
         # This content must be present for all recipes on this website.
         return normalize_string(self.soup.h1.get_text())
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         # This content must be present for all recipes on this website.

--- a/recipe_scrapers/nourishedbynutrition.py
+++ b/recipe_scrapers/nourishedbynutrition.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class NourishedByNutrition(AbstractScraper):
@@ -11,6 +11,10 @@ class NourishedByNutrition(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/nutritionbynathalie.py
+++ b/recipe_scrapers/nutritionbynathalie.py
@@ -3,7 +3,7 @@
 import re
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 BULLET_CHARACTER_ORD = 8226
 
@@ -17,6 +17,10 @@ class NutritionByNathalie(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1").get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return 0

--- a/recipe_scrapers/nytimes.py
+++ b/recipe_scrapers/nytimes.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class NYTimes(AbstractScraper):
@@ -11,6 +11,10 @@ class NYTimes(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/ohsheglows.py
+++ b/recipe_scrapers/ohsheglows.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 
 
 class OhSheGlows(AbstractScraper):
@@ -9,6 +11,10 @@ class OhSheGlows(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/panelinha.py
+++ b/recipe_scrapers/panelinha.py
@@ -3,7 +3,7 @@
 import re
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 INSTRUCTIONS_NUMBERING_REGEX = re.compile(r"^\d{1,2}\.\s*")  # noqa
@@ -16,6 +16,10 @@ class Panelinha(AbstractScraper):
 
     def title(self):
         return normalize_string(self.soup.find("h1").get_text())
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/paninihappy.py
+++ b/recipe_scrapers/paninihappy.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -10,6 +12,10 @@ class PaniniHappy(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("span", {"class": "duration"}))

--- a/recipe_scrapers/pingodoce.py
+++ b/recipe_scrapers/pingodoce.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields
 
 
@@ -12,6 +12,10 @@ class PingoDoce(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.findAll("div", {"class": "info"})[0])

--- a/recipe_scrapers/popsugar.py
+++ b/recipe_scrapers/popsugar.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -13,6 +13,10 @@ class PopSugar(AbstractScraper):
     def title(self):
         title = self._context().find("h2", {"class": "recipe-title"}).get_text()
         return normalize_string(title)
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         anchor = self._context().find(string="Total Time")

--- a/recipe_scrapers/practicalselfreliance.py
+++ b/recipe_scrapers/practicalselfreliance.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class PracticalSelfReliance(AbstractScraper):
@@ -11,6 +11,10 @@ class PracticalSelfReliance(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/primaledgehealth.py
+++ b/recipe_scrapers/primaledgehealth.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class PrimalEdgeHealth(AbstractScraper):
@@ -11,6 +11,10 @@ class PrimalEdgeHealth(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/przepisy.py
+++ b/recipe_scrapers/przepisy.py
@@ -13,6 +13,9 @@ class Przepisy(AbstractScraper):
     def title(self):
         return self.soup.find("h1", {"class": "title"}).get_text()
 
+    def author(self):
+        return self.schema.author().strip()
+
     def total_time(self):
         return get_minutes(self.soup.find("div", {"class": "time-count"}))
 

--- a/recipe_scrapers/purelypope.py
+++ b/recipe_scrapers/purelypope.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class PurelyPope(AbstractScraper):
@@ -11,6 +11,10 @@ class PurelyPope(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/purplecarrot.py
+++ b/recipe_scrapers/purplecarrot.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 from ._utils import normalize_string
 
 
@@ -10,6 +12,10 @@ class PurpleCarrot(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/realsimple.py
+++ b/recipe_scrapers/realsimple.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class RealSimple(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1").get_text(strip=True)
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.findAll("div", {"class": "recipe-meta-item"})[1])

--- a/recipe_scrapers/recipetineats.py
+++ b/recipe_scrapers/recipetineats.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class RecipeTinEats(AbstractScraper):
@@ -11,6 +11,10 @@ class RecipeTinEats(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/rosannapansino.py
+++ b/recipe_scrapers/rosannapansino.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import normalize_string
 
 
@@ -12,6 +12,10 @@ class RosannaPansino(AbstractScraper):
 
     def title(self):
         return self.soup.find("meta", {"property": "og:title"})["content"]
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     @opengraph_fallback
     def image(self):

--- a/recipe_scrapers/sallysbakingaddiction.py
+++ b/recipe_scrapers/sallysbakingaddiction.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class SallysBakingAddiction(AbstractScraper):
@@ -11,6 +11,10 @@ class SallysBakingAddiction(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/sallysblog.py
+++ b/recipe_scrapers/sallysblog.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -14,6 +14,10 @@ class SallysBlog(AbstractScraper):
         return normalize_string(
             self.soup.find("h1", {"class": "blog--detail-headline"}).get_text()
         )
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("span", {"id": "zubereitungszeit"}))

--- a/recipe_scrapers/settings/default.py
+++ b/recipe_scrapers/settings/default.py
@@ -2,7 +2,6 @@ from recipe_scrapers.plugins import (
     ExceptionHandlingPlugin,
     HTMLTagStripperPlugin,
     NormalizeStringPlugin,
-    SchemaOrgFillPlugin,
 )
 
 # Plugins to be attached.
@@ -12,7 +11,6 @@ PLUGINS = (
     ExceptionHandlingPlugin,
     HTMLTagStripperPlugin,
     NormalizeStringPlugin,
-    SchemaOrgFillPlugin,
 )
 
 SUPPRESS_EXCEPTIONS = False

--- a/recipe_scrapers/simplyquinoa.py
+++ b/recipe_scrapers/simplyquinoa.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class SimplyQuinoa(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2", {"class": "wprm-recipe-name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/simplyrecipes.py
+++ b/recipe_scrapers/simplyrecipes.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class SimplyRecipes(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1").get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/simplywhisked.py
+++ b/recipe_scrapers/simplywhisked.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class SimplyWhisked(AbstractScraper):
@@ -11,6 +11,10 @@ class SimplyWhisked(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/skinnytaste.py
+++ b/recipe_scrapers/skinnytaste.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class SkinnyTaste(AbstractScraper):
@@ -11,6 +11,10 @@ class SkinnyTaste(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/southernliving.py
+++ b/recipe_scrapers/southernliving.py
@@ -8,7 +8,7 @@
 
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -19,6 +19,10 @@ class SouthernLiving(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.schema.total_time())

--- a/recipe_scrapers/spendwithpennies.py
+++ b/recipe_scrapers/spendwithpennies.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class SpendWithPennies(AbstractScraper):
@@ -11,6 +11,13 @@ class SpendWithPennies(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        if type(self.page_data) == bytes and b"Holly Nilsson" in self.page_data:
+            return "Holly Nilsson"
+        if type(self.page_data) == str and "Holly Nilsson" in self.page_data:
+            return "Holly Nilsson"
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/streetkitchen.py
+++ b/recipe_scrapers/streetkitchen.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class StreetKitchen(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return None

--- a/recipe_scrapers/sunbasket.py
+++ b/recipe_scrapers/sunbasket.py
@@ -3,7 +3,7 @@
 import re
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -14,6 +14,10 @@ class SunBasket(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1").get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         minutes_tag = self.soup.find("span", string=re.compile(r"Minutes"))

--- a/recipe_scrapers/sweetcsdesigns.py
+++ b/recipe_scrapers/sweetcsdesigns.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class SweetCsDesigns(AbstractScraper):
@@ -11,6 +11,10 @@ class SweetCsDesigns(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/tasteofhome.py
+++ b/recipe_scrapers/tasteofhome.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import normalize_string
 
 
@@ -9,6 +9,10 @@ class TasteOfHome(AbstractScraper):
     @classmethod
     def host(cls):
         return "tasteofhome.com"
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/tastesbetterfromscratch.py
+++ b/recipe_scrapers/tastesbetterfromscratch.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class TastesBetterFromScratch(AbstractScraper):
@@ -11,6 +11,10 @@ class TastesBetterFromScratch(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/tastesoflizzyt.py
+++ b/recipe_scrapers/tastesoflizzyt.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class TastesOfLizzyT(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2", {"class": "wprm-recipe-name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/tasty.py
+++ b/recipe_scrapers/tasty.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Tasty(AbstractScraper):
@@ -11,6 +11,10 @@ class Tasty(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class TastyKitchen(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"itemprop": "name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return sum(

--- a/recipe_scrapers/theclevercarrot.py
+++ b/recipe_scrapers/theclevercarrot.py
@@ -12,6 +12,9 @@ class TheCleverCarrot(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    def author(self):
+        return self.schema.author().strip()
+
     def total_time(self):
         return self.schema.total_time()
 

--- a/recipe_scrapers/thekitchenmagpie.py
+++ b/recipe_scrapers/thekitchenmagpie.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class TheKitchenMagPie(AbstractScraper):
@@ -11,6 +11,10 @@ class TheKitchenMagPie(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/thekitchn.py
+++ b/recipe_scrapers/thekitchn.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class TheKitchn(AbstractScraper):
@@ -11,6 +11,10 @@ class TheKitchn(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/thenutritiouskitchen.py
+++ b/recipe_scrapers/thenutritiouskitchen.py
@@ -1,13 +1,17 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class TheNutritiousKitchen(AbstractScraper):
     @classmethod
     def host(cls):
         return "thenutritiouskitchen.co"
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def title(self):
         return self.schema.title()

--- a/recipe_scrapers/thespruceeats.py
+++ b/recipe_scrapers/thespruceeats.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -12,6 +12,10 @@ class TheSpruceEats(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "heading__title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/thevintagemixer.py
+++ b/recipe_scrapers/thevintagemixer.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -10,6 +12,10 @@ class TheVintageMixer(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2", {"class": "wprm-recipe-name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(

--- a/recipe_scrapers/thewoksoflife.py
+++ b/recipe_scrapers/thewoksoflife.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class Thewoksoflife(AbstractScraper):
@@ -11,6 +11,10 @@ class Thewoksoflife(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/tudogostoso.py
+++ b/recipe_scrapers/tudogostoso.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -12,6 +12,10 @@ class TudoGostoso(AbstractScraper):
 
     def title(self):
         return normalize_string(self.soup.find("h1").get_text())
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("time", {"class": "dt-duration"}))

--- a/recipe_scrapers/twopeasandtheirpod.py
+++ b/recipe_scrapers/twopeasandtheirpod.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class TwoPeasAndTheirPod(AbstractScraper):
 
     def title(self):
         return self.soup.find("h2", {"class": "wprm-recipe-name"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         minutes = self.soup.select_one(".wprm-recipe-total_time").get_text()

--- a/recipe_scrapers/usdamyplate.py
+++ b/recipe_scrapers/usdamyplate.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -12,6 +12,10 @@ class USDAMyPlate(AbstractScraper):
 
     def title(self):
         return self.soup.h1.get_text().strip()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         # not in every recipe has time given

--- a/recipe_scrapers/vanillaandbean.py
+++ b/recipe_scrapers/vanillaandbean.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class VanillaAndBean(AbstractScraper):
@@ -11,6 +11,10 @@ class VanillaAndBean(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/vegolosi.py
+++ b/recipe_scrapers/vegolosi.py
@@ -13,6 +13,9 @@ class Vegolosi(AbstractScraper):
     def title(self):
         return self.soup.find("h1").get_text().strip()
 
+    def author(self):
+        return self.schema.author().strip()
+
     def preparation_time(self):
         possible_time_info_elements = self.soup.findAll(
             "span", {"class": "tasty-recipes-prep-time"}

--- a/recipe_scrapers/watchwhatueat.py
+++ b/recipe_scrapers/watchwhatueat.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class WatchWhatUEat(AbstractScraper):
@@ -11,6 +11,10 @@ class WatchWhatUEat(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/whatsgabycooking.py
+++ b/recipe_scrapers/whatsgabycooking.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, normalize_string
 
 
@@ -12,6 +12,10 @@ class WhatsGabyCooking(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("p", {"class": "header-recipe-time"}))

--- a/recipe_scrapers/wholefoods.py
+++ b/recipe_scrapers/wholefoods.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class WholeFoods(AbstractScraper):
@@ -11,6 +11,10 @@ class WholeFoods(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/recipe_scrapers/wikicookbook.py
+++ b/recipe_scrapers/wikicookbook.py
@@ -1,5 +1,7 @@
-# mypy: disallow_untyped_defs=False
+# mypy: allow-untyped-defs
+
 from ._abstract import AbstractScraper
+from ._decorators import schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -10,6 +12,10 @@ class WikiCookbook(AbstractScraper):
 
     def title(self):
         return self.soup.find("h1").get_text().replace("Cookbook:", "")
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return get_minutes(self.soup.find("th", string="Time").find_next_sibling("td"))

--- a/recipe_scrapers/woop.py
+++ b/recipe_scrapers/woop.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -13,6 +13,10 @@ class Woop(AbstractScraper):
     def title(self):
         found = self.soup.find("meta", {"property": "og:title"})
         return normalize_string(found["content"])
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def ingredients(self):
         div = self.soup.findAll("div", {"class": "ingredients"})[0]

--- a/recipe_scrapers/yummly.py
+++ b/recipe_scrapers/yummly.py
@@ -14,6 +14,9 @@ class Yummly(AbstractScraper):
         found = self.soup.find("h1")
         return found.get_text() if found else None
 
+    def author(self):
+        return self.soup.find("a", {"class": "markdown-link"}).get_text()
+
     def total_time(self):
         data = self.soup.findAll("div", {"class": "recipe-summary-item"}, limit=2)
         return get_minutes(data[1]) if data else None

--- a/recipe_scrapers/zeitwochenmarkt.py
+++ b/recipe_scrapers/zeitwochenmarkt.py
@@ -24,6 +24,9 @@ class ZeitWochenmarkt(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    def author(self):
+        return self.soup.find("a", {"rel": "author"}).get_text().strip()
+
     def total_time(self):
         return self.schema.total_time()
 

--- a/recipe_scrapers/zenbelly.py
+++ b/recipe_scrapers/zenbelly.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
 from ._abstract import AbstractScraper
-from ._decorators import opengraph_fallback
+from ._decorators import opengraph_fallback, schemaorg_fallback
 
 
 class ZenBelly(AbstractScraper):
@@ -11,6 +11,10 @@ class ZenBelly(AbstractScraper):
 
     def title(self):
         return self.schema.title()
+
+    @schemaorg_fallback
+    def author(self):
+        pass
 
     def total_time(self):
         return self.schema.total_time()

--- a/tests/test_750g.py
+++ b/tests/test_750g.py
@@ -15,6 +15,9 @@ class TestG750gScraper(ScraperTest):
             "Salade de carottes cuites et crues à l'orange",
         )
 
+    def test_author(self):
+        self.assertEqual("750g La Table", self.harvester_class.author())
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_abril.py
+++ b/tests/test_abril.py
@@ -18,6 +18,9 @@ class TestAbrilScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Estrogonofe de carne")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "CLAUDIA")
+
     def test_image(self):
         self.assertEqual(
             "https://claudia.abril.com.br/wp-content/uploads/2020/02/receita-estrogonofe-de-carne.jpg?quality=85&strip=info&w=620&h=372&crop=1",

--- a/tests/test_acouplecooks.py
+++ b/tests/test_acouplecooks.py
@@ -22,6 +22,9 @@ class TestACoupleCooks(ScraperTest):
             "Garlic Butter Shrimp (Fast & Easy Dinner!)", self.harvester_class.title()
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Sonja Overhiser")
+
     def test_total_time(self):
         self.assertEqual(8, self.harvester_class.total_time())
 

--- a/tests/test_amazingribs.py
+++ b/tests/test_amazingribs.py
@@ -18,6 +18,9 @@ class TestAmazingRibsScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Texas Hot Guts Recipe", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Meathead Goldwyn")
+
     def test_total_time(self):
         self.assertEqual(165, self.harvester_class.total_time())
 

--- a/tests/test_averiecooks.py
+++ b/tests/test_averiecooks.py
@@ -20,6 +20,9 @@ class TestAverieCooksScraper(ScraperTest):
             self.harvester_class.title(), "Balsamic Watermelon and Cucumber Salad"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Averie Sunshine")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_bakingsense.py
+++ b/tests/test_bakingsense.py
@@ -20,6 +20,9 @@ class TestBakingSense(ScraperTest):
             self.harvester_class.title(), "Sourdough Bundt Cake with Buttermilk Glaze"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Eileen Gray")
+
     def test_total_time(self):
         self.assertEqual(60, self.harvester_class.total_time())
 

--- a/tests/test_bbcgoodfood.py
+++ b/tests/test_bbcgoodfood.py
@@ -18,6 +18,9 @@ class TestBBCGoodFoodScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Monster cupcakes")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Good Food team")
+
     def test_total_time(self):
         self.assertEqual(50, self.harvester_class.total_time())
 

--- a/tests/test_bettycrocker.py
+++ b/tests/test_bettycrocker.py
@@ -18,6 +18,9 @@ class TestBettyCrocker(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Éclair Bars")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Betty Crocker Kitchens")
+
     def test_total_time(self):
         self.assertEqual(290, self.harvester_class.total_time())
 

--- a/tests/test_bigoven.py
+++ b/tests/test_bigoven.py
@@ -18,6 +18,9 @@ class TestBigOven(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "No-Knead Herb Focaccia")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "BigOvenEditorial")
+
     def test_total_time(self):
         self.assertEqual(720, self.harvester_class.total_time())
 

--- a/tests/test_blueapron.py
+++ b/tests/test_blueapron.py
@@ -21,6 +21,9 @@ class TestBlueApronScraper(ScraperTest):
             self.harvester_class.title(),
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Blue Apron")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_bonappetit.py
+++ b/tests/test_bonappetit.py
@@ -20,6 +20,9 @@ class TestBonAppetitScraper(ScraperTest):
             self.harvester_class.title(), "Pork Chops with Celery and Almond Salad"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Adam Rapoport")
+
     def test_total_time(self):
         self.assertEqual(None, self.harvester_class.total_time())
 

--- a/tests/test_bowlofdelicious.py
+++ b/tests/test_bowlofdelicious.py
@@ -20,6 +20,9 @@ class TestBowlOfDeliciousScraper(ScraperTest):
             self.harvester_class.title(), "Six-Minute Seared Ahi Tuna Steaks"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Elizabeth Lindemann")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_budgetbytes.py
+++ b/tests/test_budgetbytes.py
@@ -20,6 +20,9 @@ class TestBudgetBytesScraper(ScraperTest):
             self.harvester_class.title(), "Creamy Coconut Curry Lentils with Spinach"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Beth - Budget Bytes")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_castironketo.py
+++ b/tests/test_castironketo.py
@@ -20,6 +20,9 @@ class TestCastIronKetoScraper(ScraperTest):
             self.harvester_class.title(), "Keto Jalapeño Popper Casserole with Chicken"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Cast Iron Keto")
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_cdkitchen.py
+++ b/tests/test_cdkitchen.py
@@ -18,6 +18,9 @@ class TestCdKitchen(ScraperTest):
     def test_title(self):
         self.assertEqual("Veal Steak Vesuvio", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "FAKelco")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_chefkoch.py
+++ b/tests/test_chefkoch.py
@@ -18,6 +18,9 @@ class TestChefkochScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Hackbraten supersaftig")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Delphinella")
+
     def test_description(self):
         self.assertEqual(
             self.harvester_class.description(),

--- a/tests/test_cookeatshare.py
+++ b/tests/test_cookeatshare.py
@@ -12,6 +12,9 @@ class TestCookEatShare(ScraperTest):
     def test_title(self):
         self.assertEqual("Pork Steak Vegetable Bake", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "CookEatShare Cookbook")
+
     def test_image(self):
         self.assertEqual(
             "https://assets.cookeatshare.com/assets/recipe-art/stock/3/full-f1e2882559f1146065432f8bdd182440.png",

--- a/tests/test_cookieandkate.py
+++ b/tests/test_cookieandkate.py
@@ -20,6 +20,9 @@ class TestCookieAndKateScraper(ScraperTest):
             self.harvester_class.title(), "Broccoli, Cheddar & Spinach Frittata"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Cookie and Kate")
+
     def test_total_time(self):
         self.assertEqual(40, self.harvester_class.total_time())
 

--- a/tests/test_cookinglight.py
+++ b/tests/test_cookinglight.py
@@ -26,6 +26,9 @@ class TestCookingLight(ScraperTest):
             self.harvester_class.title(), "Avocado, Black Bean, and Charred Tomato Bowl"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Cooking Light")
+
     def test_total_time(self):
         self.assertEqual(10, self.harvester_class.total_time())
 

--- a/tests/test_cookpad.py
+++ b/tests/test_cookpad.py
@@ -17,6 +17,9 @@ class TestCookPadScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "30分で簡単本格バターチキンカレー")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "reoririna")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_copykat.py
+++ b/tests/test_copykat.py
@@ -18,6 +18,9 @@ class TestCopyKat(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Make Tender Beef Tips in Gravy")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Stephanie Manley")
+
     def test_total_time(self):
         self.assertEqual(40, self.harvester_class.total_time())
 

--- a/tests/test_countryliving.py
+++ b/tests/test_countryliving.py
@@ -20,6 +20,9 @@ class TestCountryLivingScraper(ScraperTest):
             self.harvester_class.title(), "Roasted Mushroom and Bacon Dutch Baby"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Erika Dugan")
+
     def test_total_time(self):
         self.assertEqual(70, self.harvester_class.total_time())
 

--- a/tests/test_cuisineaz.py
+++ b/tests/test_cuisineaz.py
@@ -18,6 +18,9 @@ class CuisineAZScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Filet de saumon au four")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "CuisineAZ.com")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_cybercook.py
+++ b/tests/test_cybercook.py
@@ -18,6 +18,9 @@ class TestCybercook(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Strogonoff de Frango")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Leticia Obo Andreghetti")
+
     def test_total_time(self):
         self.assertEqual(30, self.harvester_class.total_time())
 

--- a/tests/test_delish.py
+++ b/tests/test_delish.py
@@ -18,6 +18,9 @@ class TestDelishScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Pumpkin Cheesecake Roll")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Lena Abraham")
+
     def test_total_time(self):
         self.assertEqual(self.harvester_class.total_time(), 60)
 

--- a/tests/test_ditchthecarbs.py
+++ b/tests/test_ditchthecarbs.py
@@ -18,6 +18,9 @@ class TestDitchTheCarbs(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Keto Hamburger Buns")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Libby Jenkinson")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_domesticateme.py
+++ b/tests/test_domesticateme.py
@@ -20,6 +20,9 @@ class TestDomesticateMeScraper(ScraperTest):
             self.harvester_class.title(), "The Dude Diet: Buffalo Chicken Quinoa Bake"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Serena Wolf")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -12,6 +12,9 @@ class TestDrMeScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Millionaires’ Shortbread", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Brdr. Price")
+
     def test_total_time(self):
         self.assertEqual(120, self.harvester_class.total_time())
 

--- a/tests/test_eatingwell.py
+++ b/tests/test_eatingwell.py
@@ -13,6 +13,9 @@ class TestEatingWell(ScraperTest):
             self.harvester_class.title(), "Cheesy Ground Beef & Cauliflower Casserole"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Carolyn Casner")
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_eatsmarter.py
+++ b/tests/test_eatsmarter.py
@@ -2,7 +2,7 @@ from recipe_scrapers.eatsmarter import Eatsmarter
 from tests import ScraperTest
 
 
-class TestClosetCooking(ScraperTest):
+class TestEatSmarter(ScraperTest):
 
     scraper_class = Eatsmarter
 
@@ -19,6 +19,9 @@ class TestClosetCooking(ScraperTest):
         self.assertEqual(
             self.harvester_class.title(), "Citrus Avocado Salad with Almonds"
         )
+
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "EAT SMARTER")
 
     def test_total_time(self):
         self.assertEqual(20, self.harvester_class.total_time())

--- a/tests/test_epicurious.py
+++ b/tests/test_epicurious.py
@@ -21,6 +21,9 @@ class TestEpicurious(ScraperTest):
             "Ramen Noodle Bowl with Escarole and Spicy Tofu Crumbles",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Claire Saffitz")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_fifteenspatulas.py
+++ b/tests/test_fifteenspatulas.py
@@ -18,6 +18,9 @@ class TestFifteenSpatulasScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Orange Creme Brulee")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Joanne Ozug")
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_finedininglovers_1.py
+++ b/tests/test_finedininglovers_1.py
@@ -22,6 +22,9 @@ class TestFineDiningLoversScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Zucchini Raw Vegan Lasagna")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Uno Cookbook,")
+
     def test_total_time(self):
         self.assertEqual(50, self.harvester_class.total_time())
 

--- a/tests/test_fitmencook.py
+++ b/tests/test_fitmencook.py
@@ -21,6 +21,9 @@ class TestFitMenCookScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Lean Chili with Plantains", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "FitMenCook")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_food.py
+++ b/tests/test_food.py
@@ -21,6 +21,9 @@ class TestFoodScraper(ScraperTest):
             "Chicken Noodle Soup With Carrots, Parsnips and Dill",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "JackieOhNo")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_food52.py
+++ b/tests/test_food52.py
@@ -21,6 +21,9 @@ class TestFood52(ScraperTest):
             "Sticky Pomegranate & Black Pepper Chicken Wings",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Sohla El-Waylly")
+
     def test_total_time(self):
         self.assertEqual(1520, self.harvester_class.total_time())
 

--- a/tests/test_foodandwine.py
+++ b/tests/test_foodandwine.py
@@ -18,6 +18,9 @@ class TestFoodAndWineScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Kwame’s Pepper Shrimp", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Kwame Onwuachi")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_geniuskitchen.py
+++ b/tests/test_geniuskitchen.py
@@ -18,6 +18,9 @@ class TestGeniusKitchenScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Quiche Lorraine Cups")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Bergy")
+
     def test_total_time(self):
         self.assertEqual(40, self.harvester_class.total_time())
 

--- a/tests/test_giallozafferano.py
+++ b/tests/test_giallozafferano.py
@@ -18,6 +18,9 @@ class TestGialloZafferanoScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Bavarese alle fragole")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "GialloZafferano")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_gimmesomeoven.py
+++ b/tests/test_gimmesomeoven.py
@@ -18,6 +18,9 @@ class TestGimmeSomeOvenScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Sangria")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Ali")
+
     def test_total_time(self):
         self.assertEqual(10, self.harvester_class.total_time())
 

--- a/tests/test_globo.py
+++ b/tests/test_globo.py
@@ -18,6 +18,9 @@ class TestGloboScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Strogonoff de Frango Simples", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Alm3")
+
     def test_yields(self):
         self.assertEqual("8 servings", self.harvester_class.yields())
 

--- a/tests/test_gonnawantseconds.py
+++ b/tests/test_gonnawantseconds.py
@@ -21,6 +21,9 @@ class TestGonnaWantSeconds(ScraperTest):
             "Sour Cream Chicken Enchiladas (30-Min. Meal!)",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Kathleen")
+
     def test_total_time(self):
         self.assertEqual("30", self.harvester_class.total_time())
 

--- a/tests/test_gousto.py
+++ b/tests/test_gousto.py
@@ -18,6 +18,9 @@ class TestGoustoScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Creamy Pork Tagliatelle")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Gousto")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_greatbritishchefs_1.py
+++ b/tests/test_greatbritishchefs_1.py
@@ -22,6 +22,9 @@ class TestGreatBritishChefsScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Picadillo")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Great British Chefs")
+
     def test_total_time(self):
         self.assertEqual(50, self.harvester_class.total_time())
 

--- a/tests/test_greatbritishchefs_2.py
+++ b/tests/test_greatbritishchefs_2.py
@@ -22,6 +22,9 @@ class TestGreatBritishChefsScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Beef and mushroom lasagne")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Great British Chefs")
+
     def test_total_time(self):
         self.assertEqual(135, self.harvester_class.total_time())
 

--- a/tests/test_halfbakedharvest.py
+++ b/tests/test_halfbakedharvest.py
@@ -21,6 +21,9 @@ class TestHalfBakedHarvestScraper(ScraperTest):
             "Brown Butter Corn and Feta Orzo with Crispy Prosciutto",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "halfbakedharvest")
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_hassanchef.py
+++ b/tests/test_hassanchef.py
@@ -1,10 +1,10 @@
-from recipe_scrapers.hassenchef import Hassanchef
+from recipe_scrapers.hassanchef import HassanChef
 from tests import ScraperTest
 
 
-class TestClosetCooking(ScraperTest):
+class TestHassanChef(ScraperTest):
 
-    scraper_class = Hassanchef
+    scraper_class = HassanChef
 
     def test_host(self):
         self.assertEqual("hassanchef.com", self.harvester_class.host())
@@ -17,6 +17,9 @@ class TestClosetCooking(ScraperTest):
 
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Chicken lollipop recipe")
+
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Mobasir Hassan")
 
     def test_total_time(self):
         self.assertEqual(30, self.harvester_class.total_time())

--- a/tests/test_heb.py
+++ b/tests/test_heb.py
@@ -18,6 +18,9 @@ class TestHEBScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Truffled Spaghetti Squash", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "H-E-B")
+
     def test_total_time(self):
         self.assertEqual(60, self.harvester_class.total_time())
 

--- a/tests/test_heinzbrasil.py
+++ b/tests/test_heinzbrasil.py
@@ -18,6 +18,9 @@ class TestHeinzBrasilScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Chili com carne")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Kraft Heinz")
+
     def test_image(self):
         self.assertEqual(
             "//d36rz30b5p7lsd.cloudfront.net/heinzbrasilbr/recipes/img/1e1fccb2d38d8b3e3611aa5c99706523.jpeg",

--- a/tests/test_hellofresh.py
+++ b/tests/test_hellofresh.py
@@ -23,6 +23,9 @@ class TestHelloFreshScraper(ScraperTest):
             "Thai Style Pork Stir-Fry with Veggie Rice", self.harvester_class.title()
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "HelloFresh")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_hellofresh_adhoc.py
+++ b/tests/test_hellofresh_adhoc.py
@@ -19,6 +19,9 @@ class TestHelloFreshScraperAdHoc(ScraperTest):
             self.harvester_class.title(),
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "HelloFresh")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_hostthetoast.py
+++ b/tests/test_hostthetoast.py
@@ -18,6 +18,9 @@ class TestHostthetoastScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Homemade Garlic Naan")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Morgan")
+
     def test_yields(self):
         self.assertEqual("12 servings", self.harvester_class.yields())
 

--- a/tests/test_hundredandonecookbooks.py
+++ b/tests/test_hundredandonecookbooks.py
@@ -18,6 +18,9 @@ class TestHundredAndOneCookbooksScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Blood Orange Gin Sparkler")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Heidi Swanson")
+
     def test_total_time(self):
         self.assertEqual(15, self.harvester_class.total_time())
 

--- a/tests/test_ig.py
+++ b/tests/test_ig.py
@@ -18,6 +18,9 @@ class TestIGScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Estrogonofe de cogumelos")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Fabiana Badra")
+
     def test_total_time(self):
         self.assertEqual(30, self.harvester_class.total_time())
 

--- a/tests/test_innit.py
+++ b/tests/test_innit.py
@@ -15,6 +15,9 @@ class TestInnitScraper(ScraperTest):
             self.harvester_class.title(),
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Innit Inc")
+
     def test_total_time(self):
         self.assertEqual(51, self.harvester_class.total_time())
 

--- a/tests/test_inspiralized.py
+++ b/tests/test_inspiralized.py
@@ -24,6 +24,9 @@ class TestInspiralizedScraper(ScraperTest):
             "Brussels Sprouts and Apple Salad with Parmesan",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Ali Maffucci")
+
     def test_total_time(self):
         self.assertEqual(15, self.harvester_class.total_time())
 

--- a/tests/test_jamieoliver.py
+++ b/tests/test_jamieoliver.py
@@ -18,6 +18,9 @@ class TestJamieOliverScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Bloomin' brilliant brownies")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Jamie Oliver")
+
     def test_total_time(self):
         self.assertEqual(40, self.harvester_class.total_time())
 

--- a/tests/test_justataste.py
+++ b/tests/test_justataste.py
@@ -14,6 +14,9 @@ class TestJustATasteScraper(ScraperTest):
             self.harvester_class.title(), "Baked Chicken and Cheese Taquitos"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Kelly Senyei")
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_kennymcgovern.py
+++ b/tests/test_kennymcgovern.py
@@ -18,6 +18,9 @@ class TestKennyMcGovernScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Crispy Chicken Strips")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Kenny McGovern")
+
     def test_image(self):
         self.assertEqual(
             self.harvester_class.image(),

--- a/tests/test_kingarthur.py
+++ b/tests/test_kingarthur.py
@@ -18,6 +18,9 @@ class TestKingArthurScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Spiced Rye Ginger Cookies")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "King Arthur Flour")
+
     def test_yields(self):
         self.assertEqual("22 items", self.harvester_class.yields())
 
@@ -75,6 +78,9 @@ class TestKingArthurScraperBeautifulBuns(ScraperTest):
 
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Beautiful Burger Buns")
+
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "King Arthur Flour")
 
     def test_yields(self):
         self.assertEqual("8 items", self.harvester_class.yields())

--- a/tests/test_kochbar.py
+++ b/tests/test_kochbar.py
@@ -21,6 +21,9 @@ class TestKochbarScraper(ScraperTest):
             "Ligurisches Hühnerragout mit Zucchini – Spezzatino con zucchine",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Antareja")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_kuchniadomowa.py
+++ b/tests/test_kuchniadomowa.py
@@ -18,6 +18,9 @@ class TestKuchniaDomowaScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Mizeria", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Kuchnia Domowa")
+
     def test_total_time(self):
         self.assertEqual(30, self.harvester_class.total_time())
 

--- a/tests/test_lecremedelacrumb.py
+++ b/tests/test_lecremedelacrumb.py
@@ -20,6 +20,9 @@ class TestLeCremeDeLaCrumbScraper(ScraperTest):
             self.harvester_class.title(), "Instant Pot Shredded Chicken Tacos"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Tiffany")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_livelytable.py
+++ b/tests/test_livelytable.py
@@ -18,6 +18,9 @@ class TestLivelyTableScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Easy Chipotle Shrimp Tacos")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Kaleigh")
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_lovingitvegan.py
+++ b/tests/test_lovingitvegan.py
@@ -18,6 +18,9 @@ class TestLovingitveganScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Kale Smoothie")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Alison Andrews")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_marmiton.py
+++ b/tests/test_marmiton.py
@@ -18,6 +18,9 @@ class TestMarmitonScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Ratatouille")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Mirabelle")
+
     def test_total_time(self):
         self.assertEqual(80, self.harvester_class.total_time())
 

--- a/tests/test_marthastewart.py
+++ b/tests/test_marthastewart.py
@@ -18,6 +18,9 @@ class TestMarthaStewart(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Breaded Chicken Breasts")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Martha Stewart")
+
     def test_total_time(self):
         self.assertEqual(25, self.harvester_class.total_time())
 

--- a/tests/test_matprat.py
+++ b/tests/test_matprat.py
@@ -20,6 +20,9 @@ class TestMatprat(ScraperTest):
             self.harvester_class.title(), "Butter chicken - indisk smørkylling"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "MatPrat")
+
     def test_total_time(self):
         self.assertEqual(60, self.harvester_class.total_time())
 

--- a/tests/test_melskitchencafe.py
+++ b/tests/test_melskitchencafe.py
@@ -18,6 +18,9 @@ class TestMelsKitchenCafeScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Licorice Caramels")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Mel")
+
     def test_yields(self):
         self.assertEqual("8 servings", self.harvester_class.yields())
 

--- a/tests/test_mindmegette.py
+++ b/tests/test_mindmegette.py
@@ -23,6 +23,9 @@ class TestMindmegetteScraper(ScraperTest):
             self.harvester_class.title(), "Tepsis krumpli céklával és répával"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "MME")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_minimalistbaker.py
+++ b/tests/test_minimalistbaker.py
@@ -21,6 +21,9 @@ class TestMinimalistbakerScraper(ScraperTest):
             "Cashew Ricotta Cheese (Soy-Free, Fast, Easy!)",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Minimalist Baker")
+
     def test_yields(self):
         self.assertEqual("8 servings", self.harvester_class.yields())
 

--- a/tests/test_misya.py
+++ b/tests/test_misya.py
@@ -18,6 +18,9 @@ class TestMisya(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Tortino cuore caldo")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Flavia Imperatore")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_momswithcrockpots.py
+++ b/tests/test_momswithcrockpots.py
@@ -18,6 +18,9 @@ class TestMomsWithCrockPotsScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Crockpot Macaroni & Cheese")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Karen McCormick")
+
     def test_total_time(self):
         self.assertEqual(225, self.harvester_class.total_time())
 

--- a/tests/test_motherthyme.py
+++ b/tests/test_motherthyme.py
@@ -18,6 +18,9 @@ class TestMotherThymeScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Cinnamon Roll Oatmeal")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Jenn (Mother Thyme)")
+
     def test_total_time(self):
         self.assertEqual(30, self.harvester_class.total_time())
 

--- a/tests/test_mybakingaddiction.py
+++ b/tests/test_mybakingaddiction.py
@@ -26,6 +26,9 @@ class TestMyBakingAddictionScraper(ScraperTest):
             self.harvester_class.title(), "Chocolate Coconut Zucchini Bread"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Jamie")
+
     def test_ratings(self):
         self.assertEqual(self.harvester_class.ratings(), 4.4)
 

--- a/tests/test_myrecipes.py
+++ b/tests/test_myrecipes.py
@@ -24,6 +24,9 @@ class TestMyRecipesScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Cacio e Pepe")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Adam Dolge")
+
     def test_total_time(self):
         self.assertEqual(20, self.harvester_class.total_time())
 

--- a/tests/test_nourishedbynutrition.py
+++ b/tests/test_nourishedbynutrition.py
@@ -18,6 +18,9 @@ class TestNourishedByNutritionScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Salsa Verde Chicken Enchiladas")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Jessica Bippen")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_nytimes.py
+++ b/tests/test_nytimes.py
@@ -24,6 +24,9 @@ class TestNYTimesScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Cacio e Pepe Crackers")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Laurie Ellen Pellicano")
+
     def test_ratings(self):
         self.assertEqual(self.harvester_class.ratings(), 4.0)
 

--- a/tests/test_ohsheglows.py
+++ b/tests/test_ohsheglows.py
@@ -27,6 +27,9 @@ class TestOhSheGlowsScraper(ScraperTest):
             "Obsession-Worthy Peanut Butter Cookie Ice Cream",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Angela Liddon")
+
     def test_ratings(self):
         self.assertEqual(self.harvester_class.ratings(), 4.67)
 

--- a/tests/test_panelinha_1.py
+++ b/tests/test_panelinha_1.py
@@ -16,6 +16,9 @@ class TestPanelinhaScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Rosbife")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Panelinha")
+
     def test_total_time(self):
         self.assertEqual(60, self.harvester_class.total_time())
 

--- a/tests/test_panelinha_2.py
+++ b/tests/test_panelinha_2.py
@@ -15,6 +15,9 @@ class TestPanelinhaScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Arroz sírio com frango", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Panelinha")
+
     def test_total_time(self):
         self.assertEqual(0, self.harvester_class.total_time())
 

--- a/tests/test_practicalselfreliance.py
+++ b/tests/test_practicalselfreliance.py
@@ -18,6 +18,9 @@ class TestPracticalSelfRelianceScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Zucchini Relish")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Ashley Adamant")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_primaledgehealth.py
+++ b/tests/test_primaledgehealth.py
@@ -20,6 +20,9 @@ class TestPrimalEdgeHealthScraper(ScraperTest):
             self.harvester_class.title(), "No Bake Custard (Keto & Carnivore-Friendly)"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Jessica Haggard")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_przepisy.py
+++ b/tests/test_przepisy.py
@@ -24,6 +24,9 @@ class TestPrzepisyScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Placki ziemniaczane", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "przepisy.pl")
+
     def test_total_time(self):
         self.assertEqual(40, self.harvester_class.total_time())
 

--- a/tests/test_purplecarrot.py
+++ b/tests/test_purplecarrot.py
@@ -21,6 +21,9 @@ class TestPurpleCarrotScraper(ScraperTest):
             self.harvester_class.title(),
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Purple Carrot")
+
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())
 

--- a/tests/test_realsimple.py
+++ b/tests/test_realsimple.py
@@ -18,6 +18,9 @@ class TestRealSimpleScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Vanilla Cheesecake")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Frank Mentasana")
+
     def test_total_time(self):
         self.assertEqual(540, self.harvester_class.total_time())
 

--- a/tests/test_recipetineats.py
+++ b/tests/test_recipetineats.py
@@ -18,6 +18,9 @@ class TestRecipeTinEatsScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Vietnamese Caramel Pork")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Nagi")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_sallysbakingaddiction.py
+++ b/tests/test_sallysbakingaddiction.py
@@ -20,6 +20,9 @@ class TestSallysBakingAddictionScraper(ScraperTest):
             self.harvester_class.title(), "Rosemary Garlic Pull Apart Bread"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Sally")
+
     def test_yields(self):
         self.assertEqual("1 serving", self.harvester_class.yields())
 

--- a/tests/test_simplyquinoa.py
+++ b/tests/test_simplyquinoa.py
@@ -18,6 +18,9 @@ class TestSimplyQuinoaScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "The Best Quinoa Flour Pancakes")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Alyssa")
+
     def test_total_time(self):
         self.assertEqual(20, self.harvester_class.total_time())
 

--- a/tests/test_simplyrecipes.py
+++ b/tests/test_simplyrecipes.py
@@ -18,6 +18,9 @@ class TestSimplyRecipesScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "One-Pot Chicken and Rice Soup")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Aaron Hutcherson")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_simplywhisked.py
+++ b/tests/test_simplywhisked.py
@@ -18,6 +18,9 @@ class TestSimplyWhiskedScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Buffalo Chicken Chili")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Melissa Belanger")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_skinnytaste.py
+++ b/tests/test_skinnytaste.py
@@ -21,6 +21,9 @@ class TestSkinnyTasteScraper(ScraperTest):
             "Grilled Chicken with Spinach and Melted Mozzarella",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Gina")
+
     def test_yields(self):
         self.assertEqual("6 servings", self.harvester_class.yields())
 

--- a/tests/test_southernliving.py
+++ b/tests/test_southernliving.py
@@ -20,6 +20,9 @@ class TestSouthernLiving(ScraperTest):
             self.harvester_class.title(), "Spicy Sausage-and-Cheddar Kolaches Recipe"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Paige Grandjean")
+
     def test_total_time(self):
         self.assertEqual(180, self.harvester_class.total_time())
 

--- a/tests/test_spendwithpennies.py
+++ b/tests/test_spendwithpennies.py
@@ -18,6 +18,9 @@ class TestSpendWithPenniesScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Chocolate Pudding Cake")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Holly Nilsson")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_sunbasket.py
+++ b/tests/test_sunbasket.py
@@ -18,6 +18,9 @@ class TestSunBasketScraper(ScraperTest):
             self.harvester_class.title(),
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Sun Basket")
+
     def test_total_time(self):
         self.assertEqual(15, self.harvester_class.total_time())
 

--- a/tests/test_sweetcsdesigns.py
+++ b/tests/test_sweetcsdesigns.py
@@ -20,6 +20,9 @@ class SweetCsDesignsScraper(ScraperTest):
             self.harvester_class.title(), "The Best Easy Air Fryer French Fries Recipe"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Courtney O'Dell")
+
     def test_total_time(self):
         self.assertEqual(65, self.harvester_class.total_time())
 

--- a/tests/test_tastesbetterfromscratch.py
+++ b/tests/test_tastesbetterfromscratch.py
@@ -18,6 +18,9 @@ class TestTastesBetterFromScratch(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "How to make Pulled Pork")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Lauren Allen")
+
     def test_total_time(self):
         self.assertEqual(320, self.harvester_class.total_time())
 

--- a/tests/test_tastesoflizzyt.py
+++ b/tests/test_tastesoflizzyt.py
@@ -18,6 +18,9 @@ class TestTastesOfLizzyTScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Soft Gingerbread Cookies")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Lizzy T")
+
     def test_total_time(self):
         self.assertEqual(27, self.harvester_class.total_time())
 

--- a/tests/test_tasty.py
+++ b/tests/test_tasty.py
@@ -21,6 +21,9 @@ class TestTastyScraper(ScraperTest):
             "Red Wine-Braised Short Ribs With Cashew Cauliflower Mash Recipe by Tasty",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Crystal Hatch")
+
     def test_yields(self):
         self.assertEqual("4 servings", self.harvester_class.yields())
 

--- a/tests/test_tastykitchen.py
+++ b/tests/test_tastykitchen.py
@@ -18,6 +18,9 @@ class TestTastyKitchenScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Restaurant Style Salsa")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Ree | The Pioneer Woman")
+
     def test_total_time(self):
         self.assertEqual(10, self.harvester_class.total_time())
 

--- a/tests/test_theclevercarrot.py
+++ b/tests/test_theclevercarrot.py
@@ -18,6 +18,9 @@ class TestTheCleverCarrotScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Soft Sourdough Cinnamon Rolls")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Emilie Raffa")
+
     def test_yields(self):
         self.assertEqual("8 servings", self.harvester_class.yields())
 

--- a/tests/test_thekitchenmagpie.py
+++ b/tests/test_thekitchenmagpie.py
@@ -17,6 +17,9 @@ class TestTheKitchenMagPie(ScraperTest):
     def test_title(self):
         self.assertEqual("Salmon Loaf", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Karlynn Johnston")
+
     def test_total_time(self):
         self.assertEqual(70, self.harvester_class.total_time())
 

--- a/tests/test_thekitchn.py
+++ b/tests/test_thekitchn.py
@@ -18,6 +18,9 @@ class TestKitchnScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Beef & Cheese Manicotti")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Meghan Splawn")
+
     def test_total_time(self):
         self.assertEqual(65, self.harvester_class.total_time())
 

--- a/tests/test_thevintagemixer.py
+++ b/tests/test_thevintagemixer.py
@@ -21,6 +21,9 @@ class TestTheVintageMixerScraper(ScraperTest):
             "Gluten Free and Sugar Free Cherry Baby Smash Cake",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Becky")
+
     def test_total_time(self):
         self.assertEqual(35, self.harvester_class.total_time())
 

--- a/tests/test_thewoksoflife.py
+++ b/tests/test_thewoksoflife.py
@@ -20,6 +20,9 @@ class TestThewoksoflifeScraper(ScraperTest):
             self.harvester_class.title(), "The Perfect Whole Wheat Mantou Recipe"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Judy")
+
     def test_yields(self):
         self.assertEqual("12 servings", self.harvester_class.yields())
 

--- a/tests/test_tudogostoso.py
+++ b/tests/test_tudogostoso.py
@@ -18,6 +18,9 @@ class TestTudoGostosoScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Caipirinha - Original")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Daniela Belizario")
+
     def test_total_time(self):
         self.assertEqual(5, self.harvester_class.total_time())
 

--- a/tests/test_twopeasandtheirpod.py
+++ b/tests/test_twopeasandtheirpod.py
@@ -18,6 +18,9 @@ class TestTwoPeasAndTheirPodScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Baked Chicken Taquitos")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Maria Lichty")
+
     def test_total_time(self):
         # as it is written '12-15 minutes in our test case'
         self.assertEqual(40, self.harvester_class.total_time())

--- a/tests/test_vanillaandbean.py
+++ b/tests/test_vanillaandbean.py
@@ -20,6 +20,9 @@ class TestVanillaAndBeanScraper(ScraperTest):
             self.harvester_class.title(), "Maple Oat Sourdough Sandwich Bread"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Traci York | Vanilla And Bean")
+
     def test_yields(self):
         self.assertEqual("1 serving", self.harvester_class.yields())
 

--- a/tests/test_vegolosi.py
+++ b/tests/test_vegolosi.py
@@ -21,6 +21,9 @@ class TestVegolosiScraper(ScraperTest):
             "Polpette di tofu e piselli con salsa allo zafferano",
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Vegolosi.it")
+
     def test_total_time(self):
         self.assertEqual(30, self.harvester_class.total_time())
 

--- a/tests/test_watchwhatueat.py
+++ b/tests/test_watchwhatueat.py
@@ -21,6 +21,11 @@ class TestWatchWhatUEatScraper(ScraperTest):
             "Garlic And Herb Instant Pot Cauliflower With Delicious Gravy",
         )
 
+    def test_author(self):
+        self.assertEqual(
+            self.harvester_class.author(), "Swati Kadam Gulati | Watch What U Eat"
+        )
+
     def test_yields(self):
         self.assertEqual("5 servings", self.harvester_class.yields())
 

--- a/tests/test_whatsgabycooking.py
+++ b/tests/test_whatsgabycooking.py
@@ -18,6 +18,9 @@ class TestWhatsGabyCookingScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Vegetarian Quinoa Bake")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Gaby Dalkin")
+
     def test_total_time(self):
         self.assertEqual(45, self.harvester_class.total_time())
 

--- a/tests/test_yummly.py
+++ b/tests/test_yummly.py
@@ -20,6 +20,9 @@ class TestYummlyScraper(ScraperTest):
             self.harvester_class.title(), "Easy White Cheese & Garlic Pizzas"
         )
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Sara Mellas")
+
     def test_total_time(self):
         self.assertEqual(25, self.harvester_class.total_time())
 

--- a/tests/test_zeitwochenmarkt.py
+++ b/tests/test_zeitwochenmarkt.py
@@ -15,6 +15,9 @@ class TestZeitWochenmarktScraper(ScraperTest):
     def test_title(self):
         self.assertEqual("Kohlrabi-Fenchel-Carpaccio", self.harvester_class.title())
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Angelika Schwaff")
+
     def test_total_time(self):
         self.assertEqual(30, self.harvester_class.total_time())
 

--- a/tests/test_zenbelly.py
+++ b/tests/test_zenbelly.py
@@ -18,6 +18,9 @@ class TestZenBellyScraper(ScraperTest):
     def test_title(self):
         self.assertEqual(self.harvester_class.title(), "Paleo Gingerbread")
 
+    def test_author(self):
+        self.assertEqual(self.harvester_class.author(), "Simone Miller")
+
     def test_yields(self):
         self.assertEqual("20 servings", self.harvester_class.yields())
 


### PR DESCRIPTION
Similar to #665, but this time for `schema.org` metadata fields instead of the `opengraph` image field.

Also updates `author` attribution throughout most of the scrapers.