### PR TITLE
tox: permit positional arguments when running 'unittest'-based unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = true
 
 [testenv]
 deps = -r{toxinidir}/requirements-dev.txt
-commands = coverage run -m unittest
+commands = coverage run -m unittest {posargs}
 
 # The system-provided libxml2 on MacOS is typically outdated and this can lead to lxml parsing issues
 # Using PyPi-provided binary wheels instead resolves this


### PR DESCRIPTION
`tox` version 1.0 onwards provides support for substitution of a `{posargs}` pattern in the `tox.ini` file.

This can allow callers to provide additional arguments to the `tox` environment command.

In the context of unit testing, that's often useful to specify test patterns to run - for example, by using `tox -e py -- -k <pattern>` to run only unit tests with names matched by `<pattern>`.