### PR TITLE
pre-commit: update mypy version to v1.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
     - id: black
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.0.1
     hooks:
     - id: mypy
       additional_dependencies: [types-beautifulsoup4, types-requests]


### PR DESCRIPTION
The exciting post-v1.0 world of `mypy` Python type checking :tada: 

This is intended to resolve some [type check errors](https://github.com/hhursev/recipe-scrapers/actions/runs/4243084966/jobs/7375379611#step:5:48) that appeared in #735 that relate to creation of a [`requests.Session` object within a context manager](https://github.com/hhursev/recipe-scrapers/blob/d59ea12ff5d98b20cbd98eef5f77e01519276847/recipe_scrapers/bettybossi.py#L35) that doesn't play nicely with a combination of `types-requests` v2.28.11.14 and `mypy` prior to v1.0.0 (due to python/typeshed#9702, I think).

...that's the theory, anyway.  Let's see what continuous integration says about it.