### PR TITLE
[POC] Return parsed ingredients (name, unit, quantity) 

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -10,7 +10,7 @@ import extruct
 from recipe_scrapers.settings import settings
 
 from ._exceptions import SchemaOrgException
-from ._utils import get_minutes, get_yields, normalize_string
+from ._utils import get_minutes, get_yields, normalize_ingredients, normalize_string
 
 SCHEMA_ORG_HOST = "schema.org"
 
@@ -166,9 +166,7 @@ class SchemaOrg:
         if ingredients and isinstance(ingredients[0], list):
             ingredients = list(chain(*ingredients))  # flatten
 
-        return [
-            normalize_string(ingredient) for ingredient in ingredients if ingredient
-        ]
+        return normalize_ingredients(ingredients)
 
     def nutrients(self):
         nutrients = self.data.get("nutrition", {})

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -153,12 +153,15 @@ def normalize_string(string):
 def normalize_ingredients(ingredients):
     n_ingredients = []
     for ingredient in ingredients:
-        p_ing = parser.parse(normalize_string(ingredient))[0]
+        p_ing = parser.parse(normalize_string(ingredient))
+        p_ing = p_ing[0] if len(p_ing) > 0 else None
         n_ingredients.append(
             {
-                "name": normalize_string(ingredient.replace(p_ing.surface, "")),
-                "quantity": p_ing.value,
-                "unit": p_ing.unit.name,
+                "name": normalize_string(ingredient.replace(p_ing.surface, ""))
+                if p_ing
+                else ingredient,
+                "quantity": p_ing.value if p_ing else None,
+                "unit": p_ing.unit.name if p_ing else None,
             }
         )
     return n_ingredients

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -157,7 +157,7 @@ def normalize_ingredients(ingredients):
         p_ing = p_ing[0] if len(p_ing) > 0 else None
         n_ingredients.append(
             {
-                "name": normalize_string(ingredient.replace(p_ing.surface, ""))
+                "name": normalize_string(ingredient.replace(p_ing.surface, "", 1))
                 if p_ing
                 else ingredient,
                 "quantity": p_ing.value if p_ing else None,

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -5,6 +5,7 @@ import math
 import re
 
 import isodate
+from quantulum3 import parser
 
 from ._exceptions import ElementNotFoundInHtml
 
@@ -147,6 +148,20 @@ def normalize_string(string):
         .replace("\t", " ")
         .strip(),
     )
+
+
+def normalize_ingredients(ingredients):
+    n_ingredients = []
+    for ingredient in ingredients:
+        p_ing = parser.parse(normalize_string(ingredient))[0]
+        n_ingredients.append(
+            {
+                "name": normalize_string(ingredient.replace(p_ing.surface, "")),
+                "quantity": p_ing.value,
+                "unit": p_ing.unit.name,
+            }
+        )
+    return n_ingredients
 
 
 def url_path_to_dict(path):

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -1,6 +1,6 @@
 # mypy: disallow_untyped_defs=False
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, get_yields, normalize_string
+from ._utils import get_minutes, get_yields, normalize_ingredients, normalize_string
 
 
 class AllRecipes:
@@ -126,7 +126,7 @@ class AllRecipesUser(AbstractScraper):
     def ingredients(self):
         ingredients = self.soup.findAll("span", {"class": "ingredients-item-name"})
         ingredients = [normalize_string(i.text) for i in ingredients]
-        return ingredients
+        return normalize_ingredients(ingredients)
 
     def instructions(self):
         instructions = self.soup.findAll("div", {"class": "paragraph"})

--- a/recipe_scrapers/bbcfood.py
+++ b/recipe_scrapers/bbcfood.py
@@ -1,6 +1,6 @@
 # mypy: disallow_untyped_defs=False
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, get_yields, normalize_string
+from ._utils import get_minutes, get_yields, normalize_ingredients, normalize_string
 
 
 class BBCFood(AbstractScraper):
@@ -47,7 +47,9 @@ class BBCFood(AbstractScraper):
             "li", {"class": "recipe-ingredients__list-item"}
         )
 
-        return [normalize_string(ingredient.get_text()) for ingredient in ingredients]
+        return normalize_ingredients(
+            [normalize_string(ingredient.get_text()) for ingredient in ingredients]
+        )
 
     def instructions(self):
         instructions = self.soup.findAll(

--- a/recipe_scrapers/jamieoliver.py
+++ b/recipe_scrapers/jamieoliver.py
@@ -1,6 +1,6 @@
 # mypy: disallow_untyped_defs=False
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, get_yields, normalize_string
+from ._utils import get_minutes, get_yields, normalize_ingredients, normalize_string
 
 
 class JamieOliver(AbstractScraper):
@@ -27,7 +27,9 @@ class JamieOliver(AbstractScraper):
 
     def ingredients(self):
         ingredients = self.soup.find("ul", {"class", "ingred-list"}).findAll("li")
-        return [normalize_string(ingredient.get_text()) for ingredient in ingredients]
+        return normalize_ingredients(
+            [normalize_string(ingredient.get_text()) for ingredient in ingredients]
+        )
 
     def instructions(self):
         instructions = self.soup.find("ol", {"class": "recipeSteps"}).findAll("li")

--- a/recipe_scrapers/plugins/html_tags_stripper.py
+++ b/recipe_scrapers/plugins/html_tags_stripper.py
@@ -75,7 +75,10 @@ class HTMLTagStripperPlugin(PluginInterface):
             decorated_func_result = decorated(self, *args, **kwargs)
 
             if type(decorated_func_result) is list:
-                return [stripper(item) for item in decorated_func_result]
+                return [
+                    stripper(item) if type(item) is str else item
+                    for item in decorated_func_result
+                ]
             else:
                 return stripper(decorated_func_result)
 

--- a/tests/test_acouplecooks.py
+++ b/tests/test_acouplecooks.py
@@ -34,12 +34,20 @@ class TestACoupleCooks(ScraperTest):
     def test_ingredients(self):
         self.assertEqual(
             [
-                "1 pound large shrimp, deveined (peeled or unpeeled)",
-                "3 garlic cloves",
-                "1/2 teaspoon kosher salt",
-                "3 tablespoons butter",
-                "2 lemon wedges",
-                "Fresh cilantro or parsley, for garnish",
+                {
+                    "name": "large shrimp, deveined (peeled or unpeeled)",
+                    "quantity": 1.0,
+                    "unit": "pound sterling",
+                },
+                {"name": "garlic cloves", "quantity": 3.0, "unit": "dimensionless"},
+                {"name": "kosher salt", "quantity": 0.5, "unit": "teaspoon"},
+                {"name": "butter", "quantity": 3.0, "unit": "tablespoon"},
+                {"name": "lemon wedges", "quantity": 2.0, "unit": "dimensionless"},
+                {
+                    "name": "Fresh cilantro or parsley, for garnish",
+                    "quantity": None,
+                    "unit": None,
+                },
             ],
             self.harvester_class.ingredients(),
         )

--- a/tests/test_allrecipes.py
+++ b/tests/test_allrecipes.py
@@ -48,16 +48,36 @@ class TestAllRecipesCuratedScraper(ScraperTest):
     def test_ingredients(self):
         self.assertEqual(
             [
-                "¼ cup olive oil",
-                "1 tablespoon minced garlic",
-                "½ teaspoon sea salt",
-                "8 Roma tomatoes, sliced",
-                "2 (12 inch) pre-baked pizza crusts",
-                "8 ounces shredded Mozzarella cheese",
-                "4 ounces shredded Fontina cheese",
-                "10 fresh basil leaves, washed, dried",
-                "½ cup freshly grated Parmesan cheese",
-                "½ cup crumbled feta cheese",
+                {"name": "olive oil", "quantity": 0.25, "unit": "cup"},
+                {"name": "minced garlic", "quantity": 1.0, "unit": "tablespoon"},
+                {"name": "sea salt", "quantity": 0.5, "unit": "teaspoon"},
+                {
+                    "name": "Roma tomatoes, sliced",
+                    "quantity": 8.0,
+                    "unit": "dimensionless",
+                },
+                {
+                    "name": "(1 inch) pre-baked pizza crusts",
+                    "quantity": 2.0,
+                    "unit": "dimensionless",
+                },
+                {
+                    "name": "shredded Mozzarella cheese",
+                    "quantity": 8.0,
+                    "unit": "ounce",
+                },
+                {"name": "shredded Fontina cheese", "quantity": 4.0, "unit": "ounce"},
+                {
+                    "name": "fresh basil leaves, washed, dried",
+                    "quantity": 10.0,
+                    "unit": "dimensionless",
+                },
+                {
+                    "name": "freshly grated Parmesan cheese",
+                    "quantity": 0.5,
+                    "unit": "cup",
+                },
+                {"name": "crumbled feta cheese", "quantity": 0.5, "unit": "cup"},
             ],
             self.harvester_class.ingredients(),
         )
@@ -114,15 +134,15 @@ class TestAllRecipesUserScraper(ScraperTest):
     def test_ingredients(self):
         self.assertEqual(
             [
-                "2 tablespoons white sugar",
-                "1 tablespoon brown sugar",
-                "1 1/2 tsp garlic powder",
-                "1 1/2 tsp chili powder",
-                "1 1/2 tsp paprika",
-                "1 1/2 tsp ground cumin",
-                "1 tsp salt",
-                "1 tsp onion powder",
-                "1 1/2 tsp ground black pepper",
+                {"name": "white sugar", "quantity": 2.0, "unit": "tablespoon"},
+                {"name": "brown sugar", "quantity": 1.0, "unit": "tablespoon"},
+                {"name": "garlic powder", "quantity": 1.5, "unit": "teaspoon"},
+                {"name": "chili powder", "quantity": 1.5, "unit": "teaspoon"},
+                {"name": "paprika", "quantity": 1.5, "unit": "teaspoon"},
+                {"name": "ground cumin", "quantity": 1.5, "unit": "teaspoon"},
+                {"name": "salt", "quantity": 1.0, "unit": "teaspoon"},
+                {"name": "onion powder", "quantity": 1.0, "unit": "teaspoon"},
+                {"name": "ground black pepper", "quantity": 1.5, "unit": "teaspoon"},
             ],
             self.harvester_class.ingredients(),
         )

--- a/tests/test_allrecipes.py
+++ b/tests/test_allrecipes.py
@@ -57,7 +57,7 @@ class TestAllRecipesCuratedScraper(ScraperTest):
                     "unit": "dimensionless",
                 },
                 {
-                    "name": "(1 inch) pre-baked pizza crusts",
+                    "name": "(12 inch) pre-baked pizza crusts",
                     "quantity": 2.0,
                     "unit": "dimensionless",
                 },

--- a/tests/test_altonbrown.py
+++ b/tests/test_altonbrown.py
@@ -33,15 +33,31 @@ class TestAltonBrownScraper(ScraperTest):
     def test_ingredients(self):
         self.assertEqual(
             [
-                "1 cup (2 sticks) unsalted butter, at room temperature, plus extra for the pan",
-                "1 cup all-purpose flour, plus extra for the pan",
-                "1 cup cake flour",
-                "1 tablespoon baking powder",
-                "1 1/2 cups plus 3 tablespoons sugar",
-                "1/4 teaspoon fine sea salt",
-                "8 large egg yolks, at room temperature",
-                "1 1/4 cups whole milk, at room temperature",
-                "1 teaspoon vanilla extract",
+                {
+                    "name": "1 cup (2 sticks) unsalted butter, at room temperature, plus extra for the pan",
+                    "quantity": 1.0,
+                    "unit": "cup",
+                },
+                {
+                    "name": "all-purpose flour, plus extra for the pan",
+                    "quantity": 1.0,
+                    "unit": "cup",
+                },
+                {"name": "cake flour", "quantity": 1.0, "unit": "cup"},
+                {"name": "baking powder", "quantity": 1.0, "unit": "tablespoon"},
+                {"name": "plus 3 tablespoons sugar", "quantity": 1.5, "unit": "cup"},
+                {"name": "fine sea salt", "quantity": 0.25, "unit": "teaspoon"},
+                {
+                    "name": "large egg yolks, at room temperature",
+                    "quantity": 8.0,
+                    "unit": "dimensionless",
+                },
+                {
+                    "name": "whole milk, at room temperature",
+                    "quantity": 1.25,
+                    "unit": "cup",
+                },
+                {"name": "vanilla extract", "quantity": 1.0, "unit": "teaspoon"},
             ],
             self.harvester_class.ingredients(),
         )

--- a/tests/test_amazingribs.py
+++ b/tests/test_amazingribs.py
@@ -30,20 +30,48 @@ class TestAmazingRibsScraper(ScraperTest):
     def test_ingredients(self):
         self.assertEqual(
             [
-                "2 teaspoons whole black peppercorns",
-                "2 teaspoons fresh ground black pepper",
-                "1 tablespoon mild American paprika",
-                "2 teaspoons garlic powder",
-                "2 teaspoons Morton Coarse Kosher Salt",
-                "2 teaspoons rubbed sage",
-                "2 teaspoons cayenne, chipotle, or other hot chile powder or flakes",
-                "1 medium green jalapeño",
-                "½ small onion",
-                "3 garlic cloves",
-                "20 ounces ground pork butt",
-                "12 ounces ground beef chuck",
-                "⅓ cup very cold water",
-                "4 feet pork sausage casings",
+                {
+                    "name": "whole black peppercorns",
+                    "quantity": 2.0,
+                    "unit": "teaspoon",
+                },
+                {
+                    "name": "fresh ground black pepper",
+                    "quantity": 2.0,
+                    "unit": "teaspoon",
+                },
+                {
+                    "name": "mild American paprika",
+                    "quantity": 1.0,
+                    "unit": "tablespoon",
+                },
+                {"name": "garlic powder", "quantity": 2.0, "unit": "teaspoon"},
+                {
+                    "name": "Morton Coarse Kosher Salt",
+                    "quantity": 2.0,
+                    "unit": "teaspoon",
+                },
+                {"name": "rubbed sage", "quantity": 2.0, "unit": "teaspoon"},
+                {
+                    "name": "cayenne, chipotle, or other hot chile powder or flakes",
+                    "quantity": 2.0,
+                    "unit": "teaspoon",
+                },
+                {
+                    "name": "medium green jalapeño",
+                    "quantity": 1.0,
+                    "unit": "dimensionless",
+                },
+                {"name": "small onion", "quantity": 0.5, "unit": "dimensionless"},
+                {"name": "garlic cloves", "quantity": 3.0, "unit": "dimensionless"},
+                {"name": "ground pork butt", "quantity": 20.0, "unit": "ounce"},
+                {"name": "ground beef chuck", "quantity": 12.0, "unit": "ounce"},
+                {
+                    "name": "very cold water",
+                    "quantity": 0.3333333333333333,
+                    "unit": "cup",
+                },
+                {"name": "pork sausage casings", "quantity": 4.0, "unit": "foot"},
             ],
             self.harvester_class.ingredients(),
         )


### PR DESCRIPTION
Currently ingredients are returned as unprocessed strings.
I'm proposing a change to the existing `ingredients` API to returned an array of objects with the following structure (using `quantulum3`):

```
[{
    'name': 'white sugar', 
    'quantity': 2.0, 
    'unit': 'tablespoon'
}]
```
We could also make this a non breaking change by adding an optional input parameter or separating this into two APIs.

---

This PR only updates a few tests to demonstrate the change, and if the community agrees, I can update all other tests\parsers and the documentation. 

Curious to hear what you think!

