### PR TITLE
Fix options typehint

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -485,7 +485,7 @@ def scraper_exists_for(url_path: str) -> bool:
     return host_name in get_supported_urls()
 
 
-def scrape_me(url_path: str, **options: dict[str, Any]) -> AbstractScraper:
+def scrape_me(url_path: str, **options: Any) -> AbstractScraper:
     host_name = get_host_name(url_path)
 
     try:


### PR DESCRIPTION
Very small one - I think there is a mistake in the type hint for the `**options` kwargs in `scrape_me`.

It manifests like this:

```
scraper = recipe_scrapers.scrape_me(url, wild_mode=True)

> (output of mypy)
> app/scraped_recipe/apis.py:32:81: error: Argument "wild_mode" to "scrape_me"
> has incompatible type "bool"; expected "Dict[str, Any]"  [arg-type]
>     ...stractScraper = recipe_scrapers.scrape_me(request.url, wild_mode=True)
>                                                                         ^~~~
```

The type hint for `**kwargs` is supposed to be the type of each individual kwarg - see the example at the bottom of [this section](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#functions) of the mypy docs.

I think there's another alternative, which is to use TypedDict, but this fix seems sufficient.