### PR TITLE
tox.ini: tox4 compatibility

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -17,5 +17,5 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - run: pip install "tox<4"
+      - run: pip install tox
       - run: tox -e lint

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install "tox<4"
+      - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
       # Provide code coverage reports if Linux and last py version
       - if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -23,10 +23,10 @@ jobs:
           - os: macos-latest
             python-version: "3.11"
         include:
-          # set toxenv to py-darwin on macos (check tox.ini)
+          # set toxenv to workaround-darwin on macos (check tox.ini)
           - toxenv: py
           - os: macos-latest
-            toxenv: py-darwin
+            toxenv: workaround-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,10 @@ commands = coverage run -m unittest {posargs}
 # Using PyPi-provided binary wheels instead resolves this
 # We are affected by https://bugs.launchpad.net/lxml/+bug/1949271 in test_wild_mode when using system-provided libxml2 on MacOS
 platform =
-    py-darwin: darwin
+    workaround-darwin: darwin
 install_command =
-    py-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
+    py: python -I -m pip install {opts} {packages}
+    workaround-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
 
 [testenv:lint]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ install_command =
     workaround-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
 
 [testenv:lint]
+# note: skip_install affects whether the package-under-test is installed; not whether deps are installed
 skip_install = true
+# end skip_install note
 deps = pre-commit >= 2.20.0
 commands = pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ install_command =
 [testenv:lint]
 # note: skip_install affects whether the package-under-test is installed; not whether deps are installed
 skip_install = true
+install_command = python -I -m pip install {opts} {packages}
 # end skip_install note
 deps = pre-commit >= 2.20.0
 commands = pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-isolated_build = true
-
 [testenv]
 deps = -r{toxinidir}/requirements-dev.txt
 commands = coverage run -m unittest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[tox]
+isolated_build = true
+
 [testenv]
 deps = -r{toxinidir}/requirements-dev.txt
 commands = coverage run -m unittest {posargs}


### PR DESCRIPTION
Ideally, the goal here is to update `tox.ini` so that it's backwards-compatible with `tox` v3, while also allowing us to upgrade to `tox` v4 in the nearish future.

Relates to #698.