### PR TITLE
tox.ini: update 'py-darwin' environment to use the same Python keyword arguments as the tox upstream defaults

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = coverage run -m unittest {posargs}
 platform =
     py-darwin: darwin
 install_command =
-    py-darwin: python -m pip install --only-binary=lxml {opts} {packages}
+    py-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Resolves #699.