### PR TITLE
Fix issues with new forksoverknives category

### DIFF
--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -3,8 +3,8 @@ from ._abstract import AbstractScraper
 from ._utils import normalize_string
 from ._schemaorg import SchemaOrg
 from typing import Dict, List, Optional, Tuple, Union
-
 import re
+
 
 class fok_Schema(SchemaOrg):
     def __init__(self, page_data, raw=False):
@@ -36,7 +36,9 @@ class ForksOverKnives(AbstractScraper):
         wild_mode: Optional[bool] = False,
         html: Union[str, bytes, None] = None,
     ):
-        super().__init__(url=url, proxies=proxies, timeout=timeout, wild_mode=wild_mode, html=html)
+        super().__init__(
+            url=url, proxies=proxies, timeout=timeout, wild_mode=wild_mode, html=html
+        )
         self.schema = fok_Schema(self.page_data)
 
     def author(self):

--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -1,6 +1,6 @@
 # mypy: disallow_untyped_defs=False
 import re
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 from ._abstract import AbstractScraper
 from ._schemaorg import SchemaOrg
@@ -13,7 +13,7 @@ class fok_Schema(SchemaOrg):
 
     def category(self):
         cat = super().category()
-        r = re.compile('.*<a href="\S+">(.+)</a>')
+        r = re.compile('.*<a href=".+">(.+)</a>')
         m = r.match(cat)
         if m:
             return normalize_string(m[1])

--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -78,3 +78,6 @@ class ForksOverKnives(AbstractScraper):
         ratings = ratings[1:]
         # return the first element
         return float(ratings.split()[0])
+
+    def category(self):
+        return self.schema.category()

--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -13,7 +13,7 @@ class fok_Schema(SchemaOrg):
 
     def category(self):
         cat = super().category()
-        r = re.compile('.*<a href="\S+">(.*)</a>')
+        r = re.compile('.*<a href="\S+">(.+)</a>')
         m = r.match(cat)
         if m:
             return normalize_string(m[1])

--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -1,12 +1,43 @@
 # mypy: disallow_untyped_defs=False
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
+from ._schemaorg import SchemaOrg
+from typing import Dict, List, Optional, Tuple, Union
+
+import re, html
+
+class fok_Schema(SchemaOrg):
+    def __init__(self, page_data, raw=False):
+        super().__init__(page_data)
+
+    def category(self):
+        cat = super().category()
+        r = re.compile('.*<a href="\S+">(.*)</a>')
+        m = r.match(cat)
+        if m:
+            return html.unescape(m[1])
+        return cat
 
 
 class ForksOverKnives(AbstractScraper):
     @classmethod
     def host(cls):
         return "forksoverknives.com"
+
+    def __init__(
+        self,
+        url: Union[str, None],
+        proxies: Optional[
+            Dict[str, str]
+        ] = None,  # allows us to specify optional proxy server
+        timeout: Optional[
+            Union[float, Tuple[float, float], Tuple[float, None]]
+        ] = None,  # allows us to specify optional timeout for request
+        wild_mode: Optional[bool] = False,
+        html: Union[str, bytes, None] = None,
+    ):
+        super().__init__(url=url, proxies=proxies, timeout=timeout, wild_mode=wild_mode, html=html)
+        self.schema = fok_Schema(self.page_data)
 
     def author(self):
         author = self.soup.find("div", attrs={"class": "post-info"}).find("a")

--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -8,8 +8,6 @@ from ._utils import normalize_string
 
 
 class fok_Schema(SchemaOrg):
-    def __init__(self, page_data, raw=False):
-        super().__init__(page_data)
 
     def category(self):
         cat = super().category()

--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -4,7 +4,7 @@ from ._utils import normalize_string
 from ._schemaorg import SchemaOrg
 from typing import Dict, List, Optional, Tuple, Union
 
-import re, html
+import re
 
 class fok_Schema(SchemaOrg):
     def __init__(self, page_data, raw=False):
@@ -15,7 +15,7 @@ class fok_Schema(SchemaOrg):
         r = re.compile('.*<a href="\S+">(.*)</a>')
         m = r.match(cat)
         if m:
-            return html.unescape(m[1])
+            return normalize_string(m[1])
         return cat
 
 

--- a/recipe_scrapers/forksoverknives.py
+++ b/recipe_scrapers/forksoverknives.py
@@ -1,9 +1,10 @@
 # mypy: disallow_untyped_defs=False
-from ._abstract import AbstractScraper
-from ._utils import normalize_string
-from ._schemaorg import SchemaOrg
-from typing import Dict, List, Optional, Tuple, Union
 import re
+from typing import Dict, List, Optional, Tuple, Union
+
+from ._abstract import AbstractScraper
+from ._schemaorg import SchemaOrg
+from ._utils import normalize_string
 
 
 class fok_Schema(SchemaOrg):

--- a/tests/test_data/forksoverknives.testhtml
+++ b/tests/test_data/forksoverknives.testhtml
@@ -1,45 +1,89 @@
 <!DOCTYPE html>
-<html lang="en-US" prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb#">
+<html lang="en-US">
 <head>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+
+        function gtag() {
+            dataLayer.push(arguments);
+        }
+
+        // US Default
+        gtag('consent', 'default', {
+            'ad_storage': 'granted',
+            'analytics_storage': 'granted',
+            'functionality_storage': 'granted',
+            'personalization_storage': 'granted',
+            'security_storage': 'granted',
+            'region': ['US']
+        });
+
+        // Global default
+        gtag('consent', 'default', {
+            'ad_storage': 'denied',
+            'analytics_storage': 'denied',
+            'functionality_storage': 'denied',
+            'personalization_storage': 'denied',
+            'security_storage': 'granted'
+        });
+    </script>
+
+    <!-- Google Tag Manager (new) -->
+    <script>
+        (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({
+                'gtm.start':
+                    new Date().getTime(), event: 'gtm.js'
+            });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src =
+                'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-PLC2TR2');
+    </script>
+    <!-- Google Tag Manager (legacy) -->
+    <script>
+        (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({
+                'gtm.start':
+                    new Date().getTime(), event: 'gtm.js'
+            });
+            var f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src =
+                'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-WC267H');
+    </script>
+    <!-- End Google Tag Manager -->
+
+    <!-- CookiePro Cookies Consent Notice start for forksoverknives.com -->
+        <!-- <script type="text/javascript" src="https://cookie-cdn.cookiepro.com/consent/c2c75215-55d1-441f-9bf1-4ea51df22b6b/OtAutoBlock.js" ></script> -->
+    <script src="https://cookie-cdn.cookiepro.com/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8"
+            data-domain-script="c2c75215-55d1-441f-9bf1-4ea51df22b6b"></script>
+    <script type="text/javascript">
+        function OptanonWrapper() {
+            window.dataLayer.push({event: 'OneTrustGroupsUpdated'});
+        }
+    </script>
+    <!-- CookiePro Cookies Consent Notice end for forksoverknives.com -->
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="UTF-8">
     <link rel="preconnect" href="https://fonts.gstatic.com">
-	
-<!-- Google Tag Manager for WordPress by gtm4wp.com -->
-<script data-cfasync="false" data-pagespeed-no-defer>//<![CDATA[
-	var gtm4wp_datalayer_name = "dataLayer";
-	var dataLayer = dataLayer || [];
-	var gtm4wp_use_sku_instead        = 0;
-	var gtm4wp_id_prefix              = '';
-	var gtm4wp_remarketing            = false;
-	var gtm4wp_eec                    = 1;
-	var gtm4wp_classicec              = 1;
-	var gtm4wp_currency               = 'USD';
-	var gtm4wp_product_per_impression = 0;
-	var gtm4wp_needs_shipping_address = false;
-//]]>
-</script>
-<!-- End Google Tag Manager for WordPress by gtm4wp.com -->
-<!-- Powered by Social Snap v1.1.15 - https://socialsnap.com/ -->
-<meta property="og:type" content="article">
-<meta property="og:title" content="Butternut Mac and Cheese with Broccoli">
-<meta property="og:description" content="Spiced butternut squash blended with nutritional yeast and plant milk makes a rich sauce for this vegan mac and cheese with broccoli. Get the recipe!">
-<meta property="og:url" content="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/">
-<meta property="og:site_name" content="Forks Over Knives">
-<meta property="og:updated_time" content="2021-02-03T10:43:15-08:00">
-<meta property="article:publisher" content="https://www.facebook.com/forksoverknives">
-<meta property="og:image" content="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg">
-<meta property="og:image:width" content="1366">
-<meta property="og:image:height" content="626">
-<meta property="article:published_time" content="2020-09-01T11:32:50-07:00">
-<meta property="article:modified_time" content="2021-02-03T10:43:15-08:00">
-<meta property="fb:app_id" content="1923155921341058">
-<meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="Butternut Mac and Cheese with Broccoli">
-<meta name="twitter:description" content="Spiced butternut squash blended with nutritional yeast and plant milk makes a rich sauce for this vegan mac and cheese with broccoli. Get the recipe!">
-<meta name="twitter:image:src" content="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg">
-<!-- Powered by Social Snap v1.1.15 - https://socialsnap.com/ -->
 
+    <!-- Anti-flicker snippet (recommended)  -->
+    <!-- <style>.async-hide { opacity: 0 !important}</style>
+    <script>
+      (function(a,s,y,n,c,h,i,d,e) {s.className+=' '+y;h.start=1*new Date; h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;})(window,document.documentElement,'async-hide','dataLayer',4000, {'GTM-WC267H':true});
+    </script> -->
+
+    <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
 
         <link rel="preload" href="https://www.forksoverknives.com/wp-content/themes/fork/fonts/icomoon.ttf?kab0i1" as="font" crossorigin="anonymous" />
         <link rel="preload" href="https://www.forksoverknives.com/wp-content/themes/fork/fonts/freehand575.woff2" as="font" crossorigin="anonymous" />
@@ -47,10 +91,9 @@
         <link rel="preload" href="https://www.forksoverknives.com/wp-content/themes/fork/fonts/neuzeitgro-bol-webfont.woff2" as="font" crossorigin="anonymous" />
         <link rel="preload" href="https://www.forksoverknives.com/wp-content/themes/fork/fonts/freehand575.woff2" as="font" crossorigin="anonymous" />
     
-	<!-- This site is optimized with the Yoast SEO plugin v16.0.2 - https://yoast.com/wordpress/plugins/seo/ -->
+	<!-- This site is optimized with the Yoast SEO plugin v19.10 - https://yoast.com/wordpress/plugins/seo/ -->
 	<title>Butternut Squash Mac and Cheese with Broccoli | Forks Over Knives</title>
 	<meta name="description" content="Spiced butternut squash blended with nutritional yeast and plant milk makes a rich sauce for this vegan mac and cheese with broccoli. Get the recipe!" />
-	<meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
 	<link rel="canonical" href="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" />
 	<meta property="og:locale" content="en_US" />
 	<meta property="og:type" content="article" />
@@ -59,26 +102,29 @@
 	<meta property="og:url" content="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" />
 	<meta property="og:site_name" content="Forks Over Knives" />
 	<meta property="article:publisher" content="https://www.facebook.com/forksoverknives" />
-	<meta property="article:modified_time" content="2021-02-03T18:43:15+00:00" />
+	<meta property="article:modified_time" content="2021-11-09T21:01:02+00:00" />
 	<meta property="og:image" content="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" />
 	<meta property="og:image:width" content="1366" />
 	<meta property="og:image:height" content="626" />
+	<meta property="og:image:type" content="image/jpeg" />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="Butternut Mac and Cheese with Broccoli" />
 	<meta name="twitter:description" content="Spiced butternut squash blended with nutritional yeast and plant milk makes a rich sauce for this vegan mac and cheese with broccoli. Get the recipe!" />
 	<meta name="twitter:site" content="@ForksOverKnives" />
-	<meta name="twitter:label1" content="Est. reading time">
-	<meta name="twitter:data1" content="1 minute">
+	<meta name="twitter:label1" content="Est. reading time" />
+	<meta name="twitter:data1" content="1 minute" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/","url":"https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/","name":"Butternut Squash Mac and Cheese with Broccoli | Forks Over Knives","isPartOf":{"@id":"https://www.forksoverknives.com/#website"},"primaryImageOfPage":{"@id":"https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#primaryimage"},"image":{"@id":"https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#primaryimage"},"thumbnailUrl":"https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg","datePublished":"2020-09-01T18:32:50+00:00","dateModified":"2021-11-09T21:01:02+00:00","description":"Spiced butternut squash blended with nutritional yeast and plant milk makes a rich sauce for this vegan mac and cheese with broccoli. Get the recipe!","breadcrumb":{"@id":"https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#primaryimage","url":"https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg","contentUrl":"https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg","width":1366,"height":626,"caption":"butternut broccoli vegan mac and cheese"},{"@type":"BreadcrumbList","@id":"https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.forksoverknives.com/"},{"@type":"ListItem","position":2,"name":"Butternut Squash Mac and Cheese with Broccoli"}]},{"@type":"WebSite","@id":"https://www.forksoverknives.com/#website","url":"https://www.forksoverknives.com/","name":"Forks Over Knives","description":"Plant Based Living","publisher":{"@id":"https://www.forksoverknives.com/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.forksoverknives.com/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https://www.forksoverknives.com/#organization","name":"Forks Over Knives","url":"https://www.forksoverknives.com/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.forksoverknives.com/#/schema/logo/image/","url":"https://www.forksoverknives.com/wp-content/uploads/FOK_logo_WP.jpg","contentUrl":"https://www.forksoverknives.com/wp-content/uploads/FOK_logo_WP.jpg","width":2000,"height":800,"caption":"Forks Over Knives"},"image":{"@id":"https://www.forksoverknives.com/#/schema/logo/image/"},"sameAs":["https://www.instagram.com/forksoverknives/","https://www.pinterest.com/forksoverknives/","https://www.youtube.com/user/ForksOverKnives","https://www.facebook.com/forksoverknives","https://twitter.com/ForksOverKnives"]}]}</script>
 	<!-- / Yoast SEO plugin. -->
 
 
 <link rel='dns-prefetch' href='//fonts.googleapis.com' />
 <link rel='dns-prefetch' href='//s.w.org' />
-		<script type="text/javascript">
-			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/13.0.1\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.forksoverknives.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=5.6.2"}};
-			!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode;p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([55357,56424,8205,55356,57212],[55357,56424,8203,55356,57212])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(n=t.source||{}).concatemoji?c(n.concatemoji):n.wpemoji&&n.twemoji&&(c(n.twemoji),c(n.wpemoji)))}(window,document,window._wpemojiSettings);
-		</script>
-		<style type="text/css">
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.forksoverknives.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.0.3"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){var a=String.fromCharCode,e=(p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,e),0,0),i.toDataURL());return p.clearRect(0,0,i.width,i.height),p.fillText(a.apply(this,t),0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(!p||!p.fillText)return!1;switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s([127987,65039,8205,9895,65039],[127987,65039,8203,9895,65039])?!1:!s([55356,56826,55356,56819],[55356,56826,8203,55356,56819])&&!s([55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447],[55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447]);case"emoji":return!s([129777,127995,8205,129778,127999],[129777,127995,8203,129778,127999])}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
 img.wp-smiley,
 img.emoji {
 	display: inline !important;
@@ -86,86 +132,22 @@ img.emoji {
 	box-shadow: none !important;
 	height: 1em !important;
 	width: 1em !important;
-	margin: 0 .07em !important;
+	margin: 0 0.07em !important;
 	vertical-align: -0.1em !important;
 	background: none !important;
 	padding: 0 !important;
 }
 </style>
-	<link rel='stylesheet' id='contact-form-7-css'  href='https://www.forksoverknives.com/wp-content/plugins/contact-form-7/includes/css/styles.css?ver=5.4' type='text/css' media='all' />
-<link rel='stylesheet' id='socialsnap-styles-css'  href='https://www.forksoverknives.com/wp-content/plugins/socialsnap-pro/assets/css/socialsnap.css?ver=1.1.15' type='text/css' media='all' />
-<style id='woocommerce-inline-inline-css' type='text/css'>
-.woocommerce form .form-row .required { visibility: visible; }
+	<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');--wp--preset--duotone--midnight: url('#wp-duotone-midnight');--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
 </style>
 <link rel='stylesheet' id='wp_review-style-css'  href='https://www.forksoverknives.com/wp-content/plugins/wp-review-pro/assets/css/wp-review.css?ver=1.1.0' type='text/css' media='all' />
-<link rel='stylesheet' id='fork-gfonts-css'  href='https://fonts.googleapis.com/css2?family=Caveat%3Awght%40400%3B700&#038;family=Lora%3Aital%2Cwght%400%2C400%3B0%2C700%3B1%2C400&#038;display=swap&#038;ver=5.6.2' type='text/css' media='all' />
-<link rel='stylesheet' id='fork-style-css'  href='https://www.forksoverknives.com/wp-content/themes/fork/style.css?ver=3.0.21' type='text/css' media='all' />
-<link rel='stylesheet' id='fork-theme-css'  href='https://www.forksoverknives.com/wp-content/themes/fork/theme.css?ver=3.0.21' type='text/css' media='all' />
-<link rel='stylesheet' id='sv-wc-payment-gateway-payment-form-css'  href='https://www.forksoverknives.com/wp-content/plugins/woocommerce-gateway-authorize-net-aim/vendor/skyverge/wc-plugin-framework/woocommerce/payment-gateway/assets/css/frontend/sv-wc-payment-gateway-payment-form.min.css?ver=5.3.0' type='text/css' media='all' />
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/jquery/jquery.min.js?ver=3.5.1' id='jquery-core-js'></script>
+<link rel='stylesheet' id='fork-style-css'  href='https://www.forksoverknives.com/wp-content/themes/fork/style.css?ver=3.0.46' type='text/css' media='all' />
+<link rel='stylesheet' id='fork-gfonts-css'  href='https://fonts.googleapis.com/css2?family=Caveat%3Awght%40400%3B700&#038;family=Lora%3Aital%2Cwght%400%2C400%3B0%2C700%3B1%2C400&#038;display=swap&#038;ver=6.0.3' type='text/css' media='all' />
+<link rel='stylesheet' id='fork-theme-css'  href='https://www.forksoverknives.com/wp-content/themes/fork/theme.css?ver=3.0.46' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/jquery/jquery.min.js?ver=3.6.0' id='jquery-core-js'></script>
 <script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.3.2' id='jquery-migrate-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/duracelltomi-google-tag-manager/js/gtm4wp-form-move-tracker.js?ver=1.11.6' id='gtm4wp-form-move-tracker-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/duracelltomi-google-tag-manager/js/gtm4wp-woocommerce-classic.js?ver=1.11.6' id='gtm4wp-woocommerce-classic-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/duracelltomi-google-tag-manager/js/gtm4wp-woocommerce-enhanced.js?ver=1.11.6' id='gtm4wp-woocommerce-enhanced-js'></script>
-<script>
-window.wc_ga_pro = {};
-
-window.wc_ga_pro.ajax_url = 'https://www.forksoverknives.com/wp-admin/admin-ajax.php';
-
-window.wc_ga_pro.available_gateways = {"authorize_net_aim":"Credit Card","paypal":"PayPal"};
-
-// interpolate json by replacing placeholders with variables
-window.wc_ga_pro.interpolate_json = function( object, variables ) {
-
-	if ( ! variables ) {
-		return object;
-	}
-
-	var j = JSON.stringify( object );
-
-	for ( var k in variables ) {
-		j = j.split( '{$' + k + '}' ).join( variables[ k ] );
-	}
-
-	return JSON.parse( j );
-};
-
-// return the title for a payment gateway
-window.wc_ga_pro.get_payment_method_title = function( payment_method ) {
-	return window.wc_ga_pro.available_gateways[ payment_method ] || payment_method;
-};
-
-// check if an email is valid
-window.wc_ga_pro.is_valid_email = function( email ) {
-  return /[^\s@]+@[^\s@]+\.[^\s@]+/.test( email );
-};
-
-</script>
-<!-- Start WooCommerce Google Analytics Pro -->
-		<script>
-	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-		ga( 'create', 'UA-12974007-2', {"cookieDomain":"auto","allowLinker":true} );
-	ga( 'set', 'forceSSL', true );
-	ga( 'set', 'anonymizeIp', true );
-	ga( 'require', 'linkid' );
-	ga( 'require', 'ec' );
-
-	ga( 'require:linker' );ga('linker:autoLink', ['forksoverknives.com','forksmealplanner.com'], false, true);
-	(function() {
-
-		// trigger an event the old-fashioned way to avoid a jQuery dependency and still support IE
-		var event = document.createEvent( 'Event' );
-
-		event.initEvent( 'wc_google_analytics_pro_loaded', true, true );
-
-		document.dispatchEvent( event );
-	})();
-</script>
-		<!-- end WooCommerce Google Analytics Pro -->
-		<link rel="https://api.w.org/" href="https://www.forksoverknives.com/wp-json/" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.forksoverknives.com/xmlrpc.php?rsd" />
+<link rel="https://api.w.org/" href="https://www.forksoverknives.com/wp-json/" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.forksoverknives.com/xmlrpc.php?rsd" />
 <link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.forksoverknives.com/wp-includes/wlwmanifest.xml" /> 
 <link rel='shortlink' href='https://www.forksoverknives.com/?p=128191' />
 <link rel="alternate" type="application/json+oembed" href="https://www.forksoverknives.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.forksoverknives.com%2Frecipes%2Fvegan-pasta-noodles%2Fbutternut-mac-and-cheese-broccoli%2F" />
@@ -173,13 +155,7 @@ window.wc_ga_pro.is_valid_email = function( email ) {
 <!--[if IE 7]>
 <link rel="stylesheet" href="https://www.forksoverknives.com/wp-content/plugins/wp-review-pro/assets/css/wp-review-ie7.css">
 <![endif]-->
-
-<!-- Google Tag Manager for WordPress by gtm4wp.com -->
-<script data-cfasync="false" data-pagespeed-no-defer>//<![CDATA[
-	var dataLayer_content = {"pagePostType":"recipe","pagePostType2":"single-recipe","pageAttributes":["30-minutes-or-less"],"pagePostAuthor":"Courtney Davison","cartContent":{"totals":{"applied_coupons":[],"discount_total":0,"subtotal":0,"total":0},"items":[]}};
-	dataLayer.push( dataLayer_content );//]]>
-</script>
-<!-- End Google Tag Manager for WordPress by gtm4wp.com -->		<script>
+		<script>
 			document.documentElement.className = document.documentElement.className.replace( 'no-js', 'js' );
 		</script>
 				<style>
@@ -192,199 +168,420 @@ window.wc_ga_pro.is_valid_email = function( email ) {
 					transition-delay: 0ms;
 				}
 					</style>
-			<noscript><style>.woocommerce-product-gallery{ opacity: 1 !important; }</style></noscript>
-	
+		
 <!-- Dynamic Widgets by QURL loaded - http://www.dynamic-widgets.com //-->
-		<script type='text/javascript'>
-		  	function getURLParameter(name, source) {
-			return decodeURIComponent((new RegExp('[?|&|#]' + name + '=' +
-				'([^&]+?)(&|#|;|$)').exec(source) || [,""])[1].replace(/\+/g,
-				'%20')) || null;
-			}
-
-			var accessToken = getURLParameter("access_token", location.hash);
-
-			if (typeof accessToken === 'string' && accessToken.match(/^Atza/)) {
-				document.cookie = "amazon_Login_accessToken=" + encodeURIComponent(accessToken) +
-				";secure";
-				window.location = '/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/?amazon_payments_advanced=true';
-			}
-		</script>
-		<script>
-			window.onAmazonLoginReady = function() {
-				amazon.Login.setClientId( "amzn1.application-oa2-client.9f7bcd3ccfeb44aebfa09666109561c6" );
-				jQuery( document ).trigger( 'wc_amazon_pa_login_ready' );
-			};
-		</script>
-		<link rel="icon" href="https://www.forksoverknives.com/wp-content/uploads/cropped-Forks_Favicon-32x32.jpg" sizes="32x32" />
+<link rel="icon" href="https://www.forksoverknives.com/wp-content/uploads/cropped-Forks_Favicon-32x32.jpg" sizes="32x32" />
 <link rel="icon" href="https://www.forksoverknives.com/wp-content/uploads/cropped-Forks_Favicon-192x192.jpg" sizes="192x192" />
 <link rel="apple-touch-icon" href="https://www.forksoverknives.com/wp-content/uploads/cropped-Forks_Favicon-180x180.jpg" />
 <meta name="msapplication-TileImage" content="https://www.forksoverknives.com/wp-content/uploads/cropped-Forks_Favicon-270x270.jpg" />
-    <!-- Anti-flicker snippet (recommended)  -->
-    <style>.async-hide { opacity: 0 !important}</style>
-    <script>(function(a,s,y,n,c,h,i,d,e) {s.className+=' '+y;h.start=1*new Date; h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;})(window,document.documentElement,'async-hide','dataLayer',4000, {'GTM-WC267H':true});</script>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-WC267H');</script>
-    <!-- End Google Tag Manager -->
 </head>
-<body class="recipe-template-default single single-recipe postid-128191 single-format-standard wp-custom-logo theme-fork woocommerce-no-js">
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe  height="0" width="0" style="display:none;visibility:hidden" data-src="https://www.googletagmanager.com/ns.html?id=GTM-WC267H" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
-    <div id="wrapper">
+<body class="recipe-template-default single single-recipe postid-128191 single-format-standard wp-custom-logo">
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+    <iframe  height="0" width="0"
+            style="display:none;visibility:hidden" data-src="https://www.googletagmanager.com/ns.html?id=GTM-WC267H" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->
+<div id="wrapper">
 
-                                                                                        	                            <div class="hello-bar type-2 bg-light-green" data-version="-num1-ver300">
-                                <div class="bg"></div>
-                                <div class="container -huge">
-                                  <div class="content-wrap">
-                                      <a class="text-frame" href="http://www.forksoverknives.com/meal-planner" data-type="ad" data-name="Meal Planner - Sitewide Hello" data-ad-position="page pushdown" data-ad-content="ColorSlide-inbox">
-                                                                                <strong class="title">
-                                                                                            <span>Plant-based </span>
-                                                                                            <span>eating </span>
-                                                                                            <span>simplified. </span>
-                                                                                    </strong>
-                                                                                <p>Get our weekly meal plans, straight to your inbox.</p>                                      </a>
-                                      <a class="btn mobile-hidden" href="http://www.forksoverknives.com/meal-planner" data-type="ad" data-name="Meal Planner - Sitewide Hello" data-ad-position="page pushdown" data-ad-content="ColorSlide-inbox">Sign up now!</a>                                  </div><span class="btn-close"><i class="icon-close" data-type="ui"
-                                            data-event="click"
-                                            data-name="Close sitewide app banner"></i></span>
+                                    <div class="hello-overlay" data-version="wp_woocommerce_session_PopupName-Wantmorerecipes" data-trigger="exit"
+                 data-tracking="exit_popup_recipe_display">
+                <div class="hello-wrapper recipe-app-lightbox"><span class="hello-overlay-clicker"></span>
+                    <div class="container">
+                        <div class="box"><a class="close-overlay" href="#">close</a>
+                            <div class="description">
+                                <div class="heading">
+                                                                            <div class="image-box">
+                                            <picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/150808/img-phone-01-m2x-48x96-c.jpeg, https://www.forksoverknives.com/wp-content/uploads/fly-images/150808/img-phone-01-m2x-96x192-c.jpeg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/150810/img-phone-01-218x430-c.jpeg"><img  alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/150810/img-phone-01-218x430-c.jpeg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/150810/img-phone-01-218x430-c.jpeg" alt=""></noscript>
+                </picture>                                            <svg class="decor left" version="1.1" id="Layer_1"
+                                                 xmlns="http://www.w3.org/2000/svg"
+                                                 x="0px" y="0px" viewBox="0 0 120.2 117.5"
+                                                 style="enable-background:new 0 0 120.2 117.5;" xml:space="preserve">
+                                              <g>
+                                                  <path class="st0"
+                                                        d="M51.9,14.4c-0.8,0.5-1.7,0.7-2.2,1.2c-0.7,0.7-1,1.7-1.6,2.5c-0.2,0.3-0.7,0.5-1.2,0.7c-0.7-1.5-1.4-2.8-1.8-4.2c-0.8-3-2.4-5.4-4.6-7.5c-2.1-2.1-4.1-4.3-6.3-6.3C33-0.1,31.6-0.5,30,1c-0.9,2.3-1,4.9-1.1,7.6c-0.1,2.6,0.2,5.3,0.2,7.9c0,2.6,1.3,5,1.2,7.8c-2.2,0.9-4.5,0-6.8,0.8c-0.2,0.6-0.8,1.3-0.8,2c0,1.1,0.3,2.3,0.8,3.3c1.5,3.1,3,6.3,5.1,8.5c2,1.5,3.6,2.6,5.1,3.8c0.5,0.4,0.9,0.9,0.4,1.6c-1.8,0.7-4-0.5-5.7,1c-0.1,0.4-0.2,0.8-0.1,1c0.5,1.2,1.2,2.3,1.7,3.6c0.1,0.3,0.3,0.5,0.4,0.7c-0.4,0.5-0.9,1.3-1.2,3.1C29,55,29,56.7,29.1,57.7c-1.7-1.1-3.3-2-4.6-3.2c-2.8-2.5-6-4-9.6-4.9c-3.5-0.8-7-1.8-10.6-2.4C2.4,46.9,0.7,47.4,0,50c0.5,2.9,2.1,5.8,3.7,8.6c1.6,2.8,3.6,5.4,5.3,8.1c1.7,2.7,4.6,4.4,6.3,7.3c-1.8,2.3-4.7,2.8-6.5,5.2c0.1,0.8,0,1.9,0.5,2.6c0.8,1.1,1.8,2.2,2.9,2.9c3.6,2.3,7.2,4.5,10.7,5.6c3,0.3,5.4,0.5,7.8,0.7c0.8,0.1,1.5,0.4,1.5,1.4c-1.4,1.9-4.4,2.1-5.2,4.7c0.2,0.4,0.2,0.9,0.5,1.1c1.3,0.9,2.8,1.7,4.1,2.6c4.8,3.3,10.5,3.6,15.8,4.8c0.4,2.9-2.1,2.8-3.3,4.2c0.6,0.7,1.2,1.5,1.5,1.9c2.7,1.1,5,2,7.2,2.9c1.5,0.6,3,1.4,4.5,1.7c10.3,2.3,20,1,29-4.6c1.2-0.7,2.4-1.3,3.7-2c2.8,0.9,5.5,1.8,8.1,2.7c4.4,1.5,5.6,2,10,3.5c1.9,0.6,11.2,4,12.1-0.7c0.3-1.7-3.7-3.3-4.9-3.6c-3.9-0.9-7.6-2.1-11.2-3.8c-3.7-1.8-7.4-3.8-11.4-4.9c-0.4-0.1-0.8-0.3-1-0.6c-0.4-0.4-0.7-0.9-1.1-1.5c0.5-1.6,0.9-3.1,1.2-4.4C90.8,84.2,85.3,74.5,76,68c2.8-8.5,1.9-17-2.5-24.9c-2.9-0.8-4.2,2-6.6,3.1c-0.2-1.2-0.5-2.2-0.4-3.1c0.4-4.4-0.6-8.5-2.4-12.5c-0.2-0.5-0.8-0.9-0.9-1.1c-3.1,0.4-4.6,2.5-7.1,5c0.1-1.8,0.1-2.6,0.2-3.4c0.4-3.7,0-7.3-0.8-10.8c-0.3-1.4-0.9-2.8-1.6-4.1C53.4,15.4,52.6,15,51.9,14.4 M36.4,21.5c-0.9-2.1-1.9-4.2-2.8-6.3c-1.1-2.6-1.8-5.3-1.6-8.1c0-0.3,0.3-0.6,0.5-0.9c0.4,0.3,0.9,0.5,1.1,0.8c1.5,2.1,2.6,4.6,4.5,6.4c2.2,4.7,4.9,9.3,6.2,14.4c0.1,0.6-0.2,1.2-0.3,2C40.4,27.8,38,25,36.4,21.5 M28.4,31.5c-0.6-0.7-1.4-1.5-1-2.6c1.3-0.6,2.6,0.1,3.8,0.4c1.7,0.5,3.5,1,5.1,1.8c2,1.1,3.9,2.4,5.8,3.7c2.7,2,3.3,3.4,3.7,7.5c-0.4,0.6-1.1,0.8-1.7,0.5c-2-0.8-4-1.5-5.8-2.7C34.5,37.8,31.2,34.9,28.4,31.5 M31.2,47.5c0.6-0.8,1.4-0.7,2.2-0.6c5.2,0.7,10.5,0.9,15.4,3.5c1.5,2.4,3.1,4.8,4.1,7.8c-0.1,0-0.2,0-0.2,0c-0.5,0.4-0.9,0.9-1.3,1.4c-3.8,0-6.9-1.3-9.9-3.1c0,0,0,0,0,0c-0.9-1-1.7-2-2.7-2.9c-1.3-1.3-2.8-2.3-4.3-3.2C34,50,33.5,50,33,49.9c-0.5-0.5-1-1-1.6-1.5C31.3,48.3,31.3,47.8,31.2,47.5 M41.5,72.9c-3.7-4.2-6.7-9-9.3-14c-0.8-1.6-1.3-3.3-0.4-5.3c0.7,0.1,1.4,0,1.8,0.3c7.1,6.2,12.2,13.8,15.2,22.8c0.2,0.5-0.1,1.1-0.2,1.9C45.4,77.3,43.4,75.1,41.5,72.9 M6.1,54.8C6,54.5,6.1,54,6.1,53.5c0.6,0,1.2-0.1,1.7,0.1c2.9,1.3,5.6,3.1,8.8,3.7c5.4,3.5,11,6.5,15.7,11c0.5,0.5,0.6,1.4,1,2.3c-5.2,0.3-9.4-1-13.4-3.7c-2.3-1.6-4.6-3.2-6.9-4.8C10.2,60.2,7.7,57.9,6.1,54.8 M17.9,82.5c-1.1-0.4-2.4-0.6-2.7-2c1-1.4,2.7-1.6,4.2-2c2.1-0.6,4.3-1.2,6.4-1.4c2.8-0.2,5.6-0.1,8.4,0.1c4.1,0.3,5.7,1.4,8.7,5.4c0,0.9-0.6,1.5-1.4,1.7c-2.6,0.4-5.1,1-7.7,1C28.4,85.2,23.1,84.3,17.9,82.5 M32.1,98.2c-0.3-0.1-0.5-0.5-0.8-0.8c0.1-1.2,1-1.6,1.9-2c5.8-2.6,11.5-5.8,18.2-6.3c3.5,1.8,7.2,3.3,10.4,6.5c-4.6,3.6-9.3,4.4-14.1,4.5C42.3,100.2,37.2,99.3,32.1,98.2 M53,110.5c-0.1-2.2,1.5-2.5,2.6-3.1c8.4-5,6.7-5.1,16.1-5.8c6.4,1.5,7,1.7,11.9,6.3C73.4,113.2,63.3,113.3,53,110.5 M67.3,88.7c-2.3,0.8-3.9,0.2-5.5-0.9c-2-1.5-3.4-3.4-4.3-5.7c-1.8-4.9-3.3-9.9-3.8-15.2c-0.1-0.7,0.3-1.5,0.4-2.1c1.9-0.2,2.2,1.1,2.9,2C61.7,73,65.5,81.2,67.3,88.7 M85,87.4c1.7,3.7,3.3,7.7,3,12.3c-3.3-0.5-6.1-1.2-8.7-2.8c-1.6-1-2.8-2.3-3.4-4.1c-1.2-3.8-2.6-7.5-2.6-11.7c0-3.6-0.6-7.1-1.1-11.8C78.9,74.4,82,80.9,85,87.4 M71.9,45.7c2.4,6.4,1.8,12.3,1.1,18.1c-0.1,0.7-0.2,1.4-0.3,2.1c-0.2-0.1-0.4-0.2-0.6-0.3c-3.1,0.9-3.1,3.9-4.3,6.4c-1.2-1.2-2.2-2.5-3-4c-0.7-1.4-0.9-2.8-0.6-4.3c0.8-3.2,1.5-6.4,3.2-9.3C69.1,51.9,70.2,49.1,71.9,45.7 M60.1,36.1c0.3-0.5,0.8-0.9,1.2-1.3c1.4,0.6,1.1,1.7,1.1,2.7c0.5,6.2-0.4,13.6-2.4,19.7c-1.9-0.5-2.9-1.5-3.4-3c-0.7-1.9-0.9-3.9-0.5-5.8C57.1,44.1,58.2,39.9,60.1,36.1 M51.6,18.2c2.3,7.4,2.5,14.9,0.7,22.4c-0.1,0.4-0.5,0.7-1,1.3c-1.6-2.2-2-4.7-2.4-7c-0.8-4.6-0.8-9.2-0.4-13.8c0.1-1.5,0.5-2.9,2-3.8C50.9,17.6,51.5,17.8,51.6,18.2"></path>
+                                              </g>
+                                            </svg>
+                                            <svg class="decor right" version="1.1" id="Layer_1"
+                                                 xmlns="http://www.w3.org/2000/svg"
+                                                 x="0px" y="0px" viewBox="0 0 120.2 117.5"
+                                                 style="enable-background:new 0 0 120.2 117.5;" xml:space="preserve">
+                                              <g>
+                                                  <path class="st0"
+                                                        d="M51.9,14.4c-0.8,0.5-1.7,0.7-2.2,1.2c-0.7,0.7-1,1.7-1.6,2.5c-0.2,0.3-0.7,0.5-1.2,0.7c-0.7-1.5-1.4-2.8-1.8-4.2c-0.8-3-2.4-5.4-4.6-7.5c-2.1-2.1-4.1-4.3-6.3-6.3C33-0.1,31.6-0.5,30,1c-0.9,2.3-1,4.9-1.1,7.6c-0.1,2.6,0.2,5.3,0.2,7.9c0,2.6,1.3,5,1.2,7.8c-2.2,0.9-4.5,0-6.8,0.8c-0.2,0.6-0.8,1.3-0.8,2c0,1.1,0.3,2.3,0.8,3.3c1.5,3.1,3,6.3,5.1,8.5c2,1.5,3.6,2.6,5.1,3.8c0.5,0.4,0.9,0.9,0.4,1.6c-1.8,0.7-4-0.5-5.7,1c-0.1,0.4-0.2,0.8-0.1,1c0.5,1.2,1.2,2.3,1.7,3.6c0.1,0.3,0.3,0.5,0.4,0.7c-0.4,0.5-0.9,1.3-1.2,3.1C29,55,29,56.7,29.1,57.7c-1.7-1.1-3.3-2-4.6-3.2c-2.8-2.5-6-4-9.6-4.9c-3.5-0.8-7-1.8-10.6-2.4C2.4,46.9,0.7,47.4,0,50c0.5,2.9,2.1,5.8,3.7,8.6c1.6,2.8,3.6,5.4,5.3,8.1c1.7,2.7,4.6,4.4,6.3,7.3c-1.8,2.3-4.7,2.8-6.5,5.2c0.1,0.8,0,1.9,0.5,2.6c0.8,1.1,1.8,2.2,2.9,2.9c3.6,2.3,7.2,4.5,10.7,5.6c3,0.3,5.4,0.5,7.8,0.7c0.8,0.1,1.5,0.4,1.5,1.4c-1.4,1.9-4.4,2.1-5.2,4.7c0.2,0.4,0.2,0.9,0.5,1.1c1.3,0.9,2.8,1.7,4.1,2.6c4.8,3.3,10.5,3.6,15.8,4.8c0.4,2.9-2.1,2.8-3.3,4.2c0.6,0.7,1.2,1.5,1.5,1.9c2.7,1.1,5,2,7.2,2.9c1.5,0.6,3,1.4,4.5,1.7c10.3,2.3,20,1,29-4.6c1.2-0.7,2.4-1.3,3.7-2c2.8,0.9,5.5,1.8,8.1,2.7c4.4,1.5,5.6,2,10,3.5c1.9,0.6,11.2,4,12.1-0.7c0.3-1.7-3.7-3.3-4.9-3.6c-3.9-0.9-7.6-2.1-11.2-3.8c-3.7-1.8-7.4-3.8-11.4-4.9c-0.4-0.1-0.8-0.3-1-0.6c-0.4-0.4-0.7-0.9-1.1-1.5c0.5-1.6,0.9-3.1,1.2-4.4C90.8,84.2,85.3,74.5,76,68c2.8-8.5,1.9-17-2.5-24.9c-2.9-0.8-4.2,2-6.6,3.1c-0.2-1.2-0.5-2.2-0.4-3.1c0.4-4.4-0.6-8.5-2.4-12.5c-0.2-0.5-0.8-0.9-0.9-1.1c-3.1,0.4-4.6,2.5-7.1,5c0.1-1.8,0.1-2.6,0.2-3.4c0.4-3.7,0-7.3-0.8-10.8c-0.3-1.4-0.9-2.8-1.6-4.1C53.4,15.4,52.6,15,51.9,14.4 M36.4,21.5c-0.9-2.1-1.9-4.2-2.8-6.3c-1.1-2.6-1.8-5.3-1.6-8.1c0-0.3,0.3-0.6,0.5-0.9c0.4,0.3,0.9,0.5,1.1,0.8c1.5,2.1,2.6,4.6,4.5,6.4c2.2,4.7,4.9,9.3,6.2,14.4c0.1,0.6-0.2,1.2-0.3,2C40.4,27.8,38,25,36.4,21.5 M28.4,31.5c-0.6-0.7-1.4-1.5-1-2.6c1.3-0.6,2.6,0.1,3.8,0.4c1.7,0.5,3.5,1,5.1,1.8c2,1.1,3.9,2.4,5.8,3.7c2.7,2,3.3,3.4,3.7,7.5c-0.4,0.6-1.1,0.8-1.7,0.5c-2-0.8-4-1.5-5.8-2.7C34.5,37.8,31.2,34.9,28.4,31.5 M31.2,47.5c0.6-0.8,1.4-0.7,2.2-0.6c5.2,0.7,10.5,0.9,15.4,3.5c1.5,2.4,3.1,4.8,4.1,7.8c-0.1,0-0.2,0-0.2,0c-0.5,0.4-0.9,0.9-1.3,1.4c-3.8,0-6.9-1.3-9.9-3.1c0,0,0,0,0,0c-0.9-1-1.7-2-2.7-2.9c-1.3-1.3-2.8-2.3-4.3-3.2C34,50,33.5,50,33,49.9c-0.5-0.5-1-1-1.6-1.5C31.3,48.3,31.3,47.8,31.2,47.5 M41.5,72.9c-3.7-4.2-6.7-9-9.3-14c-0.8-1.6-1.3-3.3-0.4-5.3c0.7,0.1,1.4,0,1.8,0.3c7.1,6.2,12.2,13.8,15.2,22.8c0.2,0.5-0.1,1.1-0.2,1.9C45.4,77.3,43.4,75.1,41.5,72.9 M6.1,54.8C6,54.5,6.1,54,6.1,53.5c0.6,0,1.2-0.1,1.7,0.1c2.9,1.3,5.6,3.1,8.8,3.7c5.4,3.5,11,6.5,15.7,11c0.5,0.5,0.6,1.4,1,2.3c-5.2,0.3-9.4-1-13.4-3.7c-2.3-1.6-4.6-3.2-6.9-4.8C10.2,60.2,7.7,57.9,6.1,54.8 M17.9,82.5c-1.1-0.4-2.4-0.6-2.7-2c1-1.4,2.7-1.6,4.2-2c2.1-0.6,4.3-1.2,6.4-1.4c2.8-0.2,5.6-0.1,8.4,0.1c4.1,0.3,5.7,1.4,8.7,5.4c0,0.9-0.6,1.5-1.4,1.7c-2.6,0.4-5.1,1-7.7,1C28.4,85.2,23.1,84.3,17.9,82.5 M32.1,98.2c-0.3-0.1-0.5-0.5-0.8-0.8c0.1-1.2,1-1.6,1.9-2c5.8-2.6,11.5-5.8,18.2-6.3c3.5,1.8,7.2,3.3,10.4,6.5c-4.6,3.6-9.3,4.4-14.1,4.5C42.3,100.2,37.2,99.3,32.1,98.2 M53,110.5c-0.1-2.2,1.5-2.5,2.6-3.1c8.4-5,6.7-5.1,16.1-5.8c6.4,1.5,7,1.7,11.9,6.3C73.4,113.2,63.3,113.3,53,110.5 M67.3,88.7c-2.3,0.8-3.9,0.2-5.5-0.9c-2-1.5-3.4-3.4-4.3-5.7c-1.8-4.9-3.3-9.9-3.8-15.2c-0.1-0.7,0.3-1.5,0.4-2.1c1.9-0.2,2.2,1.1,2.9,2C61.7,73,65.5,81.2,67.3,88.7 M85,87.4c1.7,3.7,3.3,7.7,3,12.3c-3.3-0.5-6.1-1.2-8.7-2.8c-1.6-1-2.8-2.3-3.4-4.1c-1.2-3.8-2.6-7.5-2.6-11.7c0-3.6-0.6-7.1-1.1-11.8C78.9,74.4,82,80.9,85,87.4 M71.9,45.7c2.4,6.4,1.8,12.3,1.1,18.1c-0.1,0.7-0.2,1.4-0.3,2.1c-0.2-0.1-0.4-0.2-0.6-0.3c-3.1,0.9-3.1,3.9-4.3,6.4c-1.2-1.2-2.2-2.5-3-4c-0.7-1.4-0.9-2.8-0.6-4.3c0.8-3.2,1.5-6.4,3.2-9.3C69.1,51.9,70.2,49.1,71.9,45.7 M60.1,36.1c0.3-0.5,0.8-0.9,1.2-1.3c1.4,0.6,1.1,1.7,1.1,2.7c0.5,6.2-0.4,13.6-2.4,19.7c-1.9-0.5-2.9-1.5-3.4-3c-0.7-1.9-0.9-3.9-0.5-5.8C57.1,44.1,58.2,39.9,60.1,36.1 M51.6,18.2c2.3,7.4,2.5,14.9,0.7,22.4c-0.1,0.4-0.5,0.7-1,1.3c-1.6-2.2-2-4.7-2.4-7c-0.8-4.6-0.8-9.2-0.4-13.8c0.1-1.5,0.5-2.9,2-3.8C50.9,17.6,51.5,17.8,51.6,18.2"></path>
+                                              </g>
+                                            </svg>
+                                        </div>
+                                                                        <h2 class="h1">Want more recipes?</h2>
                                 </div>
-                            </div>
-                                                        
-                        	        
-                        	        
-                        	        
-        
-                            <header id="header">
-                    <div class="container -huge">
-                                                    <div class="logo">
-                                <a href="https://www.forksoverknives.com/" class="custom-logo-link" rel="home"><img   alt="Forks Over Knives" data-src="https://www.forksoverknives.com/wp-content/uploads/FOK_nav_logo.svg" class="custom-logo lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/FOK_nav_logo.svg" class="custom-logo" alt="Forks Over Knives" /></noscript></a>                            </div>
-                                                                        <nav class="nav-holder"><a class="nav-opener" href="#"><span></span></a>
-                            <div class="nav-slide">
-                                <ul id="nav" class="noclass"><li id="menu-item-69168" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-69168"><a href="https://www.forksoverknives.com/our-story/">Our Story</a>
-<div class="nav-drop drop-default"><ul>	<li id="menu-item-70701" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-70701"><a href="https://www.forksoverknives.com/our-story/">Overview</a></li>
-	<li id="menu-item-70702" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-70702"><a href="https://www.forksoverknives.com/the-film/">The Film</a></li>
-	<li id="menu-item-70703" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-70703"><a href="https://www.forksoverknives.com/what-to-eat/">The Diet</a></li>
-	<li id="menu-item-70704" class="menu-item menu-item-type-post_type_archive menu-item-object-contributor menu-item-70704"><a href="https://www.forksoverknives.com/contributors/">Contributors</a></li>
-	<li id="menu-item-70705" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-70705"><a href="https://www.forksoverknives.com/faq/">FAQs</a></li>
-</ul></div></li>
-<li id="menu-item-118311" class="recipe menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-118311"><a href="https://www.forksoverknives.com/recipes/">Recipes</a>
-
-            <div class="nav-drop">
-                <div class="nav-container-holder"><div class="recipe-app-mob"><a href="https://www.forksoverknives.com/app/">get the recipe app<i class="icon-phone"></i></a></div><div class="col">
-                                    <ul class="list-dd">
-	<li id="menu-item-120468" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-120468"><a href="https://www.forksoverknives.com/recipes/">All Recipes</a></li>
-	<li id="menu-item-116062" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116062"><a href="https://www.forksoverknives.com/recipes/amazing-grains/">Amazing Grains</a></li>
-	<li id="menu-item-116063" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116063"><a href="https://www.forksoverknives.com/recipes/vegan-baked-stuffed/">Baked &amp; Stuffed</a></li>
-	<li id="menu-item-116064" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116064"><a href="https://www.forksoverknives.com/recipes/vegan-breakfast/">Breakfasts</a></li>
-</ul></div><div class="col"><ul class="list-dd">	<li id="menu-item-116065" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116065"><a href="https://www.forksoverknives.com/recipes/vegan-burgers-wraps/">Burgers &amp; Wraps</a></li>
-	<li id="menu-item-116066" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116066"><a href="https://www.forksoverknives.com/recipes/vegan-desserts/">Decadent Desserts</a></li>
-	<li id="menu-item-116067" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116067"><a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/">Menus &amp; Collections</a></li>
-	<li id="menu-item-116068" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax current-recipe-ancestor active current-recipe-parent menu-item-116068"><a href="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/">Pasta &amp; Noodles</a></li>
-</ul></div><div class="col"><ul class="list-dd">	<li id="menu-item-116069" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116069"><a href="https://www.forksoverknives.com/recipes/vegan-salads-sides/">Salads &#038; Sides</a></li>
-	<li id="menu-item-116070" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116070"><a href="https://www.forksoverknives.com/recipes/vegan-sauces-condiments/">Sauces &amp; Condiments</a></li>
-	<li id="menu-item-116071" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116071"><a href="https://www.forksoverknives.com/recipes/vegan-snacks-appetizers/">Snacks &amp; Appetizers</a></li>
-	<li id="menu-item-116072" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-116072"><a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/">Soups &amp; Stews</a></li>
-</ul></div><div class="recipe-app">
-    <b class="title">
-                <picture>
-            <source srcset="https://www.forksoverknives.com/wp-content/themes/fork/images/img-recipe-app-drop.png, https://www.forksoverknives.com/wp-content/themes/fork/images/img-recipe-app-drop.png 2x" media="(max-width: 767px)">
-            <source srcset="https://www.forksoverknives.com/wp-content/themes/fork/images/img-recipe-app-drop.png"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/themes/fork/images/img-recipe-app-drop.png" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/themes/fork/images/img-recipe-app-drop.png" alt="description"></noscript>
-        </picture>
-        Try our top-rated recipe app.</b>
-    <p><span style="font-weight: 400;">Discover hundreds of chef-created whole-food, plant-based recipes, updated weekly.</span></p>
-    <a href="https://www.forksoverknives.com/app/" data-type="ad" data-ad-position="nav-menu" data-name="Try our top-rated recipe app. Nav">Download Now</a></div></div></div>
-</li>
-<li id="menu-item-69206" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-69206"><a href="https://www.forksoverknives.com/tools/">Tools</a>
-<div class="nav-drop drop-default"><ul>	<li id="menu-item-100199" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-100199"><a href="https://www.forksoverknives.com/tools/">Overview</a></li>
-	<li id="menu-item-147701" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-147701"><a href="https://www.forksoverknives.com/meal-planner/">Meal Planner</a></li>
-	<li id="menu-item-125248" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-125248"><a href="https://www.forksoverknives.com/cooking-course/">Cooking Course</a></li>
-	<li id="menu-item-127786" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-127786"><a href="https://www.forksoverknives.com/app/">Recipe App</a></li>
-	<li id="menu-item-71062" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-71062"><a href="https://www.forksoverknives.com/books-magazines/">Books &#038; Magazines</a></li>
-</ul></div></li>
-<li id="menu-item-69208" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent menu-item-has-children menu-item-69208"><a href="https://www.forksoverknives.com/articles/">News Feed</a>
-<div class="nav-drop drop-default"><ul>	<li id="menu-item-70715" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent menu-item-70715"><a href="https://www.forksoverknives.com/articles/">All Articles</a></li>
-	<li id="menu-item-70712" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-70712"><a href="https://www.forksoverknives.com/success-stories/">Success Stories</a></li>
-	<li id="menu-item-83431" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-83431"><a href="https://www.forksoverknives.com/share-story/">Share Your Story</a></li>
-	<li id="menu-item-70713" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-70713"><a href="https://www.forksoverknives.com/how-tos/">How To</a></li>
-	<li id="menu-item-70714" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-70714"><a href="https://www.forksoverknives.com/wellness/">Wellness</a></li>
-</ul></div></li>
-<li id="menu-item-69209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-69209"><a href="https://www.forksoverknives.com/shop/">Shop</a>
-<div class="nav-drop drop-default"><ul>	<li id="menu-item-70716" class="menu-item menu-item-type-post_type_archive menu-item-object-product menu-item-70716"><a href="https://www.forksoverknives.com/shop/">All Products</a></li>
-	<li id="menu-item-70717" class="menu-item menu-item-type-taxonomy menu-item-object-product_cat menu-item-70717"><a href="https://www.forksoverknives.com/shop/?sc=961">Food</a></li>
-	<li id="menu-item-70718" class="menu-item menu-item-type-taxonomy menu-item-object-product_cat menu-item-70718"><a href="https://www.forksoverknives.com/shop/?sc=665">Books &amp; Magazines</a></li>
-	<li id="menu-item-70719" class="menu-item menu-item-type-taxonomy menu-item-object-product_cat menu-item-70719"><a href="https://www.forksoverknives.com/shop/?sc=667">DVDs</a></li>
-	<li id="menu-item-70720" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-70720"><a href="https://www.forksoverknives.com/my-account/">My Account</a></li>
-</ul></div></li>
-<li id="menu-item-71019" class="get-started menu-item menu-item-type-post_type menu-item-object-post menu-item-71019"><a href="https://www.forksoverknives.com/how-tos/plant-based-primer-beginners-guide-starting-plant-based-diet/">Beginner&#8217;s Guide</a></li>
-<li class="meal-planner"><a data-type="Meal Planner" data-event="meal planner login" data-name="Meal Planner Login - Desktop" href="https://my.forksmealplanner.com/login-full" target="_blank">meal planner log in</a></li></ul>                                <div class="control-bar-mob">
-                                    <div class="basket"><a href="https://www.forksoverknives.com/cart/"><i class="icon-basket"></i><span class="js-cart-count">(0)</span></a></div>
-                                                                        <a class="btn" data-type="Meal Planner" data-event="meal planner login" data-name="Meal Planner Login - Mobile" href="https://my.forksmealplanner.com/login-full" target="_blank">meal planner login<i class="icon-planner"></i></a>
-                                                                    </div>
-                            </div>
-                        </nav>
-                        <div class="control-bar">
-                            <ul class="controll-list">
-                                <li class="search-openclose"><a class="search-opener" href="#"><i class="icon-search"></i></a>
-                                    <div class="pop-search">
-                                        <form class="search-form" action="https://www.forksoverknives.com" method="get">
-                                            <input type="search" name="s" placeholder="Search">
-                                            <button type="submit"><i class="icon-search"></i><span>Search</span></button>
-                                        </form>
-                                    </div>
-                                </li>
-                                <li class="basket"><a href="https://www.forksoverknives.com/cart/"><i class="icon-basket"></i><span class="count"><span class="js-cart-count">0</span></span></a></li>
-                            </ul>
+                                <p>Download our recipe app and get hundreds of whole-food, plant-based recipes at your fingertips.</p>
+                                <div class="rate-box">
+                                                                            <span class="rated-count">4.7</span>
+                                                                        <div class="img-rate"><img
+                                                
+                                                width="125" alt="description" data-src="https://www.forksoverknives.com/wp-content/themes/fork/images/img-rate-4-5.svg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img
+                                                src="https://www.forksoverknives.com/wp-content/themes/fork/images/img-rate-4-5.svg"
+                                                width="125" alt="description"></noscript></div>
+                                </div>
+                                <a class="btn" href="/app/" >Download the app</a>                            </div>
                         </div>
                     </div>
-                </header>
-                    
-        <div itemscope itemtype="http://schema.org/Recipe">
-    <div class="banner">
-        <div class="bg-stretch">
-                    <span data-srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/128193/butternut-broccoli-mac-and-cheese-wordpress-1366x566-c.jpg"></span>
-                    <span data-srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/128193/butternut-broccoli-mac-and-cheese-wordpress-375x173-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/128193/butternut-broccoli-mac-and-cheese-wordpress-750x344-c.jpg 2x" data-media="(max-width: 768px)"></span>
-                    
-                </div>        <img itemprop="image"   alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" class="img-hidden lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img itemprop="image" class="img-hidden" src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" alt=""></noscript>
-        <div class="container">
-            <div class="banner-block">
-                                    <ul class="breadcrumbs">
-                        <li class="home"><a href="/recipes/">Recipes</a></li>
-                        <li itemprop="recipeCategory"><a href="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/">Pasta &amp; Noodles</a></li>
-                    </ul>
-                                <h1 class="h2" itemprop="name">Butternut Squash Mac and Cheese with Broccoli </h1>
-                <div class="rate-container">
-                    <a class="rate-box" href="#comments-section"><div class="rate-wrap"><ul class="stars-rating-list readonly"><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li></ul></div><span class="rated-count">(3)</span></a>
-                    <a class="comments-link" href="#comments-section"><span class="icon-comments"></span>3 Comments</a>
                 </div>
+            </div>
+                                            
+                            
+                            
+                            
+                                                <div class="hello-bar type-1 bg-primary-yellow"
+                             data-version="-ver-">
+                            <div class="container -huge">
+                                <div class="content-wrap">
+                                                                            <div class="image-block">
+                                            <picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/159232/CookingCourse-239x257px-113x97-c.png, https://www.forksoverknives.com/wp-content/uploads/fly-images/159232/CookingCourse-239x257px-226x193-c.png 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/159232/CookingCourse-239x257px-283x169-c.png"><img  alt="Woman prepping vegetables for Cooking Course" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/159232/CookingCourse-239x257px-283x169-c.png" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/159232/CookingCourse-239x257px-283x169-c.png" alt="Woman prepping vegetables for Cooking Course"></noscript>
+                </picture>                                        </div>
+                                                                        <a class="text-frame"
+                                       href="/cooking-course/" data-type="ad" data-name="Cooking Course - Sitewide Hello" data-ad-position="page pushdown" data-ad-content="Animated-Early Bird">
+                                        <strong class="title">Become a Plant-Based Home Chef With Forks Cooking Classes</strong>
+                                        Self-directed classes for all schedules and budgets                                    </a>
+                                    <a class="btn desktop-visible" href="/cooking-course/" data-type="ad" data-name="Cooking Course - Sitewide Hello" data-ad-position="page pushdown" data-ad-content="Animated-Early Bird">SEE THE CLASSES</a>                                </div>
+                                <span class="btn-close" data-type="ui"
+                                      data-event="click"
+                                      data-name="Close sitewide app banner"><i class="icon-close"></i></span>
                             </div>
+                        </div>
+                                            
+                            
+                            
+                    <header id="header">
+                <div class="header-mobile desktop-hidden">
+                    <div class="container -huge">
+                                                    <div class="logo">
+                                <a href="https://www.forksoverknives.com/" class="custom-logo-link" rel="home"><img width="169" height="26"   alt="Forks Over Knives" data-src="https://www.forksoverknives.com/wp-content/uploads/logo-white.svg" class="custom-logo lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img width="169" height="26"   alt="Forks Over Knives" data-src="https://www.forksoverknives.com/wp-content/uploads/logo-white.svg" class="custom-logo lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img width="169" height="26" src="https://www.forksoverknives.com/wp-content/uploads/logo-white.svg" class="custom-logo" alt="Forks Over Knives" /></noscript></noscript></a>                            </div>
+                                                <div class="search-openclose"><a class="search-opener" href="#" title="search opener"><i
+                                        class="icon-search"></i></a>
+                            <div class="pop-search">
+                                <form class="search-form" action="https://www.forksoverknives.com/search" method="get">
+                                    <label for="search"
+                                           class="screenreader-label">Search</label>
+                                    <input id="search" type="search" name="search"
+                                           placeholder="Search">
+                                    <button type="submit"><i
+                                                class="icon-search"></i><span>Search</span>
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                    <nav class="nav-holder"><a class="nav-opener" href="#" title="nav opener"><span></span></a>
+        <div class="nav-slide">
+            <div class="header-holder">
+                <div class="container -huge">
+                                            <div class="logo desktop-visible">
+                            <a href="https://www.forksoverknives.com/" class="custom-logo-link" rel="home"><img width="169" height="26"   alt="Forks Over Knives" data-src="https://www.forksoverknives.com/wp-content/uploads/logo-white.svg" class="custom-logo lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img width="169" height="26"   alt="Forks Over Knives" data-src="https://www.forksoverknives.com/wp-content/uploads/logo-white.svg" class="custom-logo lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img width="169" height="26" src="https://www.forksoverknives.com/wp-content/uploads/logo-white.svg" class="custom-logo" alt="Forks Over Knives" /></noscript></noscript></a>                        </div>
+                                        <div class="header-block">
+                                                    <div class="login-frame"><strong><a data-type="Meal Planner" data-event="meal planner login"
+                                                                data-name="Meal Planner Login - Mobile"
+                                                                href="https://my.forksmealplanner.com/login-full"
+                                                                target="_blank">Meal planner log in</a></strong></div>
+                                            </div>
+                </div>
+            </div>
+            <div class="header-frame">
+                <div class="container -huge">
+                    <ul class="main-nav">
+                                                    <li class=""><a href="/our-story/" >Our Story</a>                                <div class="nav-drop">
+                                    <div class="container -huge">
+                                        <div class="nav-drop-holder"><ul><li class=""><a href="/our-story/" >Overview</a></li><li class=""><a href="/the-film/" >The FOK Film</a></li><li class=""><a href="/what-to-eat/" >The FOK Diet</a></li><li class=""><a href="/contributors/" >Contributors</a></li></ul><ul><li class=""><a href="/faq/" >FAQs</a></li><li class=""><a href="/press/" >Press</a></li><li class=""><a href="/contact-us/" >Contact</a></li></ul></div>                                                                                                                                                                                        <div class="drop-block drop-film desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                <picture>
+                                                                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/155415/img-nav-drop-03-194x132-c.jpeg">
+                                                                    <img 
+                                                                         alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155415/img-nav-drop-03-194x132-c.jpeg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155415/img-nav-drop-03-194x132-c.jpeg"
+                                                                         alt=""></noscript>
+                                                                </picture>
+                                                            </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="/the-film/">Watch the FOK Film</a>
+                                                                                                                            </strong>
+                                                            <a class="link" href="/the-film/" data-type="ad" data-ad-position="nav-menu" data-name="Watch the Film">Watch now</a>                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                                    <li class=""><a href="/recipes/" >Recipes</a>                                <div class="nav-drop">
+                                    <div class="container -huge">
+                                        <div class="nav-drop-holder"><ul><li class=""><a href="/recipes/" >All Recipes</a></li><li class=""><a href="/recipes/amazing-grains/" >Amazing Grains</a></li><li class=""><a href="/recipes/vegan-baked-stuffed/" >Baked & Stuffed</a></li><li class=""><a href="/recipes/vegan-breakfast/" >Breakfasts</a></li></ul><ul><li class=""><a href="/recipes/vegan-burgers-wraps/" >Burgers & Wraps</a></li><li class=""><a href="/recipes/vegan-desserts/" >Decadent Desserts</a></li><li class=""><a href="/recipes/vegan-menus-collections/" >Menus & Collections</a></li><li class=""><a href="/recipes/vegan-pasta-noodles/" >Pasta & Noodles</a></li></ul><ul><li class=""><a href="/recipes/vegan-salads-sides/" >Salads & Sides</a></li><li class=""><a href="/recipes/vegan-sauces-condiments/" >Sauces & Condiments</a></li><li class=""><a href="/recipes/vegan-snacks-appetizers/" >Snacks & Appetizers</a></li><li class=""><a href="/recipes/vegan-soups-stews/" >Soups & Stews</a></li></ul></div>                                                                                                                                                                                        <div class="drop-block drop-recipe-app desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                <picture>
+                                                                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/155420/img-nav-drop-01-67x117-c.jpeg">
+                                                                    <img 
+                                                                         alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155420/img-nav-drop-01-67x117-c.jpeg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155420/img-nav-drop-01-67x117-c.jpeg"
+                                                                         alt=""></noscript>
+                                                                </picture>
+                                                                <svg class="decor decor-wheat" version="1.1" width="48"
+                                                                     id="Layer_1" xmlns="http://www.w3.org/2000/svg"
+                                                                     x="0px" y="0px" viewBox="0 0 149.7 204.2"
+                                                                     style="enable-background:new 0 0 149.7 204.2;"
+                                                                     xml:space="preserve">
+                                                                  <g>
+                                                                      <path class="st0"
+                                                                            d="M134.4,55.3c-9.2,7.2-19.5,11.6-31,13.2c-0.6,0.1-1.3-0.4-2.3-0.7c2.3-3.4,5.5-5.4,8.6-7.2c6-3.5,12.5-6.1,19.1-8.1c2.1-0.6,4.3-0.8,6.4,0.7C134.9,54,134.9,54.9,134.4,55.3 M113.9,76.9c0.9,0.1,1.7,0.7,2.5,1c-0.2,2.3-1.9,2.4-3.1,3c-8.5,4.1-19.3,6.9-28.8,7.3c-0.4-2.9,0.6-4.8,2.4-6.4c2.3-2,4.9-3.4,7.9-3.9C101.1,77,107.5,76.3,113.9,76.9 M106.8,98.7c-7.7,6.9-16.3,9.2-24.8,11.4c-1,0.3-2,0.5-3.1,0.7c0.1-0.3,0.1-0.7,0.2-1c-2.9-3.8-7.1-2.2-11.2-2.5c1.1-2.4,2.3-4.5,4-6.4c1.5-1.7,3.5-2.8,5.8-3.1c4.9-0.6,9.7-1.4,14.7-0.5C96.6,98.1,101,98.2,106.8,98.7 M55.3,139.7c-4.3,4.4-9,8.8-15.6,10.8c-1.1-4.9-1.5-9.3-0.7-13.8c0.5-2.7,1.8-5.2,4-6.9c4.7-3.8,9.2-7.7,15-10c5-2,9.7-4.7,15.9-7.9C70.2,124,62.8,132,55.3,139.7 M44,115.6c-2.3-2.8-2.4-5.4-1.6-8.2c1.1-3.6,3-6.7,5.7-9.1c5.9-5.2,12.1-10,19.2-13.5c1-0.5,2.2-0.4,3.2-0.5c1.3,2.5-0.4,3.7-1.3,5.2C63.1,99.2,53.6,109,44,115.6 M5.9,107.3c3-1.3,4.3,0.8,5.8,2c11.5,9.1,10.7,6.6,16.7,19.5c1.4,9.8,1.3,10.7-2.5,20.2C13,137.4,7.4,123.3,5.9,107.3 M11.9,71.2c-0.1-0.5,0.5-1,0.7-1.6c1.7-0.6,2.8,0.6,3.8,1.6C23.2,78,30.8,84.1,35,93.3c-0.6,5.8-0.8,11.8-3.6,18.1c-7.5-4.5-11.1-10.6-13.9-17.4C14.6,86.7,13.1,79,11.9,71.2 M26.3,42.9c-0.1-1.7-0.4-3.7,1.4-5c2.6,0.7,3.7,3,5.1,4.9c2,2.6,4,5.3,5.3,8.3c1.8,3.8,3.1,7.8,4.3,11.9c1.7,6,1.1,8.7-3,15.2c-1.3,0.5-2.4,0-3.1-1.1c-1.9-3.4-4.2-6.7-5.4-10.3C28.2,59.1,26.6,51.1,26.3,42.9 M58.9,11.3c0.3-0.4,1-0.5,1.7-0.8c0.3,0.8,0.8,1.6,0.7,2.4c-0.2,4.8-1.4,9.6-0.5,14.4c-2,9.4-3.2,19-7.1,28c-0.4,1-1.6,1.6-2.7,2.7c-3.2-7.1-3.6-13.8-2-20.8c1-4.1,1.9-8.2,3-12.3C53.4,19.9,55.4,15.2,58.9,11.3 M52.4,70.7c3.9-7.5,9-14.3,14.7-20.7c1.8-2,4-3.6,7.2-3.4c0.2,1,0.7,2,0.5,2.7c-4.9,13.3-12.9,24.6-23.8,33.6c-0.6,0.5-1.6,0.5-2.8,0.8C48.3,78.7,50.3,74.6,52.4,70.7 M82.5,42.6c1.4,0.3,1.7,1.6,2,2.7c1.8,7.7,4.4,15.2,3.4,23.5c-2.6,3.4-5,6.9-8.7,9.9c0-0.1-0.1-0.3-0.1-0.4c-0.9-0.5-1.8-0.8-2.6-1.1c-2-5.4-1.9-10.4-1-15.6c0,0,0-0.1,0-0.1c1-1.7,1.9-3.5,2.7-5.4c1.1-2.5,1.8-5.2,2.2-7.8c0.1-0.7,0-1.4-0.2-2.1c0.4-1,0.8-2,1.2-3C81.4,43,82.1,42.9,82.5,42.6 M103.5,29.8c0.7-1.2,1.3-2.7,3.1-2.9c1.5,1.6,1.3,3.7,1.4,5.6c0.2,2.7,0.5,5.5,0.1,8.1c-0.4,3.4-1.2,6.8-2.1,10.2c-1.4,4.9-3,6.6-8.6,9.3c-1.1-0.2-1.7-1.1-1.7-2.1c0.1-3.2,0-6.5,0.6-9.6C97.8,42,100.1,35.7,103.5,29.8 M121.7,35.8c2.4-2.5,4.9-4.9,7.4-7.3c3.1-2.9,6.5-5.4,10.6-6.6c0.4-0.1,0.9,0.1,1.6,0.2c-0.2,0.7-0.2,1.5-0.5,2c-2.2,3.3-5.1,6.1-6.6,9.9c-5.5,5.7-10.4,11.9-17,16.5c-0.7,0.5-1.8,0.4-3,0.7C115,44.8,117.6,39.9,121.7,35.8 M139.9,53.6c-1.1-0.9-1.9-2-2.9-2.4c-1.3-0.5-2.9-0.5-4.4-0.9c-0.6-0.2-1-0.8-1.7-1.3c1.7-1.8,3.2-3.5,4.9-4.8c3.7-2.8,6.3-6.4,8.1-10.5c1.8-4.1,3.8-8.1,5.4-12.3c0.9-2.2,0.6-4.4-2.3-5.9c-3.7,0-7.5,1.2-11.2,2.6c-3.7,1.3-7.3,3.1-11,4.6c-3.6,1.5-6.4,4.6-10.2,6c-2.4-2.7-2.3-6.3-4.8-9.1c-0.9,0-2.3-0.4-3.3,0c-1.5,0.7-3.1,1.7-4.2,2.9c-3.6,3.8-7.1,7.7-9.2,11.7c-1,3.6-1.8,6.4-2.6,9.3c-0.3,1-0.9,1.7-2.1,1.5c-2-2.2-1.5-5.9-4.4-7.4c-0.6,0.1-1.2,0.1-1.5,0.4c-1.4,1.4-2.6,3-4.1,4.4c-0.3,0.3-0.5,0.6-0.8,0.9c-1-0.3-2.3-0.5-5,0c-1.7,0.3-4.1,1.2-5.5,1.9c0.7-2.9,1-5.7,2-8.2c2-5.3,2.4-10.6,1.7-16.1c-0.7-5.4-1.3-10.8-2.3-16.2c-0.5-2.8-2.2-5-6.2-4.6c-3.8,2.4-7,6.1-10,9.9c-3,3.8-5.6,7.9-8.5,11.8c-2.8,3.9-3.7,8.8-6.8,12.8c-4.2-1.2-6.5-5-10.8-6.3c-1,0.6-2.6,1-3.4,2.1C21.7,32,20.7,34,20.3,36c-1.3,6.2-2.5,12.5-2.1,18.1c1.2,4.3,2.2,7.8,3.2,11.3c0.3,1.2,0.2,2.4-1.2,2.9c-3.4-1-5.3-5.1-9.4-4.8c-0.5,0.5-1.2,0.8-1.3,1.3c-0.6,2.4-0.8,4.8-1.4,7.1C6,80.4,8.7,88.6,9.9,96.6c-3.8,2.2-5.1-1.4-7.6-2.4l-1.9,3.1c-0.1,4.4-0.2,8.1-0.2,11.7c0,2.4-0.3,4.9,0,7.3c2.3,15.6,9.3,28.6,22,38.2c1.7,1.2,3.2,2.7,4.8,4.1c0.2,4.4,0.4,8.7,0.5,12.9c0.3,7,0.2,9,0.5,16c0.1,3,0.4,18,7.4,16.6c2.5-0.5,2.6-7,2.4-8.8c-0.7-5.9-1.1-11.9-0.7-17.8c0.5-6.2,1.4-12.4,0.8-18.6c-0.1-0.6,0-1.3,0.3-1.8c0.4-0.8,0.9-1.5,1.5-2.3l6.8-0.6c16.5-8.2,27.2-21.2,31.3-37.7c13.4-0.7,24.9-6.5,33.6-17.1c-0.4-4.5-5.1-4.8-7.9-7.6c1.6-0.9,2.8-1.9,4.1-2.3c6.4-1.8,11.6-5.5,16.2-10.2c0.6-0.6,0.9-1.6,1-1.9c-2.2-4.1-5.9-5.1-10.8-7.3c2.6-0.8,3.7-1.2,4.9-1.6c5.4-1.4,10.2-3.9,14.8-7c1.8-1.2,3.4-2.8,4.9-4.5C139.3,56.3,139.4,54.9,139.9,53.6"></path>
+                                                                  </g>
+                                                                </svg>
+                                                            </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="/app/">Try our top-rated recipe app.</a>
+                                                                                                                            </strong>
+                                                            <a class="link" href="/app/" data-type="ad" data-ad-position="nav-menu" data-name="Try our recipe app">Download</a>                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                                    <li class=""><a href="/articles/" >Articles</a>                                <div class="nav-drop">
+                                    <div class="container -huge">
+                                        <div class="nav-drop-holder"><ul><li class=""><a href="/articles/" >All Articles</a></li><li class=""><a href="/success-stories/" >Success Stories</a></li><li class=""><a href="/how-tos/" >How To</a></li><li class=""><a href="/wellness/" >Wellness</a></li></ul></div>                                                                                                                                                                                        <div class="drop-post-article desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                                                                                <a href="/share-story/">
+                                                                                                                                        <picture>
+                                                                        <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/155421/img-drop-post-article-01-194x132-c.jpeg">
+                                                                        <img 
+                                                                             alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155421/img-drop-post-article-01-194x132-c.jpeg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155421/img-drop-post-article-01-194x132-c.jpeg"
+                                                                             alt=""></noscript>
+                                                                    </picture>
+                                                                                                                                    </a>
+                                                                                                                        </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="/share-story/">Share your story</a>
+                                                                                                                            </strong>
+                                                            <p>Has a whole-food, plant-based diet impacted your life? We would love to hear about it!</p>
+                                                            <div class="link-row"><a class="link" href="/share-story/" data-type="ad" data-ad-position="nav-menu" data-name="Share your story">Learn More</a></div>
+                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                                    <li class=""><a href="/health-topics/" >Health Topics</a>                                <div class="nav-drop">
+                                    <div class="container -huge">
+                                        <div class="nav-drop-holder"><ul><li class=""><a href="/health-topics/" >All Health Topics</a></li><li class=""><a href="/health-topics/acne-and-diet/" >Acne</a></li><li class=""><a href="/health-topics/dementia-alzheimers-and-diet/" >Alzheimer's</a></li><li class=""><a href="/health-topics/diet-and-arthritis/" >Arthritis</a></li><li class=""><a href="/health-topics/asthma-and-diet/" >Asthma</a></li></ul><ul><li class=""><a href="https://www.forksoverknives.com/health-topics/autoimmune-diseases-and-diet/" >Autoimmune Disease</a></li><li class=""><a href="/health-topics/calcium-and-bone-health-diet/" >Bone Health</a></li><li class=""><a href="/health-topics/cancer-and-diet/" >Cancer</a></li><li class=""><a href="/health-topics/diet-and-depression/" >Depression</a></li><li class=""><a href="/health-topics/vegan-diet-and-diabetes/" >Diabetes</a></li></ul><ul><li class=""><a href="https://www.forksoverknives.com/health-topics/gluten-sensitivity-and-diet/" >Gluten Sensitivity</a></li><li class=""><a href="/health-topics/heart-disease-and-diet/" >Heart Disease</a></li><li class=""><a href="https://www.forksoverknives.com/health-topics/irritable-bowel-syndrome-what-to-know-about-ibs/" >IBS</a></li><li class=""><a href="/health-topics/diet-and-inflammation" >Inflammation</a></li><li class=""><a href="/health-topics/kidney-disease-diet/" >Kidney Disease</a></li></ul><ul><li class=""><a href="https://www.forksoverknives.com/health-topics/metabolic-syndrome-and-diet/" >Metabolic Syndrome</a></li><li class=""><a href="https://www.forksoverknives.com/health-topics/obesity-health-risks-and-diet/" >Obesity</a></li><li class=""><a href="https://www.forksoverknives.com/health-topics/stroke/" >Stroke</a></li></ul></div>                                                                                                                                                                                        <div class="drop-block drop-meal-planner desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                <picture>
+                                                                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/155425/img-nav-drop-02-142x77-c.png">
+                                                                    <img 
+                                                                         alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155425/img-nav-drop-02-142x77-c.png" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155425/img-nav-drop-02-142x77-c.png"
+                                                                         alt=""></noscript>
+                                                                </picture>
+                                                                <svg class="decor left decor-wheat" version="1.1"
+                                                                     width="38" id="Layer_1"
+                                                                     xmlns="http://www.w3.org/2000/svg"
+                                                                     x="0px" y="0px" viewBox="0 0 149.7 204.2"
+                                                                     style="enable-background:new 0 0 149.7 204.2;"
+                                                                     xml:space="preserve">
+                                                                  <g>
+                                                                      <path class="st0"
+                                                                            d="M134.4,55.3c-9.2,7.2-19.5,11.6-31,13.2c-0.6,0.1-1.3-0.4-2.3-0.7c2.3-3.4,5.5-5.4,8.6-7.2c6-3.5,12.5-6.1,19.1-8.1c2.1-0.6,4.3-0.8,6.4,0.7C134.9,54,134.9,54.9,134.4,55.3 M113.9,76.9c0.9,0.1,1.7,0.7,2.5,1c-0.2,2.3-1.9,2.4-3.1,3c-8.5,4.1-19.3,6.9-28.8,7.3c-0.4-2.9,0.6-4.8,2.4-6.4c2.3-2,4.9-3.4,7.9-3.9C101.1,77,107.5,76.3,113.9,76.9 M106.8,98.7c-7.7,6.9-16.3,9.2-24.8,11.4c-1,0.3-2,0.5-3.1,0.7c0.1-0.3,0.1-0.7,0.2-1c-2.9-3.8-7.1-2.2-11.2-2.5c1.1-2.4,2.3-4.5,4-6.4c1.5-1.7,3.5-2.8,5.8-3.1c4.9-0.6,9.7-1.4,14.7-0.5C96.6,98.1,101,98.2,106.8,98.7 M55.3,139.7c-4.3,4.4-9,8.8-15.6,10.8c-1.1-4.9-1.5-9.3-0.7-13.8c0.5-2.7,1.8-5.2,4-6.9c4.7-3.8,9.2-7.7,15-10c5-2,9.7-4.7,15.9-7.9C70.2,124,62.8,132,55.3,139.7 M44,115.6c-2.3-2.8-2.4-5.4-1.6-8.2c1.1-3.6,3-6.7,5.7-9.1c5.9-5.2,12.1-10,19.2-13.5c1-0.5,2.2-0.4,3.2-0.5c1.3,2.5-0.4,3.7-1.3,5.2C63.1,99.2,53.6,109,44,115.6 M5.9,107.3c3-1.3,4.3,0.8,5.8,2c11.5,9.1,10.7,6.6,16.7,19.5c1.4,9.8,1.3,10.7-2.5,20.2C13,137.4,7.4,123.3,5.9,107.3 M11.9,71.2c-0.1-0.5,0.5-1,0.7-1.6c1.7-0.6,2.8,0.6,3.8,1.6C23.2,78,30.8,84.1,35,93.3c-0.6,5.8-0.8,11.8-3.6,18.1c-7.5-4.5-11.1-10.6-13.9-17.4C14.6,86.7,13.1,79,11.9,71.2 M26.3,42.9c-0.1-1.7-0.4-3.7,1.4-5c2.6,0.7,3.7,3,5.1,4.9c2,2.6,4,5.3,5.3,8.3c1.8,3.8,3.1,7.8,4.3,11.9c1.7,6,1.1,8.7-3,15.2c-1.3,0.5-2.4,0-3.1-1.1c-1.9-3.4-4.2-6.7-5.4-10.3C28.2,59.1,26.6,51.1,26.3,42.9 M58.9,11.3c0.3-0.4,1-0.5,1.7-0.8c0.3,0.8,0.8,1.6,0.7,2.4c-0.2,4.8-1.4,9.6-0.5,14.4c-2,9.4-3.2,19-7.1,28c-0.4,1-1.6,1.6-2.7,2.7c-3.2-7.1-3.6-13.8-2-20.8c1-4.1,1.9-8.2,3-12.3C53.4,19.9,55.4,15.2,58.9,11.3 M52.4,70.7c3.9-7.5,9-14.3,14.7-20.7c1.8-2,4-3.6,7.2-3.4c0.2,1,0.7,2,0.5,2.7c-4.9,13.3-12.9,24.6-23.8,33.6c-0.6,0.5-1.6,0.5-2.8,0.8C48.3,78.7,50.3,74.6,52.4,70.7 M82.5,42.6c1.4,0.3,1.7,1.6,2,2.7c1.8,7.7,4.4,15.2,3.4,23.5c-2.6,3.4-5,6.9-8.7,9.9c0-0.1-0.1-0.3-0.1-0.4c-0.9-0.5-1.8-0.8-2.6-1.1c-2-5.4-1.9-10.4-1-15.6c0,0,0-0.1,0-0.1c1-1.7,1.9-3.5,2.7-5.4c1.1-2.5,1.8-5.2,2.2-7.8c0.1-0.7,0-1.4-0.2-2.1c0.4-1,0.8-2,1.2-3C81.4,43,82.1,42.9,82.5,42.6 M103.5,29.8c0.7-1.2,1.3-2.7,3.1-2.9c1.5,1.6,1.3,3.7,1.4,5.6c0.2,2.7,0.5,5.5,0.1,8.1c-0.4,3.4-1.2,6.8-2.1,10.2c-1.4,4.9-3,6.6-8.6,9.3c-1.1-0.2-1.7-1.1-1.7-2.1c0.1-3.2,0-6.5,0.6-9.6C97.8,42,100.1,35.7,103.5,29.8 M121.7,35.8c2.4-2.5,4.9-4.9,7.4-7.3c3.1-2.9,6.5-5.4,10.6-6.6c0.4-0.1,0.9,0.1,1.6,0.2c-0.2,0.7-0.2,1.5-0.5,2c-2.2,3.3-5.1,6.1-6.6,9.9c-5.5,5.7-10.4,11.9-17,16.5c-0.7,0.5-1.8,0.4-3,0.7C115,44.8,117.6,39.9,121.7,35.8 M139.9,53.6c-1.1-0.9-1.9-2-2.9-2.4c-1.3-0.5-2.9-0.5-4.4-0.9c-0.6-0.2-1-0.8-1.7-1.3c1.7-1.8,3.2-3.5,4.9-4.8c3.7-2.8,6.3-6.4,8.1-10.5c1.8-4.1,3.8-8.1,5.4-12.3c0.9-2.2,0.6-4.4-2.3-5.9c-3.7,0-7.5,1.2-11.2,2.6c-3.7,1.3-7.3,3.1-11,4.6c-3.6,1.5-6.4,4.6-10.2,6c-2.4-2.7-2.3-6.3-4.8-9.1c-0.9,0-2.3-0.4-3.3,0c-1.5,0.7-3.1,1.7-4.2,2.9c-3.6,3.8-7.1,7.7-9.2,11.7c-1,3.6-1.8,6.4-2.6,9.3c-0.3,1-0.9,1.7-2.1,1.5c-2-2.2-1.5-5.9-4.4-7.4c-0.6,0.1-1.2,0.1-1.5,0.4c-1.4,1.4-2.6,3-4.1,4.4c-0.3,0.3-0.5,0.6-0.8,0.9c-1-0.3-2.3-0.5-5,0c-1.7,0.3-4.1,1.2-5.5,1.9c0.7-2.9,1-5.7,2-8.2c2-5.3,2.4-10.6,1.7-16.1c-0.7-5.4-1.3-10.8-2.3-16.2c-0.5-2.8-2.2-5-6.2-4.6c-3.8,2.4-7,6.1-10,9.9c-3,3.8-5.6,7.9-8.5,11.8c-2.8,3.9-3.7,8.8-6.8,12.8c-4.2-1.2-6.5-5-10.8-6.3c-1,0.6-2.6,1-3.4,2.1C21.7,32,20.7,34,20.3,36c-1.3,6.2-2.5,12.5-2.1,18.1c1.2,4.3,2.2,7.8,3.2,11.3c0.3,1.2,0.2,2.4-1.2,2.9c-3.4-1-5.3-5.1-9.4-4.8c-0.5,0.5-1.2,0.8-1.3,1.3c-0.6,2.4-0.8,4.8-1.4,7.1C6,80.4,8.7,88.6,9.9,96.6c-3.8,2.2-5.1-1.4-7.6-2.4l-1.9,3.1c-0.1,4.4-0.2,8.1-0.2,11.7c0,2.4-0.3,4.9,0,7.3c2.3,15.6,9.3,28.6,22,38.2c1.7,1.2,3.2,2.7,4.8,4.1c0.2,4.4,0.4,8.7,0.5,12.9c0.3,7,0.2,9,0.5,16c0.1,3,0.4,18,7.4,16.6c2.5-0.5,2.6-7,2.4-8.8c-0.7-5.9-1.1-11.9-0.7-17.8c0.5-6.2,1.4-12.4,0.8-18.6c-0.1-0.6,0-1.3,0.3-1.8c0.4-0.8,0.9-1.5,1.5-2.3l6.8-0.6c16.5-8.2,27.2-21.2,31.3-37.7c13.4-0.7,24.9-6.5,33.6-17.1c-0.4-4.5-5.1-4.8-7.9-7.6c1.6-0.9,2.8-1.9,4.1-2.3c6.4-1.8,11.6-5.5,16.2-10.2c0.6-0.6,0.9-1.6,1-1.9c-2.2-4.1-5.9-5.1-10.8-7.3c2.6-0.8,3.7-1.2,4.9-1.6c5.4-1.4,10.2-3.9,14.8-7c1.8-1.2,3.4-2.8,4.9-4.5C139.3,56.3,139.4,54.9,139.9,53.6"></path>
+                                                                  </g>
+                                                                </svg>
+                                                                <svg class="decor right decor-wheat" version="1.1"
+                                                                     width="38" id="Layer_1"
+                                                                     xmlns="http://www.w3.org/2000/svg"
+                                                                     x="0px" y="0px" viewBox="0 0 149.7 204.2"
+                                                                     style="enable-background:new 0 0 149.7 204.2;"
+                                                                     xml:space="preserve">
+                                                                  <g>
+                                                                      <path class="st0"
+                                                                            d="M134.4,55.3c-9.2,7.2-19.5,11.6-31,13.2c-0.6,0.1-1.3-0.4-2.3-0.7c2.3-3.4,5.5-5.4,8.6-7.2c6-3.5,12.5-6.1,19.1-8.1c2.1-0.6,4.3-0.8,6.4,0.7C134.9,54,134.9,54.9,134.4,55.3 M113.9,76.9c0.9,0.1,1.7,0.7,2.5,1c-0.2,2.3-1.9,2.4-3.1,3c-8.5,4.1-19.3,6.9-28.8,7.3c-0.4-2.9,0.6-4.8,2.4-6.4c2.3-2,4.9-3.4,7.9-3.9C101.1,77,107.5,76.3,113.9,76.9 M106.8,98.7c-7.7,6.9-16.3,9.2-24.8,11.4c-1,0.3-2,0.5-3.1,0.7c0.1-0.3,0.1-0.7,0.2-1c-2.9-3.8-7.1-2.2-11.2-2.5c1.1-2.4,2.3-4.5,4-6.4c1.5-1.7,3.5-2.8,5.8-3.1c4.9-0.6,9.7-1.4,14.7-0.5C96.6,98.1,101,98.2,106.8,98.7 M55.3,139.7c-4.3,4.4-9,8.8-15.6,10.8c-1.1-4.9-1.5-9.3-0.7-13.8c0.5-2.7,1.8-5.2,4-6.9c4.7-3.8,9.2-7.7,15-10c5-2,9.7-4.7,15.9-7.9C70.2,124,62.8,132,55.3,139.7 M44,115.6c-2.3-2.8-2.4-5.4-1.6-8.2c1.1-3.6,3-6.7,5.7-9.1c5.9-5.2,12.1-10,19.2-13.5c1-0.5,2.2-0.4,3.2-0.5c1.3,2.5-0.4,3.7-1.3,5.2C63.1,99.2,53.6,109,44,115.6 M5.9,107.3c3-1.3,4.3,0.8,5.8,2c11.5,9.1,10.7,6.6,16.7,19.5c1.4,9.8,1.3,10.7-2.5,20.2C13,137.4,7.4,123.3,5.9,107.3 M11.9,71.2c-0.1-0.5,0.5-1,0.7-1.6c1.7-0.6,2.8,0.6,3.8,1.6C23.2,78,30.8,84.1,35,93.3c-0.6,5.8-0.8,11.8-3.6,18.1c-7.5-4.5-11.1-10.6-13.9-17.4C14.6,86.7,13.1,79,11.9,71.2 M26.3,42.9c-0.1-1.7-0.4-3.7,1.4-5c2.6,0.7,3.7,3,5.1,4.9c2,2.6,4,5.3,5.3,8.3c1.8,3.8,3.1,7.8,4.3,11.9c1.7,6,1.1,8.7-3,15.2c-1.3,0.5-2.4,0-3.1-1.1c-1.9-3.4-4.2-6.7-5.4-10.3C28.2,59.1,26.6,51.1,26.3,42.9 M58.9,11.3c0.3-0.4,1-0.5,1.7-0.8c0.3,0.8,0.8,1.6,0.7,2.4c-0.2,4.8-1.4,9.6-0.5,14.4c-2,9.4-3.2,19-7.1,28c-0.4,1-1.6,1.6-2.7,2.7c-3.2-7.1-3.6-13.8-2-20.8c1-4.1,1.9-8.2,3-12.3C53.4,19.9,55.4,15.2,58.9,11.3 M52.4,70.7c3.9-7.5,9-14.3,14.7-20.7c1.8-2,4-3.6,7.2-3.4c0.2,1,0.7,2,0.5,2.7c-4.9,13.3-12.9,24.6-23.8,33.6c-0.6,0.5-1.6,0.5-2.8,0.8C48.3,78.7,50.3,74.6,52.4,70.7 M82.5,42.6c1.4,0.3,1.7,1.6,2,2.7c1.8,7.7,4.4,15.2,3.4,23.5c-2.6,3.4-5,6.9-8.7,9.9c0-0.1-0.1-0.3-0.1-0.4c-0.9-0.5-1.8-0.8-2.6-1.1c-2-5.4-1.9-10.4-1-15.6c0,0,0-0.1,0-0.1c1-1.7,1.9-3.5,2.7-5.4c1.1-2.5,1.8-5.2,2.2-7.8c0.1-0.7,0-1.4-0.2-2.1c0.4-1,0.8-2,1.2-3C81.4,43,82.1,42.9,82.5,42.6 M103.5,29.8c0.7-1.2,1.3-2.7,3.1-2.9c1.5,1.6,1.3,3.7,1.4,5.6c0.2,2.7,0.5,5.5,0.1,8.1c-0.4,3.4-1.2,6.8-2.1,10.2c-1.4,4.9-3,6.6-8.6,9.3c-1.1-0.2-1.7-1.1-1.7-2.1c0.1-3.2,0-6.5,0.6-9.6C97.8,42,100.1,35.7,103.5,29.8 M121.7,35.8c2.4-2.5,4.9-4.9,7.4-7.3c3.1-2.9,6.5-5.4,10.6-6.6c0.4-0.1,0.9,0.1,1.6,0.2c-0.2,0.7-0.2,1.5-0.5,2c-2.2,3.3-5.1,6.1-6.6,9.9c-5.5,5.7-10.4,11.9-17,16.5c-0.7,0.5-1.8,0.4-3,0.7C115,44.8,117.6,39.9,121.7,35.8 M139.9,53.6c-1.1-0.9-1.9-2-2.9-2.4c-1.3-0.5-2.9-0.5-4.4-0.9c-0.6-0.2-1-0.8-1.7-1.3c1.7-1.8,3.2-3.5,4.9-4.8c3.7-2.8,6.3-6.4,8.1-10.5c1.8-4.1,3.8-8.1,5.4-12.3c0.9-2.2,0.6-4.4-2.3-5.9c-3.7,0-7.5,1.2-11.2,2.6c-3.7,1.3-7.3,3.1-11,4.6c-3.6,1.5-6.4,4.6-10.2,6c-2.4-2.7-2.3-6.3-4.8-9.1c-0.9,0-2.3-0.4-3.3,0c-1.5,0.7-3.1,1.7-4.2,2.9c-3.6,3.8-7.1,7.7-9.2,11.7c-1,3.6-1.8,6.4-2.6,9.3c-0.3,1-0.9,1.7-2.1,1.5c-2-2.2-1.5-5.9-4.4-7.4c-0.6,0.1-1.2,0.1-1.5,0.4c-1.4,1.4-2.6,3-4.1,4.4c-0.3,0.3-0.5,0.6-0.8,0.9c-1-0.3-2.3-0.5-5,0c-1.7,0.3-4.1,1.2-5.5,1.9c0.7-2.9,1-5.7,2-8.2c2-5.3,2.4-10.6,1.7-16.1c-0.7-5.4-1.3-10.8-2.3-16.2c-0.5-2.8-2.2-5-6.2-4.6c-3.8,2.4-7,6.1-10,9.9c-3,3.8-5.6,7.9-8.5,11.8c-2.8,3.9-3.7,8.8-6.8,12.8c-4.2-1.2-6.5-5-10.8-6.3c-1,0.6-2.6,1-3.4,2.1C21.7,32,20.7,34,20.3,36c-1.3,6.2-2.5,12.5-2.1,18.1c1.2,4.3,2.2,7.8,3.2,11.3c0.3,1.2,0.2,2.4-1.2,2.9c-3.4-1-5.3-5.1-9.4-4.8c-0.5,0.5-1.2,0.8-1.3,1.3c-0.6,2.4-0.8,4.8-1.4,7.1C6,80.4,8.7,88.6,9.9,96.6c-3.8,2.2-5.1-1.4-7.6-2.4l-1.9,3.1c-0.1,4.4-0.2,8.1-0.2,11.7c0,2.4-0.3,4.9,0,7.3c2.3,15.6,9.3,28.6,22,38.2c1.7,1.2,3.2,2.7,4.8,4.1c0.2,4.4,0.4,8.7,0.5,12.9c0.3,7,0.2,9,0.5,16c0.1,3,0.4,18,7.4,16.6c2.5-0.5,2.6-7,2.4-8.8c-0.7-5.9-1.1-11.9-0.7-17.8c0.5-6.2,1.4-12.4,0.8-18.6c-0.1-0.6,0-1.3,0.3-1.8c0.4-0.8,0.9-1.5,1.5-2.3l6.8-0.6c16.5-8.2,27.2-21.2,31.3-37.7c13.4-0.7,24.9-6.5,33.6-17.1c-0.4-4.5-5.1-4.8-7.9-7.6c1.6-0.9,2.8-1.9,4.1-2.3c6.4-1.8,11.6-5.5,16.2-10.2c0.6-0.6,0.9-1.6,1-1.9c-2.2-4.1-5.9-5.1-10.8-7.3c2.6-0.8,3.7-1.2,4.9-1.6c5.4-1.4,10.2-3.9,14.8-7c1.8-1.2,3.4-2.8,4.9-4.5C139.3,56.3,139.4,54.9,139.9,53.6"></path>
+                                                                  </g>
+                                                                </svg>
+                                                            </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="/meal-planner/">Make life easy with our meal planner.</a>
+                                                                                                                            </strong>
+                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                                    <li class=""><a href="/meal-planner/" >Meal planner</a>                                <div class="nav-drop desktop-visible">
+                                    <div class="container -huge">
+                                                                                                                                                                                                                                <div class="drop-post-article desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                                                                                <a href="/meal-planner/">
+                                                                                                                                        <picture>
+                                                                        <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/155426/img-drop-post-article-02-194x132-c.jpeg">
+                                                                        <img 
+                                                                             alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155426/img-drop-post-article-02-194x132-c.jpeg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155426/img-drop-post-article-02-194x132-c.jpeg"
+                                                                             alt=""></noscript>
+                                                                    </picture>
+                                                                                                                                    </a>
+                                                                                                                        </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="/meal-planner/">Healthy eating shouldn’t be a hassle</a>
+                                                                                                                            </strong>
+                                                            <p>With weekly meal plans, Forks Meal Planner takes the hard work out of making nutritious meals the whole family will enjoy!</p>
+                                                            <div class="link-row"><a class="link" href="/meal-planner/" data-type="ad" data-ad-position="nav-menu" data-name="Meal Planner Plans">Learn More</a><a class="link" href="https://my.forksmealplanner.com/login-full?fokref=%2Fwellness%2F&_ga=2.131682255.1185845504.1621964730-2007668424.1608313071" data-type="ad" data-ad-position="nav-menu" data-name="Meal Planner Plans">Meal Planner Login</a></div>
+                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                                    <li class=""><a href="/cooking-course/" >Cooking course</a>                                <div class="nav-drop desktop-visible">
+                                    <div class="container -huge">
+                                                                                                                                                                                                                                <div class="drop-post-article desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                                                                                <a href="/cooking-course/">
+                                                                                                                                        <picture>
+                                                                        <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/155427/img-drop-post-article-03-194x132-c.jpeg">
+                                                                        <img 
+                                                                             alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155427/img-drop-post-article-03-194x132-c.jpeg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155427/img-drop-post-article-03-194x132-c.jpeg"
+                                                                             alt=""></noscript>
+                                                                    </picture>
+                                                                                                                                    </a>
+                                                                                                                        </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="/cooking-course/">Become a plant-based home chef in 90 days</a>
+                                                                                                                            </strong>
+                                                            <p>The Forks Cooking Course includes 55 hours of content you can complete at your own pace.</p>
+                                                            <div class="link-row"><a class="link" href="/cooking-course/" data-type="ad" data-ad-position="nav-menu" data-name="Cooking course">Learn More</a></div>
+                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                                    <li class=""><a href="/how-tos/plant-based-primer-beginners-guide-starting-plant-based-diet/" >Beginner’s Guide</a>                                <div class="nav-drop desktop-visible">
+                                    <div class="container -huge">
+                                                                                                                                                                                                                                <div class="drop-post-article desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                                                                                <a href="/how-tos/plant-based-primer-beginners-guide-starting-plant-based-diet/">
+                                                                                                                                        <picture>
+                                                                        <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/155428/img-drop-post-article-04-194x132-c.jpeg">
+                                                                        <img 
+                                                                             alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155428/img-drop-post-article-04-194x132-c.jpeg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/155428/img-drop-post-article-04-194x132-c.jpeg"
+                                                                             alt=""></noscript>
+                                                                    </picture>
+                                                                                                                                    </a>
+                                                                                                                        </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="/how-tos/plant-based-primer-beginners-guide-starting-plant-based-diet/">How a plant-based diet can boost your health</a>
+                                                                                                                            </strong>
+                                                            <p>One of the most powerful steps you can take to improve your health, boost energy levels, and prevent chronic diseases is to move to a plant-based diet.</p>
+                                                            <div class="link-row"><a class="link" href="/how-tos/plant-based-primer-beginners-guide-starting-plant-based-diet/" data-type="ad" data-ad-position="nav-menu" data-name="Beginners guide">Learn More</a></div>
+                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                                    <li class=""><a target="_blank" href="https://shop.forksoverknives.com/?utm_source=forksoverknives.com&utm_medium=referral&utm_campaign=fok.com&utm_content=nav-link" >Shop</a>                                <div class="nav-drop">
+                                    <div class="container -huge">
+                                        <div class="nav-drop-holder"><ul><li class=""><a href="https://www.forksoverknives.com/meal-planner/?utm_source=forksoverknives.com&utm_medium=referral&utm_campaign=shop+nav+link+meal+planner" >Meal Planner</a></li><li class=""><a href="https://www.forksoverknives.com/cooking-course/?utm_source=forksoverknives.com&utm_medium=referral&utm_campaign=shop+nav+link+cooking+course" >Cooking Course</a></li><li class=""><a target="_blank" href="https://shop.forksoverknives.com/collections/magazines?utm_source=forksoverknives.com&utm_medium=referral&utm_campaign=fok.com&utm_content=nav-link" >Magazines</a></li><li class=""><a target="_blank" href="https://shop.forksoverknives.com/collections/books?utm_source=forksoverknives.com&utm_medium=referral&utm_campaign=fok.com&utm_content=nav-link" >Books</a></li><li class=""><a target="_blank" href="https://shop.forksoverknives.com/collections/dvds?utm_source=forksoverknives.com&utm_medium=referral&utm_campaign=fok.com&utm_content=nav-link" >DVDs</a></li><li class=""><a href="http://www.forksoverknives.com/frozen" >Frozen Bowls</a></li></ul><ul><li class=""><a target="_blank" href="https://shop.forksoverknives.com/account/login?utm_source=forksoverknives.com&utm_medium=referral&utm_campaign=fok.com&utm_content=nav-link" >My Account</a></li></ul></div>                                                                                                                                                                                        <div class="drop-block drop-shop desktop-visible">
+                                                                                                                    <div class="image-block desktop-visible">
+                                                                <picture>
+                                                                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/161572/FOK_APPROVED_COVER_REV22-scaled-e1668541089158-75x102-c.webp">
+                                                                    <img 
+                                                                         alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/161572/FOK_APPROVED_COVER_REV22-scaled-e1668541089158-75x102-c.webp" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/161572/FOK_APPROVED_COVER_REV22-scaled-e1668541089158-75x102-c.webp"
+                                                                         alt=""></noscript>
+                                                                </picture>
+                                                                <svg class="decor decor-wheat" version="1.1" width="48"
+                                                                     id="Layer_1" xmlns="http://www.w3.org/2000/svg"
+                                                                     x="0px" y="0px" viewBox="0 0 149.7 204.2"
+                                                                     style="enable-background:new 0 0 149.7 204.2;"
+                                                                     xml:space="preserve">
+                                                                  <g>
+                                                                      <path class="st0"
+                                                                            d="M134.4,55.3c-9.2,7.2-19.5,11.6-31,13.2c-0.6,0.1-1.3-0.4-2.3-0.7c2.3-3.4,5.5-5.4,8.6-7.2c6-3.5,12.5-6.1,19.1-8.1c2.1-0.6,4.3-0.8,6.4,0.7C134.9,54,134.9,54.9,134.4,55.3 M113.9,76.9c0.9,0.1,1.7,0.7,2.5,1c-0.2,2.3-1.9,2.4-3.1,3c-8.5,4.1-19.3,6.9-28.8,7.3c-0.4-2.9,0.6-4.8,2.4-6.4c2.3-2,4.9-3.4,7.9-3.9C101.1,77,107.5,76.3,113.9,76.9 M106.8,98.7c-7.7,6.9-16.3,9.2-24.8,11.4c-1,0.3-2,0.5-3.1,0.7c0.1-0.3,0.1-0.7,0.2-1c-2.9-3.8-7.1-2.2-11.2-2.5c1.1-2.4,2.3-4.5,4-6.4c1.5-1.7,3.5-2.8,5.8-3.1c4.9-0.6,9.7-1.4,14.7-0.5C96.6,98.1,101,98.2,106.8,98.7 M55.3,139.7c-4.3,4.4-9,8.8-15.6,10.8c-1.1-4.9-1.5-9.3-0.7-13.8c0.5-2.7,1.8-5.2,4-6.9c4.7-3.8,9.2-7.7,15-10c5-2,9.7-4.7,15.9-7.9C70.2,124,62.8,132,55.3,139.7 M44,115.6c-2.3-2.8-2.4-5.4-1.6-8.2c1.1-3.6,3-6.7,5.7-9.1c5.9-5.2,12.1-10,19.2-13.5c1-0.5,2.2-0.4,3.2-0.5c1.3,2.5-0.4,3.7-1.3,5.2C63.1,99.2,53.6,109,44,115.6 M5.9,107.3c3-1.3,4.3,0.8,5.8,2c11.5,9.1,10.7,6.6,16.7,19.5c1.4,9.8,1.3,10.7-2.5,20.2C13,137.4,7.4,123.3,5.9,107.3 M11.9,71.2c-0.1-0.5,0.5-1,0.7-1.6c1.7-0.6,2.8,0.6,3.8,1.6C23.2,78,30.8,84.1,35,93.3c-0.6,5.8-0.8,11.8-3.6,18.1c-7.5-4.5-11.1-10.6-13.9-17.4C14.6,86.7,13.1,79,11.9,71.2 M26.3,42.9c-0.1-1.7-0.4-3.7,1.4-5c2.6,0.7,3.7,3,5.1,4.9c2,2.6,4,5.3,5.3,8.3c1.8,3.8,3.1,7.8,4.3,11.9c1.7,6,1.1,8.7-3,15.2c-1.3,0.5-2.4,0-3.1-1.1c-1.9-3.4-4.2-6.7-5.4-10.3C28.2,59.1,26.6,51.1,26.3,42.9 M58.9,11.3c0.3-0.4,1-0.5,1.7-0.8c0.3,0.8,0.8,1.6,0.7,2.4c-0.2,4.8-1.4,9.6-0.5,14.4c-2,9.4-3.2,19-7.1,28c-0.4,1-1.6,1.6-2.7,2.7c-3.2-7.1-3.6-13.8-2-20.8c1-4.1,1.9-8.2,3-12.3C53.4,19.9,55.4,15.2,58.9,11.3 M52.4,70.7c3.9-7.5,9-14.3,14.7-20.7c1.8-2,4-3.6,7.2-3.4c0.2,1,0.7,2,0.5,2.7c-4.9,13.3-12.9,24.6-23.8,33.6c-0.6,0.5-1.6,0.5-2.8,0.8C48.3,78.7,50.3,74.6,52.4,70.7 M82.5,42.6c1.4,0.3,1.7,1.6,2,2.7c1.8,7.7,4.4,15.2,3.4,23.5c-2.6,3.4-5,6.9-8.7,9.9c0-0.1-0.1-0.3-0.1-0.4c-0.9-0.5-1.8-0.8-2.6-1.1c-2-5.4-1.9-10.4-1-15.6c0,0,0-0.1,0-0.1c1-1.7,1.9-3.5,2.7-5.4c1.1-2.5,1.8-5.2,2.2-7.8c0.1-0.7,0-1.4-0.2-2.1c0.4-1,0.8-2,1.2-3C81.4,43,82.1,42.9,82.5,42.6 M103.5,29.8c0.7-1.2,1.3-2.7,3.1-2.9c1.5,1.6,1.3,3.7,1.4,5.6c0.2,2.7,0.5,5.5,0.1,8.1c-0.4,3.4-1.2,6.8-2.1,10.2c-1.4,4.9-3,6.6-8.6,9.3c-1.1-0.2-1.7-1.1-1.7-2.1c0.1-3.2,0-6.5,0.6-9.6C97.8,42,100.1,35.7,103.5,29.8 M121.7,35.8c2.4-2.5,4.9-4.9,7.4-7.3c3.1-2.9,6.5-5.4,10.6-6.6c0.4-0.1,0.9,0.1,1.6,0.2c-0.2,0.7-0.2,1.5-0.5,2c-2.2,3.3-5.1,6.1-6.6,9.9c-5.5,5.7-10.4,11.9-17,16.5c-0.7,0.5-1.8,0.4-3,0.7C115,44.8,117.6,39.9,121.7,35.8 M139.9,53.6c-1.1-0.9-1.9-2-2.9-2.4c-1.3-0.5-2.9-0.5-4.4-0.9c-0.6-0.2-1-0.8-1.7-1.3c1.7-1.8,3.2-3.5,4.9-4.8c3.7-2.8,6.3-6.4,8.1-10.5c1.8-4.1,3.8-8.1,5.4-12.3c0.9-2.2,0.6-4.4-2.3-5.9c-3.7,0-7.5,1.2-11.2,2.6c-3.7,1.3-7.3,3.1-11,4.6c-3.6,1.5-6.4,4.6-10.2,6c-2.4-2.7-2.3-6.3-4.8-9.1c-0.9,0-2.3-0.4-3.3,0c-1.5,0.7-3.1,1.7-4.2,2.9c-3.6,3.8-7.1,7.7-9.2,11.7c-1,3.6-1.8,6.4-2.6,9.3c-0.3,1-0.9,1.7-2.1,1.5c-2-2.2-1.5-5.9-4.4-7.4c-0.6,0.1-1.2,0.1-1.5,0.4c-1.4,1.4-2.6,3-4.1,4.4c-0.3,0.3-0.5,0.6-0.8,0.9c-1-0.3-2.3-0.5-5,0c-1.7,0.3-4.1,1.2-5.5,1.9c0.7-2.9,1-5.7,2-8.2c2-5.3,2.4-10.6,1.7-16.1c-0.7-5.4-1.3-10.8-2.3-16.2c-0.5-2.8-2.2-5-6.2-4.6c-3.8,2.4-7,6.1-10,9.9c-3,3.8-5.6,7.9-8.5,11.8c-2.8,3.9-3.7,8.8-6.8,12.8c-4.2-1.2-6.5-5-10.8-6.3c-1,0.6-2.6,1-3.4,2.1C21.7,32,20.7,34,20.3,36c-1.3,6.2-2.5,12.5-2.1,18.1c1.2,4.3,2.2,7.8,3.2,11.3c0.3,1.2,0.2,2.4-1.2,2.9c-3.4-1-5.3-5.1-9.4-4.8c-0.5,0.5-1.2,0.8-1.3,1.3c-0.6,2.4-0.8,4.8-1.4,7.1C6,80.4,8.7,88.6,9.9,96.6c-3.8,2.2-5.1-1.4-7.6-2.4l-1.9,3.1c-0.1,4.4-0.2,8.1-0.2,11.7c0,2.4-0.3,4.9,0,7.3c2.3,15.6,9.3,28.6,22,38.2c1.7,1.2,3.2,2.7,4.8,4.1c0.2,4.4,0.4,8.7,0.5,12.9c0.3,7,0.2,9,0.5,16c0.1,3,0.4,18,7.4,16.6c2.5-0.5,2.6-7,2.4-8.8c-0.7-5.9-1.1-11.9-0.7-17.8c0.5-6.2,1.4-12.4,0.8-18.6c-0.1-0.6,0-1.3,0.3-1.8c0.4-0.8,0.9-1.5,1.5-2.3l6.8-0.6c16.5-8.2,27.2-21.2,31.3-37.7c13.4-0.7,24.9-6.5,33.6-17.1c-0.4-4.5-5.1-4.8-7.9-7.6c1.6-0.9,2.8-1.9,4.1-2.3c6.4-1.8,11.6-5.5,16.2-10.2c0.6-0.6,0.9-1.6,1-1.9c-2.2-4.1-5.9-5.1-10.8-7.3c2.6-0.8,3.7-1.2,4.9-1.6c5.4-1.4,10.2-3.9,14.8-7c1.8-1.2,3.4-2.8,4.9-4.5C139.3,56.3,139.4,54.9,139.9,53.6"></path>
+                                                                  </g>
+                                                                </svg>
+                                                            </div>
+                                                                                                                <div class="description">
+                                                            <strong class="title">
+                                                                                                                                    <a href="https://shop.forksoverknives.com/products/quick-easy-recipes-special-issue-forks-over-knives-magazine">NEW QUICK & EASY RECIPES SPECIAL ISSUE</a>
+                                                                                                                            </strong>
+                                                            <a class="link" target="_blank" href="https://shop.forksoverknives.com/products/quick-easy-recipes-special-issue-forks-over-knives-magazine" data-type="ad" data-ad-position="nav-menu" data-name="Shop magazine">Shop now</a>                                                        </div>
+                                                    </div>
+                                                                                                                                                                        </div>
+                                </div>
+                            </li>
+                                            </ul>
+                    <div class="search-openclose desktop-visible"><a class="search-opener" href="#"
+                                                                     title="search opener"><i
+                                    class="icon-search"></i></a>
+                        <div class="pop-search">
+                            <form class="search-form" action="https://www.forksoverknives.com/search" method="get">
+                                <label for="search2" class="screenreader-label">Search</label>
+                                <input id="search2" type="search" name="search"
+                                       placeholder="Search">
+                                <button type="submit"><i
+                                            class="icon-search"></i><span>Search</span></button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
+    </nav>
+            </header>
+        <script type="application/ld+json">
+{"@context":"https:\/\/schema.org","@type":"Recipe","image":"https:\/\/www.forksoverknives.com\/wp-content\/uploads\/butternut-broccoli-mac-and-cheese-wordpress.jpg","recipeCategory":"<a href=\"https:\/\/www.forksoverknives.com\/recipes\/vegan-pasta-noodles\/\">Pasta &amp; Noodles<\/a>","name":"Butternut Squash Mac and Cheese with Broccoli","description":"Spiced butternut squash blended with nutritional yeast and a little plant milk makes a delightfully rich and \u201ccheesy\u201d sauce for pasta and broccoli. Pumpkin, acorn squash, or delicata squash will also work in this recipe.\r\n\r\nTo make this recipe gluten-free, chose a whole grain pasta made with rice, corn, and\/or quinoa.","prepTime":"PT30M","totalTime":"PT30M","recipeIngredient":["1 medium butternut squash (1\u00be lb.)","1 onion, finely chopped (1 cup)","4 cloves garlic, minced","\u00bd teaspoon finely chopped fresh thyme","2 cups unsweetened, unflavored plant milk, such as almond, soy, cashew, or rice","2 tablespoons nutritional yeast","1 tablespoon white wine vinegar","\u00bc teaspoon sea salt","\u215b teaspoon freshly ground black pepper","3 cups dried whole grain penne pasta (8 oz.)","3 cups small broccoli florets","Fresh basil leaves"],"recipeInstructions":["Peel squash; halve squash and remove seeds. Cut squash into large pieces. Place squash pieces in a steamer basket in a large pan. Add water to saucepan to just below basket. Bring to boiling. Steam, covered, about 12 minutes or until tender.","Heat a large saucepan over medium. Add onion, garlic, thyme, and \u00bc cup water to pan. Cook about 10 minutes or until onion is tender, stirring occasionally and adding water, 1 to 2 Tbsp. at a time, as needed to prevent sticking.","Transfer onion mixture to a blender. Add squash and the next five ingredients (through pepper). Cover and blend until smooth. Pour squash mixture into a large saucepan.","Cook pasta according to package directions, adding broccoli the last 5 minutes of cooking; drain. Add drained pasta and broccoli to squash mixture; toss to coat. Serve warm topped with fresh basil."],"aggregateRating":{"@type":"aggregateRating","ratingValue":"4.13","reviewCount":"45"}}
+</script>
+<div class="banner">
+    <div class="bg-stretch">
+                    <span data-srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/128193/butternut-broccoli-mac-and-cheese-wordpress-1366x566-c.jpg"></span>
+                    <span data-srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/128193/butternut-broccoli-mac-and-cheese-wordpress-375x173-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/128193/butternut-broccoli-mac-and-cheese-wordpress-1366x566-c.jpg 2x" data-media="(max-width: 768px)"></span>
+                    
+                </div>    <div class="container">
+        <div class="banner-block">
+                            <ul class="breadcrumbs">
+                    <li class="home"><a href="/recipes/">Recipes</a></li>
+                    <li><a href="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/">Pasta &amp; Noodles</a></li>
+                </ul>
+                        <h1 class="h2">Butternut Squash Mac and Cheese with Broccoli </h1>
+            <div class="rate-container">
+                <a class="rate-box" href="#comments-section">
+                    <div class="rate-wrap"><ul class="stars-rating-list readonly"><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 13%;"></i></li></ul></div><span
+                            class="rated-count">(45)</span>
+                </a>
+                <a class="comments-link" href="#comments-section"><span
+                            class="icon-comments"></span>75 Comments</a>
+            </div>
+                    </div>
     </div>
+</div>
 
-    <main>
-        <div class="container">
+<main>
+    <div class="container">
 
-                        <div class="intro-post">
+                    <div class="intro-post">
                 <div class="post-container">
                     <div class="box-post-control">
                                                     <ul class="add-info">
                                                                                                     <li><i class="icon-time"></i>
                                         <span>
-                                                                                            <span>Prep-time: <time datetime="PT30M" itemprop="prepTime">30 minutes</time> / </span>
-                                                                                                                                        <span>Ready In: <time datetime="PT30M" itemprop="totalTime">30 minutes</time></span></span>
-                                                                                                                                </span>
+                                                                                    <span>Prep-time: <time datetime="PT30M">30 minutes</time> / </span>
+                                                                                                                                <span>Ready In: <time datetime="PT30M">30 minutes</time></span></span>
+                                                                                                                        </span>
                                     </li>
                                                                                                     <li><i class="icon-serving"></i><span>Makes 6 cups</span></li>
                                                                                                                                     <li class="print-box">
-                                        <a class="popup-print print-recipe-link" href="#"><i class="icon-print"></i><span>print/save recipe</span></a>
+                                        <a class="popup-print print-recipe-link"
+                                           href="#"><i class="icon-print"></i><span>print/save recipe</span></a>
                                         <div class="slide-print">
-    <form class="print-form" action="">
+
+    <form class="print-form" action="" id="Recipe popup">
         <p>Please enter your email to continue.</p>
         <div class="row-input">
-            <input type="email" placeholder="Email" class="print-form-input">
+            <label for="email" class="screenreader-label">Email</label>
+            <input id="email" type="email" placeholder="Email" class="print-form-input">
         </div>
         <div class="btns-row">
             <a class="popup-print" href="#">Cancel</a>
@@ -396,100 +593,114 @@ window.wc_ga_pro.is_valid_email = function( email ) {
                                                             </ul>
                                             </div>
                     <div class="post-openclose">
-                                                    <div itemprop="description">
-                                <p><span style="font-weight: 400;">Spiced butternut squash blended with nutritional yeast and a little plant milk makes a delightfully rich and “cheesy” sauce for pasta and broccoli. </span><span style="font-weight: 400;">Pumpkin, acorn squash, or delicata squash will also work in this recipe.</span></p>
+                                                    <p><span style="font-weight: 400;">Spiced butternut squash blended with nutritional yeast and a little plant milk makes a delightfully rich and “cheesy” sauce for pasta and broccoli. </span><span style="font-weight: 400;">Pumpkin, acorn squash, or delicata squash will also work in this recipe.</span></p>
 <p>To make this recipe gluten-free, chose a whole grain pasta made with rice, corn, and/or quinoa.</p>
-<img   alt="butternut broccoli vegan mac and cheese" data-pin-url="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-pin-media="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" data-pin-description="Butternut Squash Mac and Cheese with Broccoli" data-src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" class="ss-hidden-pin-image lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img   alt="butternut broccoli vegan mac and cheese" data-pin-url="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-pin-media="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" data-pin-description="Butternut Squash Mac and Cheese with Broccoli" data-src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" class="ss-hidden-pin-image lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" class="ss-hidden-pin-image" alt="butternut broccoli vegan mac and cheese" data-pin-url="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-pin-media="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" data-pin-description="Butternut Squash Mac and Cheese with Broccoli"/></noscript></noscript>                            </div>
                                                         <div class="post-info">
                                 <p>
-                                                                            By <a href="https://www.forksoverknives.com/contributors/darshana-thacker/">Darshana Thacker</a>,
+                                                                            By <a href="https://www.forksoverknives.com/contributors/darshana-thacker/">Darshana Thacker Wendel</a>,
                                                                                                                 <time datetime="2020-09-01">Sep 1, 2020</time>
                                                                     </p>
                             </div>
                                                 <div class="share-frame">
-                                                            <a class="btn" href="https://my.forksmealplanner.com/login-full?fokrecipeid=8238" target="_blank" data-type="Meal Planner" data-event="add recipe" data-name="Butternut Squash Mac and Cheese with Broccoli">Add to meal planner</a>
+                                                            <a class="btn"
+                                   href="https://my.forksmealplanner.com/login-full?fokrecipeid=8238"
+                                   target="_blank" data-type="Meal Planner" data-event="add recipe"
+                                   data-name="Butternut Squash Mac and Cheese with Broccoli">Add to meal planner</a>
                                                         <div class="social-wrapper"><strong class="title">Share</strong>
-                                <div class="ss-inline-share-wrapper ss-hover-animation-fade ss-with-counter-border ss-inline-total-counter-left ss-left-inline-content ss-small-icons ss-with-spacing ss-rounded-icons"><div class="ss-inline-share-content"><div class="ss-inline-counter"><span class="ss-total-counter ss-total-shares ss-share-inline_content-total-shares" data-ss-ss-post-id="128191"><span>3.9K</span><span>Shares</span></span></div><ul class="ss-social-icons-container"><li class=""><a href="#" data-ss-ss-link="https://www.facebook.com/sharer.php?t=Butternut%20Squash%20Mac%20and%20Cheese%20with%20Broccoli&#038;u=https%3A%2F%2Fwww.forksoverknives.com%2Frecipes%2Fvegan-pasta-noodles%2Fbutternut-mac-and-cheese-broccoli%2F" class="ss-facebook-color" rel="nofollow noopener" data-ss-ss-network-id="facebook" data-ss-ss-post-id="128191" data-ss-ss-location="inline_content" data-ss-ss-permalink="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-ss-ss-type="share" data-has-api="true"><span class="ss-share-network-content"><i class="ss-network-icon"><svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M32 16.098C32 7.208 24.837 0 16 0S0 7.207 0 16.098C0 24.133 5.851 30.792 13.5 32V20.751H9.437v-4.653H13.5V12.55c0-4.034 2.389-6.263 6.043-6.263 1.751 0 3.582.315 3.582.315v3.961h-2.018c-1.987 0-2.607 1.241-2.607 2.514v3.02h4.438l-.71 4.653H18.5V32C26.149 30.792 32 24.133 32 16.098z" /></svg></i><span class="ss-network-label">Facebook</span></span></a></li><li class=""><a href="#" data-ss-ss-link="https://twitter.com/intent/tweet?text=Butternut+Squash+Mac+and+Cheese+with+Broccoli&#038;url=https%3A%2F%2Fwww.forksoverknives.com%2Frecipes%2Fvegan-pasta-noodles%2Fbutternut-mac-and-cheese-broccoli%2F" class="ss-twitter-color" rel="nofollow noopener" data-ss-ss-network-id="twitter" data-ss-ss-post-id="128191" data-ss-ss-location="inline_content" data-ss-ss-permalink="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-ss-ss-type="share"><span class="ss-share-network-content"><i class="ss-network-icon"><svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M28.75 9.5c0 0.25 0 0.563 0 0.813 0 8.688-6.625 18.688-18.688 18.688-3.688 0-7.188-1.063-10.063-2.938 0.5 0.063 1.063 0.063 1.563 0.063 3.063 0 5.938-1 8.188-2.813-2.875 0-5.313-1.938-6.188-4.563 0.438 0.125 0.813 0.125 1.25 0.125 0.625 0 1.188-0.063 1.75-0.188-3-0.625-5.25-3.313-5.25-6.438 0-0.063 0-0.063 0-0.125 0.875 0.5 1.875 0.813 2.938 0.813-1.75-1.125-2.938-3.188-2.938-5.438 0-1.188 0.375-2.313 0.938-3.313 3.188 4 8.063 6.625 13.5 6.875-0.125-0.5-0.188-1-0.188-1.5 0-3.625 2.938-6.563 6.563-6.563 1.938 0 3.625 0.813 4.813 2.063 1.5-0.313 2.938-0.813 4.188-1.563-0.5 1.5-1.563 2.813-2.875 3.625 1.313-0.188 2.563-0.5 3.75-1.063-0.875 1.313-2 2.5-3.25 3.438z"></path></svg></i><span class="ss-network-label">Twitter</span></span></a></li><li class=""><a href="#" data-ss-ss-link="https://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.forksoverknives.com%2Frecipes%2Fvegan-pasta-noodles%2Fbutternut-mac-and-cheese-broccoli%2F&#038;media=https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg&#038;description=Butternut%20Squash%20Mac%20and%20Cheese%20with%20Broccoli" class="ss-pinterest-color" rel="nofollow noopener" data-ss-ss-network-id="pinterest" data-ss-ss-post-id="128191" data-ss-ss-location="inline_content" data-ss-ss-permalink="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-ss-ss-type="share" data-has-api="true"><span class="ss-share-network-content"><i class="ss-network-icon"><svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M10.625 12.25c0-1.375 0.313-2.5 1.063-3.438 0.688-0.938 1.563-1.438 2.563-1.438 0.813 0 1.438 0.25 1.875 0.813s0.688 1.25 0.688 2.063c0 0.5-0.125 1.125-0.313 1.813-0.188 0.75-0.375 1.625-0.688 2.563-0.313 1-0.563 1.75-0.688 2.313-0.25 1-0.063 1.875 0.563 2.625 0.625 0.688 1.438 1.063 2.438 1.063 1.75 0 3.188-1 4.313-2.938 1.125-2 1.688-4.375 1.688-7.188 0-2.125-0.688-3.875-2.063-5.25-1.375-1.313-3.313-2-5.813-2-2.813 0-5.063 0.875-6.75 2.688-1.75 1.75-2.625 3.875-2.625 6.375 0 1.5 0.438 2.75 1.25 3.75 0.313 0.313 0.375 0.688 0.313 1.063-0.125 0.313-0.25 0.813-0.375 1.5-0.063 0.25-0.188 0.438-0.375 0.5s-0.375 0.063-0.563 0c-1.313-0.563-2.25-1.438-2.938-2.75s-1-2.813-1-4.5c0-1.125 0.188-2.188 0.563-3.313s0.875-2.188 1.625-3.188c0.75-1.063 1.688-1.938 2.688-2.75 1.063-0.813 2.313-1.438 3.875-1.938 1.5-0.438 3.125-0.688 4.813-0.688 1.813 0 3.438 0.313 4.938 0.938 1.5 0.563 2.813 1.375 3.813 2.375 1.063 1.063 1.813 2.188 2.438 3.5 0.563 1.313 0.875 2.688 0.875 4.063 0 3.75-0.938 6.875-2.875 9.313-1.938 2.5-4.375 3.688-7.375 3.688-1 0-1.938-0.188-2.813-0.688-0.875-0.438-1.5-1-1.875-1.688-0.688 2.938-1.125 4.688-1.313 5.25-0.375 1.438-1.25 3.188-2.688 5.25h-1.313c-0.25-2.563-0.188-4.688 0.188-6.375l2.438-10.313c-0.375-0.813-0.563-1.813-0.563-3.063z"></path></svg></i><span class="ss-network-label">Pinterest</span></span></a></li><li class=""><a href="#" data-ss-ss-link="mailto:?body=https%3A%2F%2Fwww.forksoverknives.com%2Frecipes%2Fvegan-pasta-noodles%2Fbutternut-mac-and-cheese-broccoli%2F&#038;subject=Butternut%20Squash%20Mac%20and%20Cheese%20with%20Broccoli" class="ss-envelope-color" rel="nofollow noopener" data-ss-ss-network-id="envelope" data-ss-ss-post-id="128191" data-ss-ss-location="inline_content" data-ss-ss-permalink="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-ss-ss-type="share"><span class="ss-share-network-content"><i class="ss-network-icon"><svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M32 12.964v14.179c0 1.571-1.286 2.857-2.857 2.857h-26.286c-1.571 0-2.857-1.286-2.857-2.857v-14.179c0.536 0.589 1.143 1.107 1.804 1.554 2.964 2.018 5.964 4.036 8.875 6.161 1.5 1.107 3.357 2.464 5.304 2.464h0.036c1.946 0 3.804-1.357 5.304-2.464 2.911-2.107 5.911-4.143 8.893-6.161 0.643-0.446 1.25-0.964 1.786-1.554zM32 7.714c0 2-1.482 3.804-3.054 4.893-2.786 1.929-5.589 3.857-8.357 5.804-1.161 0.804-3.125 2.446-4.571 2.446h-0.036c-1.446 0-3.411-1.643-4.571-2.446-2.768-1.946-5.571-3.875-8.339-5.804-1.268-0.857-3.071-2.875-3.071-4.5 0-1.75 0.946-3.25 2.857-3.25h26.286c1.554 0 2.857 1.286 2.857 2.857z"></path></svg></i><span class="ss-network-label">Email</span></span></a></li><li class=""><a href="#" data-ss-ss-link="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" class="ss-copy-color" rel="nofollow noopener" data-ss-ss-network-id="copy" data-ss-ss-post-id="128191" data-ss-ss-location="inline_content" data-ss-ss-permalink="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-ss-ss-type="share"><span class="ss-share-network-content"><i class="ss-network-icon"><svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"></path></svg></i><span class="ss-network-label">Copy Link</span></span></a></li></ul></div></div>                            </div>
+                                                            </div>
                         </div>
                     </div>
                 </div>
             </div>
-            
-                                        <section class="section-ingredients">
-                    <h2 class="h1">Ingredients</h2>
-                                            <ul>
-                                                    <li><span itemprop="recipeIngredient">1 medium butternut squash (1¾ lb.)</span></li>
-                                                    <li><span itemprop="recipeIngredient">1 onion, finely chopped (1 cup)</span></li>
-                                                    <li><span itemprop="recipeIngredient">4 cloves garlic, minced</span></li>
-                                                    <li><span itemprop="recipeIngredient">½ teaspoon finely chopped fresh thyme</span></li>
-                                                    <li><span itemprop="recipeIngredient">2 cups unsweetened, unflavored plant milk, such as almond, soy, cashew, or rice</span></li>
-                                                    <li><span itemprop="recipeIngredient">2 tablespoons nutritional yeast</span></li>
-                                                    <li><span itemprop="recipeIngredient">1 tablespoon white wine vinegar</span></li>
-                                                    <li><span itemprop="recipeIngredient">¼ tsp. sea salt</span></li>
-                                                    <li><span itemprop="recipeIngredient">⅛ tsp. freshly ground black pepper</span></li>
-                                                    <li><span itemprop="recipeIngredient">3 cups dried whole grain penne pasta (8 oz.)</span></li>
-                                                    <li><span itemprop="recipeIngredient">3 cups small broccoli florets</span></li>
-                                                    <li><span itemprop="recipeIngredient">Fresh basil leaves</span></li>
-                                                </ul>
-                                    </section>
-            
-                        <section class="section-instruction">
+        
+                            <section class="section-ingredients">
+                <h2 class="h1">Ingredients</h2>
+                                    <ul>
+                                                    <li><span>1 medium butternut squash (1¾ lb.)</span></li>
+                                                    <li><span>1 onion, finely chopped (1 cup)</span></li>
+                                                    <li><span>4 cloves garlic, minced</span></li>
+                                                    <li><span>½ teaspoon finely chopped fresh thyme</span></li>
+                                                    <li><span>2 cups unsweetened, unflavored plant milk, such as almond, soy, cashew, or rice</span></li>
+                                                    <li><span>2 tablespoons nutritional yeast</span></li>
+                                                    <li><span>1 tablespoon white wine vinegar</span></li>
+                                                    <li><span>¼ teaspoon sea salt</span></li>
+                                                    <li><span>⅛ teaspoon freshly ground black pepper</span></li>
+                                                    <li><span>3 cups dried whole grain penne pasta (8 oz.)</span></li>
+                                                    <li><span>3 cups small broccoli florets</span></li>
+                                                    <li><span>Fresh basil leaves</span></li>
+                                            </ul>
+                            </section>
+        
+                    <section class="section-instruction">
                 <div class="s-box">
                     <div class="col col-8 instruction-box">
                         <h2 class="h1">Instructions</h2>
                         <ol>
-                                                            <li itemprop="recipeInstructions">Peel squash; halve squash and remove seeds. Cut squash into large pieces. Place squash pieces in a steamer basket in a large pan. Add water to saucepan to just below basket. Bring to boiling. Steam, covered, about 12 minutes or until tender.</li>
-                                                            <li itemprop="recipeInstructions">Heat a large saucepan over medium. Add onion, garlic, thyme, and ¼ cup water to pan. Cook about 10 minutes or until onion is tender, stirring occasionally and adding water, 1 to 2 Tbsp. at a time, as needed to prevent sticking.</li>
-                                                            <li itemprop="recipeInstructions">Transfer onion mixture to a blender. Add squash and the next five ingredients (through pepper). Cover and blend until smooth. Pour squash mixture into a large saucepan.</li>
-                                                            <li itemprop="recipeInstructions">Cook pasta according to package directions, adding broccoli the last 5 minutes of cooking; drain. Add drained pasta and broccoli to squash mixture; toss to coat. Serve warm topped with fresh basil.</li>
+                                                            <li>Peel squash; halve squash and remove seeds. Cut squash into large pieces. Place squash pieces in a steamer basket in a large pan. Add water to saucepan to just below basket. Bring to boiling. Steam, covered, about 12 minutes or until tender.</li>
+                                                            <li>Heat a large saucepan over medium. Add onion, garlic, thyme, and ¼ cup water to pan. Cook about 10 minutes or until onion is tender, stirring occasionally and adding water, 1 to 2 Tbsp. at a time, as needed to prevent sticking.</li>
+                                                            <li>Transfer onion mixture to a blender. Add squash and the next five ingredients (through pepper). Cover and blend until smooth. Pour squash mixture into a large saucepan.</li>
+                                                            <li>Cook pasta according to package directions, adding broccoli the last 5 minutes of cooking; drain. Add drained pasta and broccoli to squash mixture; toss to coat. Serve warm topped with fresh basil.</li>
                                                     </ol>
                         <div class="tags"><b class="title">tags:</b><ul class="tags-list"><li><a href="https://www.forksoverknives.com/tag/30-minutes-or-less/" rel="tag">30 minutes or less</a></li></ul></div>
                         <div class="comments-section" id="comments-section">
     <div class="rate-container">
         <div class="rate-box">
-            <div class="rate-wrap"><ul class="stars-rating-list readonly"><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li></ul></div><span class="rated-count">(3)</span>
-        </div><a class="comments-link" href="#comments-section"><span class="icon-comments"></span>3 Comments</a>
+            <div class="rate-wrap"><ul class="stars-rating-list readonly"><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 13%;"></i></li></ul></div><span
+                    class="rated-count">(45)</span>
+        </div>
+        <a class="comments-link" href="#comments-section"><span
+                    class="icon-comments"></span>75 Comments</a>
     </div>
     <div class="headline">
-        <h2>Comments <span>(3)</span></h2>
+        <h2>Comments <span>(75)</span></h2>
         <div class="rate-box">
-            <div class="rate-wrap"><ul class="stars-rating-list readonly"><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li></ul></div>            <span class="rated-count">(5 from 3 votes)
-                <div class="comment-popup js-comment-msg-success"><div class="frame"><a class="close" href="#"><i class="icon-close"></i></a>
+            <div class="rate-wrap"><ul class="stars-rating-list readonly"><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 100%;"></i></li><li class="star"><i class="icon-star"></i><i class="icon-star selected-star" style="width: 13%;"></i></li></ul></div>            <span class="rated-count">(4.13 from 45 votes)
+                <div class="comment-popup js-comment-msg-success"><div class="frame"><a class="close" href="#"><i
+                                    class="icon-close"></i></a>
                         <strong class="title-line js-comment-success-with-rate">Your Rating has been added</strong>
                         <strong class="title-line js-comment-success">Your Comment has been added</strong>
                     </div></div>
             </span>
         </div>
     </div>
-    <div class="comments-open-close active"><a class="comments-opener" href="#">Add a Comment and/or Rating<i class="icon-arrow-down"></i></a>
+    <div class="comments-open-close active"><a class="comments-opener" href="#">Add a Comment and/or Rating<i
+                    class="icon-arrow-down"></i></a>
         <div class="comments-slide">
             <div class="slide-frame">
                 
                                         <div id="respond" class="comment-respond">
-                        <form id="commentform" class="comment-form" action="https://www.forksoverknives.com/wp-comments-post.php?wpe-comment-post=fok" method="post">
+                        <form id="commentform" class="comment-form"
+                              action="https://www.forksoverknives.com/wp-comments-post.php?wpe-comment-post=fok" method="post">
                             <strong class="title js-reply-title">Leave a Reply</strong>
-                                                        <div class="rate-box"><span class="title">Recipe Rating</span>
-                                <div class="rate-wrap">
-                                    <ul class="stars-rating-list" id="stars">
-                                        <li class="star" data-value="1"><i class="icon-star"></i><i class="icon-star selected-star"></i></li>
-                                        <li class="star" data-value="2"><i class="icon-star"></i><i class="icon-star selected-star"></i></li>
-                                        <li class="star" data-value="3"><i class="icon-star"></i><i class="icon-star selected-star"></i></li>
-                                        <li class="star" data-value="4"><i class="icon-star"></i><i class="icon-star selected-star"></i></li>
-                                        <li class="star" data-value="5"><i class="icon-star"></i><i class="icon-star selected-star"></i></li>
-                                    </ul>
-                                    <div class="comment-popup error-popup js-comment-msg-rating-error">
-                                        <div class="frame"><strong class="title-line"><i class="icon-attention"></i>Please provide a rating</strong></div>
+                                                            <div class="rate-box"><span class="title">Recipe Rating</span>
+                                    <div class="rate-wrap">
+                                        <ul class="stars-rating-list" id="stars">
+                                            <li class="star" data-value="1"><i class="icon-star"></i><i
+                                                        class="icon-star selected-star"></i></li>
+                                            <li class="star" data-value="2"><i class="icon-star"></i><i
+                                                        class="icon-star selected-star"></i></li>
+                                            <li class="star" data-value="3"><i class="icon-star"></i><i
+                                                        class="icon-star selected-star"></i></li>
+                                            <li class="star" data-value="4"><i class="icon-star"></i><i
+                                                        class="icon-star selected-star"></i></li>
+                                            <li class="star" data-value="5"><i class="icon-star"></i><i
+                                                        class="icon-star selected-star"></i></li>
+                                        </ul>
+                                        <div class="comment-popup error-popup js-comment-msg-rating-error">
+                                            <div class="frame"><strong class="title-line"><i class="icon-attention"></i>Please
+                                                    provide a rating</strong></div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
                                                         <label for="comment-field" class="js-comment-label-text1">Comment</label>
                             <label for="comment-field" class="js-comment-label-text2">Reply</label>
-                            <textarea id="comment-field" name="comment" cols="67" rows="7" placeholder="Write your review or comment here…"></textarea>
-                                                        <label for="name-field">Name*</label>
-                            <input id="name-field" type="text" name="author" placeholder="">
-                            <label for="email-field">Email*</label>
-                            <input id="email-field" type="email" name="email" placeholder=""><span class="note">Your email address will not be published. Required fields are marked *</span>
-                                                        <div class="gglcptch gglcptch_invisible"><div id="gglcptch_recaptcha_305333591" class="gglcptch_recaptcha"></div>
+                            <textarea id="comment-field" name="comment" cols="67" rows="7"
+                                      placeholder="Write your review or comment here…"></textarea>
+                                                            <label for="name-field">Name*</label>
+                                <input id="name-field" type="text" name="author" placeholder="">
+                                <label for="email-field">Email*</label>
+                                <input id="email-field" type="email" name="email" placeholder=""><span class="note">Your email address will not be published. Required fields are marked *</span>
+                                                        <div class="gglcptch gglcptch_invisible"><div id="gglcptch_recaptcha_1239544430" class="gglcptch_recaptcha"></div>
 				<noscript>
 					<div style="width: 302px;">
 						<div style="width: 302px; height: 422px; position: relative;">
@@ -504,11 +715,13 @@ window.wc_ga_pro.is_valid_email = function( email ) {
 				</noscript></div>                            <div class="submit-frame">
                                 <input name="submit" class="btn" type="submit" value="Submit">
                                 <input class="btn" type="reset" value="Cancel" id="cancel-comment-reply-link">
-                                <input type="hidden" name="comment_post_ID" value="128191" id="comment_post_ID">
+                                <input type="hidden" name="comment_post_ID" value="128191"
+                                       id="comment_post_ID">
                                 <input type="hidden" name="comment_parent" id="comment_parent" value="0">
                                 <input type="hidden" name="wp-review-user-rating-val" value="0">
                             </div>
-                            <div class="error-message js-comment-msg-error"><span class="note">You need to provide a comment or rating to submit</span></div>
+                            <div class="error-message js-comment-msg-error"><span class="note">You need to provide a comment or rating to submit</span>
+                            </div>
                             <div class="error-message js-comment-msg-error-custom"><span class="note"></span></div>
                         </form>
                     </div>
@@ -516,10 +729,2366 @@ window.wc_ga_pro.is_valid_email = function( email ) {
         </div>
     </div>
     <div class="comments-container">
-                        <div class="wp_review_comment even thread-even depth-1 comment-block comment" id="comment-12054">
+                        <div class="wp_review_comment even thread-even depth-1 comment-block comment" id="comment-65850">
+        <div class="comment-inner" id="comment-inner-65850">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Elsa</strong><span class="time">6 days ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-65850" rel='nofollow' class='comment-reply-link reply' href='#comment-65850' data-commentid="65850" data-postid="128191" data-belowelement="comment-inner-65850" data-respondelement="respond" data-replyto="Reply to Elsa" aria-label='Reply to Elsa'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65850">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Was pretty good. Took others comments into account and added more nutritional yeast, used lemon juice instead of vinegar, added some hot sauce, used leeks instead of onion, but still a bit bland and soupy. Added some chopped Kale with broccoli. Needs something else&#8230;..</p>
+</div>        </div>
+    <div class="wp_review_comment odd alt depth-2 comment-block comment" id="comment-65865">
+        <div class="comment-inner" id="comment-inner-65865">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Chili Dave</strong><span class="time">5 days ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65865">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>It was pretty good.  I did add more nutritional yeast and hot sauce.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="comment even thread-odd thread-alt depth-1 comment-block" id="comment-65831">
+        <div class="comment-inner" id="comment-inner-65831">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Beth</strong><span class="time">6 days ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-65831" rel='nofollow' class='comment-reply-link reply' href='#comment-65831' data-commentid="65831" data-postid="128191" data-belowelement="comment-inner-65831" data-respondelement="respond" data-replyto="Reply to Beth" aria-label='Reply to Beth'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65831">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>How many cups of cubed squash would that be?</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt thread-even depth-1 comment-block" id="comment-65820">
+        <div class="comment-inner" id="comment-inner-65820">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Joanne</strong><span class="time">7 days ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-65820" rel='nofollow' class='comment-reply-link reply' href='#comment-65820' data-commentid="65820" data-postid="128191" data-belowelement="comment-inner-65820" data-respondelement="respond" data-replyto="Reply to Joanne" aria-label='Reply to Joanne'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65820">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Can i substitute nutritional yeast or leave out all together?</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even thread-odd thread-alt depth-1 comment-block" id="comment-65814">
+        <div class="comment-inner" id="comment-inner-65814">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Gail Fuson</strong><span class="time">7 days ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-65814" rel='nofollow' class='comment-reply-link reply' href='#comment-65814' data-commentid="65814" data-postid="128191" data-belowelement="comment-inner-65814" data-respondelement="respond" data-replyto="Reply to Gail Fuson" aria-label='Reply to Gail Fuson'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65814">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Why can these recipes not be printable</p>
+</div>        </div>
+    <div class="comment odd alt depth-2 comment-block" id="comment-65837">
+        <div class="comment-inner" id="comment-inner-65837">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Candace Lamoree</strong><span class="time">6 days ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65837">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>There is a print recipe option at the top of the recipe.  I just saved it as a pdf.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even depth-2 comment-block" id="comment-65836">
+        <div class="comment-inner" id="comment-inner-65836">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Doireann</strong><span class="time">6 days ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65836">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Agreed.  It&#8217;s ridiculous.</p>
+<p>As to the suggestion in a reply to your comment, using the file&gt;print function (at least in Safari) results in a ridiculously wonky printout with giant empty spaces, overlapping type, instructions cut off or left out, and having to figure out which pages you need because otherwise it will print the entire webpage (upwards of 30 pages of paper).</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt depth-2 comment-block" id="comment-65819">
+        <div class="comment-inner" id="comment-inner-65819">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Ralph</strong><span class="time">7 days ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65819">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>And to print, in the new screen that opens, in Chrome there should be a print button and in Safari go to File at the very top of the browser bar, click that and then click print</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even depth-2 comment-block" id="comment-65818">
+        <div class="comment-inner" id="comment-inner-65818">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Jasmine</strong><span class="time">7 days ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65818">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>That’s always annoying!  They are printable from the app at least</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt depth-2 comment-block" id="comment-65817">
+        <div class="comment-inner" id="comment-inner-65817">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Ralph</strong><span class="time">7 days ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65817">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>It is. At the top of the article is a print/save button. Click on that and it will open it as a pdf. Hold your curser near the bottom of the page and a little box with four options should open. The last, the down arrow, is the download button. Click that and download to your desktop or downloads folder. (I&#8217;m using safari but it works in Chrome browser too. In Chrome in the new window that opens, the download button is the down arrow at the top of the screen.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="comment even thread-even depth-1 comment-block" id="comment-65749">
+        <div class="comment-inner" id="comment-inner-65749">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Peggy</strong><span class="time">2 weeks ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-65749" rel='nofollow' class='comment-reply-link reply' href='#comment-65749' data-commentid="65749" data-postid="128191" data-belowelement="comment-inner-65749" data-respondelement="respond" data-replyto="Reply to Peggy" aria-label='Reply to Peggy'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65749">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Because my husband and I will be attending a Thanksgiving dinner and we are now plant-based, I&#8217;ll be trying this recipe to bring for us.  Glad I read all of the other comments as it&#8217;ll give me a better idea for what to add and what to change.  THANKS!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-odd thread-alt depth-1 comment-block comment" id="comment-65682">
+        <div class="comment-inner" id="comment-inner-65682">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Steve</strong><span class="time">2 weeks ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-65682" rel='nofollow' class='comment-reply-link reply' href='#comment-65682' data-commentid="65682" data-postid="128191" data-belowelement="comment-inner-65682" data-respondelement="respond" data-replyto="Reply to Steve" aria-label='Reply to Steve'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65682">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Made this last night using suggestions by other commenters.  Doubled up on the nutritional yeast and only used one cup of milk.  Added hot sauce and some Taijin seasoning.  It tasted pretty darn good.  I&#8217;d make it again.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-even depth-1 comment-block comment" id="comment-65200">
+        <div class="comment-inner" id="comment-inner-65200">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Steph</strong><span class="time">1 month ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-65200" rel='nofollow' class='comment-reply-link reply' href='#comment-65200' data-commentid="65200" data-postid="128191" data-belowelement="comment-inner-65200" data-respondelement="respond" data-replyto="Reply to Steph" aria-label='Reply to Steph'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65200">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>THIS is so delicious! Honestly, I was doubtful but wow was I 100% wrong. I will definitely prepare this again!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-odd thread-alt depth-1 comment-block comment" id="comment-64958">
+        <div class="comment-inner" id="comment-inner-64958">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Ami Ross</strong><span class="time">2 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-64958" rel='nofollow' class='comment-reply-link reply' href='#comment-64958' data-commentid="64958" data-postid="128191" data-belowelement="comment-inner-64958" data-respondelement="respond" data-replyto="Reply to Ami Ross" aria-label='Reply to Ami Ross'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="64958">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:40%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I followed the directions exactly, and it was WAY too soupy. Any suggestions for thickening it up so this whole batch isn’t wasted?  Thank you.</p>
+</div>        </div>
+    <div class="comment even depth-2 comment-block" id="comment-65242">
+        <div class="comment-inner" id="comment-inner-65242">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Julia</strong><span class="time">1 month ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65242">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>You can always add flour to the sauce.  There&#8217;s also either cornstarch or arrowroot powder.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-64596">
+        <div class="comment-inner" id="comment-inner-64596">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Susan Packwood</strong><span class="time">3 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-64596" rel='nofollow' class='comment-reply-link reply' href='#comment-64596' data-commentid="64596" data-postid="128191" data-belowelement="comment-inner-64596" data-respondelement="respond" data-replyto="Reply to Susan Packwood" aria-label='Reply to Susan Packwood'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="64596">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Good!  Really needed more salt and mine was a little too soupy .  But I used peas instead of broccoli which would have taken up more volume.  But I love butternut squash, so I loved the taste.</p>
+</div>        </div>
+    <div class="wp_review_comment even depth-2 comment-block comment" id="comment-64711">
+        <div class="comment-inner" id="comment-inner-64711">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Amy</strong><span class="time">2 months ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="64711">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Trying it, looks good.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-odd thread-alt depth-1 comment-block comment" id="comment-64488">
+        <div class="comment-inner" id="comment-inner-64488">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Debbie</strong><span class="time">3 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-64488" rel='nofollow' class='comment-reply-link reply' href='#comment-64488' data-commentid="64488" data-postid="128191" data-belowelement="comment-inner-64488" data-respondelement="respond" data-replyto="Reply to Debbie" aria-label='Reply to Debbie'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="64488">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I really enjoyed this meal, and will make it again. As others stated, it was a bit bland. I did what one suggested and doubled the Nutritional Yeast. Then when I heated it to eat again, I sprinkled more Nutrtional Yeast, Onion Powder, and Thyme.</p>
+</div>        </div>
+    <div class="wp_review_comment even depth-2 comment-block comment" id="comment-65273">
+        <div class="comment-inner" id="comment-inner-65273">
+            <div class="meta">
+                <div class="title-block"><strong class="name">JC</strong><span class="time">1 month ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65273">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:60%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Pretty good! Play with the seasoning to ensure you get it right. I added a little crushed red pepper for some heat and a lot more “nooch”. I also added sage. That helped.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-64017">
+        <div class="comment-inner" id="comment-inner-64017">
+            <div class="meta">
+                <div class="title-block"><strong class="name">DiAne</strong><span class="time">4 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-64017" rel='nofollow' class='comment-reply-link reply' href='#comment-64017' data-commentid="64017" data-postid="128191" data-belowelement="comment-inner-64017" data-respondelement="respond" data-replyto="Reply to DiAne" aria-label='Reply to DiAne'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="64017">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Have been wanting to find a good vegan mac and cheese recipe and this fills the spot. Easy to prepare. I used acorn squash as that is what I had on hand. It all came together so easily.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even thread-odd thread-alt depth-1 comment-block" id="comment-62837">
+        <div class="comment-inner" id="comment-inner-62837">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Karole</strong><span class="time">7 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-62837" rel='nofollow' class='comment-reply-link reply' href='#comment-62837' data-commentid="62837" data-postid="128191" data-belowelement="comment-inner-62837" data-respondelement="respond" data-replyto="Reply to Karole" aria-label='Reply to Karole'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="62837">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>What are nutrients values?</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt thread-even depth-1 comment-block" id="comment-62759">
+        <div class="comment-inner" id="comment-inner-62759">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Connie Reilly</strong><span class="time">7 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-62759" rel='nofollow' class='comment-reply-link reply' href='#comment-62759' data-commentid="62759" data-postid="128191" data-belowelement="comment-inner-62759" data-respondelement="respond" data-replyto="Reply to Connie Reilly" aria-label='Reply to Connie Reilly'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="62759">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Can you use Yellow summer squash?</p>
+</div>        </div>
+    <div class="comment even depth-2 comment-block" id="comment-64716">
+        <div class="comment-inner" id="comment-inner-64716">
+            <div class="meta">
+                <div class="title-block"><strong class="name">D'Awn</strong><span class="time">2 months ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="64716">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>As a southern gal who grew up on yellow summer squash, I&#8217;d say no. The water content in summer squash is much higher than in winter squash.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt depth-2 comment-block" id="comment-62937">
+        <div class="comment-inner" id="comment-inner-62937">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Betty</strong><span class="time">6 months ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="62937">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>They are two different types of squash so I&#8217;m not certain that would be a good substitute.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-62057">
+        <div class="comment-inner" id="comment-inner-62057">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Josa Mendoza</strong><span class="time">8 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-62057" rel='nofollow' class='comment-reply-link reply' href='#comment-62057' data-commentid="62057" data-postid="128191" data-belowelement="comment-inner-62057" data-respondelement="respond" data-replyto="Reply to Josa Mendoza" aria-label='Reply to Josa Mendoza'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="62057">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>OK this was really good. I did doctor it up a little bit though, I didn’t have any plant-based milk so I used a can of coconut cream. Everything else was pretty much the same I also added the franks hot sauce like some of the other readers commented. I will make this again.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-61577">
+        <div class="comment-inner" id="comment-inner-61577">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Carol</strong><span class="time">9 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-61577" rel='nofollow' class='comment-reply-link reply' href='#comment-61577' data-commentid="61577" data-postid="128191" data-belowelement="comment-inner-61577" data-respondelement="respond" data-replyto="Reply to Carol" aria-label='Reply to Carol'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="61577">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Beautiful &#8211; the colors are radiant.  I love Broccoli, I love Butternut Squash, and I Love Pasta!  I am in the third week of a 6 week juice fast and I am adding this recipe to the list of those I will be making after my cleanse is over.<br />
+Thank you for posting it!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-60981">
+        <div class="comment-inner" id="comment-inner-60981">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Sarah</strong><span class="time">10 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-60981" rel='nofollow' class='comment-reply-link reply' href='#comment-60981' data-commentid="60981" data-postid="128191" data-belowelement="comment-inner-60981" data-respondelement="respond" data-replyto="Reply to Sarah" aria-label='Reply to Sarah'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="60981">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I made this to bring to work and I like it. Added a little extra nutritional yeast and vinegar. The basil really makes it for me. I&#8217;m going to add chickpeas and eat it with a side of broccoli when I go to work.</p>
+</div>        </div>
+    <div class="comment odd alt depth-2 comment-block" id="comment-65812">
+        <div class="comment-inner" id="comment-inner-65812">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Sharon</strong><span class="time">1 week ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="65812">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Chick peas is the move!Oh and playing with the spices.  I like coconut and oat milk but someone suggested coconut cream.  That’s what I used. Very good!  Great recipe!!! Glad I bought that squash even though I decided not to make what I’d planned.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even depth-2 comment-block" id="comment-61578">
+        <div class="comment-inner" id="comment-inner-61578">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Carol</strong><span class="time">9 months ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="61578">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>I like your addition of chickpeas!  When I make it I may add sweet peas, too, or maybe 1 inch cuts of steamed fresh green beans.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-60973">
+        <div class="comment-inner" id="comment-inner-60973">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Maja</strong><span class="time">10 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-60973" rel='nofollow' class='comment-reply-link reply' href='#comment-60973' data-commentid="60973" data-postid="128191" data-belowelement="comment-inner-60973" data-respondelement="respond" data-replyto="Reply to Maja" aria-label='Reply to Maja'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="60973">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:40%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I was looking forward to try this recipe, but I must say I&#8217;m disappointed. The dish was way too bland, I was hoping for a deeper, more cheezy taste.Maybe with less milk and more nutritional yeast it would be better. But it definitely needs something to spice it up.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even thread-odd thread-alt depth-1 comment-block" id="comment-60958">
+        <div class="comment-inner" id="comment-inner-60958">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Deb</strong><span class="time">10 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-60958" rel='nofollow' class='comment-reply-link reply' href='#comment-60958' data-commentid="60958" data-postid="128191" data-belowelement="comment-inner-60958" data-respondelement="respond" data-replyto="Reply to Deb" aria-label='Reply to Deb'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="60958">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Thank you for this recipe. I wanted to try this because I love squash. It wasn&#8217;t a fantastic dish but it wasn&#8217;t bad either. It definitely needs some extra spice. I added some garlic powder,  onion powder, and next time maybe some veggie broth while cooking the onions instead of water. I used the whole wheat elbows which is new for me also, getting used to that flavor. (my kids don&#8217;t like the wheat pastas). It made a lot for just me eating it so I froze some hoping it will be good later. I&#8217;m new to plant based eating but open to try most any recipe.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-60671">
+        <div class="comment-inner" id="comment-inner-60671">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Wilhelm van Greunen</strong><span class="time">11 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-60671" rel='nofollow' class='comment-reply-link reply' href='#comment-60671' data-commentid="60671" data-postid="128191" data-belowelement="comment-inner-60671" data-respondelement="respond" data-replyto="Reply to Wilhelm van Greunen" aria-label='Reply to Wilhelm van Greunen'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="60671">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I made this and it was super delicious! I will definitely add it to my plant-based recipe collection. I used about 800g of cubed butternut (we use the metric system in Namibia where I&#8217;m from), and my sauce had the perfect consistency and clung to the pasta very well.u</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-60644">
+        <div class="comment-inner" id="comment-inner-60644">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Valerie Russell</strong><span class="time">11 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-60644" rel='nofollow' class='comment-reply-link reply' href='#comment-60644' data-commentid="60644" data-postid="128191" data-belowelement="comment-inner-60644" data-respondelement="respond" data-replyto="Reply to Valerie Russell" aria-label='Reply to Valerie Russell'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="60644">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Very tasty recipe. I roasted the cubed butternut squash instead of steaming it, and used oat milk. Yes, it is very saucy, but it is yummy squash puree, so all is forgiven.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt thread-even depth-1 comment-block" id="comment-60523">
+        <div class="comment-inner" id="comment-inner-60523">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Elizabeth Conley</strong><span class="time">11 months ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-60523" rel='nofollow' class='comment-reply-link reply' href='#comment-60523' data-commentid="60523" data-postid="128191" data-belowelement="comment-inner-60523" data-respondelement="respond" data-replyto="Reply to Elizabeth Conley" aria-label='Reply to Elizabeth Conley'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="60523">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Best vegan Mac and cheese recipe I&#8217;ve made so far. It made alot of sauce. Next time I&#8217;ll make twice as much pasta I think. A little bland but nothing some hot sauce couldn&#8217;t fix</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-59414">
+        <div class="comment-inner" id="comment-inner-59414">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Jane</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-59414" rel='nofollow' class='comment-reply-link reply' href='#comment-59414' data-commentid="59414" data-postid="128191" data-belowelement="comment-inner-59414" data-respondelement="respond" data-replyto="Reply to Jane" aria-label='Reply to Jane'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="59414">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:60%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I don&#8217;t think I&#8217;ll make this again. The sauce was grainy and didn&#8217;t cover the pasta, just sunk down to the bottom. I also had to add more seasoning.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt thread-even depth-1 comment-block" id="comment-59268">
+        <div class="comment-inner" id="comment-inner-59268">
+            <div class="meta">
+                <div class="title-block"><strong class="name">edith</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-59268" rel='nofollow' class='comment-reply-link reply' href='#comment-59268' data-commentid="59268" data-postid="128191" data-belowelement="comment-inner-59268" data-respondelement="respond" data-replyto="Reply to edith" aria-label='Reply to edith'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="59268">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>I love pasta, mac and cheese and broccoli, but I really don&#8217;t like squash. And sub suggestions or is it a bust for me?</p>
+</div>        </div>
+    <div class="comment even depth-2 comment-block" id="comment-59279">
+        <div class="comment-inner" id="comment-inner-59279">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Anna</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="59279">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>It works well with sweet potato and potato mix or just sweet potato. Carrot might work too.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-odd thread-alt depth-1 comment-block comment" id="comment-59092">
+        <div class="comment-inner" id="comment-inner-59092">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Diane Cutler</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-59092" rel='nofollow' class='comment-reply-link reply' href='#comment-59092' data-commentid="59092" data-postid="128191" data-belowelement="comment-inner-59092" data-respondelement="respond" data-replyto="Reply to Diane Cutler" aria-label='Reply to Diane Cutler'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="59092">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>We love this recipe. I didn’t have broccoli so I used carrots instead and it is so good. We will be having this again and again. I have also shared it with other, even if they are not plant based.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-even depth-1 comment-block comment" id="comment-59057">
+        <div class="comment-inner" id="comment-inner-59057">
+            <div class="meta">
+                <div class="title-block"><strong class="name">K Boyd</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-59057" rel='nofollow' class='comment-reply-link reply' href='#comment-59057' data-commentid="59057" data-postid="128191" data-belowelement="comment-inner-59057" data-respondelement="respond" data-replyto="Reply to K Boyd" aria-label='Reply to K Boyd'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="59057">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:60%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>This is not my favorite FoK recipe. I added lots more vegetables and some hot sauce.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt thread-odd thread-alt depth-1 comment-block" id="comment-58891">
+        <div class="comment-inner" id="comment-inner-58891">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Linda</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-58891" rel='nofollow' class='comment-reply-link reply' href='#comment-58891' data-commentid="58891" data-postid="128191" data-belowelement="comment-inner-58891" data-respondelement="respond" data-replyto="Reply to Linda" aria-label='Reply to Linda'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="58891">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Tasty and easy! I made a few modifications based on the reviews. I reduced the amount of oat milk to 1 cup, used a jar of pumpkin puree instead of butternut squash (lazy weeknight!), substituted lemon juice for the vinegar, and also roasted the onion, garlic, and broccoli in the oven. I topped the pasta with toasted pine nuts, a spring of rosemary, and chopped red chilis which added a nice spice. I&#8217;ll definitely make this one again.</p>
+</div>        </div>
+    <div class="comment even depth-2 comment-block" id="comment-59278">
+        <div class="comment-inner" id="comment-inner-59278">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Carol</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="59278">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Linda, what size can of pumpkin puree did you use?  Thanks!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt depth-2 comment-block" id="comment-58932">
+        <div class="comment-inner" id="comment-inner-58932">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Sparti</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="58932">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Thanks for this review and all your tips! I’m going to try your suggestions 🙂</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-even depth-1 comment-block comment" id="comment-58334">
+        <div class="comment-inner" id="comment-inner-58334">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Christina</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-58334" rel='nofollow' class='comment-reply-link reply' href='#comment-58334' data-commentid="58334" data-postid="128191" data-belowelement="comment-inner-58334" data-respondelement="respond" data-replyto="Reply to Christina" aria-label='Reply to Christina'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="58334">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Easy to make and quite surprisingly creamy. It won&#8217;t replace exactly the flavour of what you expect from a mac and cheese but enjoying it as an alternative and being open to trying something different, this delivers! It was a bit on the sweet side so I added a little more white wine vinegar and some miso paste. A tasty and healthy alternative to a comforting dish. We will definitely make again!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-odd thread-alt depth-1 comment-block comment" id="comment-57788">
+        <div class="comment-inner" id="comment-inner-57788">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Francine Shogel</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-57788" rel='nofollow' class='comment-reply-link reply' href='#comment-57788' data-commentid="57788" data-postid="128191" data-belowelement="comment-inner-57788" data-respondelement="respond" data-replyto="Reply to Francine Shogel" aria-label='Reply to Francine Shogel'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="57788">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>It was delicious! Made a lot of sauce, so asking if can be frozen?</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even thread-even depth-1 comment-block" id="comment-57770">
+        <div class="comment-inner" id="comment-inner-57770">
+            <div class="meta">
+                <div class="title-block"><strong class="name">GP</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-57770" rel='nofollow' class='comment-reply-link reply' href='#comment-57770' data-commentid="57770" data-postid="128191" data-belowelement="comment-inner-57770" data-respondelement="respond" data-replyto="Reply to GP" aria-label='Reply to GP'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="57770">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Not made but will try for sure&#8230;could I sub low fat COCONUT milk/cream?</p>
+</div>        </div>
+    <div class="comment odd alt depth-2 comment-block" id="comment-62829">
+        <div class="comment-inner" id="comment-inner-62829">
+            <div class="meta">
+                <div class="title-block"><strong class="name">cathleen morris</strong><span class="time">7 months ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="62829">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>The sauce was sweet and an unusual taste… I added a bit of Frank’s hot sauce to counteract but ultimately I ended up adding tomato sauce and it was actually very good, just not a Mac n cheese dish</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-57544">
+        <div class="comment-inner" id="comment-inner-57544">
+            <div class="meta">
+                <div class="title-block"><strong class="name">EH</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-57544" rel='nofollow' class='comment-reply-link reply' href='#comment-57544' data-commentid="57544" data-postid="128191" data-belowelement="comment-inner-57544" data-respondelement="respond" data-replyto="Reply to EH" aria-label='Reply to EH'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="57544">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>As someone who didn&#8217;t grow up with mac and cheese I really had no expectations and found this recipe to be better than anticipated (only roughly stuck to the proportions given though). The sauce was creamy and extremely filling (had it over leftover rice and steamed vegetables) and I didn&#8217;t mind the sweet taste of the butternut squash. I substituted the plant milk with a couple of teaspoons of cashew butter and water. Next time I will use lemon juice instead of vinegar. Thyme wasn&#8217;t at hand. Nutmeg might be good in this recipe. The only thing I didn&#8217;t enjoy so much about this sauce was the oniony aftertaste due to the onions being cooked rather than fried/sautéed.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-56836">
+        <div class="comment-inner" id="comment-inner-56836">
+            <div class="meta">
+                <div class="title-block"><strong class="name">MB</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-56836" rel='nofollow' class='comment-reply-link reply' href='#comment-56836' data-commentid="56836" data-postid="128191" data-belowelement="comment-inner-56836" data-respondelement="respond" data-replyto="Reply to MB" aria-label='Reply to MB'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="56836">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Wouldn’t normally take the time to comment but this was delicious! Will add more yeast and add salt at the table to taste. Creamy and nourishing!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-55457">
+        <div class="comment-inner" id="comment-inner-55457">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Tina</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-55457" rel='nofollow' class='comment-reply-link reply' href='#comment-55457' data-commentid="55457" data-postid="128191" data-belowelement="comment-inner-55457" data-respondelement="respond" data-replyto="Reply to Tina" aria-label='Reply to Tina'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="55457">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>This tastes delicious! Added less plant-based milk because it would have been too much. Was still plenty!</p>
+</div>        </div>
+    <div class="wp_review_comment odd alt depth-2 comment-block comment" id="comment-60961">
+        <div class="comment-inner" id="comment-inner-60961">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Colleen</strong><span class="time">10 months ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="60961">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:60%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I didn’t know what to expect out of this but it was better than I thought. I, like others, added more spice as I felt it was a bit bland. I also added more pasta too to have a better pasta/sauce ratio.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-even depth-1 comment-block comment" id="comment-52274">
+        <div class="comment-inner" id="comment-inner-52274">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Sharon</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-52274" rel='nofollow' class='comment-reply-link reply' href='#comment-52274' data-commentid="52274" data-postid="128191" data-belowelement="comment-inner-52274" data-respondelement="respond" data-replyto="Reply to Sharon" aria-label='Reply to Sharon'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="52274">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:20%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Sadly, this recipe didn&#8217;t do it for me. Even with unsweetened milked, this meal tasted sweet and not savory. Also, it might be helpful to suggested squash quantity rather than &#8220;medium&#8221; as it I felt like there was too much squash. </p>
+<p>I am never a fan when I have to throw out food (grew up in a family where this was a practically a sin), but this meal could not be eatened.</p>
+</div>        </div>
+    <div class="comment odd alt depth-2 comment-block" id="comment-58087">
+        <div class="comment-inner" id="comment-inner-58087">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Peg</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="58087">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Wayyyy too much milk in this recipe. It came out more like squash soup with pasta and broccoli in it. That said, it was tasty. I would just use about half the amount of milk next time.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even depth-2 comment-block comment" id="comment-58084">
+        <div class="comment-inner" id="comment-inner-58084">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Kris</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="58084">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:40%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>New to this, I knew it wasn&#8217;t going to be what I&#8217;m used to, but I do love my veggies. I felt it had way too much onion in it. Towards the end of my bowl, that&#8217;s all I tasted. I also think it needs another seasoning added to it.<br />
+Other than that, it was very healthy.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt depth-2 comment-block" id="comment-57839">
+        <div class="comment-inner" id="comment-inner-57839">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Marlo</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="57839">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>I’ve made this recipe many times. Delicious!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="comment even thread-odd thread-alt depth-1 comment-block" id="comment-52224">
+        <div class="comment-inner" id="comment-inner-52224">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Geana a Johnson</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-52224" rel='nofollow' class='comment-reply-link reply' href='#comment-52224' data-commentid="52224" data-postid="128191" data-belowelement="comment-inner-52224" data-respondelement="respond" data-replyto="Reply to Geana a Johnson" aria-label='Reply to Geana a Johnson'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="52224">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Love butternut squash.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-52181">
+        <div class="comment-inner" id="comment-inner-52181">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Candice</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-52181" rel='nofollow' class='comment-reply-link reply' href='#comment-52181' data-commentid="52181" data-postid="128191" data-belowelement="comment-inner-52181" data-respondelement="respond" data-replyto="Reply to Candice" aria-label='Reply to Candice'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="52181">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:80%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>This was simple to make but the flavor was a little too sweet for the family.</p>
+</div>        </div>
+    <div class="comment even depth-2 comment-block" id="comment-55050">
+        <div class="comment-inner" id="comment-inner-55050">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Sharyn</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="55050">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>How many calories does this have per serving?</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-odd thread-alt depth-1 comment-block comment" id="comment-50732">
+        <div class="comment-inner" id="comment-inner-50732">
+            <div class="meta">
+                <div class="title-block"><strong class="name">CJ</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-50732" rel='nofollow' class='comment-reply-link reply' href='#comment-50732' data-commentid="50732" data-postid="128191" data-belowelement="comment-inner-50732" data-respondelement="respond" data-replyto="Reply to CJ" aria-label='Reply to CJ'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="50732">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:20%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I really wanted to love this! I felt it was too much sauce to pasta ratio and it wasn’t a bold enough flavour for me, maybe with less milk would have been better and more nutritional yeast. Thankyou for the recipe, Nice to give it a try, just wasn’t for me 🙂</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment even thread-even depth-1 comment-block" id="comment-50545">
+        <div class="comment-inner" id="comment-inner-50545">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Didi Lacroix</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-50545" rel='nofollow' class='comment-reply-link reply' href='#comment-50545' data-commentid="50545" data-postid="128191" data-belowelement="comment-inner-50545" data-respondelement="respond" data-replyto="Reply to Didi Lacroix" aria-label='Reply to Didi Lacroix'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="50545">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Really yummy! I&#8217;ve made another vegan Mac &amp; cheese before and it was not half as delicious as this one. Great texture as well. And I like that it incorporates broccoli, which includes a green vegetable.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="comment odd alt thread-odd thread-alt depth-1 comment-block" id="comment-49640">
+        <div class="comment-inner" id="comment-inner-49640">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Deb Lee</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-49640" rel='nofollow' class='comment-reply-link reply' href='#comment-49640' data-commentid="49640" data-postid="128191" data-belowelement="comment-inner-49640" data-respondelement="respond" data-replyto="Reply to Deb Lee" aria-label='Reply to Deb Lee'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="49640">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>When is the vinegar added? I can&#8217;t se it in the instructions.</p>
+</div>        </div>
+    <div class="comment even depth-2 comment-block" id="comment-50115">
+        <div class="comment-inner" id="comment-inner-50115">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Hilary Thompson</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="50115">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>In point 3 the instruction is &#8220;add the next five ingredients&#8221;, this includes the vinegar. </p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-45737">
+        <div class="comment-inner" id="comment-inner-45737">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Sueathome</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-45737" rel='nofollow' class='comment-reply-link reply' href='#comment-45737' data-commentid="45737" data-postid="128191" data-belowelement="comment-inner-45737" data-respondelement="respond" data-replyto="Reply to Sueathome" aria-label='Reply to Sueathome'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="45737">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>I made this and it is divine! I replace vinegar with lemon juice. I never use the yeast. It was superb!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-34994">
+        <div class="comment-inner" id="comment-inner-34994">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Melinda W</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-34994" rel='nofollow' class='comment-reply-link reply' href='#comment-34994' data-commentid="34994" data-postid="128191" data-belowelement="comment-inner-34994" data-respondelement="respond" data-replyto="Reply to Melinda W" aria-label='Reply to Melinda W'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="34994">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>This is absolutely delicious!!<br />
+Is the nutritional information available?</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-28807">
+        <div class="comment-inner" id="comment-inner-28807">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Angie</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-28807" rel='nofollow' class='comment-reply-link reply' href='#comment-28807' data-commentid="28807" data-postid="128191" data-belowelement="comment-inner-28807" data-respondelement="respond" data-replyto="Reply to Angie" aria-label='Reply to Angie'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="28807">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>A very tasty and healthy recipe. Not too complicated to make. Great for taking to work and reheating too.</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-18948">
+        <div class="comment-inner" id="comment-inner-18948">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Mary Ciulla</strong><span class="time">2 years ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-18948" rel='nofollow' class='comment-reply-link reply' href='#comment-18948' data-commentid="18948" data-postid="128191" data-belowelement="comment-inner-18948" data-respondelement="respond" data-replyto="Reply to Mary Ciulla" aria-label='Reply to Mary Ciulla'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="18948">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Even when I was not a vegetarian or a vegan I put broccoli, or cauliflower, in my macaroni and cheese.  I can&#8217;t wait to make this!</p>
+</div>        </div>
+    <div class="comment odd alt depth-2 comment-block" id="comment-37934">
+        <div class="comment-inner" id="comment-inner-37934">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Kathleen Baas</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="37934">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Can&#8217;t wait to try this!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="comment even thread-even depth-1 comment-block" id="comment-18943">
+        <div class="comment-inner" id="comment-inner-18943">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Corinne Krepel</strong><span class="time">2 years ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-18943" rel='nofollow' class='comment-reply-link reply' href='#comment-18943' data-commentid="18943" data-postid="128191" data-belowelement="comment-inner-18943" data-respondelement="respond" data-replyto="Reply to Corinne Krepel" aria-label='Reply to Corinne Krepel'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="18943">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Wondering if I can use frozen butternut squash??</p>
+</div>        </div>
+    <div class="comment odd alt depth-2 comment-block" id="comment-45743">
+        <div class="comment-inner" id="comment-inner-45743">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Sueathome</strong><span class="time">1 year ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="45743">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="comment-text-inner"><p>Absolutely</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-13828">
+        <div class="comment-inner" id="comment-inner-13828">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Jennifer</strong><span class="time">2 years ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-13828" rel='nofollow' class='comment-reply-link reply' href='#comment-13828' data-commentid="13828" data-postid="128191" data-belowelement="comment-inner-13828" data-respondelement="respond" data-replyto="Reply to Jennifer" aria-label='Reply to Jennifer'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="13828">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>Never thought it would be this good!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-13718">
+        <div class="comment-inner" id="comment-inner-13718">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Jackie Heath</strong><span class="time">2 years ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-13718" rel='nofollow' class='comment-reply-link reply' href='#comment-13718' data-commentid="13718" data-postid="128191" data-belowelement="comment-inner-13718" data-respondelement="respond" data-replyto="Reply to Jackie Heath" aria-label='Reply to Jackie Heath'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="13718">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>What a lovely,  creamy dish. This dish was very easy to make, and tasted great, I will definitely make this again</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment even thread-odd thread-alt depth-1 comment-block comment" id="comment-12596">
+        <div class="comment-inner" id="comment-inner-12596">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Allyson</strong><span class="time">2 years ago</span></div>
+                <div class="holder">
+                    <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-12596" rel='nofollow' class='comment-reply-link reply' href='#comment-12596' data-commentid="12596" data-postid="128191" data-belowelement="comment-inner-12596" data-respondelement="respond" data-replyto="Reply to Allyson" aria-label='Reply to Allyson'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="12596">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>This was delicious! 10/10 will make again!</p>
+</div>        </div>
+</div><!-- #comment-## -->
+    <div class="wp_review_comment odd alt thread-even depth-1 comment-block comment" id="comment-12054">
         <div class="comment-inner" id="comment-inner-12054">
             <div class="meta">
-                <div class="title-block"><strong class="name">Marg</strong><span class="time">2 days ago</span></div>
+                <div class="title-block"><strong class="name">Marg</strong><span class="time">2 years ago</span></div>
                 <div class="holder">
                     <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-12054" rel='nofollow' class='comment-reply-link reply' href='#comment-12054' data-commentid="12054" data-postid="128191" data-belowelement="comment-inner-12054" data-respondelement="respond" data-replyto="Reply to Marg" aria-label='Reply to Marg'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
                         <div class="report-popup comment-popup">
@@ -556,11 +3125,52 @@ window.wc_ga_pro.is_valid_email = function( email ) {
 </div><!-- .review-star -->
 </div><div class="comment-text-inner"><p>Yummy comfort food</p>
 </div>        </div>
-    </div><!-- #comment-## -->
+    <div class="wp_review_comment even depth-2 comment-block comment" id="comment-18403">
+        <div class="comment-inner" id="comment-inner-18403">
+            <div class="meta">
+                <div class="title-block"><strong class="name">Dannielle</strong><span class="time">2 years ago</span></div>
+                <div class="holder">
+                                        <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
+                        <div class="report-popup comment-popup">
+                            <div class="frame">
+                                <form class="form" action="#" method="post"><strong class="title-line">Do you want to report this comment as inappropriate?</strong>
+                                    <div class="submit-frame">
+                                        <input class="btn cancel" type="reset" value="Cancel">
+                                        <input class="btn" type="submit" value="Yes, report">
+                                        <input type="hidden" name="comment_id" value="18403">
+                                        <input type="hidden" name="report" value="1">
+                                    </div>
+                                </form>
+                                <div class="message-block"><a class="close" href="#"><i class="icon-close"></i></a><strong class="title-line" style="display: none;">Thank you. An admin will review this comment ASAP.</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+                                    <div class="wp-review-usercomment-rating wp-review-usercomment-rating-star"><div class="review-star">
+	<div class="review-result-wrapper">
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<i class="mts-icon-star"></i>
+		<div class="review-result" style="width:100%; color:#018b8b;">
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+			<i class="mts-icon-star"></i>
+		</div><!-- .review-result -->
+	</div><!-- .review-result-wrapper -->
+</div><!-- .review-star -->
+</div><div class="comment-text-inner"><p>This dish is delicious. I’m the only vegan in my household and getting my husband and kids on board can be a challenge. This dish is a hit with my entire family. Including my father who is a diehard vegan critic</p>
+</div>        </div>
+</div><!-- #comment-## -->
+</div><!-- #comment-## -->
     <div class="wp_review_comment odd alt thread-odd thread-alt depth-1 comment-block comment" id="comment-11940">
         <div class="comment-inner" id="comment-inner-11940">
             <div class="meta">
-                <div class="title-block"><strong class="name">Donna</strong><span class="time">2 days ago</span></div>
+                <div class="title-block"><strong class="name">Donna</strong><span class="time">2 years ago</span></div>
                 <div class="holder">
                     <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-11940" rel='nofollow' class='comment-reply-link reply' href='#comment-11940' data-commentid="11940" data-postid="128191" data-belowelement="comment-inner-11940" data-respondelement="respond" data-replyto="Reply to Donna" aria-label='Reply to Donna'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
                         <div class="report-popup comment-popup">
@@ -597,11 +3207,11 @@ window.wc_ga_pro.is_valid_email = function( email ) {
 </div><!-- .review-star -->
 </div><div class="comment-text-inner"><p>My kids and I love this!  I use elbow style macaroni and plenty of broccoli.</p>
 </div>        </div>
-    </div><!-- #comment-## -->
+</div><!-- #comment-## -->
     <div class="wp_review_comment even thread-even depth-1 comment-block comment" id="comment-11844">
         <div class="comment-inner" id="comment-inner-11844">
             <div class="meta">
-                <div class="title-block"><strong class="name">aram</strong><span class="time">3 days ago</span></div>
+                <div class="title-block"><strong class="name">aram</strong><span class="time">2 years ago</span></div>
                 <div class="holder">
                     <a data-redirect_to="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/#comment-11844" rel='nofollow' class='comment-reply-link reply' href='#comment-11844' data-commentid="11844" data-postid="128191" data-belowelement="comment-inner-11844" data-respondelement="respond" data-replyto="Reply to aram" aria-label='Reply to aram'>Reply</a>                    <div class="report-holder"><a class="report" href="#"><span class="icon-flag"></span></a>
                         <div class="report-popup comment-popup">
@@ -638,73 +3248,75 @@ window.wc_ga_pro.is_valid_email = function( email ) {
 </div><!-- .review-star -->
 </div><div class="comment-text-inner"><p>I have no idea why broccoli is so good with cheese but it is &#8211; and that nutritional yeast always gives food a nice cheesy flavor!</p>
 </div>        </div>
-    </div><!-- #comment-## -->
+</div><!-- #comment-## -->
 
             <div class="more-comments text-center js-comment-page"></div>    </div>
 </div>
                     </div>
                     <div class="col col-3 s-post-mod">
-                <div class="rail-ads recipe-add">
-    <div class="image-holder">
-        <h2> <span>Discover finger-lickin’</span>good food with our app</h2>
-                    <div class="image-block">
-                <picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/133124/img-rail-ads-01-m2x-375x445-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/133124/img-rail-ads-01-m2x-750x890-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/133125/img-rail-ads-01-285x410-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133125/img-rail-ads-01-285x410-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133125/img-rail-ads-01-285x410-c.jpg" alt="description"></noscript>
-                </picture>            </div>
-            </div>
-    <div class="description">
-        <p>Get inspired! Our chefs add delicious new plant-based recipes every week to keep mealtime exciting and satisfying.</p>
-        <a class="btn" href="https://www.forksoverknives.com/app/"  data-type="ad" data-name="Discover finger-lickin’ good food with our app [sidebar]">Get the recipe app</a>    </div>
-</div>
-<div class="rail-ads meal-planner">
+            <div class="rail-ads meal-planner">
     <div class="image-holder">
         <h2> <span>Healthy eating</span>shouldn't be a hassle</h2>
                     <div class="image-block">
                 <picture>
                     <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/133128/img-rail-ads-02-m2x-375x283-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/133128/img-rail-ads-02-m2x-750x565-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/133129/img-rail-ads-02-287x259-c.png"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133129/img-rail-ads-02-287x259-c.png" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133129/img-rail-ads-02-287x259-c.png" alt="description"></noscript>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/133129/img-rail-ads-02-287x259-c.png"><img  alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133129/img-rail-ads-02-287x259-c.png" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133129/img-rail-ads-02-287x259-c.png" alt=""></noscript>
                 </picture>            </div>
             </div>
     <div class="description">
         <p>With weekly meal plans, Forks Meal Planner takes the hard work out of making nutritious meals the whole family will enjoy.</p>
         <a class="btn" href="https://www.forksoverknives.com/meal-planner/"  data-type="ad" data-name="Healthy eating shouldn&#8217;t be a hassle[sidebar]">Get meal planner</a>    </div>
 </div>
-</div>                </div>
+<div class="rail-ads cooking-course">
+    <div class="image-holder">
+        <h2> <span>Learn how to cook</span>plant-based meals at home</h2>
+                    <div class="image-block">
+                <picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/133112/img-inline-ads-03-m2x-346x262-c.png, https://www.forksoverknives.com/wp-content/uploads/fly-images/133112/img-inline-ads-03-m2x-691x524-c.png 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/133113/img-inline-ads-03-312x275-c.png"><img  alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133113/img-inline-ads-03-312x275-c.png" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/133113/img-inline-ads-03-312x275-c.png" alt=""></noscript>
+                </picture>            </div>
+            </div>
+    <div class="description">
+        <p>Forks Over Knives&#8217; online cooking course will help you learn new techniques, flavors, and skills to live your very best life.</p>
+        <a class="btn" href="https://www.forksoverknives.com/cooking-course/"  data-type="ad" data-name="Learn how to cook plant-based meals at home[sidebar]">Join the course</a>    </div>
+</div>
+</div>
+                </div>
             </section>
+        
+                <section class="section-recipe" id="recipe">
             
-                        <section class="section-recipe" id="recipe">
-                
-                                    <div itemscope itemtype="http://schema.org/Person" class="author-block">
+                            <div itemscope itemtype="http://schema.org/Person" class="author-block">
         <div class="holder">
                             <div itemprop="image" class="img-box">
                     <picture>
                     <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-201x201-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-400x400-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-220x220-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-220x220-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-220x220-c.jpg" alt="description"></noscript>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-220x220-c.jpg"><img  alt="Headshot of Darshana Thacker" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-220x220-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/28913/Darshana-Thacker-732x506-1-220x220-c.jpg" alt="Headshot of Darshana Thacker"></noscript>
                 </picture>                </div>
                         <div class="text"><b class="title">about the author</b>
-                <h2 itemprop="name">Darshana Thacker</h2>
+                <h2 itemprop="name">Darshana Thacker Wendel</h2>
                 <div itemprop="description">
-                    <p>Darshana Thacker is chef and culinary project manager for Forks Over Knives. A graduate of the Natural Gourmet Institute, she is the author of <a href="https://www.forksoverknives.com/product/forks-over-knives-flavor/"><em>Forks Over Knives: Flavor!</em></a> She created the recipes for <a href="http://www.forksoverknives.com/fokfamily/" target="_blank" rel="noopener"><em>Forks Over Knives Family</em></a> and was a lead recipe contributor to the <em>New York Times</em> bestseller <a href="http://smarturl.it/amazonFOK" target="_blank" rel="noopener"><em>The Forks Over Knives Plan</em></a>. Her recipes have been published in <em>The Prevent and Reverse Heart Disease Cookbook</em>, <em><a href="/product/forks-over-knives-the-cookbook/">Forks Over Knives—The Cookbook</a>,</em> <a href="http://www.forksoverknives.com/product/forks-over-knives-the-plant-based-way-to-health/" target="_blank" rel="noopener"><em>Forks Over Knives: The Plant-Based Way to Health</em></a>, and <em>LA Yoga</em> magazine online. Visit <a href="http://www.darshanaskitchen.com/" target="_blank" rel="noopener">DarshanasKitchen.com</a> for more.</p>
-<img   alt="butternut broccoli vegan mac and cheese" data-pin-url="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-pin-media="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" data-pin-description="Butternut Squash Mac and Cheese with Broccoli" data-src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" class="ss-hidden-pin-image lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img   alt="butternut broccoli vegan mac and cheese" data-pin-url="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-pin-media="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" data-pin-description="Butternut Squash Mac and Cheese with Broccoli" data-src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" class="ss-hidden-pin-image lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" class="ss-hidden-pin-image" alt="butternut broccoli vegan mac and cheese" data-pin-url="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" data-pin-media="https://www.forksoverknives.com/wp-content/uploads/butternut-broccoli-mac-and-cheese-wordpress.jpg" data-pin-description="Butternut Squash Mac and Cheese with Broccoli"/></noscript></noscript>                    <a class="more" href="https://www.forksoverknives.com/contributors/darshana-thacker/">see more from this author</a>
+                    <p>Darshana Thacker Wendel is a whole-food, plant-based chef and former culinary projects manager for Forks Over Knives. A graduate of the Natural Gourmet Institute, she is the author of<a href="https://shop.forksoverknives.com//products/forks-over-knives-flavor"> <em>Forks Over Knives: Flavor!</em></a> She created the recipes for<em><a href="https://shop.forksoverknives.com/products/forks-over-knives-family"> Forks Over Knives Family</a></em> and was a lead recipe contributor to the New York Times bestseller<em><a href="https://www.amazon.com/gp/product/1476753296/ref=as_li_qf_sp_asin_il_tl?ie=UTF8&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1476753296&amp;linkCode=as2&amp;tag=forovekni-20"> The Forks Over Knives Plan</a></em>. Her recipes have been published in<em><a href="https://www.amazon.com/dp/B00JPR5JE6/ref=dp-kindle-redirect?_encoding=UTF8&amp;btkr=1" target="_blank" rel="noopener"> The Prevent and Reverse Heart Disease Cookbook</a></em>, <em><a href="https://shop.forksoverknives.com/products/forks-over-knives-the-cookbook" target="_blank" rel="noopener">Forks Over Knives—The Cookbook</a></em>,<em><a href="https://shop.forksoverknives.com/products/forks-over-knives-the-plant-based-way-to-health"> Forks Over Knives: The Plant-Based Way to Health</a></em>, and LA Yoga magazine online. Visit<a href="http://darshanaskitchen.com/" target="_blank" rel="noopener"> DarshanasKitchen.com</a> and follow her on<a href="https://www.instagram.com/darshanas_kitchen/?hl=en" target="_blank" rel="noopener"> Instagram</a> for more.</p>
+                    <a class="more" href="https://www.forksoverknives.com/contributors/darshana-thacker/">see more from this author</a>
                 </div>
             </div>
         </div>
     </div>
-                <div class="container">
-    <div class="download-block" id="download-pdf">
+            <div class="container">
+    <div class="download-block">
         <div class="image-block">
             <picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-159x229-c.png, https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-317x451-c.png 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-341x406-c.png"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-341x406-c.png" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-341x406-c.png" alt="description"></noscript>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-159x229-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-317x451-c.jpg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-341x406-c.jpg"><img  alt="Forks Meal Planner Free Plan" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-341x406-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152205/forks-mealplanner-freeplan-341x406-c.jpg" alt="Forks Meal Planner Free Plan"></noscript>
                 </picture>        </div>
         <div class="download-col">
             <span class="title">Free download</span>
             <h2>Free 5-Day Meal Plan!</h2>
             <p><span style="font-weight: 400;">Get a taste for healthy, fuss-free meal planning with this free five-day meal plan from Forks Meal Planner!</span></p>
-            <form class="download-form" action="https://www.forksoverknives.com" id="download-thanksgiving-cookbook-form" method="post">
+            <form class="download-form" action="https://www.forksoverknives.com" method="post" id="Meal Planner Master Plan">
                 <div class="row">
-                    <input type="email" name="df_email" placeholder="Email Address" class="download-form-input">
+                    <label for="recipe-download" class="screenreader-label">Email Address</label>
+                    <input id="recipe-download" type="email" name="df_email" placeholder="Email Address" class="download-form-input">
                     <input type="hidden" name="df_ac_list_id" value="J7uWg3">
                     <input type="hidden" name="custom_params" value='a:1:{i:0;a:2:{s:4:"name";s:23:"InterestedinMealPlanner";s:5:"value";s:23:"InterestedinMealPlanner";}}'>
                     <button type="submit" class="download-form-button" data-download="https://www.forksoverknives.com/wp-content/uploads/FMP-Master-Plan-Final.pdf"><span class="icon-download"></span></button>
@@ -712,231 +3324,155 @@ window.wc_ga_pro.is_valid_email = function( email ) {
             </form>
         </div>
     </div>
-</div>            </section>
-            <section class="section-more">
+</div>
+        </section>
+        <section class="section-more">
     <h2 class="h1">More from Forks Over Knives</h2>
     <div class="slider">
             <article class="slide">
                         <div class="img-box">
-                <a href="https://www.forksoverknives.com/recipes/vegan-desserts/strawberry-lemonade-nice-cream/"><picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152304/strawberry-lemonade-nice-cream-option-1-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/152304/strawberry-lemonade-nice-cream-option-1-360x270-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152304/strawberry-lemonade-nice-cream-option-1-360x270-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152304/strawberry-lemonade-nice-cream-option-1-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152304/strawberry-lemonade-nice-cream-option-1-360x270-c.jpg" alt="description"></noscript>
-                </picture></a>
-                                <a class="category" href="https://www.forksoverknives.com/recipes/vegan-desserts/">Decadent Desserts</a>            </div>
-                        <h3><a href="https://www.forksoverknives.com/recipes/vegan-desserts/strawberry-lemonade-nice-cream/">Strawberry-Lemonade Nice Cream</a></h3>
-        </article>
-            <article class="slide">
-                        <div class="img-box">
-                <a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/rhubarb-and-red-quinoa-soup/"><picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152116/rhubarb-red-quinoa-soup-wordpress-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/152116/rhubarb-red-quinoa-soup-wordpress-360x270-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152116/rhubarb-red-quinoa-soup-wordpress-360x270-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152116/rhubarb-red-quinoa-soup-wordpress-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152116/rhubarb-red-quinoa-soup-wordpress-360x270-c.jpg" alt="description"></noscript>
+                <a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/sweet-potato-soup-with-cannelini-beans-and-rainbow-chard/"><picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/26677/Sweet-potato-cannelloni-bean-soup-Wp2-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/26677/Sweet-potato-cannelloni-bean-soup-Wp2-360x270-c.jpg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/26677/Sweet-potato-cannelloni-bean-soup-Wp2-360x270-c.jpg"><img  alt="Sweet Potato Soup with Cannellini Beans and Rainbow Chard" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/26677/Sweet-potato-cannelloni-bean-soup-Wp2-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/26677/Sweet-potato-cannelloni-bean-soup-Wp2-360x270-c.jpg" alt="Sweet Potato Soup with Cannellini Beans and Rainbow Chard"></noscript>
                 </picture></a>
                                 <a class="category" href="https://www.forksoverknives.com/recipes/vegan-soups-stews/">Soups &amp; Stews</a>            </div>
-                        <h3><a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/rhubarb-and-red-quinoa-soup/">Rhubarb and Red Quinoa Soup</a></h3>
+            <h3><a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/sweet-potato-soup-with-cannelini-beans-and-rainbow-chard/">Sweet Potato Soup with Cannellini Beans and Rainbow Chard</a></h3>
         </article>
-            <article class="slide">
+        <article class="slide">
                         <div class="img-box">
-                <a href="https://www.forksoverknives.com/recipes/amazing-grains/lots-of-vegetables-vegan-risotto/"><picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152085/creamy-vegan-risotto-wordpress-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/152085/creamy-vegan-risotto-wordpress-360x270-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/152085/creamy-vegan-risotto-wordpress-360x270-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152085/creamy-vegan-risotto-wordpress-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/152085/creamy-vegan-risotto-wordpress-360x270-c.jpg" alt="description"></noscript>
-                </picture></a>
-                                <a class="category" href="https://www.forksoverknives.com/recipes/amazing-grains/">Amazing Grains</a>            </div>
-                        <h3><a href="https://www.forksoverknives.com/recipes/amazing-grains/lots-of-vegetables-vegan-risotto/">Lots-of-Vegetables Risotto</a></h3>
-        </article>
-            <article class="slide">
-                        <div class="img-box">
-                <a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/air-fryer-recipes-crispy-oil-free"><picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/151736/Air-Fyer-Listicle-Collage-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/151736/Air-Fyer-Listicle-Collage-360x270-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/151736/Air-Fyer-Listicle-Collage-360x270-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/151736/Air-Fyer-Listicle-Collage-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/151736/Air-Fyer-Listicle-Collage-360x270-c.jpg" alt="description"></noscript>
+                <a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/vegan-sweet-potato-recipes-baked-roasted-beyond/"><picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/159628/Barbecue-Stuffed-Sweet-Potatoes-wordpress-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/159628/Barbecue-Stuffed-Sweet-Potatoes-wordpress-360x270-c.jpg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/159628/Barbecue-Stuffed-Sweet-Potatoes-wordpress-360x270-c.jpg"><img  alt="Barbecue Stuffed Sweet Potatoes with onion and cucumbers on a white countertop" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/159628/Barbecue-Stuffed-Sweet-Potatoes-wordpress-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/159628/Barbecue-Stuffed-Sweet-Potatoes-wordpress-360x270-c.jpg" alt="Barbecue Stuffed Sweet Potatoes with onion and cucumbers on a white countertop"></noscript>
                 </picture></a>
                                 <a class="category" href="https://www.forksoverknives.com/recipes/vegan-menus-collections/">Menus &amp; Collections</a>            </div>
-                        <h3><a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/air-fryer-recipes-crispy-oil-free">8 Vegan Air-Fryer Recipes You Need to Try</a></h3>
+            <h3><a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/vegan-sweet-potato-recipes-baked-roasted-beyond/">42 Vegan Sweet Potato Recipes: Baked, Roasted, and Beyond</a></h3>
         </article>
-            <article class="slide">
+        <article class="slide">
                         <div class="img-box">
-                <a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/caribbean-black-bean-soup-with-mango-relish/"><picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/151929/caribbean-black-bean-soup-wordpress-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/151929/caribbean-black-bean-soup-wordpress-360x270-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/151929/caribbean-black-bean-soup-wordpress-360x270-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/151929/caribbean-black-bean-soup-wordpress-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/151929/caribbean-black-bean-soup-wordpress-360x270-c.jpg" alt="description"></noscript>
+                <a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/french-green-lentil-stew/"><picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/161760/French-Green-Lentil-Stew-wordpress-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/161760/French-Green-Lentil-Stew-wordpress-360x270-c.jpg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/161760/French-Green-Lentil-Stew-wordpress-360x270-c.jpg"><img  alt="French Green Lentil Stew in a blue ceramic bowl with a side of crackers" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/161760/French-Green-Lentil-Stew-wordpress-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/161760/French-Green-Lentil-Stew-wordpress-360x270-c.jpg" alt="French Green Lentil Stew in a blue ceramic bowl with a side of crackers"></noscript>
                 </picture></a>
                                 <a class="category" href="https://www.forksoverknives.com/recipes/vegan-soups-stews/">Soups &amp; Stews</a>            </div>
-                        <h3><a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/caribbean-black-bean-soup-with-mango-relish/">Caribbean Black Bean Soup with Mango Relish</a></h3>
+            <h3><a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/french-green-lentil-stew/">French Green Lentil Stew</a></h3>
         </article>
-            <article class="slide">
+        <article class="slide">
                         <div class="img-box">
-                <a href="https://www.forksoverknives.com/recipes/vegan-desserts/blueberry-tartlets-mini-tarts/"><picture>
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/151909/blueberry-pic-2-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/151909/blueberry-pic-2-360x270-c.jpg 2x" media="(max-width: 767px)">
-                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/151909/blueberry-pic-2-360x270-c.jpg"><img  alt="description" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/151909/blueberry-pic-2-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/151909/blueberry-pic-2-360x270-c.jpg" alt="description"></noscript>
+                <a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/edible-gifts-vegan-goodies/"><picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/90132/Fudgy-Mexican-Chocolate-Brownies-for-Wordpress-1-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/90132/Fudgy-Mexican-Chocolate-Brownies-for-Wordpress-1-360x270-c.jpg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/90132/Fudgy-Mexican-Chocolate-Brownies-for-Wordpress-1-360x270-c.jpg"><img  alt="" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/90132/Fudgy-Mexican-Chocolate-Brownies-for-Wordpress-1-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/90132/Fudgy-Mexican-Chocolate-Brownies-for-Wordpress-1-360x270-c.jpg" alt=""></noscript>
                 </picture></a>
-                                <a class="category" href="https://www.forksoverknives.com/recipes/vegan-desserts/">Decadent Desserts</a>            </div>
-                        <h3><a href="https://www.forksoverknives.com/recipes/vegan-desserts/blueberry-tartlets-mini-tarts/">Blueberry Tartlets</a></h3>
+                                <a class="category" href="https://www.forksoverknives.com/recipes/vegan-menus-collections/">Menus &amp; Collections</a>            </div>
+            <h3><a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/edible-gifts-vegan-goodies/">17 Edible Goodies to Gift: Vegan and Delicious!</a></h3>
         </article>
-        </div>
+        <article class="slide">
+                        <div class="img-box">
+                <a href="https://www.forksoverknives.com/recipes/vegan-baked-stuffed/mini-vegan-tamale-pie/"><picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/161758/Tamale-Pies-wordpress-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/161758/Tamale-Pies-wordpress-360x270-c.jpg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/161758/Tamale-Pies-wordpress-360x270-c.jpg"><img  alt="Mini Vegan Tamale Pie in white ramekins" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/161758/Tamale-Pies-wordpress-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/161758/Tamale-Pies-wordpress-360x270-c.jpg" alt="Mini Vegan Tamale Pie in white ramekins"></noscript>
+                </picture></a>
+                                <a class="category" href="https://www.forksoverknives.com/recipes/vegan-baked-stuffed/">Baked &amp; Stuffed</a>            </div>
+            <h3><a href="https://www.forksoverknives.com/recipes/vegan-baked-stuffed/mini-vegan-tamale-pie/">Mini Vegan Tamale Pie</a></h3>
+        </article>
+        <article class="slide">
+                        <div class="img-box">
+                <a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/banana-recipes-ways-to-use-ripe-overripe-bananas/"><picture>
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/116401/banana-recipes-scaled-360x270-c.jpg, https://www.forksoverknives.com/wp-content/uploads/fly-images/116401/banana-recipes-scaled-360x270-c.jpg 2x" media="(max-width: 767px)">
+                    <source srcset="https://www.forksoverknives.com/wp-content/uploads/fly-images/116401/banana-recipes-scaled-360x270-c.jpg"><img  alt="recipes for ripe and overripe bananas" data-src="https://www.forksoverknives.com/wp-content/uploads/fly-images/116401/banana-recipes-scaled-360x270-c.jpg" class="lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="><noscript><img src="https://www.forksoverknives.com/wp-content/uploads/fly-images/116401/banana-recipes-scaled-360x270-c.jpg" alt="recipes for ripe and overripe bananas"></noscript>
+                </picture></a>
+                                <a class="category" href="https://www.forksoverknives.com/recipes/vegan-menus-collections/">Menus &amp; Collections</a>            </div>
+            <h3><a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/banana-recipes-ways-to-use-ripe-overripe-bananas/">29 Recipes for Ripe and Overripe Bananas</a></h3>
+        </article>
+    </div>
 </section>
-        </div>
-        <div class="join-block">
+    </div>
+    <section class="join-section section bg-light-gray">
+    <div class="decor-container">
+        <svg class="decor decor-leafy-green" version="1.1" width="164" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 206 171" style="enable-background:new 0 0 206 171;" xml:space="preserve">
+                <g>
+                    <path class="st0" d="M197.8,66.9c-0.6,5-3.1,8.8-7.5,11c-4.3,2.1-8.8,3.8-13.1,5.7c-1.1,0.5-2.2,1-4.1,1.9c6,3.6,11.6,0.7,16.8,1.3c0.5,2.4-0.6,3.7-1.9,4.7c-4,3.1-8,6.1-12.2,8.9c-2.9,1.9-6.1,3.3-9.3,4.9c-9.8,4.9-19.5,5.2-29.3,0c-0.6-0.3-1.1-0.6-1.7-0.8c-3.9-1.6-5.4-1-7.8,2.5c-2.8,4.3-5.5,8.7-8.5,12.9c-8.4,12.1-20.1,19.3-34.4,22.7c-0.8,0.2-1.7,0.2-3.3,0.4c3.1-3.6,8.3-2.7,10.5-6.6c-1.5-1.8-3.4-1.4-5.1-1c-3.4,0.8-6.7,1.9-10,3c-9.5,3-17.1,9.4-26.6,6.4c-0.8-0.3-19.8-0.2-21.2-0.9c1.3-1.1,2.1-2,3.1-2.6c10.5-6.2,21.2-11.9,33.6-13.4c1.7-0.2,12.8-4.5,12.2-6c-0.3-0.8-7.1,0.6-8.1,0.3c-0.8-0.2-1.8,0.1-2.7,0.2c-4.7,0.7-15.4,4-20.2,4.7c-0.5,0.1-0.9-0.1-2-0.3c1.2-1.3,5.8-9.6,16.3-13.9c10.9-4.4,9.8-10.3,41.3-10.2c4.1,0,9.5-2,9.7-3.9c0.2-1.8-8.8,1.2-12.9,0.4c-2.4-0.4-4.9-0.7-7.3-1c-1.6-0.2-3.2-0.5-5.7-0.9c1.3-1,6.9-3.6,7.7-3.8c4.4-1.3,8.8-3,13.4-3.7c11.5-1.8,23-3.3,34.5-4.7c7.1-0.8,13-4.1,18.8-7.8c0.9-0.6,1.5-1.8,2.7-3.4c-1.9-0.3-7.8,2.8-8.8,2.9c-2.7,0.3-5.3,1-8,1.4c-7.8,1.3-15.5,2.8-23.3,3.6c-3.4,0.4-12.7-1.1-25.3,1.8c0.7-1.2,9-10.5,9.7-11.2c2.4-2.9,8.9-7.2,11.8-9.6c3-2.4,6.6-4.4,10-6.2c6.9-3.8,17.1-6.1,24.4-7.2c1.4-0.2,2.9-0.4,4.3-0.7c1.2-0.3,4.8-1,4-1.4c-5.8-2.8-12-3.8-18.1-1.3c-5.5,2.3-14.8,4-20.2,7.4c-8.5,5.2-20,13.5-27.3,20.3c-6.3,6-7.8,7.4-14.3,11.3c-4,2.4-5.1,3.9-9.5,5.9c0.4-0.7,2.1-1.8,2.7-2.3c6.8-6.1,8.2-6.7,14.9-13C100,66.2,102.1,65.3,109,56c5-6.8,9.5-14.7,9.1-23.3c-0.1-1.9-3,3.8-3.9,6.9c-1.5,5.6-6.3,11-9.9,15.1C98,62.2,82.6,72.9,81.2,73.6c0.1-6.3,0.5-16.9-6.4-20.3c-0.2,1.1-0.5,1.9-0.5,2.7c-0.1,7.9-2.7,14.6-8,20.8C57.5,87.1,47.8,96.3,38.5,106c-2.5,2.6-4.8,5.4-7.3,8c-0.7,0.7-1.4,1.3-2.6,2.3c-0.2-1.2-0.4-1.8-0.3-2.3c0.6-4.6,1.2-9.2,1.8-13.8c0.3-2.6,1.5-4.2,4.1-5c3.9-1.2,6.8-3.7,8.7-7.3c2.6-5,5.2-10.1,7.7-15.2c0.8-1.7,1.7-3.2,3.5-3.9c4.1-1.5,6.5-4.7,7.8-8.6c1-2.9,1.6-6,2-9c0.4-3.1,1.4-5.7,3.3-8.1c4.8-6.1,9.8-12,16-16.8c0.9-0.7,2-1.3,3.1-1.9l0.8,0.6c-0.3,1.2-0.5,2.4-0.8,3.6c-0.5,2.6-0.3,0.6-0.5,3.3c-0.1,1.2,2.1,6.1,2.9,5.2c4.3-5.3,11.5-13.4,16.8-17.5c4.9-3.9,18-10.6,24.2-11.3c7.4-0.8,10.8,0,14.2,5c0.8,1.2,2.2,4.9,3.1,6.2c1.3,2,2.8,2.6,5.2,2.1c9.9-2.3,18.6,0.8,26.7,6.3c1.4,0.9,2.7,2.1,2.4,4.6c-3.4,1.7-2,1.4-3.8,1.8c-2.3,0.5-5.8,2.9-7.4,3.3c-5.7,1.2,11.3,2.1,13.9,2.9c6,1.8,9.5,7.9,12,13.2C197.8,57.5,198.4,62.1,197.8,66.9L197.8,66.9z M56.2,108.8c2.2-1.6,4.4-3.3,6.6-4.7c7.4-4.4,14.8-8.8,22.2-13.1c5.5-3.2,10.8-4.6,15.8-4.9c0.3,0,5.2-0.5,5.5-0.3c-0.4,0.3-5.5,1.3-5.9,1.5c-6.2,2.8-8.9,2.6-15,5.6c-7.6,3.6-18.7,10.8-26.2,15.3c-1.2,0.7-2.4,1.4-3.6,2.1c-0.3,0.2-0.6,0.3-0.9,0.4c0.2-0.3,0.5-0.7,0.8-1c0.3-0.3,0.6-0.5,0.9-0.8L56.2,108.8L56.2,108.8z M9,158.4c-1,1.7-1.7,3.8-4,4.6c-1.6-1.6-0.4-3,0.3-4.2c2.7-4.7,5.6-9.3,8.4-13.9c0.3-0.6,0.6-1.1,1-1.7l0,0c-0.3,0-0.5,0-0.8,0l0,0C31.7,118.8,53.6,98,74.3,76.1c0.1-0.1,0.5,0,1,0c0.4,2-0.9,3.4-2,4.7c-4.1,4.9-8.3,9.9-12.6,14.7c-9.5,10.4-19.3,20.5-28.6,31C23.2,136.2,15.5,146.8,9,158.4L9,158.4zM203.2,53c-3.8-5.8-7.7-11.6-13.6-15.6c-0.2-0.1-0.2-0.5-0.4-0.9c3.2-5.1,0.8-9.2-2.7-13c-6.3-6.8-14.2-9.1-23.2-8.2c-3.3,0.3-6.6,1-10.3,1.6c-1-2.5-1.7-4.7-2.8-6.7c-4.4-7.9-12.3-11.5-22.2-9.6C114.9,2.9,103.2,8,94,17.9c-1.3,1.4-2.6,2.2-4.4,1.5c-2.5-0.9-4.8-0.2-7.1,0.9c-6.4,3.1-11.8,7.3-16.3,12.8C59.6,41,55.7,50.2,52.8,59.9c-0.5,1.7-0.7,3.6-2.6,4.5c-3.7,1.8-5.7,5-6.6,8.6c-1.1,4.5-3.8,7.8-6.7,11.1c-1.9,2.1-4,3.7-6.8,4c-4.3,0.5-6.6,3.3-7.7,7.2c-0.6,2.2-1,4.5-1.3,6.8c-1.1,8.1-2.1,16.1-3.2,24.2c-0.4,2.9-1.6,5.3-3.2,7.8c-3.4,5.3-7,10.6-9.7,16.3c-2.2,4.6-3.3,9.7-4.7,14.7c-0.6,2.2-0.5,4.6,2.4,5.8c0.5-0.3,1-0.5,1.3-0.9c4-3.9,7.7-8,11.9-11.6c8.3-7.1,17.3-12,29-8.7c7.3,2.1,14.6,1.3,21.7-1.4c2.4-0.9,4.7-1,7.2-0.2c2.1,0.6,4.3,0.8,6.5,0.9c6,0.3,11.5-1.8,16.5-4.8c5.6-3.3,10.8-7.1,16.5-10.1C126.3,127.5,134,112,134,112c-0.2,0.4,11.2,4.2,12,4.4c5.8,1.4,12.1,1.1,17.8-0.4c12.9-3.4,25.9-13.4,31-26.1c2.6-6.6-3.5-6.6-0.5-7.4c6.3-1.7,9.7-5.5,10.8-12.4C206.2,63.5,207,58.8,203.2,53L203.2,53z"></path>
+                </g>
+              </svg>
+        <svg class="decor decor-nuts desktop-visible" version="1.1" width="164" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 136 126" style="enable-background:new 0 0 136 126;" xml:space="preserve">
+                <g>
+                    <path class="st0" d="M130.8,111.2c-3.4,1-6.9,2.1-10.4,2.9c-6,1.4-12.2,0.7-18.3,0.9c-9.6,0.4-19-1.2-28.2-3.7c-4.3-1.2-8.3-2.8-12.3-6.3c1.5-0.3,2.3-0.6,3-0.6c6.8,0.1,13.5,0.3,20.3,0.3c5.1,0,10.1,0.7,15.1,1.8c1.8,0.4,3.6,0.9,5.6,0.9c-0.3-0.6-0.4-1.1-0.7-1.2c-6.1-2.6-12.2-4.7-18.9-5.4c-8.2-0.8-16.5-0.8-24.7,0.3c-1.9,0.2-3.8,0.1-5.2,0.2c-2.8-2.1-5.2-3.7-6.6-6.8v0c0,0,0-0.1,0-0.1c0.7-0.5,1.3-1.1,2.1-1.3c3-1.1,6.2-1.7,9.4-1.9l0,0c1.2-0.1,2.5-0.1,3.7,0c9.8,0.4,19.4,1.7,28.9,4c2,0.5,4,1.3,5.9,2.3c5.3,2.7,10.5,5.6,15.7,8.4c0.7,0.4,1.4,1,2.4,0.6c0.2-0.4,0.4-1,0.6-1.7c-4.8-2.9-9.6-5.7-14.3-8.6c-4.6-2.8-9.5-4.7-14.6-6c-6.6-1.8-13.4-2.3-20.1-2.8c-0.8-0.1-1.5-0.1-2.3-0.1c-0.7,0-1.4,0-2.1,0.1c-2.1,0.2-4.2,0.6-6.3,1.2c-2.8,0.9-5.7,1.8-8.5,2.6c-0.3,0.1-0.7-0.3-1.4-0.6c0.1,0,0.9-1.8,1-2c0.6-1.1,0.9-1.8,1.9-2.4c0.4-0.3,0.9-0.6,1.3-1c3.5-2.7,7.6-5.6,12.1-6.2c1.9-0.3,3.8-0.6,5.7-0.7c2.7-0.1,5.5-0.4,8.2,0c6.5,0.9,12.9,2.2,18.7,5.7c4.2,2.5,8.5,4.8,12.7,7.3c7.7,4.5,15,9.7,20.6,16.9c0.5,0.6,0.7,1.4,1.1,2C131.4,110.6,131.2,111.1,130.8,111.2L130.8,111.2z M16.8,82.9c14-6,28.3-7.9,41.6-13.5c-7.9-0.5-15.1,2.9-22.8,3.8c-7.7,0.8-15.1,4.2-23.8,3.6c3.3-6.4,10.4-7.1,14.9-12.1c-7.5-1.5-11.9,5.6-18.2,5.3c-1.6-2.2-0.8-4.2,0.5-6c3.4-4.8,7.7-8.7,13.1-10.8c4-1.6,8.1-3.2,12.3-3.9c9.5-1.5,18.9-3,28.8-0.8c4.9,1.1,9.8,2,14.7,3.2c2.7,1.4,5.5,2.7,8.3,4C74,72.5,43.1,84.9,16.8,82.9z M49.4,21.1c-2.5-2.5-4.9-5.2-7.3-7.9c-0.2-0.3-0.2-0.8-0.4-1.5c0.6-0.4,1.2-0.9,1.9-1.2C52.1,7.2,61,6.6,69.9,6.8c4.9,0.1,9.7,0.4,14.6,0.4c6.8,0,12.9,2.2,18.9,4.9c2.5,1.1,4.7,2.8,7,4.3c1.6,1.1,3,2.3,4.5,3.5c2.6,2.2,4.4,4.8,5.6,9c-3.3-2.5-5.1-5.2-7.3-7.4c-6-5.8-12.9-9.5-21.5-9.5c-0.4,0-0.8,0.2-1.5,0.4c0.5,0.5,0.8,1.1,1.2,1.3c5.1,1.7,9.7,4.1,14.5,6.4c5.6,2.8,10,7.1,14.7,11c1,0.8,1.7,1.8,2.6,2.8l-0.3,4.5c-0.8-0.1-1.3,0-1.5-0.2c-2-2.2-4-4.4-5.9-6.6c-2.4-2.8-5.2-5-8.5-6.6c-6.1-3.1-12.1-6.2-18.6-8.1c-5.1-1.5-10.3-2.5-15.6-2.5c-5.5,0-11-0.1-16.6-0.1c-0.1,0.7-0.2,1.3-0.3,1.7c0.7,0.9,1.6,0.7,2.4,0.8c5.9,0.4,11.9,0.6,17.8,1.1c2.1,0.2,4.2,0.5,6.2,1.1c9.3,3,18.2,6.9,26.8,11.7c3.9,2.2,7.4,5,10.2,8.5c0.5,0.6,0.7,1.4,1.1,2.2c-2.8,1.9-5.8,2.1-9.3,2.4c-1.2-0.8-2.9-1.7-4.4-2.9c-6.5-5.2-13.5-9.5-20.9-13.1c-6-2.9-12.4-4.3-18.9-5.3c-0.3,0-0.6,0.4-1.2,0.7c1.7,1.1,3.5,1.5,5.2,2.1c4.8,1.7,9.4,3.7,13.8,6.3c5.8,3.5,11.7,6.9,17.5,10.3c0.7,0.4,1.1,1,2.3,2.1c-5.2,0.8-9.5,0.2-13.7-1.1c-9.2-2.7-18-6.2-26-11.6C59.5,28,53.8,25.5,49.4,21.1L49.4,21.1z M134.5,107.4c-3.3-5.3-7-10.2-12-13.9c-2.7-2-5.4-4.1-7.7-6.6c-2.8-3-6.3-5-10-6.7c-7.4-3.5-15-5.9-23-6.9c3.4-3.4,6.7-7.1,9.9-10.7c1-1.2,1.9-2.5,2.7-3.9c6.6,1.6,13.4,1.2,20.3-1.2c8.3-2.9,11.8-7.1,12.8-16.4c0.5-5-0.8-9.7-2.8-14.2c-2.9-6.5-7.9-11.4-13.1-16.2c-0.5-0.4-1.1-0.6-1.6-1c-9-5.5-18.9-8.3-29.4-9.4c-4-0.4-8.1-0.5-12,0.5c-3.3,0.9-6.7,1.3-10,1.6C52.1,3,46.4,5.2,40.9,8c-2.8,1.4-4.6,3.7-5.1,6.8c0.3,0.7,0.4,1.4,0.7,1.8c2.8,3.7,5.4,7.6,8.6,11c5,5.4,10.5,10.3,16.6,14.6c-2.1-0.4-6.6-0.4-7-0.4c-2.1,0.2-4.3,0.3-6.4,0.2c-5.8-0.1-11.4,0.8-17,2c-8,1.7-14,6.3-20.3,11c-1.1,0.8-3,1.8-4.6,3.4c-4.7,4.9-5.8,12.5-6.3,18c2,8.8,3.9,12.1,9.4,15.6c4,2.5,8.3,4.3,13.1,4.4c5,0.1,10.1,0.2,15.1,0c1.3-0.1,2.6-0.2,3.9-0.3c-1.3,5.5,0.2,9.9,4.5,15.1c6.2,7.6,14.3,12,23.9,13.2c8.6,1,17.2,1.8,25.9,1.6c8.5-0.2,16.8-1.7,24.9-4c4.4-1.2,8.7-3.2,13-4.9c0.6-0.2,1-0.8,1.6-1.2C136.5,112.9,136.1,110.1,134.5,107.4L134.5,107.4z"></path>
+                </g>
+              </svg>
+        <svg class="decor decor-orange desktop-visible" version="1.1" width="164" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 189 171" style="enable-background:new 0 0 189 171;" xml:space="preserve">
+                <g>
+                    <path class="st0" d="M159.1,120.7c-0.2,0.1-0.5,0.3-0.7,0.4c-0.1-0.2-0.3-0.4-0.2-0.5c0.2-0.2,0.4-0.4,0.7-0.5C158.8,120.1,159.1,120.7,159.1,120.7z M146.5,158.5l0-0.1c-0.2,0-0.5,0.1-0.7,0c-0.2,0-0.5-0.1-0.7-0.2c0.2-0.1,0.4-0.2,0.6-0.3c0.8-0.3,1.6-0.6,2.4-0.9c4.9-1.9,9.8-4,14.5-6.5c3.8-2.1,7.4-4.3,11.2-6.4c0.2-0.1,0.5-0.2,0.8-0.2c0,0.3,0,0.6-0.1,0.8c-2.2,3.2-4.9,5.7-8.5,7.1c-4.8,1.9-9.7,3.8-14.6,5.7C149.6,157.9,148,158.2,146.5,158.5L146.5,158.5z M136.6,101.7c0.1-0.2,0.1-0.4,0.2-0.4c0.2,0,0.4-0.1,0.5,0c0.4,0.2,0.7,0.5,1,0.7c4.9,4.2,9.7,8.3,14.6,12.5c0.2,0.2,0.5,0.4,0.7,0.6c0.8,0.8,0.9,1.2,0.2,2.2c-2.3,3.6-5.6,5.9-9.6,7.3c-0.7,0.3-1.2,0-1.4-0.8c-0.9-3.2-1.9-6.4-2.8-9.6c-1.1-3.7-2.1-7.4-3.2-11.2C136.7,102.7,136.6,102.1,136.6,101.7L136.6,101.7z M118.7,130.6c0.1,1.1-0.1,1.4-1.1,2c-1.6,1-3.3,1.9-4.9,2.9c-3.5,2.2-7.4,2.9-11.2,3.9c-0.4,0.1-0.8,0.1-1.3,0.1c-4.3-0.3-8.5-1.3-12.4-3.2c-0.9-0.5-1-0.7-0.4-1.7c1.4-2.4,2.8-4.7,4.2-7c4.1-7.1,8.6-13.9,11.8-21.5c0.4-1,0.9-1.9,1.5-2.8c1.6-2.5,2.8-5.2,3.9-7.9c0.7-1.8,1.7-3.6,2.6-5.4c0.1-0.2,0.5-0.3,0.7-0.5c0.1,0.3,0.3,0.5,0.3,0.8c0.1,0.2,0.1,0.4,0.1,0.6c1,7.2,2,14.3,4.1,21.3c0.5,1.5,0.6,3.1,0.8,4.6C117.9,121.5,118.3,126.1,118.7,130.6z M40.4,63.8c0.1-1.7,0.1-3.5,0.3-5.3c0.7-6.7,1.4-13.3,2.4-20c0.6-4.3,1.5-8.7,2.3-13c0.2-1.1,0.6-1.2,1.5-0.5c3.9,3,7.8,6,11.6,9.2c6.6,5.7,13.2,11.3,20.1,16.7c0.7,0.5,1.3,1.1,1.9,1.6c0.4,0.4,0.3,1.1-0.3,1.2c-2.1,0.6-4.2,1.3-6.4,1.8c-5.6,1.4-11,3.4-16.2,6c-1.4,0.7-2.9,1.2-4.3,1.8c-2.7,1.1-5.4,2.3-8.1,3.4c-1.4,0.6-2.9,1.2-4.3,1.8C39.9,67.1,40.8,65.4,40.4,63.8L40.4,63.8z M43.5,90.9c0.2-0.2,0.4-0.5,0.6-0.5c1-0.2,2.1-0.6,3.1-0.5c1.4,0.1,2.7-0.2,4-0.6c1.1-0.3,2.2-0.6,3.3-0.9c6.4-1.9,12.8-4,18.9-7c5.3-2.6,10.4-5.4,15.7-8.1c0.8-0.4,1.7-0.7,2.5-1.1c0.3,1.1-0.7,1.6-1.1,2.4c-0.8,1.6-1.7,3.1-2.6,4.7c-2,3.6-4,7.1-6,10.7c-0.5,0.8-1,1.6-1.7,2.2c-0.9,0.8-1.4,1.8-2,2.8c-1.5,2.9-2.9,5.8-4.4,8.7c-2.7,5.2-5.6,10.3-7.5,15.9c-0.1,0.2-0.1,0.5-0.2,0.6c-0.3,0.2-0.7,0.6-1,0.6c-0.7-0.1-1.4-0.3-2-0.7c-1-0.6-1.9-1.3-2.8-1.9c-3.5-2.2-6.2-5.2-7.6-9c-1.5-4.2-3.5-8-5.8-11.8c-1-1.7-2-3.5-2.9-5.2C43.8,91.8,43.7,91.4,43.5,90.9L43.5,90.9z M8.2,68.5H8.1c0-1.3,0.1-2.5,0-3.8c-0.3-4.8-0.6-9.6,0.2-14.4c1.1-6.1,2.2-12.2,3.6-18.2c0.1-0.5,0.2-1.1,0.5-1.5c0.2-0.3,0.7-0.4,1-0.5c0.1,0,0.4,0.5,0.4,0.7c-0.2,1.9-0.3,3.8-0.7,5.6c-0.9,4.7-1.7,9.5-1.7,14.3c0,4.4-0.3,8.8-0.4,13.2c-0.1,3.9-0.4,7.8,0,11.6c0.6,5.6,1.2,11.2,2.9,16.7c2,6.6,5,12.7,9.1,18.2c4.8,6.4,10.1,12.3,16,17.8c3.7,3.4,7.6,6.6,11.9,9.4c6,3.9,12.2,7.4,18.6,10.7c2.5,1.3,5.2,2.3,8,2.9c5.6,1.1,11.2,2,16.8,3c4.9,0.8,9.9,0.5,14.8,0.1c0.4,0,0.8-0.2,1.2-0.4c0.2-0.1,0.3-0.3,0.4-0.5c0-0.1-0.2-0.4-0.3-0.4c-2.1-0.4-4.1-0.7-6.2-1.2c-7-1.6-14.2-1.7-21.1-3.8c-0.1,0-0.2,0-0.3,0c-5.6-0.8-10.7-3-15.8-5.1c-2.8-1.2-5.4-2.9-7.7-4.8c-2.3-1.9-4.9-3.7-7.2-5.6c-3.8-3.2-7.5-6.4-11.3-9.6c-0.6-0.5-1-1.1-1.5-1.6c-2.2-2.6-4.4-5.4-6.7-7.9c-3.1-3.3-5.6-7-7.1-11.4c-1.6-5.1-3.4-10.1-4.1-15.5c-1-7.4-0.8-14.9-1.3-22.3c0-0.4,0-0.8,0.1-1.3c0.3-2.2,0.6-4.3,0.8-6.5c0.3-2.6,0.3-5.2,0.7-7.8c0.5-3.4,1.1-6.8,1.9-10.2c0.7-3,1.8-5.8,2.3-8.8c0.8-5,2.6-9.7,3.7-14.6c0.8-3.4,1-3.2,3.4-1.1c1.5,1.3,3,2.6,4.6,3.9c0.7,0.5,0.8,1.2,0.4,2c-1.1,2.3-2,4.6-3.2,6.8c-1.5,2.8-2.5,5.8-3.1,8.9c-1.1,5.9-2.1,11.8-3.3,17.6c-0.5,2.6-0.7,5.2-0.5,7.8c0.2,2.7,0.8,5.4,0.9,8.1c0.2,2.5,1.4,4.6,2.6,6.7c1.1,1.9,2.6,2.6,4.8,2c1.3-0.3,2.7-0.3,3.6-1.6c0.2-0.3,0.7-0.5,1.1-0.6c3.1-1.1,6-2.4,9.2-3.2c6.1-1.6,12.1-3.7,18-5.9c2.5-0.9,5-1.6,7.5-2.5c3.2-1.2,6.3-2.4,9.4-3.7c0.9-0.3,1.7-1.3,2.5-1.1c0.9,0.2,1.7,1.1,2.5,1.8c0.9,0.7,1.8,1.5,2.6,2.3c0.6,0.6,0.5,1.1-0.3,1.4c-4.2,1.5-8.3,3-12.5,4.5c-1.5,0.5-2.9,1.1-4.5,1.6c-10.4,3.4-20.6,7.4-30.7,11.4c-1.3,0.5-2.5,1.1-3.8,1.6c-2.1,0.9-2.9,2.6-2.9,4.8c0,1,0.1,2.1,0.4,3.1c0.5,1.7,1.1,3.4,1.9,5c3.1,6.4,6.8,12.5,11.2,18.2c3,3.9,7,6.6,10.9,9.5c0.3,0.2,0.7,0.4,1.1,0.6c1.5,0.6,2.7,0.2,3.6-1.1c0.5-0.8,1-1.6,1.4-2.5c3.7-8,8.4-15.5,13.3-22.8c3.9-5.7,7.5-11.7,10.8-17.8c1.9-3.6,3.9-7.2,5.9-10.7c0.6-1,1-1.1,2-0.3c1.4,1.1,2.8,2.2,4.1,3.4c3.3,2.9,3.6,1.9,1.2,6.3c-2.1,3.9-4.3,7.7-6.3,11.6c-2,3.9-4.2,7.7-6.9,11.3c-4.3,5.7-8,11.8-11.2,18.2c-1.3,2.6-2.6,5.3-3.7,8c-1.4,3.5-1.1,4.6,1.8,7.1c0.1,0.1,0.2,0.1,0.2,0.2c5.6,4.3,11.7,7.4,18.8,8.3c1.3,0.2,2.8,0.2,4.1,0c4.9-1,9.7-2.2,13.8-5.1c0.7-0.5,1.4-0.9,2.2-1.3c3.4-1.9,5.1-4.5,4.4-8.5c-0.4-2.2-0.7-4.4-0.7-6.6c0-4.1-0.6-8.1-1.3-12.2c-0.9-4.8-1.9-9.7-2-14.6c0-0.5-0.1-1-0.2-1.6c-0.5-3-1-6-1.6-9c0-0.2,0-0.4,0.1-0.6c0-0.1,0.4-0.1,0.5,0c2.3,1.8,4.5,3.8,6.9,5.5c2.3,1.7,3.6,3.7,3.2,6.6c0,0.2,0,0.4,0.1,0.6c0.8,6.6,1.6,13.1,2.5,19.7c0.4,2.8,1.1,5.6,1.8,8.3c0.4,1.5,1.1,2.9,1.7,4.4c0.6,1.7,2.3,2.1,3.7,2.8c1.1,0.5,2-0.1,2.9-0.7c0.4-0.3,1-0.5,1.5-0.5c4.5-0.6,8.8-2.2,13-3.7c2.5-0.9,4.9-1.9,6.8-3.8c0.6-0.6,1.1-0.4,1.6,0.1c1.2,1.3,2.5,2.6,3.6,3.9c0.8,0.9,0.8,1.3-0.3,1.9c-0.6,0.4-1.3,0.7-2,1c-8.1,4-16.2,8-24.3,12c-5,2.5-10.2,4.5-15.7,5.6c-1.7,0.3-3.4,1.1-5.1,1.7c-0.2,0.1-0.4,0.4-0.6,0.6c0.2,0.1,0.4,0.2,0.6,0.2c1.5,0.1,3,0.4,4.4,0.3c6.4-0.6,12.7-1.7,18.6-4.4c5.4-2.5,10.9-5.1,16.2-7.7c2.4-1.2,4.6-2.6,6.9-3.8c1.6-0.9,2.9-2.4,4.8-2.9c1.2,1.4,2.5,2.8,3.7,4.2c0.2,0.2,0.4,0.5,0.6,0.7c0.4,0.5,0.3,1-0.2,1.3c-1.2,0.8-2.6,1.5-3.8,2.3c-3.4,2.5-7.1,4.5-10.9,6.4c-6.3,3.3-12.7,6.5-19.4,9c-2.8,1-5.5,2-8.4,2.6c-1.6,0.4-3.3,0.8-4.9,1.2c-4.7,1.1-9.4,2.5-14.1,3.3c-8.5,1.4-17,1.1-25.5,0.1c-0.7-0.1-1.5-0.2-2.1-0.6c-1.2-0.6-2.4-0.6-3.6-0.9c-2.8-0.6-5.6-1.1-8.2-2.3c-4.7-2.1-9.3-4.4-13.7-7.1c-6.7-3.9-13.4-8-19.3-13.1c-0.2-0.1-0.3-0.2-0.5-0.4c-4.2-3.3-8.3-6.8-11.6-11.1c-3.3-4.3-6.6-8.7-9.8-13.1c-1.1-1.5-2-3.2-2.7-5c-1.6-4.1-3-8.3-4.4-12.5C9.4,90.2,8,82.8,8.2,75.1C8.3,72.9,8.2,70.7,8.2,68.5L8.2,68.5z M100.9,170.8c3.4-0.1,6.8-0.2,10.2-0.2c4,0,7.9-0.4,11.9-1.2c2.2-0.4,4.4-0.8,6.6-0.9c7-0.6,13.8-2.3,20.3-5c8.2-3.3,15.9-7.5,23.6-11.7c5.4-3,9.6-6.7,14.4-11c0.3-0.3,0.6-0.6,0.8-0.8c0.6-0.6,0.4-1.1-0.1-1.5c-0.6-0.6-1.2-1.1-1.7-1.7c-5.7-5.4-8-7.5-13.8-12.8c-3.4-3.1-7-6-10.5-8.9c-4.7-3.9-9.4-7.8-14.1-11.6c-5.7-4.6-11.4-9.1-17.1-13.7c-0.4-0.3-0.8-0.6-1.1-1c-2.2-2.5-4.8-4.5-7.4-6.6c-4.6-3.6-9.2-7.4-13.7-11.2c-1.3-1.1-2.4-2.4-3.6-3.6c-4.9-4.3-9.8-8.5-14.7-12.8c-2.4-2.1-4.8-4.3-7.1-6.4c-1.5-1.3-2.9-2.8-4.3-4.1c-8-7.1-16.3-13.9-24.6-20.6c-1.6-1.3-3.4-2.5-5.2-3.5C41.5,15.4,36.9,12,29.9,6c-1.4-1.2-2.9-2.4-4.5-3.4C24,1.7,22.5,1,21.1,0.4c-1.8-0.8-3.3-0.5-4.9,1c-2.5,2.2-4.3,7.2-5.5,10c-3.2,7.6-5,15.6-6.6,23.7C3.3,39,2.9,42.9,2.2,46.8c-0.3,2-0.9,4.1-1.2,6.1C0.4,57.2-0.1,61.4,0,65.6c0.1,4.8,0,9.6,0.5,14.4C1.1,85.3,2,90.7,3.6,95.8c1.2,3.7,2.2,7.4,3.3,11.1C18,145.7,59.8,173,100.9,170.8C100.9,170.9,100.9,170.8,100.9,170.8z"></path>
+                </g>
+              </svg>
+        <svg class="decor decor-onion" version="1.1" width="164" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 216.2 228.2" style="enable-background:new 0 0 216.2 228.2;" xml:space="preserve">
+                <g>
+                    <path class="st0" d="M210.4,150.5c0.2-0.6,0.5-1.1,1.4-0.9c0.9,0.9,1.4,2.1,1.9,3.4c0.5,1.5,1.1,2.9,1.5,4.4c0.7,2.2,1,4.4,1,6.6c-0.1,3.9-0.1,7.8-0.7,11.7c-0.2,1.5-0.6,3.1-1.1,4.6c-2.3,7.9-6,15.1-11.3,21.3c-0.3,0.3-0.6,0.6-0.9,0.9l-0.6,0.6c-1.8,1.7-3.6,3.3-5.2,5.2c-1.9,2.1-4,4-6.3,5.7c-4.5,3.4-9.1,6.7-14.5,8.8c-0.4,0.1-0.7,0.3-1.1,0.4c-4.4,1.2-8.8,2.6-13.4,3.3l-1.4,0.2l-2.7,0.4c-3.2,0.5-6.4,0.9-9.6,1.1c-2,0.1-3.9,0-5.8-0.4c-3.7-0.8-7.5-1.5-11.2-2.4c-5.5-1.3-10.8-3.4-15.9-6c-4.5-2.3-9-4.7-13.3-7.5c-0.6-0.4-1.2-0.7-1.8-1c-4.8-3.1-10-3.6-15.5-2.8c-1.5,0.2-3.1,0.5-4.6,0.8c-2.8,0.6-5.4,0.3-8.1-0.6c-0.6-0.2-1.3-0.4-2-0.6c-0.1-0.4-0.1-0.9-0.3-1.3c-0.2-0.5-0.4-0.9-0.6-1.3c-0.8-1.6-0.5-3,0.8-4.2c0.8-0.7,1.6-1.5,2.4-2.1c0.8-0.6,1.6-1.1,2.8-1.1c2,1.2,3,3.4,4.9,4.3c1-0.1,1.7-0.5,2.4-1l0.4-0.3l0.2-0.1c5.7-3.7,12-5.6,18.8-5.7c4.9-0.1,9.8,0,14.6,0.6c1,0.1,1.9,0.3,2.9,0.3c5.9,0.1,11.7,1.1,17.5,1.9c8.1,1.1,16,0.8,23.9-1.3c6.2-1.6,12.3-4,17.9-7.3c2.1-1.2,4.1-2.6,6.2-3.9c3.5-2.1,6.6-4.9,9.6-7.7c1.8-1.7,3.4-3.5,5.2-5.1c3.6-3.4,6.2-7.5,8.4-11.9c0.8-1.5,1.3-3.1,1.7-4.7C209.4,153.9,209.9,152.2,210.4,150.5L210.4,150.5z M104.1,209.3c1.2,1.3,2.8,2,4.3,2.8c2.8,1.5,5.5,3,8.3,4.4c1.7,0.8,3.4,1.6,5.1,2.1c3.7,1.1,7.4,2,11,3c3.1,0.8,6.3,1.3,9.6,1.5c0.3,0,0.8,0.2,1-0.5c-0.3-0.2-0.6-0.4-1-0.5c-6-2.1-12-4.3-18-6.4c-1.2-0.4-2.4-0.9-3.5-1.4c-3.8-1.9-7.8-2.9-11.9-3.8l-1.4-0.3C106.5,209.9,105.3,209.6,104.1,209.3L104.1,209.3z M129.7,222.9c-0.6-0.9-1.2-0.9-2-0.6C128.3,222.5,128.9,222.7,129.7,222.9z M107.3,206.9c-0.4,0-0.8-0.2-1.1,0.5c1.4,0.7,2.9,1.1,4.4,1.4c1.2,0.3,2.5,0.4,3.7,0.8c1.5,0.5,3,1,4.5,1.5l3,1c4,1.4,8,2.7,11.9,4.4c2.8,1.2,5.6,2.3,8.5,3.3c1.7,0.6,3.4,1,5.1,1.3c3.8,0.6,7.6,1.1,11.3,1.5c1.2,0.1,2.6,0.2,3.8,0c6.8-1,12.8-4,18.6-7.6c0.1,0,0.1-0.2,0.3-0.4c-0.3-0.1-0.5-0.3-0.7-0.3c-0.9,0.1-1.7,0.3-2.6,0.4c-2.3,0.4-4.6,1-6.9,1.3c-7.3,0.9-14.4,0.2-21.6-1.2c-2.1-0.4-4.2-0.8-6.3-1.2c-4.1-0.7-8.3-1.4-12.4-2.2c-4.3-0.8-8.7-1.6-12.9-2.9c-0.6-0.2-1.2-0.2-1.7-0.3C113.1,207.7,110.2,207.3,107.3,206.9L107.3,206.9z M202,190.8c-1.5-0.2-2.3,0.5-3.1,1c-6.2,3.7-12.9,6.1-19.8,8c-10.2,2.9-20.6,3.5-31.1,2.5c-6.3-0.6-12.6-1.2-19-1.4c-4.1-0.1-8.2-0.3-12.3-1.1c-2.6-0.5-5.2-0.8-7.9-0.6c-2.4,0.2-4.7,0-7-0.3c-2.9-0.4-5.8-0.3-8.6,0.9c-1.6,0.7-3.3,1.2-5,1.8c-1.4,0.6-2.8,1.2-4.4,1.8c0.5,0.6,1,0.5,1.5,0.5l0.2,0c0.1,0,0.2,0,0.2,0c4.3-0.2,8.6-0.6,12.9-0.5c5.2,0.1,10.4,0,15.5,0.7c0.7,0.1,1.4,0,2.1,0.1c4.4,0.2,8.8,0.3,13.2,0.6c3.8,0.3,7.6,0.8,11.3,1.7c3.8,0.9,7.7,1.4,11.6,1.9c5.4,0.7,10.9,0.3,16.4,0.4c1.7,0,3.3-0.1,5-0.1c4.7-0.2,9-1.8,13.1-3.9c4.6-2.3,8.4-5.7,11.8-9.5C199.9,194,201.1,192.6,202,190.8L202,190.8z M73.8,199.5c0,0-0.1,0-0.1,0l-0.3,0c-0.1,0-0.3,0-0.4,0.1c-0.3,0.2-0.5,0.4-1.1,1c0.8-0.1,1-0.1,1.2-0.2C73.5,200.2,73.9,200.1,73.8,199.5L73.8,199.5z M207.1,150.1l0.9,0.6c0,0.3,0.1,0.5,0.1,0.7c-0.2,0.5-0.4,1.1-0.8,1.5c-1.7,2.2-3.5,4.2-5.8,5.8c-1.4,1-2.6,2-4,3c-5.3,3.8-10.8,7.4-16.8,10.2c-4.4,2.1-8.9,4-13.5,5.7c-6.6,2.6-13.4,4.4-20.3,5.8c-6.9,1.4-13.8,2.6-20.9,3.3c-6.5,0.6-13,1.5-19.4,2.9c-3.1,0.7-6.1,1.6-9.1,2.4c-0.9,0.3-1.9,0.6-2.8,0.8c-5.4,1-10.3,3.1-14.8,6c-0.6,0.4-1.3,1-2.1,0.3c0-0.9,0.7-1.4,1.3-1.9c2.8-2.1,5.8-4,9-5.5c4.8-2.2,9.6-4.3,14.6-6c3-1,6-1.8,9-2.5c4.2-1.1,8.4-2,12.5-3c1.4-0.3,2.8-0.7,4.3-1c8.1-1.3,16.2-2.6,24.3-3.9c4.3-0.7,8.5-1.5,12.5-3c4.2-1.6,8.3-3.6,12.2-5.7c0.5-0.3,0.9-0.6,1.4-0.9l0.9-0.6c0.3-0.2,0.6-0.4,0.9-0.6c5.3-3.3,10.7-6.6,16.3-9.3c2.6-1.3,5.2-2.7,7.8-4.1C205.6,150.7,206.3,150.4,207.1,150.1L207.1,150.1z M31.6,0c2.6,1.9,3.9,4.7,6.3,6.9c3-1.5,5.4-3.5,8.3-4.7c0.5,0.4,0.2,0.7,0,1c-2,2.5-2.9,5.2-3.1,8c-0.2,2.8-0.4,5.5-0.1,8.4c3.4,2.9,7.3,5.4,12,6.8c5.6,1.7,10.9,4,16,6.5c2.2,1.1,4.6,2.1,7.1,2.8c6.4,1.8,12.3,4.4,17.9,7.3c0.7,0.4,1.3,0.7,1.9,1.2c4.6,3.4,9.1,6.8,13,10.7c3.1,3.2,5.8,6.6,8,10.4c2.2,3.6,4.6,7.1,6.4,11c1.4,3,2.4,6,2.9,9.2c0.6,3.5,1.1,7.1,1.1,10.8c0,3.5-0.5,7-1.3,10.4c-0.1,0.5-0.3,1.1-0.4,1.6c-0.4,2.5-1.1,4.9-2,7.2c0.8-0.4,1.6-0.8,2.3-1.2c2.1-0.9,4.1-1.7,6.2-2.6c0.5-0.2,0.9-0.4,1.4-0.5c4.9-1.1,9.7-2.6,14.7-2.9c2.5-0.2,5.1-0.2,7.6,0c4.5,0.3,9,0.8,13.4,1.4c0.9,0.1,2,0.3,2.8,0.9c0.9,0.6,1.9,0.9,3,1.2l1.1,0.4c1.9,0.6,3.7,1.2,5.7,1.3c2.4,1.9,4.8,3.7,7.1,5.6c1.6,1.3,3,2.8,4.5,4.2c1.4,1.4,2.8,2.7,4.2,4.1c0.1,0.1,0.2,0.2,0.4,0.4l0.7,0.7c0.6,0.6,1.2,1.2,1.7,1.9c2.2,3,4.3,6.1,6.4,9.1c0.8,1.2,1.4,2.6,1.6,4.1c0,0.4-0.1,0.8-0.1,1.2l-1.7,0.4c-0.3-0.2-0.5-0.3-0.7-0.5c-0.1-0.2-0.3-0.4-0.4-0.6l-0.9-1.1c-0.6-0.8-1.1-1.5-1.6-2.3c-2.4-4-5.5-7.3-8.5-10.8c-1.4-1.5-3-2.8-4.8-3.8c-2.9-1.8-5.9-3.5-9-4.9c-2.1-0.9-4.3-2-6.4-2.9c-1.6-0.7-3.3-0.9-5.2-0.6c-2.2,0.4-4.5,0.6-6.7,0.8c-2.4,0.2-4.7,0.4-6.9,1.2c-0.5,0.2-0.9,0.3-1.4,0.4c-6.7,1.3-12.4,4.8-17.6,9c-4.4,3.5-8.6,7.4-12.1,11.9c-1.5,1.9-3,3.9-4.4,5.9c-2,2.8-3.9,5.6-5.9,8.4c-0.4,0.6-0.9,1.3-1.5,1.8c-2,1.9-3.5,4.2-4.7,6.7c-0.2,0.4-0.4,0.7-0.6,1.1c-2.4,1.7-4.3,3.9-5.9,6.3c-0.9,1.3-1.9,2.5-3,3.6c-1.4,1.4-2.6,2.9-3.7,4.6c-1.6,2.6-3.7,4.7-6.2,6.6c-2.3,1.8-4.5,3.8-6.7,5.7c-0.8,0.7-1.7,1.3-2.6,1.9c-0.8,0.5-1.8,0.8-2.7,1.1c-1.2,0.3-2.4,0.5-3.6,0.8c-0.4-0.8,0.2-1.2,0.6-1.5c1.8-1.3,3.4-2.9,4.9-4.5l0.9-1c0.5-0.5,0.9-1,1.4-1.4c1.1-1.1,1.9-2.5,2.3-4c0.7-2.5,1.7-5,2-7.6c0.2-1.7,0.9-3.4,1.3-5.1c0.5-1.9,1-3.8,1.3-5.7c0.7-4.4,2.5-8.4,4.4-12.4c0-0.1,0.1-0.2,0.1-0.3c0.8-1,1.6-2.2,2.3-3.3c-2.1,0.9-4,2-5.8,3.2c-3.5,2.4-5.2,3.2-9.3,4.1c-1.1,0.8-1.9,1.7-2.2,3.1c-1.5,0.7-2.7,1.8-3.3,3.3c-2.8,0.1-5-0.7-7.1-1.8c-2.7,0.2-4.8-0.6-6.7-2c-2.3-1.7-4.7-3.1-7.4-4.2c-1.1-0.5-2.2-0.8-3.5-0.6c-0.9,0.1-1.9,0.1-2.8,0.1c-2.4,0-4.7-0.4-7-1c-7.5-2-13.9-5.4-19.7-9.5c-3-2.1-5.7-4.4-8.4-6.8c-1.2-1-2.1-2.2-3-3.4c-2.1-2.8-3.8-5.8-5.2-8.9c-0.8-1.7-1.6-3.5-2.3-5.3c-1.9-4.8-2.5-10-2.6-15.2c-0.1-3.1,0-6.2,0-9.3c0-8,2.5-15.9,5.7-23.7c2.3-5.8,5-11.5,8.1-17c1.9-3.5,4.1-6.8,6.3-10.2c2.6-4,4.5-8.1,5.9-12.3c0.8-2.4,1.3-4.8,0.8-7.2c-0.2-1.2-0.6-2.4-1.3-3.4c-0.6-0.9-1.2-1.9-1.7-2.8l-1.7-2.8c-0.3-0.5-0.5-1,0.5-1.6c1.9,0.2,3,1.4,4.3,2c0.8-0.2,0.9-0.6,0.8-0.9c-0.2-2.2-0.6-4.4-1.4-6.4c-0.3-0.8-0.6-1.7-0.7-2.5c-0.1-0.4,0.2-0.8,0.3-1.5l4.5,2.7c0.3-0.5,0.6-0.8,0.6-1.1c0-1.2-0.2-2.5-0.2-3.7C30.7,1,30.7,0.4,31.6,0z M197.7,135.6l0.9,0.7c-0.6,1.1-1.5,1.7-2.4,2.3c-2.8,2-5.4,4.1-8,6.4c-4,3.6-8.7,5.9-13.6,8c-6.7,2.8-13.3,5.6-20,8.4c-1.6,0.7-3.3,1.2-4.9,1.8c-4,1.6-8,3.2-12,4.8c-0.8,0.3-1.6,0.8-2.3,1.3c-3.2,2-6.6,3.4-10.1,4.8c-1.1,0.4-2.2,0.9-3.2,1.4c-4,1.8-8,3.7-12,5.4c-3,1.3-6,2.5-9,3.6c-3,1.1-6.1,2.1-9.1,3.2c-0.3,0.1-0.5,0.1-1.3,0.3c1.1-1.4,2.1-1.8,3-2.3c1.4-0.9,2.8-1.8,3.9-3.1c0.4-0.4,0.8-0.9,1.3-1.2c2.8-1.2,5.1-3.2,7.9-4.5c2.3-1,4.3-2.7,6.4-4.2c1.3-0.9,2.6-1.8,3.9-2.6c1.3-0.9,2.5-1.9,3.8-2.7c1.7-1.1,3.4-2.2,5.2-3.3c2.7-1.6,5.5-3,8.2-4.6c9.6-5.9,19.8-10.3,30.5-13.4c5.4-1.6,10.7-3,16.1-4.5c4.6-1.3,9.1-2.9,13.6-4.7C195.4,136.5,196.5,136.1,197.7,135.6L197.7,135.6z M145.3,114.8c-3.2,0.3-6,1.6-8.8,3c-1.3,0.7-2.6,1.4-3.9,2c-4.1,1.8-8.2,3.7-11.9,6.2c0,0,0,0.1,0,0.1c-0.2,0.4-0.5,0.8-0.8,1.2c-0.3,0.4-0.6,0.8-1,1.2l-1,1.2c-2.5,3.3-5.1,6.5-8.4,9.4c-1.7,1.4-3.2,2.9-4.8,4.3c-0.6,0.5-1.2,1-1.8,1.4c-0.7,1.2-1.4,2.5-2,3.7c-1.1,2-2.1,4.2-3,6.4c-0.9,2.1-1.5,4.2-2.3,6.3c-1.7,4.5-3.4,9-3.9,13.8c-0.2,1.8-0.5,3.5-1.2,5.1c-0.2,0.5-0.2,1.1-0.4,1.9c0.6-0.2,1-0.3,1.3-0.5c1.2-1,2.5-2,3.5-3.1c2.2-2.5,4.2-5.2,5.8-8.1c2.5-4.5,5.1-9.1,7.7-13.5c0.9-1.6,1.9-3.1,2.9-4.6l1.2-1.8c0.3-0.5,0.7-1,1.1-1.5l1.1-1.5c0.5-0.7,1.1-1.5,1.5-2.3c1.5-2.4,3.2-4.7,5.1-6.8c6.3-7.1,12.9-13.9,20.1-20.1c1.4-1.2,2.6-2.7,4.5-3.4C145.7,114.9,145.5,114.8,145.3,114.8L145.3,114.8z M180,125.7c2.3-0.2,4.4,0.6,6.9,1.2l-0.3,1c-0.4,0.2-0.6,0.4-0.7,0.4c-1.6,0.1-3.1,0.2-4.7,0.3c-2.6,0.1-5,0.8-7.5,1.5c-6.4,1.8-12.7,4-18.8,6.5c-3.4,1.4-6.7,2.9-9.8,4.7c-0.2,0.1-0.3,0.2-0.5,0.3c-4.5,3.4-9.5,6.1-13.9,9.8c-4,3.3-8,6.5-12,9.8l-0.3,0.2c-0.5,0.4-1,0.8-1.7,0.8c0-0.3-0.1-0.5,0-0.6c2.1-3.5,4.6-6.6,7.4-9.5c1.5-1.6,3.3-3.1,4.9-4.6c0.5-0.5,1-0.9,1.5-1.4c2-2.3,4.4-4.1,7.1-5.6c2.2-1.3,4.3-2.6,6.5-4c2.6-1.6,5.3-2.9,8.2-3.9c2.3-0.8,4.5-1.8,6.8-2.6c2.1-0.7,4.3-1.4,6.5-1.9C170.3,127.1,175.1,126.1,180,125.7z M63.2,151.8c-1,0.9-2.2,1.6-2.5,3.3c2.2,0.8,4.4,1.7,6.6,2.5c1.2,0.4,2.5,0.6,3.5,0.8c1.5-0.4,2.5-0.9,3.1-2c0-1.5-1.3-2-2.7-2.4c-2.2-0.6-4.4-1.3-6.6-2C64.2,152,63.7,151.9,63.2,151.8L63.2,151.8z M72.7,152.5l-0.3,0.4c0.2,0.2,0.4,0.4,0.6,0.5c0.3,0.1,0.6,0.5,1-0.2L72.7,152.5z M105.1,132.8c-0.6,0.7-1.2,1.5-1.8,2.2c-3.6,4.6-8.8,7.7-13.9,10.9c-0.9,0.5-1.9,0.9-2.8,1.3l-0.7,2.2c-0.6,0.1-1,0.1-1.4,0.1c-0.5,0-1,0.1-1.6,0.1c0,1.2-1.3,2.1-0.7,3.2c0.2,0,0.4,0.1,0.6,0c0.4-0.1,0.8-0.2,1.2-0.4c5.2-2.4,10.1-5.1,14.6-8.3c0.6-1.2,1.2-2.4,1.9-3.6c0.6-1,1.1-2.1,1.6-3.1C103.1,135.8,104,134.2,105.1,132.8z M31.5,36.8c-0.2,0.3-0.5,0.6-0.6,0.9c-0.6,1.5-1.3,3-1.8,4.4c-1.3,3.7-3.2,7.3-5.3,10.8C20.5,58.5,17.3,64,14,69.5c-2.7,4.5-4.5,9.3-6.3,14c-0.3,0.7-0.4,1.4-0.6,2.1c-0.6,2.9-1.2,5.7-1.7,8.6c-1.2,6.6-0.9,13,0.8,19.2c1,3.7,3.1,6.8,5.4,9.9c4.4,6.2,10.9,10.6,17.8,14.7c1.9,1.1,3.8,2.2,5.9,3.1c4.3,2,9,3.4,13.7,4.9c1.7,0.5,3.5,0.8,5.3,1.2c0.3,0.1,0.6-0.1,0.8-0.1c0.3-0.5-0.7-0.8,0.3-1.2c0.6,0.2,1.3,0.4,1.9,0.6c0.7,0.2,1.3,0.5,2,0.6c0.6,0.2,1.2,0.6,2.1,0.1c-0.2-0.2-0.4-0.4-0.6-0.5c-4.2-2.1-8.5-4.1-12.7-6.2c-4.7-2.4-9.3-5-13.5-7.9c-2.9-2-5.7-4.2-8.3-6.5c-1.5-1.4-2.8-2.9-4.1-4.5l-1-1.2l-0.5-0.6c-3.8-4.5-6.3-9.6-8-15.1c-0.7-2.1-1.1-4.2-1.4-6.4c-0.5-3.3-0.6-6.7,0.6-10.1c1.8-5.3,3.5-10.6,5.2-15.9c0.1-0.3,0.2-0.5,0.3-0.8c1.8-3.9,3.5-7.8,5.8-11.5c2-3.3,3.2-6.7,4.3-10.1c0.9-2.7,1.8-5.5,3.1-8.1C31.3,40.2,31.8,38.6,31.5,36.8L31.5,36.8z M44.1,33.6c0.2,0.9,0.2,1.4,0.5,1.8c1.4,2.8,2.9,5.4,5.2,7.7c3.8,3.8,7.6,7.6,11.4,11.4c0.8,0.8,1.6,1.7,2.4,2.6c4.9,5.3,9.8,10.6,15.3,15.5c1.4,1.3,2.6,2.8,3.7,4.3c1.6,2.1,2.9,4.2,4.5,6.3c1.7,2.3,3.1,4.8,3.9,7.4c0.8,2.7,1.5,5.4,2.1,8.1c1.4,7.1,1.7,14.3,0,21.7c-0.4,1.7-0.6,3.4-1.1,5.1c-0.6,2.1-1,4.3-1.9,6.4c-1.6,3.4-3.4,6.7-5.3,9.9c-0.7,1.2-1.8,2.4-2.6,3.6c-0.3,0.4-0.5,0.8-0.8,1.2c1.7,0.2,2.7-0.6,3.5-1.5c1.4-1.6,2.8-3.2,4.2-4.8c5.3-6.5,9.2-13.3,10.5-20.8c0.1-0.5,0.2-1.1,0.4-1.6c0.7-3,1-6.1,0.9-9.1c-0.2-4-0.6-7.9-1.1-11.8c-0.9-6.5-3.4-12.5-6.4-18.3c-1.6-2.9-3.7-5.6-5.5-8.5c-1.8-2.9-4.1-5.6-6.5-8.2c-4.9-5.4-10.6-10.3-15.9-15.4c-0.7-0.7-1.5-1.3-2.4-1.8l-1.2-0.7l-2.3-1.3c-4.7-2.7-9.4-5.4-13.7-8.5C45.3,34.1,44.9,34,44.1,33.6L44.1,33.6z M63.6,119.5c-1.3,0.5-1.6,1.4-1.6,2.3c-0.1,3.5-0.1,6.9,1.1,10.2c0.9,2.6,1.9,5.3,3.1,7.8c0.7,1.4,1.7,2.7,2.7,4c0.1,0.2,0.5,0.2,1,0.4c0.1-0.6,0.2-1,0.1-1.4c-0.4-2.9-0.9-5.7-1.4-8.6c-0.7-3.6-1.4-7.2-2.1-10.8c-0.2-0.9-0.4-1.7-0.6-2.5C65.4,120,64.9,119.5,63.6,119.5L63.6,119.5z M46.7,46c-0.3-0.3-0.6-0.6-1.4-0.2c0,1,0,2,0,3.1c0,2,0.2,4.1,0.1,6.1c-0.1,6.4-1.6,12.7-3.5,19c-0.8,2.8-1.5,5.7-2,8.6c-0.6,2.9-1.3,5.9-2,8.8c-0.4,1.8-1,3.6-1.1,5.3c-0.6,5.8-0.6,11.6,1,17.1c0.9,3.1,2,6.1,3.6,9c1.6,3,3.7,5.6,6,8.2l1,1.2c1.9,2.3,4.1,4.3,6.7,6.1c1.5,1.1,2.9,2.3,4.4,3.4c1,0.7,2,1.4,3.1,2l0.1,0.1c0.2,0.2,0.5,0.3,0.9,0.1c-0.1-0.2-0.1-0.3-0.3-0.4c-0.2-0.3-0.5-0.5-0.8-0.8c-4.5-4.3-8.4-9-11.6-14c-2.5-3.9-3.7-8.1-4.1-12.6c-0.3-4.4,0.1-8.9,1.2-13.4c1.5-5.9,2.8-11.8,4.4-17.6c0.4-1.6,1-3.2,1.8-4.7c1.2-2.2,3.1-3.7,5.8-3.7c2.9,0.4,4.3,1.9,5,3.9c0.7,1.8,1.3,3.6,1.8,5.5c0.7,2.3,1.6,4.4,2.8,6.5c1.5,2.6,3.5,4.9,5.9,7c2,1.8,3.6,3.8,5.1,5.9c2.2,3.3,3.6,6.9,4.2,10.7c0.5,2.9,0.7,5.9,0.3,9c-0.1,0.6-0.5,1.3,0.2,1.7c0.1-0.1,0.4-0.2,0.4-0.4c0.2-0.6,0.4-1.2,0.6-1.8c1.8-6.7,1.4-13.2-0.1-19.6c-1.6-6.7-4.3-12.9-7.9-18.9c-1.5-2.6-3-5.2-4.6-7.8c-1.2-2.1-2.4-4.1-4.1-5.9c-1.6-1.7-3-3.6-4.5-5.4c-1.2-1.4-2.3-3-3.6-4.4c-3.3-3.6-6.2-7.4-9.6-10.9C50.1,50,48.4,48,46.7,46L46.7,46z M39.4,37c-0.9,0.3-0.9,0.9-1.1,1.4c-0.9,2.6-1.7,5.1-2.5,7.7c-0.5,1.6-1,3.2-1.7,4.7c-2,4.3-4,8.6-6.2,12.9c-3.1,6-5.2,12.2-6.5,18.4c-0.8,3.8-1.4,7.7-1.7,11.5c-0.2,1.9-0.3,3.8,0,5.6c0.5,3.8,1,7.7,2.5,11.3c0.8,1.9,1.7,3.8,2.6,5.8c2.8,6.3,7.1,11.6,13,15.9c2.3,1.6,4.6,3.2,6.9,4.8c0.6,0.4,1.3,0.8,2,1.2c3,1.6,5.9,3.1,8.9,4.7c1.1,0.6,2.2,1.2,3.7,0.9c-0.9-0.5-1.8-1-2.7-1.5c-4.9-2.8-9.5-5.9-13.1-9.8c-2.4-2.6-4.7-5.2-7-7.9l-2.3-2.7c-0.7-0.8-1.3-1.7-1.8-2.6l-0.6-0.9c-1.2-1.9-1.9-4-2.6-6.2l-0.3-1.1c-0.1-0.4-0.2-0.7-0.3-1.1c-0.6-1.9-0.8-4-0.6-6c0.4-4,0.9-8.1,2.3-12c2.3-6.7,4.5-13.4,7.4-20c0.5-1,0.7-2.1,1-3.2c0.7-2.9,1.2-5.7,2-8.6c1.2-3.9,1.4-7.9,1.9-11.8c0.1-0.4,0-0.9,0-1.3c-0.1-3.4-1.2-6.5-2.4-9.6C39.8,37.3,39.5,37.2,39.4,37L39.4,37z M61.5,95.6c-0.6,0.5-1.2,0.8-1.5,1.3c-1.2,1.6-1.8,3.4-2.4,5.2c-1.9,6.3-3.1,12.6-4.1,19c-0.4,2.3,0,4.4,0.7,6.5c0.3,0.7,0.6,1.5,0.9,2.2c1.4,4.2,4.3,7.6,7.6,10.8c0.4,0.4,0.8,0.8,1.5,0.7c0.4-0.8-0.2-1.3-0.4-1.9c-0.5-1.1-1.2-2.2-1.6-3.3c-1.1-3.1-2.1-6.3-3-9.5c-0.4-1.3-0.5-2.8-0.6-4.2c-0.2-4.2,1.9-7.7,5.5-10.9c0.9-0.8,1.9-1.2,3.2-1.2c1.3,0.4,2.1,1.2,2.8,2.2c1.4,2.1,2.2,4.4,2.6,6.8c0.2,1,0.3,2.1,0.6,3.1c0.7,2.5,1,5,1.1,7.5c0.1,3.2,0.1,6.4-0.2,9.6c-0.1,0.8-0.4,1.6,0.4,2.5c0.3-0.5,0.6-0.7,0.6-0.9c1.1-4.2,2.7-8.3,3.3-12.5c0.5-3.1,0.8-6.3,0-9.3c-1.2-4.6-4.3-8-8.8-10.5c-2.3-1.2-3.9-2.9-4.8-5c-0.6-1.4-1.1-3-1.6-4.4c-0.3-0.9-0.5-1.8-0.9-2.7C62.3,96.3,61.9,96,61.5,95.6L61.5,95.6z M74.6,42.6c0.4,0.7,0.5,1,0.7,1.3c1.4,1.4,2.8,2.9,4.3,4.1c4.9,4.1,8.9,8.8,13.4,13.2c1,1,1.8,2.2,2.6,3.4c1.3,1.9,2.5,3.9,3.6,5.9c2.9,5,4.8,10.3,5.9,16c0.2,1.3,0.5,2.6,0.6,3.9c0.5,3.5,1.2,6.9,1,10.5c-0.3,5.3-0.9,10.5-2.1,15.8c-0.7,3-1.8,5.8-3.3,8.6c-2.4,4.3-4.9,8.6-7.7,12.7c-0.3,0.4-0.9,0.9-0.4,1.5c0.6-0.5,1.1-1,1.6-1.4c3.5-2.7,6.2-6,9-9.1c1.9-2.2,3.6-4.6,4.9-7c1.5-2.7,2.6-5.5,3.8-8.3c0.5-1.3,0.8-2.7,1-4c1-6.6,0.9-13-1.3-19.1c-0.3-0.7-0.5-1.5-0.7-2.3c-1.2-5-3.6-9.5-6.3-13.8c-2.3-3.7-4.6-7.3-6.9-11c-0.9-1.4-1.9-2.8-3.1-4c-2.4-2.5-4.9-4.9-7.3-7.3c-3.4-3.5-7.6-6.2-11.7-8.9C76,43,75.5,42.9,74.6,42.6L74.6,42.6z M84,130.3l-3.1,8.7l0.6,0.2c0.4-0.7,0.8-1.5,1.1-2.2c0.3-0.7,0.5-1.4,0.7-2.1c0.3-0.8,0.6-1.6,0.7-2.4C84.1,131.8,85,131.1,84,130.3L84,130.3z M100,56l-0.5,0.4c1.5,2.1,3,4.1,4.6,6.2c4.2,5.7,7.6,11.7,9.8,18.3c1.7,4.9,3.1,9.8,3.3,15.1c0.1,2,0,4.1-0.1,6.1c0,5.9-0.5,11.8-3.4,17.5c-0.1,0.2-0.2,0.3-0.2,0.5c-0.8,2.5-2.2,4.8-3.9,7.1c-0.6,0.8-1.2,1.5-1.8,2.3c2.8-2.8,5.7-5.4,9-7.6c0.5-0.3,1-0.7,1.4-1c2.5-5.1,4-10.4,4.6-15.7c0.9-8.3,0-16.3-2.5-24c-1.1-3.3-2.6-6.3-4.7-9.1c-4.1-5.3-8.7-10.3-13.8-14.8C101.2,56.8,100.6,56.4,100,56L100,56z"></path>
+                </g>
+              </svg>
+    </div>
     <div class="container">
-        <form class="join-form" action="https://www.forksoverknives.com" method="post" id="newsletter-footer-signup-form">
-            <h2>Join our mailing list</h2>            <p><span style="font-weight: 400;">Get free recipes and the latest info on living a happy, healthy plant-based lifestyle.</span></p>
-            <div class="row">
-                <div class="input-box">
-                    <input type="text" placeholder="Name" name="join_name">
-                </div>
-                <div class="input-box">
-                    <input type="email" placeholder="Email" name="join_email">
-                </div>
-                <div class="input-box submit">
-                    <input type="hidden" name="join_ac_list_id" value="J7uWg3">
-                    <input type="hidden" name="custom_params" value='s:0:"";'>
-                    <button type="submit">subscribe</button>
-                </div>
-            </div>
-            <div class="row success">
-                <p>Thank you! You have been successfully subscribed.</p>
+        <h2>Join our mailing list</h2>        <p><span style="font-weight: 400;">Get free recipes and the latest info on living a happy, healthy plant-based lifestyle.</span></p>
+        <form class="subscribe-form" action="https://www.forksoverknives.com" method="post" id="Join our mailing list">
+            <label for="join-name" class="screenreader-label">Name</label>
+            <input id="join-name" type="text" placeholder="Name" name="join_name">
+            <label for="join-email" class="screenreader-label">Email</label>
+            <input id="join-email" type="email" placeholder="Email" name="join_email">
+            <input type="hidden" name="join_ac_list_id" value="J7uWg3">
+            <input type="hidden" name="custom_params" value='b:0;'>
+            <div class="subscribe-form_submit">
+                <input class="btn" type="submit" value="Subscribe">
             </div>
         </form>
+        <div class="row success" style="display: none;">
+            <p>Thank you! You have been successfully subscribed.</p>
+        </div>
     </div>
-</div>    </main>
-</div>
-                        <footer id="footer">
-                <div class="container">
-                                    <div class="cols-holder">
-                                                    <div class="col-2">
-                                <div class="box active"><a class="title" href="#">our story</a>
+</section>
+</main>
+    <footer id="footer">
+        <div class="container container-lg">
+                            <div class="footer-holder">
+                    <div class="footer-nav_holder">
+                                                    <nav class="footer-nav"><strong class="title-opener">Our Story</strong>
                                 <ul id="menu-our-story" class="slide"><li id="menu-item-69236" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-69236"><a href="https://www.forksoverknives.com/our-story/">Overview</a></li>
-<li id="menu-item-69220" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-69220"><a href="https://www.forksoverknives.com/the-film/">The FOK Film</a></li>
+<li id="menu-item-69220" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-69220"><a href="https://www.forksoverknives.com/the-film/">The FOK film</a></li>
 <li id="menu-item-69219" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-69219"><a href="https://www.forksoverknives.com/what-to-eat/">The FOK Diet</a></li>
-<li id="menu-item-69694" class="menu-item menu-item-type-post_type_archive menu-item-object-contributor menu-item-69694"><a href="https://www.forksoverknives.com/contributors/">Contributors</a></li>
 <li id="menu-item-69214" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-69214"><a href="https://www.forksoverknives.com/faq/">FAQs</a></li>
 <li id="menu-item-78711" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-78711"><a href="https://www.forksoverknives.com/contact-us/">Contact Us</a></li>
-</ul>                                </div>
-                            </div>
-                                                                            <div class="col-2">
-                                <div class="box"><a class="title" href="#">successes</a>
-                                    <ul id="menu-success-stories" class="slide"><li id="menu-item-71119" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-71119"><a href="https://www.forksoverknives.com/success-stories/">Success Stories</a></li>
-<li id="menu-item-83430" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-83430"><a href="https://www.forksoverknives.com/share-story/">Share Your Story</a></li>
-</ul>                                </div>
-                            </div>
-                                                                            <div class="col-2">
-                                <div class="box"><a class="title" href="#">recipes</a>
-                                    <ul id="menu-recipes" class="slide"><li id="menu-item-92711" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-92711"><a href="https://www.forksoverknives.com/recipes/">All Recipes</a></li>
-<li id="menu-item-120469" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120469"><a href="https://www.forksoverknives.com/recipes/amazing-grains/">Amazing Grains</a></li>
-<li id="menu-item-120472" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120472"><a href="https://www.forksoverknives.com/recipes/vegan-baked-stuffed/">Baked &#038; Stuffed</a></li>
-<li id="menu-item-120470" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120470"><a href="https://www.forksoverknives.com/recipes/vegan-breakfast/">Breakfasts</a></li>
-<li id="menu-item-120471" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120471"><a href="https://www.forksoverknives.com/recipes/vegan-burgers-wraps/">Burgers &#038; Wraps</a></li>
-<li id="menu-item-120473" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120473"><a href="https://www.forksoverknives.com/recipes/vegan-desserts/">Decadent Desserts</a></li>
-<li id="menu-item-120474" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120474"><a href="https://www.forksoverknives.com/recipes/vegan-menus-collections/">Menus &#038; Collections</a></li>
-<li id="menu-item-120475" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax current-recipe-ancestor active current-recipe-parent menu-item-120475"><a href="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/">Pasta &#038; Noodles</a></li>
-<li id="menu-item-120477" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120477"><a href="https://www.forksoverknives.com/recipes/vegan-salads-sides/">Salads &#038; Sides</a></li>
-<li id="menu-item-120476" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120476"><a href="https://www.forksoverknives.com/recipes/vegan-sauces-condiments/">Sauces &#038; Condiments</a></li>
-<li id="menu-item-120479" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120479"><a href="https://www.forksoverknives.com/recipes/vegan-snacks-appetizers/">Snacks &#038; Appetizers</a></li>
-<li id="menu-item-120478" class="menu-item menu-item-type-taxonomy menu-item-object-recipe_tax menu-item-120478"><a href="https://www.forksoverknives.com/recipes/vegan-soups-stews/">Soups &#038; Stews</a></li>
-<li id="menu-item-127787" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-127787"><a href="https://www.forksoverknives.com/app/">Get the Recipe App</a></li>
-</ul>                                </div>
-                            </div>
-                                                                            <div class="col-2">
-                                <div class="box"><a class="title" href="#">tools</a>
-                                    <ul id="menu-tools" class="slide"><li id="menu-item-100200" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-100200"><a href="https://www.forksoverknives.com/tools/">Overview</a></li>
-<li id="menu-item-151326" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-151326"><a href="https://www.forksoverknives.com/how-tos/plant-based-primer-beginners-guide-starting-plant-based-diet/">Beginner’s Guide</a></li>
-<li id="menu-item-147700" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-147700"><a href="https://www.forksoverknives.com/meal-planner/">Meal Planner</a></li>
-<li id="menu-item-125273" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-125273"><a href="https://www.forksoverknives.com/cooking-course/">Cooking Course</a></li>
+</ul>                            </nav>
+                                                                            <nav class="footer-nav"><strong class="title-opener">Sections</strong>
+                                <ul id="menu-sections" class="slide"><li id="menu-item-155432" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-155432"><a href="/recipes/">Recipes</a></li>
+<li id="menu-item-155433" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-155433"><a href="/articles/">Articles</a></li>
+<li id="menu-item-161001" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-161001"><a href="https://www.forksoverknives.com/share-story/">SHARE YOUR STORY</a></li>
+</ul>                            </nav>
+                                                                            <nav class="footer-nav"><strong class="title-opener">Tools</strong>
+                                <ul id="menu-tools" class="slide"><li id="menu-item-147700" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-147700"><a href="https://www.forksoverknives.com/?page_id=147454">Meal Planner</a></li>
+<li id="menu-item-125273" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-125273"><a href="https://www.forksoverknives.com/cooking-course-main-landing">Cooking Course-MAIN</a></li>
 <li id="menu-item-127785" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-127785"><a href="https://www.forksoverknives.com/app/">Recipe App</a></li>
-<li id="menu-item-71063" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-71063"><a href="https://www.forksoverknives.com/books-magazines/">Books &#038; Magazines</a></li>
-</ul>                                </div>
-                            </div>
-                                                                            <div class="col-2">
-                                                                    <div class="box"><a class="title" href="#">news feed</a>
-                                        <ul id="menu-news-feed" class="slide"><li id="menu-item-69241" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent menu-item-69241"><a href="https://www.forksoverknives.com/articles/">All Articles</a></li>
-<li id="menu-item-77961" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-77961"><a href="https://www.forksoverknives.com/success-stories/">Success Stories</a></li>
-<li id="menu-item-69268" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-69268"><a href="https://www.forksoverknives.com/how-tos/">How To</a></li>
-<li id="menu-item-69267" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-69267"><a href="https://www.forksoverknives.com/wellness/">Wellness</a></li>
-</ul>                                    </div>
-                                                                                                    <div class="box"><a class="title" href="#">shop</a>
-                                        <ul id="menu-shop" class="slide"><li id="menu-item-69253" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-69253"><a href="https://www.forksoverknives.com/shop/">All Products</a></li>
-<li id="menu-item-69256" class="menu-item menu-item-type-taxonomy menu-item-object-product_cat menu-item-69256"><a href="https://www.forksoverknives.com/shop/?sc=961">Food</a></li>
-<li id="menu-item-70805" class="menu-item menu-item-type-taxonomy menu-item-object-product_cat menu-item-70805"><a href="https://www.forksoverknives.com/shop/?sc=665">Books &#038; Magazines</a></li>
-<li id="menu-item-70806" class="menu-item menu-item-type-taxonomy menu-item-object-product_cat menu-item-70806"><a href="https://www.forksoverknives.com/shop/?sc=667">DVDs</a></li>
-<li id="menu-item-86034" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-86034"><a href="https://www.forksoverknives.com/my-account/">My Account</a></li>
-<li id="menu-item-69259" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-69259"><a href="https://www.forksoverknives.com/cart/">Cart</a></li>
-</ul>                                    </div>
-                                                            </div>
+<li id="menu-item-151326" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-151326"><a href="https://www.forksoverknives.com/how-tos/plant-based-primer-beginners-guide-starting-plant-based-diet/">Beginner’s Guide</a></li>
+</ul>                            </nav>
+                                                                            <nav class="footer-nav"><strong class="title-opener">Shop</strong>
+                                <ul id="menu-shop" class="slide"><li id="menu-item-158285" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-158285"><a target="_blank" rel="noopener" href="https://shop.forksoverknives.com/?utm_source=forksoverknives.com&#038;utm_medium=referral&#038;utm_campaign=fok.com&#038;utm_content=footer-link">All Products</a></li>
+<li id="menu-item-158287" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-158287"><a target="_blank" rel="noopener" href="https://shop.forksoverknives.com/collections/books?utm_source=forksoverknives.com&#038;utm_medium=referral&#038;utm_campaign=fok.com&#038;utm_content=footer-link">Books</a></li>
+<li id="menu-item-158288" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-158288"><a target="_blank" rel="noopener" href="https://shop.forksoverknives.com/collections/magazines?utm_source=forksoverknives.com&#038;utm_medium=referral&#038;utm_campaign=fok.com&#038;utm_content=footer-link">Magazines</a></li>
+<li id="menu-item-158289" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-158289"><a target="_blank" rel="noopener" href="https://shop.forksoverknives.com/collections/dvds?utm_source=forksoverknives.com&#038;utm_medium=referral&#038;utm_campaign=fok.com&#038;utm_content=footer-link">DVDs</a></li>
+<li id="menu-item-158286" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-158286"><a target="_blank" rel="noopener" href="https://shop.forksoverknives.com/account/login?utm_source=forksoverknives.com&#038;utm_medium=referral&#038;utm_campaign=fok.com&#038;utm_content=footer-link">My Account</a></li>
+</ul>                            </nav>
                                             </div>
-                                                            <div class="footer-bottom">
-                                                <ul class="social-footer">
-                            <li><a class="icon-facebook" href="https://www.facebook.com/forksoverknives"></a></li><li><a class="icon-twitter" href="https://twitter.com/ForksOverKnives"></a></li><li><a class="icon-youtube-play" href="https://www.youtube.com/user/ForksOverKnives"></a></li><li><a class="icon-instagram" href="https://www.instagram.com/forksoverknives/"></a></li><li><a class="icon-pinterest-p" href="https://www.pinterest.com/forksoverknives/"></a></li>                        </ul>
-                                                <div class="b-box">
-                            <ul id="menu-footer" class="b-nav"><li id="menu-item-119926" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-119926"><a href="https://www.forksoverknives.com/forks-over-knives-terms-of-use/">Terms of Use</a></li>
+                                            <ul class="social-networks">
+                            <li><a class="icon-facebook" href="https://www.facebook.com/forksoverknives" title="Follow us on facebook"></a></li><li><a class="icon-twitter" href="https://twitter.com/ForksOverKnives" title="Follow us on twitter"></a></li><li><a class="icon-youtube-play" href="https://www.youtube.com/user/ForksOverKnives" title="Follow us on youtube-play"></a></li><li><a class="icon-instagram" href="https://www.instagram.com/forksoverknives/" title="Follow us on instagram"></a></li><li><a class="icon-pinterest-p" href="https://www.pinterest.com/forksoverknives/" title="Follow us on pinterest-p"></a></li>                        </ul>
+                                    </div>
+                        <div class="footer-frame">
+                <div class="footer-copy">
+                    <span class="copy">                 <mark>© 2022 </mark>Forks Over Knives, LLC</span>               <p>All Rights Reserved.</p>                </div>
+                <ul id="menu-footer" class="footer-list"><li id="menu-item-119926" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-119926"><a href="https://www.forksoverknives.com/forks-over-knives-terms-of-use/">Terms of Use</a></li>
 <li id="menu-item-69261" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy menu-item-69261"><a href="https://www.forksoverknives.com/privacy-policy/">Privacy Policy</a></li>
 <li id="menu-item-83962" class="menu-item menu-item-type-post_type_archive menu-item-object-press_new menu-item-83962"><a href="https://www.forksoverknives.com/press/">Press</a></li>
-</ul>                                                        <div class="copyright-block">
-                                <p class="copy">&copy; 2021 <a href="https://www.forksoverknives.com">Forks Over Knives, LLC</a></p><span>All Rights Reserved.</span>
-                            </div>
-                                                    </div>
+<li id="menu-item-158470" class="ot-sdk-show-settings menu-item menu-item-type-custom menu-item-object-custom menu-item-158470"><a title="ot-sdk-btn" href="#">Do not sell my information</a></li>
+</ul>            </div>
                     </div>
-                </div>
-                            </footer>
-            </div>
-            <script async type="text/javascript" src="//static.klaviyo.com/onsite/js/klaviyo.js?company_id=KCHNEa"></script>
-        <script type="text/javascript">
-        if ("") {
-            var _learnq = _learnq || [];
-            _learnq.push(["identify", {
-                "$email": ""
-            }]);
-        } else {
-            // See if current user is a commenter
-            if ("") {
-                _learnq.push(["identify", {
-                    "$email": ""
-                }]);
-            }
-        }
-        </script>
-        <!-- end: Klaviyo Code. --><style></style>	<script type="text/javascript">
-		(function () {
-			var c = document.body.className;
-			c = c.replace(/woocommerce-no-js/, 'woocommerce-js');
-			document.body.className = c;
-		})();
-	</script>
-	<link rel='stylesheet' id='gglcptch-css'  href='https://www.forksoverknives.com/wp-content/plugins/google-captcha/css/gglcptch.css?ver=1.61' type='text/css' media='all' />
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/dist/vendor/wp-polyfill.min.js?ver=7.4.4' id='wp-polyfill-js'></script>
-<script type='text/javascript' id='wp-polyfill-js-after'>
-( 'fetch' in window ) || document.write( '<script src="https://www.forksoverknives.com/wp-includes/js/dist/vendor/wp-polyfill-fetch.min.js?ver=3.0.0"></scr' + 'ipt>' );( document.contains ) || document.write( '<script src="https://www.forksoverknives.com/wp-includes/js/dist/vendor/wp-polyfill-node-contains.min.js?ver=3.42.0"></scr' + 'ipt>' );( window.DOMRect ) || document.write( '<script src="https://www.forksoverknives.com/wp-includes/js/dist/vendor/wp-polyfill-dom-rect.min.js?ver=3.42.0"></scr' + 'ipt>' );( window.URL && window.URL.prototype && window.URLSearchParams ) || document.write( '<script src="https://www.forksoverknives.com/wp-includes/js/dist/vendor/wp-polyfill-url.min.js?ver=3.6.4"></scr' + 'ipt>' );( window.FormData && window.FormData.prototype.keys ) || document.write( '<script src="https://www.forksoverknives.com/wp-includes/js/dist/vendor/wp-polyfill-formdata.min.js?ver=3.0.12"></scr' + 'ipt>' );( Element.prototype.matches && Element.prototype.closest ) || document.write( '<script src="https://www.forksoverknives.com/wp-includes/js/dist/vendor/wp-polyfill-element-closest.min.js?ver=2.0.2"></scr' + 'ipt>' );
-</script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/dist/i18n.min.js?ver=ac389435e7fd4ded01cf603f3aaba6a6' id='wp-i18n-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/dist/vendor/lodash.min.js?ver=4.17.19' id='lodash-js'></script>
-<script type='text/javascript' id='lodash-js-after'>
-window.lodash = _.noConflict();
-</script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/dist/url.min.js?ver=98645f0502e5ed8dadffd161e39072d2' id='wp-url-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/dist/hooks.min.js?ver=84b89ab09cbfb4469f02183611cc0939' id='wp-hooks-js'></script>
-<script type='text/javascript' id='wp-api-fetch-js-translations'>
-( function( domain, translations ) {
-	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
-	localeData[""].domain = domain;
-	wp.i18n.setLocaleData( localeData, domain );
-} )( "default", { "locale_data": { "messages": { "": {} } } } );
-</script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/dist/api-fetch.min.js?ver=4dec825c071b87c57f687eb90f7c23c3' id='wp-api-fetch-js'></script>
-<script type='text/javascript' id='wp-api-fetch-js-after'>
-wp.apiFetch.use( wp.apiFetch.createRootURLMiddleware( "https://www.forksoverknives.com/wp-json/" ) );
-wp.apiFetch.nonceMiddleware = wp.apiFetch.createNonceMiddleware( "0fc17dc557" );
-wp.apiFetch.use( wp.apiFetch.nonceMiddleware );
-wp.apiFetch.use( wp.apiFetch.mediaUploadMiddleware );
-wp.apiFetch.nonceEndpoint = "https://www.forksoverknives.com/wp-admin/admin-ajax.php?action=rest-nonce";
-</script>
-<script type='text/javascript' id='contact-form-7-js-extra'>
-/* <![CDATA[ */
-var wpcf7 = {"cached":"1"};
-/* ]]> */
-</script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/contact-form-7/includes/js/index.js?ver=5.4' id='contact-form-7-js'></script>
-<script type='text/javascript' id='socialsnap-js-js-extra'>
-/* <![CDATA[ */
-var socialsnap_script = {"ajaxurl":"https:\/\/www.forksoverknives.com\/wp-admin\/admin-ajax.php","on_media_width":"250","on_media_height":"250","nonce":"2e9b156af8","post_id":"128191","click_tracking":"1"};
-/* ]]> */
-</script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/socialsnap-pro/assets/js/socialsnap.js?ver=1.1.15' id='socialsnap-js-js'></script>
+    </footer>
+</div>
+<style></style><link rel='stylesheet' id='gglcptch-css'  href='https://www.forksoverknives.com/wp-content/plugins/google-captcha/css/gglcptch.css?ver=1.68' type='text/css' media='all' />
 <script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/wp-review-pro/assets/js/jquery.appear.js?ver=1.1' id='wp_review-jquery-appear-js'></script>
 <script type='text/javascript' id='wp_review-js-js-extra'>
 /* <![CDATA[ */
@@ -945,99 +3481,17 @@ var wpreview = {"ajaxurl":"https:\/\/www.forksoverknives.com\/wp-admin\/admin-aj
 </script>
 <script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/wp-review-pro/assets/js/main.js?ver=1.1.0' id='wp_review-js-js'></script>
 <script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/wp-review-pro/assets/js/jquery.knob.min.js?ver=1.1' id='jquery-knob-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/wp-smush-pro/app/assets/js/smush-lazy-load.min.js?ver=3.8.4' id='smush-lazy-load-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/comment-reply.min.js?ver=5.6.2' id='comment-reply-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/themes/fork/js/jquery.main.js?ver=3.0.21' id='fork-script-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/themes/fork/js/theme.js?ver=3.0.21' id='fork-theme-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/woocommerce/assets/js/jquery-payment/jquery.payment.min.js?ver=3.0.0' id='jquery-payment-js'></script>
-<script type='text/javascript' id='sv-wc-payment-gateway-payment-form-js-extra'>
-/* <![CDATA[ */
-var sv_wc_payment_gateway_payment_form_params = {"card_number_missing":"Card number is missing","card_number_invalid":"Card number is invalid","card_number_digits_invalid":"Card number is invalid (only digits allowed)","card_number_length_invalid":"Card number is invalid (wrong length)","cvv_missing":"Card security code is missing","cvv_digits_invalid":"Card security code is invalid (only digits are allowed)","cvv_length_invalid":"Card security code is invalid (must be 3 or 4 digits)","card_exp_date_invalid":"Card expiration date is invalid","check_number_digits_invalid":"Check Number is invalid (only digits are allowed)","check_number_missing":"Check Number is missing","drivers_license_state_missing":"Drivers license state is missing","drivers_license_number_missing":"Drivers license number is missing","drivers_license_number_invalid":"Drivers license number is invalid","account_number_missing":"Account Number is missing","account_number_invalid":"Account Number is invalid (only digits are allowed)","account_number_length_invalid":"Account number is invalid (must be between 5 and 17 digits)","routing_number_missing":"Routing Number is missing","routing_number_digits_invalid":"Routing Number is invalid (only digits are allowed)","routing_number_length_invalid":"Routing number is invalid (must be 9 digits)"};
-/* ]]> */
-</script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/woocommerce-gateway-authorize-net-aim/vendor/skyverge/wc-plugin-framework/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.min.js?ver=5.3.0' id='sv-wc-payment-gateway-payment-form-js'></script>
-<script type='text/javascript' id='wc-authorize-net-aim-js-extra'>
-/* <![CDATA[ */
-var wc_authorize_net_aim_params = {"accept_js_enabled":"","login_id":"52rw9g4gREW","client_key":"","general_error":"An error occurred, please try again or try an alternate form of payment.","ajax_url":"https:\/\/www.forksoverknives.com\/wp-admin\/admin-ajax.php","ajax_log":"","ajax_log_nonce":"95f49d9294"};
-/* ]]> */
-</script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/woocommerce-gateway-authorize-net-aim/assets/js/frontend/wc-authorize-net-aim.min.js?ver=3.14.5' id='wc-authorize-net-aim-js'></script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/wp-embed.min.js?ver=5.6.2' id='wp-embed-js'></script>
-<script type='text/javascript' data-cfasync="false" async="async" defer="defer" src='https://www.google.com/recaptcha/api.js?render=explicit&#038;ver=1.61' id='gglcptch_api-js'></script>
+<script type='text/javascript' src='https://www.forksoverknives.com/wp-includes/js/comment-reply.min.js?ver=6.0.3' id='comment-reply-js'></script>
+<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/themes/fork/js/jquery.main.js?ver=3.0.46' id='fork-script-js'></script>
+<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/themes/fork/js/theme.js?ver=3.0.46' id='fork-theme-js'></script>
+<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/wp-smush-pro/app/assets/js/smush-lazy-load.min.js?ver=3.12.3' id='smush-lazy-load-js'></script>
+<script type='text/javascript' data-cfasync="false" async="async" defer="defer" src='https://www.google.com/recaptcha/api.js?render=explicit&#038;ver=1.68' id='gglcptch_api-js'></script>
 <script type='text/javascript' id='gglcptch_script-js-extra'>
 /* <![CDATA[ */
 var gglcptch = {"options":{"version":"invisible","sitekey":"6LcP5KoaAAAAAC9oSp0P74hfz_gy90-rM4P0ClW8","error":"<strong>Warning<\/strong>:&nbsp;More than one reCAPTCHA has been found in the current form. Please remove all unnecessary reCAPTCHA fields to make it work properly.","disable":0},"vars":{"visibility":false}};
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/google-captcha/js/script.js?ver=1.61' id='gglcptch_script-js'></script>
-
-		<div id="ss-copy-popup" class="ss-popup-overlay">
-			<div class="ss-popup">
-
-				<div class="ss-popup-heading">
-					<span>Copy link</span>
-					<a href="#" class="ss-close-modal" rel="nofollow noopener">
-						<svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M17.883 16.667l7.058-7.058c0.517-0.517 0.517-1.367 0-1.883s-1.367-0.517-1.883 0l-7.058 7.058-7.058-7.058c-0.517-0.517-1.367-0.517-1.883 0s-0.517 1.367 0 1.883l7.058 7.058-7.058 7.058c-0.517 0.517-0.517 1.367 0 1.883 0.258 0.258 0.6 0.392 0.942 0.392s0.683-0.133 0.942-0.392l7.058-7.058 7.058 7.058c0.258 0.258 0.6 0.392 0.942 0.392s0.683-0.133 0.942-0.392c0.517-0.517 0.517-1.367 0-1.883l-7.058-7.058z"></path></svg>					</a>
-				</div><!-- END .ss-popup-heading -->
-
-				<div class="ss-popup-content">
-
-					<div class="ss-copy-action">
-						<input type="text" readonly="readonly" value="https://www.forksoverknives.com/recipes/vegan-pasta-noodles/butternut-mac-and-cheese-broccoli/" class="ss-copy-action-field" aria-label="Copy" />
-						<a href="#" class="ss-button" rel="nofollow noopener">Copy<span class="ss-share-network-tooltip">Copied</span></a>
-						<svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M25.313 28v-18.688h-14.625v18.688h14.625zM25.313 6.688c1.438 0 2.688 1.188 2.688 2.625v18.688c0 1.438-1.25 2.688-2.688 2.688h-14.625c-1.438 0-2.688-1.25-2.688-2.688v-18.688c0-1.438 1.25-2.625 2.688-2.625h14.625zM21.313 1.313v2.688h-16v18.688h-2.625v-18.688c0-1.438 1.188-2.688 2.625-2.688h16z"></path></svg>					</div><!-- END .ss-copy-action -->
-
-					<div class="ss-powered-by">Powered by <a href="https://socialsnap.com/?utm_source=WordPress&amp;utm_medium=link&amp;utm_campaign=inthewild" target="_blank" rel="nofollow noopener"><svg class="ss-svg-icon" aria-hidden="true" role="img" focusable="false" width="30" height="32" viewBox="0 0 30 32" xmlns="http://www.w3.org/2000/svg"><path d="M22.293 0.146l7.602 4.172c0.386 0.201 0.386 0.541 0 0.757l-16.688 9.147c-1.684 0.943-2.241 2.271-1.669 3.461 0 0.093 0 0.201-0.201 0.263-0.207 0.088-0.441 0.088-0.649 0l-10.399-5.702c-0.386-0.201-0.386-0.541 0-0.757l20.628-11.311c0.428-0.225 0.937-0.236 1.375-0.031zM7.892 31.854l-7.602-4.172c-0.386-0.201-0.386-0.541 0-0.757l16.688-9.147c1.684-0.943 2.241-2.271 1.669-3.461 0-0.093 0-0.201 0.201-0.263 0.207-0.088 0.442-0.088 0.649 0l10.399 5.702c0.386 0.201 0.386 0.541 0 0.757l-20.628 11.311c-0.428 0.225-0.937 0.237-1.375 0.031z"></path></svg>Social Snap</a></div><!-- END .ss-powered-by -->
-				</div><!-- END .ss-popup-content -->
-			</div><!-- END .ss-popup -->
-		</div><!-- END #ss-copy-popup -->
-
-		<!-- WooCommerce JavaScript -->
-<script type="text/javascript">
-jQuery(function($) { 
-		( function() {
-
-			function trackEvents() {
-							}
-
-			if ( 'undefined' !== typeof ga ) {
-				trackEvents();
-			} else {
-				// avoid using jQuery in case it's not available when this script is loaded
-				document.addEventListener( 'wc_google_analytics_pro_loaded', trackEvents );
-			}
-
-		} ) ();
-		
- });
-</script>
-		<!-- Social Snap Share count cache indicator -->
-		<script type="text/javascript">
-
-			var SocialSnapURL 				= window.location.href;
-			var SocialSnapShareCacheExpired = 0;
-			var SocialSnapShareNetworks     = ["facebook","twitter","pinterest","envelope","copy"];
-
-			if ( -1 !== SocialSnapURL.indexOf('ss_cache_refresh') ) {
-
-				SocialSnapShareCacheExpired = true;
-
-			} else {
-
-				var SocialSnapServerTimestamp 	= 1618854746;
-				var SocialSnapBrowserTimestamp 	= Date.now();
-
-				if ( ! SocialSnapBrowserTimestamp ) {
-					SocialSnapBrowserTimestamp = new Date().getTime();
-				}
-
-				SocialSnapBrowserTimestamp = Math.floor( SocialSnapBrowserTimestamp / 1000 );
-
-				SocialSnapShareCacheExpired = SocialSnapShareCacheExpired && ( SocialSnapBrowserTimestamp - SocialSnapServerTimestamp < 60 );
-			}
-
-		</script>
-		<!-- Social Snap Share count cache indicator -->
-		    <script async type="text/javascript" src="https://static.klaviyo.com/onsite/js/klaviyo.js?company_id=JTHu38"></script>
+<script type='text/javascript' src='https://www.forksoverknives.com/wp-content/plugins/google-captcha/js/script.js?ver=1.68' id='gglcptch_script-js'></script>
+<script async type="text/javascript" src="https://static.klaviyo.com/onsite/js/klaviyo.js?company_id=KCHNEa"></script>
 </body>
 </html>

--- a/tests/test_forksoverknives.py
+++ b/tests/test_forksoverknives.py
@@ -10,7 +10,7 @@ class TestForksOverKnives(ScraperTest):
         self.assertEqual("forksoverknives.com", self.harvester_class.host())
 
     def test_author(self):
-        self.assertEqual("Darshana Thacker", self.harvester_class.author())
+        self.assertEqual("Darshana Thacker Wendel", self.harvester_class.author())
 
     def test_title(self):
         self.assertEqual(
@@ -40,8 +40,8 @@ class TestForksOverKnives(ScraperTest):
                 "2 cups unsweetened, unflavored plant milk, such as almond, soy, cashew, or rice",
                 "2 tablespoons nutritional yeast",
                 "1 tablespoon white wine vinegar",
-                "¼ tsp. sea salt",
-                "⅛ tsp. freshly ground black pepper",
+                "¼ teaspoon sea salt",
+                "⅛ teaspoon freshly ground black pepper",
                 "3 cups dried whole grain penne pasta (8 oz.)",
                 "3 cups small broccoli florets",
                 "Fresh basil leaves",
@@ -56,7 +56,11 @@ class TestForksOverKnives(ScraperTest):
         )
 
     def test_ratings(self):
-        self.assertEqual(5.0, self.harvester_class.ratings())
+        self.assertEqual(4.13, self.harvester_class.ratings())
 
     def test_language(self):
         self.assertEqual("en-US", self.harvester_class.language())
+
+    def test_category(self):
+        print(self.harvester_class.category())
+        self.assertEqual("Pasta & Noodles", self.harvester_class.category())

--- a/tests/test_forksoverknives.py
+++ b/tests/test_forksoverknives.py
@@ -62,5 +62,4 @@ class TestForksOverKnives(ScraperTest):
         self.assertEqual("en-US", self.harvester_class.language())
 
     def test_category(self):
-        print(self.harvester_class.category())
         self.assertEqual("Pasta & Noodles", self.harvester_class.category())


### PR DESCRIPTION
Recently fok recipes started including anchor tags in the category, linking to the category page. So, the category would look like:

"<a
href=\"https:\/\/www.forksoverknives.com\/recipes\/vegan-soups-stews\/\">Soups \&amp; Stews<\/a>"

Gourmand calls schema.category() to get the category, so this overrides that. Also, instead of leaving it:
Soups \&amp; Stews
import html and unescape it to return:
Soups & Stews