### PR TITLE
Revert "Fixup: remove overwrite of schema.org data with 'mainEntity' contents during schema.org processing"

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -52,6 +52,8 @@ class SchemaOrg:
                 if in_context and item_type.lower() in low_schema:
                     self.format = syntax
                     self.data = item
+                    if item_type.lower() == "webpage":
+                        self.data = self.data.get("mainEntity")
                     return
                 elif in_context and "@graph" in item:
                     for graph_item in item.get("@graph", ""):
@@ -59,8 +61,12 @@ class SchemaOrg:
                         if not isinstance(graph_item_type, str):
                             continue
                         if graph_item_type.lower() in low_schema:
+                            in_graph = SCHEMA_ORG_HOST in graph_item.get("@context", "")
                             self.format = syntax
-                            if graph_item_type.lower() == "recipe":
+                            if graph_item_type.lower() == "webpage" and in_graph:
+                                self.data = self.data.get("mainEntity")
+                                return
+                            elif graph_item_type.lower() == "recipe":
                                 self.data = graph_item
                                 return
 

--- a/recipe_scrapers/sallysblog.py
+++ b/recipe_scrapers/sallysblog.py
@@ -41,7 +41,3 @@ class SallysBlog(AbstractScraper):
                 for instruction in instructions
             ]
         )
-
-    def image(self):
-        image = self.soup.find("meta", {"property", "og:image"})
-        return image["content"] if image else None


### PR DESCRIPTION
Although this change seemed fine going by the unit test results, I think there might be a less disruptive / more data-safe way to handle this.  `mainEntity` does seem valid for both `WebPage` and `Recipe` data.

Reverts hhursev/recipe-scrapers#666