### PR TITLE
Fixup / workaround: provide tox 'install_command' for the 'py' unit test environment name

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = coverage run -m unittest {posargs}
 platform =
     py-darwin: darwin
 install_command =
-    py-darwin: python -m pip install --only-binary=lxml {opts} {packages}
+    py-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
 
 [testenv:lint]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands = coverage run -m unittest {posargs}
 platform =
     py-darwin: darwin
 install_command =
+    py: python -I -m pip install {opts} {packages}
     py-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ commands = coverage run -m unittest {posargs}
 platform =
     py-darwin: darwin
 install_command =
-    py: python -I -m pip install {opts} {packages}
     py-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
 
 [testenv:lint]


### PR DESCRIPTION
Attempts to resolve #698 (I've tested this locally, but not on an OSX platform, so I'm uncertain whether tests will pass across all platforms).

Bases upon #700 so that both install command configurations are consistent (and both are consistent with the `tox` default).