### PR TITLE
GitHub Actions workflows: version-constrain 'tox' to less-than v4

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -17,5 +17,5 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - run: pip install tox
+      - run: pip install "tox<4"
       - run: tox -e lint

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install tox
+      - run: pip install "tox<4"
       - run: tox -e ${{ matrix.toxenv }}
       # Provide code coverage reports if Linux and last py version
       - if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands = coverage run -m unittest {posargs}
 platform =
     py-darwin: darwin
 install_command =
-    py-darwin: python -m pip install --only-binary=lxml {opts} {packages}
+    py-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Attempts to resolve #698 using a short-term solution.

Bases upon #700 so that both install command configurations are consistent (and both are consistent with the `tox` default).