### PR TITLE
Unit tests: move scraper construction from setUp (per-method) to setUpClass (per-case)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,22 +11,23 @@ class ScraperTest(unittest.TestCase):
     test_file_extension = "testhtml"
     scraper_class: Any
 
-    @property
-    def expected_requests(self) -> Iterator[Tuple[str, str, str]]:
+    @classmethod
+    def expected_requests(cls) -> Iterator[Tuple[str, str, str]]:
         """
         Descriptions of the expected requests that the scraper-under-test will make, as
         tuples of: HTTP method, URL, path-to-content-file
         """
-        filename = self.test_file_name or self.scraper_class.__name__.lower()
-        path = f"tests/test_data/{filename}.{self.test_file_extension}"
+        filename = cls.test_file_name or cls.scraper_class.__name__.lower()
+        path = f"tests/test_data/{filename}.{cls.test_file_extension}"
         yield responses.GET, "https://test.example.com", path
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         with responses.RequestsMock() as rsps:
             start_url = None
-            for method, url, path in self.expected_requests:
+            for method, url, path in cls.expected_requests():
                 start_url = start_url or url
                 with open(path, encoding="utf-8") as f:
                     rsps.add(method, url, body=f.read())
 
-            self.harvester_class = self.scraper_class(url=start_url)
+            cls.harvester_class = cls.scraper_class(url=start_url)

--- a/tests/test_farmhousedelivery_1.py
+++ b/tests/test_farmhousedelivery_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestFarmhouseDeliveryScraper(ScraperTest):
 
     scraper_class = FarmhouseDelivery
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "farmhousedelivery_1"
 
     def test_host(self):
         self.assertEqual("recipes.farmhousedelivery.com", self.harvester_class.host())

--- a/tests/test_farmhousedelivery_2.py
+++ b/tests/test_farmhousedelivery_2.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestFarmhouseDeliveryScraper(ScraperTest):
 
     scraper_class = FarmhouseDelivery
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "farmhousedelivery_2"
 
     def test_host(self):
         self.assertEqual("recipes.farmhousedelivery.com", self.harvester_class.host())

--- a/tests/test_finedininglovers_1.py
+++ b/tests/test_finedininglovers_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestFineDiningLoversScraper(ScraperTest):
 
     scraper_class = FineDiningLovers
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "finedininglovers_1"
 
     def test_host(self):
         self.assertEqual("finedininglovers.com", self.harvester_class.host())

--- a/tests/test_finedininglovers_2.py
+++ b/tests/test_finedininglovers_2.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestFineDiningLoversScraper(ScraperTest):
 
     scraper_class = FineDiningLovers
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "finedininglovers_2"
 
     def test_host(self):
         self.assertEqual("finedininglovers.com", self.harvester_class.host())

--- a/tests/test_foodnetwork.py
+++ b/tests/test_foodnetwork.py
@@ -8,8 +8,8 @@ class TestFoodNetworkScraper(ScraperTest):
 
     scraper_class = FoodNetwork
 
-    @property
-    def expected_requests(self):
+    @classmethod
+    def expected_requests(cls):
         yield GET, "https://www.foodnetwork.com/recipes/tyler-florence/chicken-marsala-recipe-1951778", "tests/test_data/foodnetwork.testhtml"
 
     def test_host(self):

--- a/tests/test_gousto.py
+++ b/tests/test_gousto.py
@@ -8,8 +8,8 @@ class TestGoustoScraper(ScraperTest):
 
     scraper_class = Gousto
 
-    @property
-    def expected_requests(self):
+    @classmethod
+    def expected_requests(cls):
         yield GET, "https://gousto.co.uk/cookbook/creamy-pork-tagliatelle", "tests/test_data/gousto.testhtml"
 
     def test_host(self):

--- a/tests/test_goustojson.py
+++ b/tests/test_goustojson.py
@@ -8,8 +8,8 @@ class TestGoustoScraper(ScraperTest):
 
     scraper_class = GoustoJson
 
-    @property
-    def expected_requests(self):
+    @classmethod
+    def expected_requests(cls):
         yield GET, "https://www.gousto.co.uk/cookbook/recipes/malaysian-style-coconut-meat-free-chicken-pickled-cucumber", "tests/test_data/gousto.testjson"
         yield GET, "https://production-api.gousto.co.uk/cmsreadbroker/v1/recipe/malaysian-style-coconut-meat-free-chicken-pickled-cucumber", "tests/test_data/gousto.testjson"
 

--- a/tests/test_greatbritishchefs_1.py
+++ b/tests/test_greatbritishchefs_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestGreatBritishChefsScraper(ScraperTest):
 
     scraper_class = GreatBritishChefs
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "greatbritishchefs_1"
 
     def test_host(self):
         self.assertEqual("greatbritishchefs.com", self.harvester_class.host())

--- a/tests/test_greatbritishchefs_2.py
+++ b/tests/test_greatbritishchefs_2.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestGreatBritishChefsScraper(ScraperTest):
 
     scraper_class = GreatBritishChefs
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "greatbritishchefs_2"
 
     def test_host(self):
         self.assertEqual("greatbritishchefs.com", self.harvester_class.host())

--- a/tests/test_kptncook.py
+++ b/tests/test_kptncook.py
@@ -8,8 +8,8 @@ class TestKptnCookScraper(ScraperTest):
 
     scraper_class = KptnCook
 
-    @property
-    def expected_requests(self):
+    @classmethod
+    def expected_requests(cls):
         yield responses.GET, "https://mobile.kptncook.com/recipe/pinterest/Low-Carb-Tarte-Flamb%C3%A9e-with-Serrano-Ham-%26-Cream-Cheese/315c3c32?lang=en", "tests/test_data/kptncook.testhtml"
         yield responses.POST, "https://mobile.kptncook.com/recipes/search?kptnkey=6q7QNKy-oIgk-IMuWisJ-jfN7s6&lang=en", "tests/test_data/kptncook.testjson"
 

--- a/tests/test_marleyspoon.py
+++ b/tests/test_marleyspoon.py
@@ -8,8 +8,8 @@ class TestMarleySpoonScraper(ScraperTest):
 
     scraper_class = MarleySpoon
 
-    @property
-    def expected_requests(self):
+    @classmethod
+    def expected_requests(cls):
         yield responses.GET, "https://marleyspoon.de/menu/113813-glasierte-veggie-burger-mit-roestkartoffeln-und-apfel-gurken-salat", "tests/test_data/marleyspoon.testhtml"
         yield responses.GET, "https://api.marleyspoon.com/recipes/113813?brand=ms&country=de&product_type=web", "tests/test_data/marleyspoon.testjson"
 

--- a/tests/test_panelinha_1.py
+++ b/tests/test_panelinha_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestPanelinhaScraper(ScraperTest):
 
     scraper_class = Panelinha
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "panelinha_1"
 
     def test_host(self):
         self.assertEqual("panelinha.com.br", self.harvester_class.host())

--- a/tests/test_panelinha_2.py
+++ b/tests/test_panelinha_2.py
@@ -4,10 +4,7 @@ from tests import ScraperTest
 
 class TestPanelinhaScraper(ScraperTest):
     scraper_class = Panelinha
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "panelinha_2"
 
     def test_host(self):
         self.assertEqual("panelinha.com.br", self.harvester_class.host())

--- a/tests/test_reishunger_1.py
+++ b/tests/test_reishunger_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestReishungerScraper(ScraperTest):
 
     scraper_class = Reishunger
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "reishunger_1"
 
     def test_host(self):
         self.assertEqual("reishunger.de", self.harvester_class.host())

--- a/tests/test_reishunger_2.py
+++ b/tests/test_reishunger_2.py
@@ -4,10 +4,7 @@ from tests import ScraperTest
 
 class TestReishungerScraper(ScraperTest):
     scraper_class = Reishunger
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "reishunger_2"
 
     def test_host(self):
         self.assertEqual("reishunger.de", self.harvester_class.host())

--- a/tests/test_seriouseats_1.py
+++ b/tests/test_seriouseats_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestSeriousEats(ScraperTest):
 
     scraper_class = SeriousEats
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "seriouseats_1"
 
     def test_host(self):
         self.assertEqual("seriouseats.com", self.harvester_class.host())

--- a/tests/test_seriouseats_2.py
+++ b/tests/test_seriouseats_2.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestSeriousEats(ScraperTest):
 
     scraper_class = SeriousEats
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "seriouseats_2"
 
     def test_host(self):
         self.assertEqual("seriouseats.com", self.harvester_class.host())

--- a/tests/test_thehappyfoodie_1.py
+++ b/tests/test_thehappyfoodie_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestTheHappyFoodie(ScraperTest):
 
     scraper_class = TheHappyFoodie
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "thehappyfoodie_1"
 
     def test_host(self):
         self.assertEqual("thehappyfoodie.co.uk", self.harvester_class.host())

--- a/tests/test_thehappyfoodie_2.py
+++ b/tests/test_thehappyfoodie_2.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestTheHappyFoodie(ScraperTest):
 
     scraper_class = TheHappyFoodie
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "thehappyfoodie_2"
 
     def test_host(self):
         self.assertEqual("thehappyfoodie.co.uk", self.harvester_class.host())

--- a/tests/test_thespruceeats_1.py
+++ b/tests/test_thespruceeats_1.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestTheSpruceEatsScraper(ScraperTest):
 
     scraper_class = TheSpruceEats
-
-    @property
-    def test_file_name(self):
-        return "{}_1".format(self.scraper_class.__name__.lower())
+    test_file_name = "thespruceeats_1"
 
     def test_host(self):
         self.assertEqual("thespruceeats.com", self.harvester_class.host())

--- a/tests/test_thespruceeats_2.py
+++ b/tests/test_thespruceeats_2.py
@@ -5,10 +5,7 @@ from tests import ScraperTest
 class TestTheSpruceEatsScraper(ScraperTest):
 
     scraper_class = TheSpruceEats
-
-    @property
-    def test_file_name(self):
-        return "{}_2".format(self.scraper_class.__name__.lower())
+    test_file_name = "thespruceeats_2"
 
     def test_host(self):
         self.assertEqual("thespruceeats.com", self.harvester_class.host())

--- a/tests/test_wild_mode.py
+++ b/tests/test_wild_mode.py
@@ -6,9 +6,10 @@ class TestWildMode(ScraperTest):
 
     scraper_class = SchemaScraperFactory
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         with open("tests/test_data/wild_mode.testhtml", encoding="utf-8") as testfile:
-            self.harvester_class = self.scraper_class.generate(
+            cls.harvester_class = cls.scraper_class.generate(
                 url="https://test.example.com/", html=testfile.read()
             )
 

--- a/tests/test_woolworths.py
+++ b/tests/test_woolworths.py
@@ -8,8 +8,8 @@ class TestWoolworthsScraper(ScraperTest):
 
     scraper_class = Woolworths
 
-    @property
-    def expected_requests(self):
+    @classmethod
+    def expected_requests(cls):
         yield GET, "https://www.woolworths.com.au/shop/recipes/asparagus-salad-with-lemon-vinaigrette", "tests/test_data/woolworths.testhtml"
         yield GET, "https://foodhub.woolworths.com.au/content/woolworths-foodhub/en/asparagus-salad-with-lemon-vinaigrette.model.json", "tests/test_data/woolworths.testhtml"
 


### PR DESCRIPTION
This significantly reduces the amount of time taken (and compute resource used) to run the unit test suite.

There's at least one tradeoff: it makes the test cases somewhat stateful (side-effects introduced during one test method could affect other test methods).