### PR TITLE
Fix outdated Eatingwell.com scraper leveraging schema

### DIFF
--- a/recipe_scrapers/eatingwell.py
+++ b/recipe_scrapers/eatingwell.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 
+
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, get_yields, normalize_string
 
 
 class EatingWell(AbstractScraper):
@@ -25,21 +25,6 @@ class EatingWell(AbstractScraper):
         return self.schema.instructions()
 
     def total_time(self):
-        # Old Implementation, new Implementation based on schema below
-        # d = {
-        #
-        # }
-        # divlist = self.soup.findAll("div", {"class": "mntl-recipe-details__item"})
-        #
-        ## For every element that matches mntl-recipe-details__item class
-        # for element in divlist:
-        #    # Find the child that contains "Value" (this is what we care about for number of minutes)
-        #    val = element.findChildren("div", {"class": "mntl-recipe-details__value"})
-        #    # If the value contains the text "mins", it is either total_time or active_time
-        #    if ("mins" in val[0].text):
-        #        # Set the dict to this value and return it after the loop ends
-        #        d["total"] = val[0].text
-        #
         return self.schema.total_time()
 
     def yields(self):

--- a/recipe_scrapers/eatingwell.py
+++ b/recipe_scrapers/eatingwell.py
@@ -13,7 +13,7 @@ class EatingWell(AbstractScraper):
         return self.schema.title()
 
     def author(self):
-        return self.soup.find("span", {"class": "author-name"}).get_text()
+        return self.schema.author()
 
     def image(self):
         return self.schema.image()
@@ -25,19 +25,22 @@ class EatingWell(AbstractScraper):
         return self.schema.instructions()
 
     def total_time(self):
-        div = self.soup.findAll("div", {"class": "recipe-meta-item"})
-        d = {
-            normalize_string(key): normalize_string(value)
-            for key, value in [i.text.split(":") for i in div]
-            if value is not None
-        }
-        return get_minutes(d.get("total"))
+        # Old Implementation, new Implementation based on schema below
+        # d = {
+        #
+        # }
+        # divlist = self.soup.findAll("div", {"class": "mntl-recipe-details__item"})
+        #
+        ## For every element that matches mntl-recipe-details__item class
+        # for element in divlist:
+        #    # Find the child that contains "Value" (this is what we care about for number of minutes)
+        #    val = element.findChildren("div", {"class": "mntl-recipe-details__value"})
+        #    # If the value contains the text "mins", it is either total_time or active_time
+        #    if ("mins" in val[0].text):
+        #        # Set the dict to this value and return it after the loop ends
+        #        d["total"] = val[0].text
+        #
+        return self.schema.total_time()
 
     def yields(self):
-        div = self.soup.findAll("div", {"class": "recipe-meta-item"})
-        d = {
-            normalize_string(key): normalize_string(value)
-            for key, value in (i.text.split(":") for i in div)
-            if value is not None
-        }
-        return get_yields(d.get("Servings"))
+        return self.schema.yields()

--- a/tests/test_data/eatingwell.testhtml
+++ b/tests/test_data/eatingwell.testhtml
@@ -1,384 +1,3417 @@
-<!doctype html> <html lang="en"> <head> <title>Cheesy Ground Beef & Cauliflower Casserole Recipe | EatingWell</title> <meta charset="utf-8"> <link rel="shortcut icon" href="/favicon.ico" type="image/vnd.microsoft.icon"> <link rel="icon" href="/img/favicons/favicon-32.png" sizes="32x32"> <meta http-equiv="X-UA-Compatible" content="IE=edge"> <link rel="apple-touch-icon" href="/img/favicons/favicon-57.png"> <link rel="apple-touch-icon" href="/img/favicons/favicon-57.png" sizes="57x57"> <link rel="apple-touch-icon" href="/img/favicons/favicon-72.png" sizes="72x72"> <link rel="apple-touch-icon" href="/img/favicons/favicon-76.png" sizes="76x76"> <link rel="apple-touch-icon" href="/img/favicons/favicon-114.png" sizes="114x114"> <link rel="apple-touch-icon" href="/img/favicons/favicon-120.png" sizes="120x120"> <link rel="apple-touch-icon" href="/img/favicons/favicon-144.png" sizes="144x144"> <link rel="apple-touch-icon" href="/img/favicons/favicon-152.png" sizes="152x152"> <link rel="apple-touch-icon" href="/img/favicons/favicon-180.png" sizes="180x180"> <link rel="icon" sizes="192x192" href="/img/favicons/favicon-192.png"> <link rel="manifest" href="/manifest.json"> <link rel="preload" as="script" href="https://karma.mdpcdn.com/service/js-min/karma.js"> <link rel="preload" as="script" href="https://securepubads.g.doubleclick.net/tag/js/gpt.js"> <meta name="viewport" content="width=device-width,initial-scale=1"> <meta name="original-source" content="EatingWell.com, September 2021"> <meta name="description" content="This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream."> <link rel="canonical" href="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/"> <meta property="og:title" content="Cheesy Ground Beef &amp; Cauliflower Casserole"> <meta property="og:type" content="article"> <meta property="og:site_name" content="EatingWell"> <meta property="og:url" content="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/"> <meta property="og:description" content="This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream. "> <meta name="pinterest:url" content="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/"> <meta name="twitter:card" content="summary_large_image"> <meta name="twitter:url" content="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/"> <meta name="twitter:title" content="Cheesy Ground Beef &amp; Cauliflower Casserole"> <meta name="twitter:description" content="This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream."> <meta name="twitter:site" content="@EatingWell"> <meta name="pinterest:media" content="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg"> <meta name="twitter:image" content="https://imagesvc.meredithcorp.io/v3/mm/image?q=85&c=sc&rect=0%2C102%2C2000%2C1102&poi=%5B1160%2C700%5D&w=2000&h=1000&url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg"> <meta property="og:image" content="https://imagesvc.meredithcorp.io/v3/mm/image?q=85&c=sc&rect=0%2C102%2C2000%2C1102&poi=%5B1160%2C700%5D&w=2000&h=1000&url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg"> <meta property="og:image:width" content="2000"> <meta property="og:image:height" content="1000"> <meta name="robots" content="max-image-preview:large"> <meta property="fb:app_id" content="165082593548215"> <meta property="fb:pages" content="10053803772"> <script type="application/ld+json"> [
-      {
-        "@context": "http://schema.org",
-        "@type": "BreadcrumbList",
-        "itemListElement": [
-          {
-            "@type": "ListItem",
-            "position": 1,
-            "item": {
-              "@id": "https://www.eatingwell.com/",
-              "name": "Home",
-              "image": null
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 2,
-            "item": {
-              "@id": "https://www.eatingwell.com/recipes/",
-              "name": "Healthy Recipes",
-              "image": null
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 3,
-            "item": {
-              "@id": "https://www.eatingwell.com/recipes/17965/main-dishes/",
-              "name": "Healthy Main Dish Recipes",
-              "image": null
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 4,
-            "item": {
-              "@id": "https://www.eatingwell.com/recipes/17923/main-dishes/casseroles/",
-              "name": "Healthy Casserole Recipes",
-              "image": null
-            }
-          }
-        ]
-      },
-      {
-        "@context": "http://schema.org",
-        "@type": "Recipe",
-        "mainEntityOfPage": "https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/",
-        "name": "Cheesy Ground Beef & Cauliflower Casserole",
-        "image": {
-          "@type": "ImageObject",
-          "url": "https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg",
-          "width": 2000,
-          "height": 2000
-        },
-        "datePublished": "2021-09-23T18:20:24.000Z",
-        "description": "Ground beef and cauliflower combine to create a hearty weeknight casserole that both kids and adults will love. Serve with tortilla chips and sour cream.",
-        "prepTime": null,
-        "cookTime": null,
-        "totalTime": "P0DT0H30M",
-        "recipeIngredient": [
-          "1 tablespoon extra-virgin olive oil",
-          "½ cup chopped onion",
-          "1 medium green bell pepper, chopped",
-          "1 pound lean ground beef",
-          "3 cups bite-size cauliflower florets",
-          "3 cloves garlic, minced",
-          "2 tablespoons chili powder",
-          "2 teaspoons ground cumin",
-          "1 teaspoon dried oregano",
-          "½ teaspoon salt",
-          "¼ teaspoon ground chipotle ",
-          "1 (15 ounce) can no-salt-added petite-diced tomatoes",
-          "2 cups shredded extra-sharp Cheddar cheese",
-          "⅓ cup sliced pickled jalapeños"
-        ],
-        "recipeInstructions": [
-          {
-            "@type": "HowToStep",
-            "text": "Position rack in upper third of oven. Preheat broiler to high.\n"
-          },
-          {
-            "@type": "HowToStep",
-            "text": "Heat oil in a large oven-safe skillet over medium heat. Add onion and bell pepper; cook, stirring, until softened, about 5 minutes. Add beef and cauliflower; cook, stirring and breaking the beef up into smaller pieces, until it is no longer pink, 5 to 7 minutes. Stir in garlic, chili powder, cumin, oregano, salt and chipotle; cook until fragrant, about 1 minute. Add tomatoes and their juices; bring to a simmer and cook, stirring occasionally, until liquid is reduced and the cauliflower is tender, about 3 minutes more. Remove from heat.\n"
-          },
-          {
-            "@type": "HowToStep",
-            "text": "Sprinkle cheese over the beef mixture and top with sliced jalapeños. Broil until the cheese is melted and browned in spots, 2 to 3 minutes.\n"
-          }
-        ],
-        "recipeCategory": [
-          "Healthy Recipes",
-          "Healthy Main Dish Recipes",
-          "Healthy Casserole Recipes"
-        ],
-        "recipeCuisine": [],
-        "author": [
-          {
-            "@type": "Person",
-            "name": "EatingWell"
-          }
-        ],
-        "aggregateRating": {
-          "@type": "AggregateRating",
-          "itemReviewed": "Cheesy Ground Beef & Cauliflower Casserole",
-          "bestRating": "5",
-          "worstRating": "1"
-        },
-        "nutrition": {
-          "@type": "NutritionInformation",
-          "calories": "351 calories",
-          "carbohydrateContent": "11 g",
-          "cholesterolContent": "86 mg",
-          "fatContent": "23 g",
-          "fiberContent": "3 g",
-          "proteinContent": "26 g",
-          "saturatedFatContent": "11 g",
-          "servingSize": null,
-          "sodiumContent": "672 mg",
-          "sugarContent": "4 g",
-          "transFatContent": null,
-          "unsaturatedFatContent": null
-        },
-        "review": []
-      }
-    ] </script> <link rel="dns-prefetch" href="//karma.mdpcdn.com"> <link rel="dns-prefetch" href="//imagesvc.meredithcorp.io"> <link rel="dns-prefetch" href="//cdn.segment.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin> <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" crossorigin><link rel="preload" href="/dist/fontWoff2.css" as="style" crossorigin> <script> (function() {
-            var ots = document.createElement('script');
-            ots.async = false;
-            ots.src = 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js';
-            ots.charset = 'utf-8';
-            ots.type = 'text/javascript';
-            ots.setAttribute('data-domain-script', '709f4a38-08d7-4c5b-8c44-b12a39f035aa');
-            document.head.appendChild(ots);
-          })(); </script> <script> // Arguments passed to this function:
-          //  OneTrust ID (required): The OneTrust-assigned ID for this site.
-          //  Environment (optional): Test environment is assumed. Specify 'prod' for production.
+<!DOCTYPE html>
+<html id="recipeScTemplate_1-0" class="comp no-js taxlevel-3 recipeScTemplate html mntl-html" data-ab="99,99,56,99,99,99" data-resource-version="1.6.0" lang="en" data-mantle-resource-version="3.14.56" data-eatingwell-resource-version="1.6.0" data-tracking-container="true">				
+<!--
+<globe-environment environment="k8s-prod" application="eatingwell" dataCenter="us-west-1"/>
+-->
+<head class="loc head">				
+					
+					<script type="text/javascript">var Mntl = window.Mntl || {};</script>
+					
+					    <link rel="preconnect" href="//js-sec.indexww.com">
+    <link rel="preconnect" href="//c.amazon-adsystem.com">
+    <link rel="preconnect" href="//securepubads.g.doubleclick.net">
 
-          var mdp = mdp || {};
-          mdp.locinfo = (function () {
-            let locCode = 0;
-            const init = function () {
-              const otCountry = otStubData.userLocation.country;
-              const euNtns = ['BE','BG','CZ','DK','DE','EE','IE','GR','ES','FR','IT','CY','LV','LT','LU','HU','MT','NL','AT','PL','PT','RO','SI','SK','FI','SE','GB','HR','LI','NO','IS'];
-              if (euNtns.indexOf(otCountry) !== -1) {
-                locCode = 1;
-                document.body.classList.add('euUser');
-                setTimeout(() => {
-                  for (let element of document.getElementsByClassName('euDisabled')) {
-                    element.style.display='none';
-                  }
-                  for (let element of document.getElementsByClassName('euEnabled')) {
-                    element.style.display='block';
-                  }
-                }, 0);
-              } else if (otCountry === 'US') {
-                locCode = 2;
-                const ccpaLink = document.getElementsByClassName('ot-sdk-show-settings')[0];
-                ccpaLink.setAttribute('data-tracking-label', 'California Do Not Sell');
-              }
-              if (locCode === 0) {
-                const otParent = document.getElementsByClassName('ot-sdk-show-settings-parent');
-                if (otParent.length !== 0) {
-                  otParent[0].style.display = 'none';
-                }
-              }
-            };
+					
+					
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-            return {
-              init: init
-            };
-          }());
+<meta name="robots" content="max-image-preview:large, NOODP, NOYDIR" />
 
-          function OptanonWrapper() {
-            mdp.locinfo.init();
-            const gpcTag = document.createElement('script');
-            gpcTag.src = 'https://ddrvjrfwnij7n.cloudfront.net/js/gpc/gpc.min.js';
-            document.head.append(gpcTag);
-          } </script> <script id="universal-data-layer"> (function setDataLayer(global) {
-        function UniversalDataLayer(udl) {
-          this._data = udl;
-          this.get = function (key, ns) {
-            if (ns !== undefined) {
-              if (this._data[ns] !== undefined && this._data[ns][key] !== undefined) {
-                return this._data[ns][key];
-              }
-              return null;
-            }
-            if (this._data[key] !== undefined) {
-              return this._data[key];
-            }
-            return null;
-          };
-          this.set = function (key, value, ns) {
-            if (ns !== undefined) {
-              if (this._data[ns] === undefined) {
-                this._data[ns] = {};
-              }
-              this._data[ns][key] = value;
-            } else {
-              this._data[key] = value;
-            }
-          }
-          this.getAsync = function (key) {
-            return new Promise(r => {
-              if (this.get(key) !== undefined) {
-                r(this.get(key));
-              }
-              r(null);
-            });
-          };
-          this.setAsync = function (key, value) {
-            return new Promise(r => {
-              this._data[key] = value;
-              r(this);
-            });
-          }
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="canonical" href="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/" />
+<title>Cheesy Ground Beef & Cauliflower Casserole</title>
+<meta name="description" content="This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream." itemprop="description">
+<meta name="parsely-section" content="Healthy Recipes" />
+<meta name="parsely-tags" content="Healthy Low-Carb Recipes,Gluten-Free Dinner Recipes,Healthy Meat Main Dish Recipes,Healthy Vegetable Main Dish Recipes,High Protein, Low-Carb Recipes,Special Diet Dinner Recipes,Low-Carb Diet Center,Low-Carb Dinner Recipes,Healthy Lifestyle Diets,Healthy Cooking Methods & Styles" />
+<!-- Pinterest Pins -->
+<meta itemprop="name" content="Cheesy Ground Beef &amp; Cauliflower Casserole" />
+<meta property="article:section" content="EatingWell" />
+<!-- Facebook Open Graph Tags -->
+<meta property="fb:app_id" content="165082593548215" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="EatingWell" />
+<meta property="og:url" content="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/" />
+<meta property="og:title" content="Cheesy Ground Beef &amp; Cauliflower Casserole" />
+<meta property="og:description" content="This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream." />
+<meta property="og:image" content="https://www.eatingwell.com/thmb/32d8L6W6cwt652tjjXAHosP3ViE=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg" />
+<meta property="article:opinion" content="false" />
+<meta property="article:author" content="https://www.facebook.com/EatingWell/" />
+<!-- Twitter Cards -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@EatingWell" />
+<meta name="twitter:title" content="Cheesy Ground Beef &amp; Cauliflower Casserole" />
+<meta name="twitter:description" content="This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream." />
+<meta name="twitter:image" content="https://www.eatingwell.com/thmb/WvIYGpT4jV7kynU9HtMMY4oEFVs=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():focal(1159x699:1161x701)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg" />
+					
+					<link type="text/css" rel="stylesheet" data-glb-css href="/static/1.6.0/cache/eNqtV1kS2yAMvVAZ9w797SUwlm0mLB7ASXP7isVrCDhpP2KQkJ4kkARprKOOs0ZS5QQ0zNrGc-BH87rAJR2ATIIyGLXowKxCflVSrl60tJy0AuVsQzsbxO68A70pHgXwV4B48G4AHEfgw-h-jVQN8JtbBwpMlllyxyA_xZXmWaeSGOCCGh4gBLkgnUYyAsVdWsnJgOcgUIZV8FXROx9wTaumNSjNzCzbuJs7OufQG82c1vvtDifmj_2JsQSjLFFX9oBphWfhIsoBi7TsEwADjE-QhhN3IXN4R70OHOXCnsjv_ajgve6qdWZmbjbQrYih6BgpJ38yy5UzOn4rxaZw7R4TXOI6iXTdgjCWYD6igzywT3QdYBfhHifP_mynRidF-HymFhpX_BYUo5Tfr4H3n2REGkkrNLvZrVXmMCTGTZOpng_oJmF08hX6fQ4a7NfYSfhWDhunEG87O6eV3TIkKJDIrh-zmp3h3nHSU-Z7zZEmdpaSmue_Awnagvhid_4b7qmNn3t4vYGfjgvuHB6kpeaVc6Edm3AVxWOL8y9isHN7DmNjfYEnse8diFLePQVXkO6vOC9ZXMQ_EKWzG7UhTmvh-FTqkw5TAhOeL3WwYxDuQF44j2SluWDt4Fa0d9XT3U1uNePU9_N7vDlWsvIC2OmVda51nYRhR2qyvAtbd4BY29BFkOVBafy7DzseFxXhlgvRamqSnkXJ25Ns3M_UL-t54V7AH97iVtJL4iIUV0B_91KuiFhgMan9wRiWhoJphkBE4Lt5m-VwWYy_IJyHDp_3gMsrzkvu5rGtnBk5mEHolorG3viExbRm7IkuaKZ-FodKIWF7ENw9QyXt5pXK_xm_OexeG4me-L8sPvGBGjaeyJzaUkYSrPX_zFqq_D-hI1mJJQYcQtmmFZ1-FsIyA6CC3pEs7HGvtUP_4lCzEYQi_jq9poN3wM0eiGt9tdOuo3Yks8J3srG7FptdqQdaV331B1-HQg9pKJhQ8LACnA8xqbxw_gLhZhqH.min.css"/>
+					
+					<style type="text/css">#onetrust-banner-sdk{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}#onetrust-banner-sdk .onetrust-vendors-list-handler{cursor:pointer;color:#1f96db;font-size:inherit;font-weight:bold;text-decoration:none;margin-left:5px}#onetrust-banner-sdk .onetrust-vendors-list-handler:hover{color:#1f96db}#onetrust-banner-sdk:focus{outline:2px solid #000;outline-offset:-2px}#onetrust-banner-sdk a:focus{outline:2px solid #000}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{outline-offset:1px}#onetrust-banner-sdk .ot-close-icon,#onetrust-pc-sdk .ot-close-icon,#ot-sync-ntfy .ot-close-icon{background-image:url("data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iMzQ4LjMzM3B4IiBoZWlnaHQ9IjM0OC4zMzNweCIgdmlld0JveD0iMCAwIDM0OC4zMzMgMzQ4LjMzNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzQ4LjMzMyAzNDguMzM0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGc+PHBhdGggZmlsbD0iIzU2NTY1NiIgZD0iTTMzNi41NTksNjguNjExTDIzMS4wMTYsMTc0LjE2NWwxMDUuNTQzLDEwNS41NDljMTUuNjk5LDE1LjcwNSwxNS42OTksNDEuMTQ1LDAsNTYuODVjLTcuODQ0LDcuODQ0LTE4LjEyOCwxMS43NjktMjguNDA3LDExLjc2OWMtMTAuMjk2LDAtMjAuNTgxLTMuOTE5LTI4LjQxOS0xMS43NjlMMTc0LjE2NywyMzEuMDAzTDY4LjYwOSwzMzYuNTYzYy03Ljg0Myw3Ljg0NC0xOC4xMjgsMTEuNzY5LTI4LjQxNiwxMS43NjljLTEwLjI4NSwwLTIwLjU2My0zLjkxOS0yOC40MTMtMTEuNzY5Yy0xNS42OTktMTUuNjk4LTE1LjY5OS00MS4xMzksMC01Ni44NWwxMDUuNTQtMTA1LjU0OUwxMS43NzQsNjguNjExYy0xNS42OTktMTUuNjk5LTE1LjY5OS00MS4xNDUsMC01Ni44NDRjMTUuNjk2LTE1LjY4Nyw0MS4xMjctMTUuNjg3LDU2LjgyOSwwbDEwNS41NjMsMTA1LjU1NEwyNzkuNzIxLDExLjc2N2MxNS43MDUtMTUuNjg3LDQxLjEzOS0xNS42ODcsNTYuODMyLDBDMzUyLjI1OCwyNy40NjYsMzUyLjI1OCw1Mi45MTIsMzM2LjU1OSw2OC42MTF6Ii8+PC9nPjwvc3ZnPg==");background-size:contain;background-repeat:no-repeat;background-position:center;height:12px;width:12px}#onetrust-banner-sdk .powered-by-logo,#onetrust-banner-sdk .ot-pc-footer-logo a,#onetrust-pc-sdk .powered-by-logo,#onetrust-pc-sdk .ot-pc-footer-logo a,#ot-sync-ntfy .powered-by-logo,#ot-sync-ntfy .ot-pc-footer-logo a{background-size:contain;background-repeat:no-repeat;background-position:center;height:25px;width:152px;display:block}#onetrust-banner-sdk h3 *,#onetrust-banner-sdk h4 *,#onetrust-banner-sdk h6 *,#onetrust-banner-sdk button *,#onetrust-banner-sdk a[data-parent-id] *,#onetrust-pc-sdk h3 *,#onetrust-pc-sdk h4 *,#onetrust-pc-sdk h6 *,#onetrust-pc-sdk button *,#onetrust-pc-sdk a[data-parent-id] *,#ot-sync-ntfy h3 *,#ot-sync-ntfy h4 *,#ot-sync-ntfy h6 *,#ot-sync-ntfy button *,#ot-sync-ntfy a[data-parent-id] *{font-size:inherit;font-weight:inherit;color:inherit}#onetrust-banner-sdk .ot-hide,#onetrust-pc-sdk .ot-hide,#ot-sync-ntfy .ot-hide{display:none !important}#onetrust-pc-sdk .ot-sdk-row .ot-sdk-column{padding:0}#onetrust-pc-sdk .ot-sdk-container{padding-right:0}#onetrust-pc-sdk .ot-sdk-row{flex-direction:initial;width:100%}#onetrust-pc-sdk [type="checkbox"]:checked,#onetrust-pc-sdk [type="checkbox"]:not(:checked){pointer-events:initial}#onetrust-pc-sdk [type="checkbox"]:disabled+label::before,#onetrust-pc-sdk [type="checkbox"]:disabled+label:after,#onetrust-pc-sdk [type="checkbox"]:disabled+label{pointer-events:none;opacity:0.7}#onetrust-pc-sdk #vendor-list-content{transform:translate3d(0, 0, 0)}#onetrust-pc-sdk li input[type="checkbox"]{z-index:1}#onetrust-pc-sdk li .ot-checkbox label{z-index:2}#onetrust-pc-sdk li .ot-checkbox input[type="checkbox"]{height:auto;width:auto}#onetrust-pc-sdk li .host-title a,#onetrust-pc-sdk li .ot-host-name a,#onetrust-pc-sdk li .accordion-text,#onetrust-pc-sdk li .ot-acc-txt{z-index:2;position:relative}#onetrust-pc-sdk input{margin:3px 0.1ex}#onetrust-pc-sdk .pc-logo,#onetrust-pc-sdk .ot-pc-logo{height:60px;width:180px;background-position:center;background-size:contain;background-repeat:no-repeat}#onetrust-pc-sdk .screen-reader-only,#onetrust-pc-sdk .ot-scrn-rdr,.ot-sdk-cookie-policy .screen-reader-only,.ot-sdk-cookie-policy .ot-scrn-rdr{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}#onetrust-pc-sdk.ot-fade-in,.onetrust-pc-dark-filter.ot-fade-in,#onetrust-banner-sdk.ot-fade-in{animation-name:onetrust-fade-in;animation-duration:400ms;animation-timing-function:ease-in-out}#onetrust-pc-sdk.ot-hide{display:none !important}.onetrust-pc-dark-filter.ot-hide{display:none !important}#ot-sdk-btn.ot-sdk-show-settings,#ot-sdk-btn.optanon-show-settings{color:#68b631;border:1px solid #68b631;height:auto;white-space:normal;word-wrap:break-word;padding:0.8em 2em;font-size:0.8em;line-height:1.2;cursor:pointer;-moz-transition:0.1s ease;-o-transition:0.1s ease;-webkit-transition:1s ease;transition:0.1s ease}#ot-sdk-btn.ot-sdk-show-settings:hover,#ot-sdk-btn.optanon-show-settings:hover{color:#fff;background-color:#68b631}.onetrust-pc-dark-filter{background:rgba(0,0,0,0.5);z-index:2147483646;width:100%;height:100%;overflow:hidden;position:fixed;top:0;bottom:0;left:0}@keyframes onetrust-fade-in{0%{opacity:0}100%{opacity:1}}.ot-cookie-label{text-decoration:underline}@media only screen and (min-width: 426px) and (max-width: 896px) and (orientation: landscape){#onetrust-pc-sdk p{font-size:0.75em}}#onetrust-banner-sdk .banner-option-input:focus+label{outline:1px solid #000;outline-style:auto}.category-vendors-list-handler+a:focus,.category-vendors-list-handler+a:focus-visible{outline:2px solid #000}#onetrust-pc-sdk .ot-userid-title{margin-top:10px}#onetrust-pc-sdk .ot-userid-title>span,#onetrust-pc-sdk .ot-userid-timestamp>span{font-weight:700}#onetrust-pc-sdk .ot-userid-desc{font-style:italic}#onetrust-pc-sdk .ot-host-desc a{pointer-events:initial}#onetrust-pc-sdk .ot-ven-hdr>p a{position:relative;z-index:2;pointer-events:initial}
+#onetrust-banner-sdk,#onetrust-pc-sdk,#ot-sdk-cookie-policy,#ot-sync-ntfy{font-size:16px}#onetrust-banner-sdk *,#onetrust-banner-sdk ::after,#onetrust-banner-sdk ::before,#onetrust-pc-sdk *,#onetrust-pc-sdk ::after,#onetrust-pc-sdk ::before,#ot-sdk-cookie-policy *,#ot-sdk-cookie-policy ::after,#ot-sdk-cookie-policy ::before,#ot-sync-ntfy *,#ot-sync-ntfy ::after,#ot-sync-ntfy ::before{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}#onetrust-banner-sdk div,#onetrust-banner-sdk span,#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-banner-sdk p,#onetrust-banner-sdk img,#onetrust-banner-sdk svg,#onetrust-banner-sdk button,#onetrust-banner-sdk section,#onetrust-banner-sdk a,#onetrust-banner-sdk label,#onetrust-banner-sdk input,#onetrust-banner-sdk ul,#onetrust-banner-sdk li,#onetrust-banner-sdk nav,#onetrust-banner-sdk table,#onetrust-banner-sdk thead,#onetrust-banner-sdk tr,#onetrust-banner-sdk td,#onetrust-banner-sdk tbody,#onetrust-banner-sdk .ot-main-content,#onetrust-banner-sdk .ot-toggle,#onetrust-banner-sdk #ot-content,#onetrust-banner-sdk #ot-pc-content,#onetrust-banner-sdk .checkbox,#onetrust-pc-sdk div,#onetrust-pc-sdk span,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#onetrust-pc-sdk p,#onetrust-pc-sdk img,#onetrust-pc-sdk svg,#onetrust-pc-sdk button,#onetrust-pc-sdk section,#onetrust-pc-sdk a,#onetrust-pc-sdk label,#onetrust-pc-sdk input,#onetrust-pc-sdk ul,#onetrust-pc-sdk li,#onetrust-pc-sdk nav,#onetrust-pc-sdk table,#onetrust-pc-sdk thead,#onetrust-pc-sdk tr,#onetrust-pc-sdk td,#onetrust-pc-sdk tbody,#onetrust-pc-sdk .ot-main-content,#onetrust-pc-sdk .ot-toggle,#onetrust-pc-sdk #ot-content,#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk .checkbox,#ot-sdk-cookie-policy div,#ot-sdk-cookie-policy span,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy p,#ot-sdk-cookie-policy img,#ot-sdk-cookie-policy svg,#ot-sdk-cookie-policy button,#ot-sdk-cookie-policy section,#ot-sdk-cookie-policy a,#ot-sdk-cookie-policy label,#ot-sdk-cookie-policy input,#ot-sdk-cookie-policy ul,#ot-sdk-cookie-policy li,#ot-sdk-cookie-policy nav,#ot-sdk-cookie-policy table,#ot-sdk-cookie-policy thead,#ot-sdk-cookie-policy tr,#ot-sdk-cookie-policy td,#ot-sdk-cookie-policy tbody,#ot-sdk-cookie-policy .ot-main-content,#ot-sdk-cookie-policy .ot-toggle,#ot-sdk-cookie-policy #ot-content,#ot-sdk-cookie-policy #ot-pc-content,#ot-sdk-cookie-policy .checkbox,#ot-sync-ntfy div,#ot-sync-ntfy span,#ot-sync-ntfy h1,#ot-sync-ntfy h2,#ot-sync-ntfy h3,#ot-sync-ntfy h4,#ot-sync-ntfy h5,#ot-sync-ntfy h6,#ot-sync-ntfy p,#ot-sync-ntfy img,#ot-sync-ntfy svg,#ot-sync-ntfy button,#ot-sync-ntfy section,#ot-sync-ntfy a,#ot-sync-ntfy label,#ot-sync-ntfy input,#ot-sync-ntfy ul,#ot-sync-ntfy li,#ot-sync-ntfy nav,#ot-sync-ntfy table,#ot-sync-ntfy thead,#ot-sync-ntfy tr,#ot-sync-ntfy td,#ot-sync-ntfy tbody,#ot-sync-ntfy .ot-main-content,#ot-sync-ntfy .ot-toggle,#ot-sync-ntfy #ot-content,#ot-sync-ntfy #ot-pc-content,#ot-sync-ntfy .checkbox{font-family:inherit;font-weight:normal;-webkit-font-smoothing:auto;letter-spacing:normal;line-height:normal;padding:0;margin:0;height:auto;min-height:0;max-height:none;width:auto;min-width:0;max-width:none;border-radius:0;border:none;clear:none;float:none;position:static;bottom:auto;left:auto;right:auto;top:auto;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;white-space:normal;background:none;overflow:visible;vertical-align:baseline;visibility:visible;z-index:auto;box-shadow:none}#onetrust-banner-sdk label:before,#onetrust-banner-sdk label:after,#onetrust-banner-sdk .checkbox:after,#onetrust-banner-sdk .checkbox:before,#onetrust-pc-sdk label:before,#onetrust-pc-sdk label:after,#onetrust-pc-sdk .checkbox:after,#onetrust-pc-sdk .checkbox:before,#ot-sdk-cookie-policy label:before,#ot-sdk-cookie-policy label:after,#ot-sdk-cookie-policy .checkbox:after,#ot-sdk-cookie-policy .checkbox:before,#ot-sync-ntfy label:before,#ot-sync-ntfy label:after,#ot-sync-ntfy .checkbox:after,#ot-sync-ntfy .checkbox:before{content:"";content:none}
+#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{position:relative;width:100%;max-width:100%;margin:0 auto;padding:0 20px;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{width:100%;float:left;box-sizing:border-box;padding:0;display:initial}@media (min-width: 400px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:90%;padding:0}}@media (min-width: 550px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:100%}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{margin-left:4%}#onetrust-banner-sdk .ot-sdk-column:first-child,#onetrust-banner-sdk .ot-sdk-columns:first-child,#onetrust-pc-sdk .ot-sdk-column:first-child,#onetrust-pc-sdk .ot-sdk-columns:first-child,#ot-sdk-cookie-policy .ot-sdk-column:first-child,#ot-sdk-cookie-policy .ot-sdk-columns:first-child{margin-left:0}#onetrust-banner-sdk .ot-sdk-two.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-two.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-two.ot-sdk-columns{width:13.3333333333%}#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-three.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-three.ot-sdk-columns{width:22%}#onetrust-banner-sdk .ot-sdk-four.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-four.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-four.ot-sdk-columns{width:30.6666666667%}#onetrust-banner-sdk .ot-sdk-eight.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eight.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eight.ot-sdk-columns{width:65.3333333333%}#onetrust-banner-sdk .ot-sdk-nine.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-nine.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-nine.ot-sdk-columns{width:74%}#onetrust-banner-sdk .ot-sdk-ten.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-ten.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-ten.ot-sdk-columns{width:82.6666666667%}#onetrust-banner-sdk .ot-sdk-eleven.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eleven.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eleven.ot-sdk-columns{width:91.3333333333%}#onetrust-banner-sdk .ot-sdk-twelve.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-twelve.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-twelve.ot-sdk-columns{width:100%;margin-left:0}}#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6{margin-top:0;font-weight:600;font-family:inherit}#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem;line-height:1.2}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem;line-height:1.25}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem;line-height:1.3}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem;line-height:1.35}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem;line-height:1.5}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem;line-height:1.6}@media (min-width: 550px){#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem}}#onetrust-banner-sdk p,#onetrust-pc-sdk p,#ot-sdk-cookie-policy p{margin:0 0 1em 0;font-family:inherit;line-height:normal}#onetrust-banner-sdk a,#onetrust-pc-sdk a,#ot-sdk-cookie-policy a{color:#565656;text-decoration:underline}#onetrust-banner-sdk a:hover,#onetrust-pc-sdk a:hover,#ot-sdk-cookie-policy a:hover{color:#565656;text-decoration:none}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{display:inline-block;height:38px;padding:0 30px;color:#555;text-align:center;font-size:0.9em;font-weight:400;line-height:38px;letter-spacing:0.01em;text-decoration:none;white-space:nowrap;background-color:transparent;border-radius:2px;border:1px solid #bbb;cursor:pointer;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{color:#333;border-color:#888;opacity:0.7}#onetrust-banner-sdk .ot-sdk-button:focus,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:focus,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:focus,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{outline:2px solid #000}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-banner-sdk button.ot-sdk-button-primary,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-pc-sdk button.ot-sdk-button-primary,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary,#ot-sdk-cookie-policy button.ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary{color:#fff;background-color:#33c3f0;border-color:#33c3f0}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-banner-sdk button.ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:hover,#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-banner-sdk button.ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:focus,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-pc-sdk button.ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:hover,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-pc-sdk button.ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:focus{color:#fff;background-color:#1eaedb;border-color:#1eaedb}#onetrust-banner-sdk input[type="text"],#onetrust-pc-sdk input[type="text"],#ot-sdk-cookie-policy input[type="text"]{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #d1d1d1;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-banner-sdk input[type="text"],#onetrust-pc-sdk input[type="text"],#ot-sdk-cookie-policy input[type="text"]{-webkit-appearance:none;-moz-appearance:none;appearance:none}#onetrust-banner-sdk input[type="text"]:focus,#onetrust-pc-sdk input[type="text"]:focus,#ot-sdk-cookie-policy input[type="text"]:focus{border:1px solid #000;outline:0}#onetrust-banner-sdk label,#onetrust-pc-sdk label,#ot-sdk-cookie-policy label{display:block;margin-bottom:0.5rem;font-weight:600}#onetrust-banner-sdk input[type="checkbox"],#onetrust-pc-sdk input[type="checkbox"],#ot-sdk-cookie-policy input[type="checkbox"]{display:inline}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{list-style:circle inside}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{padding-left:0;margin-top:0}#onetrust-banner-sdk ul ul,#onetrust-pc-sdk ul ul,#ot-sdk-cookie-policy ul ul{margin:1.5rem 0 1.5rem 3rem;font-size:90%}#onetrust-banner-sdk li,#onetrust-pc-sdk li,#ot-sdk-cookie-policy li{margin-bottom:1rem}#onetrust-banner-sdk th,#onetrust-banner-sdk td,#onetrust-pc-sdk th,#onetrust-pc-sdk td,#ot-sdk-cookie-policy th,#ot-sdk-cookie-policy td{padding:12px 15px;text-align:left;border-bottom:1px solid #e1e1e1}#onetrust-banner-sdk button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-container:after,#onetrust-banner-sdk .ot-sdk-row:after,#onetrust-pc-sdk .ot-sdk-container:after,#onetrust-pc-sdk .ot-sdk-row:after,#ot-sdk-cookie-policy .ot-sdk-container:after,#ot-sdk-cookie-policy .ot-sdk-row:after{content:"";display:table;clear:both}#onetrust-banner-sdk .ot-sdk-row,#onetrust-pc-sdk .ot-sdk-row,#ot-sdk-cookie-policy .ot-sdk-row{margin:0;max-width:none;display:block}
+#onetrust-banner-sdk{box-shadow:0 0 18px rgba(0,0,0,.2)}#onetrust-banner-sdk.otFlat{position:fixed;z-index:2147483645;bottom:0;right:0;left:0;background-color:#fff;max-height:90%;overflow-x:hidden;overflow-y:auto}#onetrust-banner-sdk.otFlat.top{top:0px;bottom:auto}#onetrust-banner-sdk.otRelFont{font-size:1rem}#onetrust-banner-sdk>.ot-sdk-container{overflow:hidden}#onetrust-banner-sdk::-webkit-scrollbar{width:11px}#onetrust-banner-sdk::-webkit-scrollbar-thumb{border-radius:10px;background:#c1c1c1}#onetrust-banner-sdk{scrollbar-arrow-color:#c1c1c1;scrollbar-darkshadow-color:#c1c1c1;scrollbar-face-color:#c1c1c1;scrollbar-shadow-color:#c1c1c1}#onetrust-banner-sdk #onetrust-policy{margin:1.25em 0 .625em 2em;overflow:hidden}#onetrust-banner-sdk #onetrust-policy .ot-gv-list-handler{float:left;font-size:.82em;padding:0;margin-bottom:0;border:0;line-height:normal;height:auto;width:auto}#onetrust-banner-sdk #onetrust-policy-title{font-size:1.2em;line-height:1.3;margin-bottom:10px}#onetrust-banner-sdk #onetrust-policy-text{clear:both;text-align:left;font-size:.88em;line-height:1.4}#onetrust-banner-sdk #onetrust-policy-text *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk #onetrust-policy-text a{font-weight:bold;margin-left:5px}#onetrust-banner-sdk #onetrust-policy-title,#onetrust-banner-sdk #onetrust-policy-text{color:dimgray;float:left}#onetrust-banner-sdk #onetrust-button-group-parent{min-height:1px;text-align:center}#onetrust-banner-sdk #onetrust-button-group{display:inline-block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{background-color:#68b631;color:#fff;border-color:#68b631;margin-right:1em;min-width:125px;height:auto;white-space:normal;word-break:break-word;word-wrap:break-word;padding:12px 10px;line-height:1.2;font-size:.813em;font-weight:600}#onetrust-banner-sdk #onetrust-pc-btn-handler.cookie-setting-link{background-color:#fff;border:none;color:#68b631;text-decoration:underline;padding-left:0;padding-right:0}#onetrust-banner-sdk .onetrust-close-btn-ui{width:44px;height:44px;background-size:12px;border:none;position:relative;margin:auto;padding:0}#onetrust-banner-sdk .banner_logo{display:none}#onetrust-banner-sdk .ot-b-addl-desc{clear:both;float:left;display:block}#onetrust-banner-sdk #banner-options{float:left;display:table;margin-right:0;margin-left:1em;width:calc(100% - 1em)}#onetrust-banner-sdk .banner-option-input{cursor:pointer;width:auto;height:auto;border:none;padding:0;padding-right:3px;margin:0 0 10px;font-size:.82em;line-height:1.4}#onetrust-banner-sdk .banner-option-input *{pointer-events:none;font-size:inherit;line-height:inherit}#onetrust-banner-sdk .banner-option-input[aria-expanded=true]~.banner-option-details{display:block;height:auto}#onetrust-banner-sdk .banner-option-input[aria-expanded=true] .ot-arrow-container{transform:rotate(90deg)}#onetrust-banner-sdk .banner-option{margin-bottom:12px;margin-left:0;border:none;float:left;padding:0}#onetrust-banner-sdk .banner-option:first-child{padding-left:2px}#onetrust-banner-sdk .banner-option:not(:first-child){padding:0;border:none}#onetrust-banner-sdk .banner-option-header{cursor:pointer;display:inline-block}#onetrust-banner-sdk .banner-option-header :first-child{color:dimgray;font-weight:bold;float:left}#onetrust-banner-sdk .banner-option-header .ot-arrow-container{display:inline-block;border-top:6px solid transparent;border-bottom:6px solid transparent;border-left:6px solid dimgray;margin-left:10px;vertical-align:middle}#onetrust-banner-sdk .banner-option-details{display:none;font-size:.83em;line-height:1.5;padding:10px 0px 5px 10px;margin-right:10px;height:0px}#onetrust-banner-sdk .banner-option-details *{font-size:inherit;line-height:inherit;color:dimgray}#onetrust-banner-sdk .ot-arrow-container,#onetrust-banner-sdk .banner-option-details{transition:all 300ms ease-in 0s;-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s}#onetrust-banner-sdk .ot-dpd-container{float:left}#onetrust-banner-sdk .ot-dpd-title{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-title,#onetrust-banner-sdk .ot-dpd-desc{font-size:.88em;line-height:1.4;color:dimgray}#onetrust-banner-sdk .ot-dpd-title *,#onetrust-banner-sdk .ot-dpd-desc *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text *{margin-bottom:0}#onetrust-banner-sdk.ot-iab-2 .onetrust-vendors-list-handler{display:block;margin-left:0;margin-top:5px;clear:both;margin-bottom:0;padding:0;border:0;height:auto;width:auto}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk.ot-close-btn-link{padding-top:25px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container{top:15px;transform:none;right:15px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container button{padding:0;white-space:pre-wrap;border:none;height:auto;line-height:1.5;text-decoration:underline;font-size:.69em}#onetrust-banner-sdk #onetrust-policy-text,#onetrust-banner-sdk .ot-dpd-desc,#onetrust-banner-sdk .ot-b-addl-desc{font-size:.813em;line-height:1.5}#onetrust-banner-sdk .ot-dpd-desc{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-desc>.ot-b-addl-desc{margin-top:10px;margin-bottom:10px;font-size:1em}@media only screen and (max-width: 425px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:6px;right:2px}#onetrust-banner-sdk #onetrust-policy{margin-left:0;margin-top:3em}#onetrust-banner-sdk #onetrust-button-group{display:block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk .onetrust-close-btn-ui{top:auto;transform:none}#onetrust-banner-sdk #onetrust-policy-title{display:inline;float:none}#onetrust-banner-sdk #banner-options{margin:0;padding:0;width:100%}}@media only screen and (min-width: 426px)and (max-width: 896px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:0;right:0}#onetrust-banner-sdk #onetrust-policy{margin-left:1em;margin-right:1em}#onetrust-banner-sdk .onetrust-close-btn-ui{top:10px;right:10px}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:95%}#onetrust-banner-sdk.ot-iab-2 #onetrust-group-container{width:100%}#onetrust-banner-sdk #onetrust-button-group-parent{width:100%;position:relative;margin-left:0}#onetrust-banner-sdk #onetrust-button-group button{display:inline-block}#onetrust-banner-sdk #onetrust-button-group{margin-right:0;text-align:center}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler{float:left}#onetrust-banner-sdk .has-reject-all-button #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-accept-btn-handler{float:right}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group{width:calc(100% - 2em);margin-right:0}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler.cookie-setting-link{padding-left:0px;text-align:left}#onetrust-banner-sdk.ot-buttons-fw .ot-sdk-three button{width:100%;text-align:center}#onetrust-banner-sdk.ot-buttons-fw #onetrust-button-group-parent button{float:none}#onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link{text-align:center}}@media only screen and (min-width: 550px){#onetrust-banner-sdk .banner-option:not(:first-child){border-left:1px solid #d8d8d8;padding-left:25px}}@media only screen and (min-width: 425px)and (max-width: 550px){#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group,#onetrust-banner-sdk.ot-iab-2 #onetrust-policy,#onetrust-banner-sdk.ot-iab-2 .banner-option{width:100%}}@media only screen and (min-width: 769px){#onetrust-banner-sdk #onetrust-button-group{margin-right:30%}#onetrust-banner-sdk #banner-options{margin-left:2em;margin-right:5em;margin-bottom:1.25em;width:calc(100% - 7em)}}@media only screen and (min-width: 897px)and (max-width: 1023px){#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:75%;transform:translateY(-50%)}#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;padding:0;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{position:relative;margin:0;right:-22px;top:2px}}@media only screen and (min-width: 1024px){#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{right:-12px}#onetrust-banner-sdk #onetrust-policy{margin-left:2em}#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:60%;transform:translateY(-50%)}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-title{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text,#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:1em;width:50%;border-right:1px solid #d8d8d8;padding-right:1rem}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-container{width:45%;padding-left:1rem;display:inline-block;float:none}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-title{line-height:1.7}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent{left:auto;right:4%;margin-left:0}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{margin:auto;width:30%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:60%}#onetrust-banner-sdk #onetrust-button-group{margin-right:auto}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{margin-top:1em}}@media only screen and (min-width: 890px){#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group-parent{padding-left:3%;padding-right:4%;margin-left:0}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group{margin-right:0;margin-top:1.25em;width:100%}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button{width:100%;margin-bottom:5px;margin-top:5px}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button:last-of-type{margin-bottom:20px}}@media only screen and (min-width: 1280px){#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:55%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{width:44%;padding-left:2%;padding-right:2%}#onetrust-banner-sdk:not(.ot-iab-2).vertical-align-content #onetrust-button-group-parent{position:absolute;left:55%}}
+#onetrust-consent-sdk #onetrust-banner-sdk {background-color: #E4F1EF;}
+#onetrust-consent-sdk #onetrust-policy-title,
+#onetrust-consent-sdk #onetrust-policy-text,
+#onetrust-consent-sdk .ot-b-addl-desc,
+#onetrust-consent-sdk .ot-dpd-desc,
+#onetrust-consent-sdk .ot-dpd-title,
+#onetrust-consent-sdk #onetrust-policy-text *:not(.onetrust-vendors-list-handler),
+#onetrust-consent-sdk .ot-dpd-desc *:not(.onetrust-vendors-list-handler),
+#onetrust-consent-sdk #onetrust-banner-sdk #banner-options *,
+#onetrust-banner-sdk .ot-cat-header {
+color: #000000;
+}
+#onetrust-consent-sdk #onetrust-banner-sdk .banner-option-details {
+background-color: #E9E9E9;}
+#onetrust-consent-sdk #onetrust-banner-sdk a[href],
+#onetrust-consent-sdk #onetrust-banner-sdk a[href] font,
+#onetrust-consent-sdk #onetrust-banner-sdk .ot-link-btn
+{
+color: #000000;
+}#onetrust-consent-sdk #onetrust-accept-btn-handler,
+#onetrust-banner-sdk #onetrust-reject-all-handler {
+background-color: #006646;border-color: #006646;
+color: #FFFFFF;
+}
+#onetrust-consent-sdk #onetrust-banner-sdk *:focus,
+#onetrust-consent-sdk #onetrust-banner-sdk:focus {
+outline-color: #000000;
+outline-width: 1px;
+}
+#onetrust-consent-sdk #onetrust-pc-btn-handler,
+#onetrust-consent-sdk #onetrust-pc-btn-handler.cookie-setting-link {
+color: #000000; border-color: #000000;
+background-color:
+#E4F1EF;
+} #onetrust-consent-sdk #onetrust-banner-sdk #onetrust-close-btn-container {
+top: 25px;
+right: 25px;
+}
+#onetrust-consent-sdk #onetrust-banner-sdk .onetrust-close-btn-ui {
+width: 12px;
+height: 12px;
+}
+#onetrust-banner-sdk #onetrust-policy-text a.ot-sdk-show-settings {
+margin-left: 0;
+}
+#onetrust-consent-sdk #onetrust-button-group {
+text-align: center;
+}
+@media only screen and (min-width: 425px) and (max-width: 550px) {
+#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent #onetrust-button-group {
+width: auto;
+}
+}
+@media only screen and (min-width: 426px) and (max-width: 896px) {
+#onetrust-consent-sdk #onetrust-banner-sdk .onetrust-close-btn-ui {
+top: 0;
+right: 0;
+}
+}
+@media (min-width: 896px) {
+#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns {
+left: auto;
+right: 4%;
+margin-left: 0;
+margin-top: 5%;
+}
+}
+@media only screen and (min-width: 769px) {
+#onetrust-banner-sdk #onetrust-button-group {
+margin-right: 0;
+}
+}
+@media only screen and (min-width: 1024px){
+#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent {
+margin-top: 5%;
+}
+}
+#onetrust-consent-sdk #onetrust-banner-sdk {
+display: none;
+}
+/* hides banner after it has already been interacted with */
+#onetrust-consent-sdk:not(.show-banner) #onetrust-banner-sdk {
+display: none;
+}</style>
+					
+					<script type="text/javascript" data-glb-js="top" src="/static/1.6.0/cache/eNqFU-1uwjAMfKFF3StsCO3XJIR4gXy4qWmadI4DKk-_BCZWIBSpilL77Nzl4iayZNTNID07aHQYxuDBc2ycnELiZh_zJ3QHun9rbsH7AjpNEU-QEcG3aO8hf38OVbyB11oFacBUEgfwJlAzBAPk8UTikqogdQg9Pja_I_GTgKbIhN5WeiRGh4xViq0XS2kThsX812b3XB53FLguiyBjEuxI6r5OesgboQhkPwbM5l0hOQd54-0RnHtObma7jtSel8oxY1IxqUpi9b2pRLe7z0qUi4wtq_UB5kxnYuSkYIGhNGcbk8fspIgusChv6nUFS7JQLkNE2YLDyNeaR7AduXYD0oI4IBwXTrM8nB-jQ90LfmLaDJ-fYtKcCEwZIs6xUh61yExeiyK0HQuS6F5jMY-oRwbxX1SGKWuipeLE3ftlXQWfYXXbCFqC2Enl4MPEX1cLpKo.min.js"></script>
+
+					
+					<script type="text/javascript">var Mntl = window.Mntl || {};window.Mntl = window.Mntl || {};
+window.Mntl.csrf = window.Mntl.csrf || window.Mntl.csrfInit('3730b9db8c61022102fa843c5968bd25', true);(function() {
+    Mntl.utilities.onLoad(function() {
+        var geolocationResponse = {};
+        const externalJS = {
+            src: '\//cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+            'data-domain-script': '709f4a38-08d7-4c5b-8c44-b12a39f035aa',
+            'data-ignore-ga': true,
+            'data-language': 'en',
+            async: true,
+            charset: 'UTF-8',
+            onerror: 'Mntl.CMP.onError()',
+            id: 'onetrust-script'
+        };
+        geolocationResponse.stateCode = 'FL';
+        geolocationResponse.countryCode = 'US';
+        geolocationResponse.regionCode = 'US';
+        if (Object.keys(geolocationResponse).length) {
+            window.OneTrust = window.OneTrust || {};
+            window.OneTrust.geolocationResponse = geolocationResponse;
         }
-        global.udl = new UniversalDataLayer({
-      "affiliate_link_count": 0,
-      "author": [],
-      "channel": "Healthy Recipes",
-      "category": "Healthy Casserole Recipes",
-      "cms_id": "7919044",
-      "sub_category": "Healthy Casserole Recipes",
-      "primary_image": "https://static.onecms.io/wp-content/uploads/sites/44/2021/08/16/cheesy-ground-beef-and-cauliflower-casserole.jpg",
-      "headline": "Cheesy Ground Beef & Cauliflower Casserole",
-      "post_or_index": "post",
-      "title": "cheesy ground beef & cauliflower casserole",
-      "last_updated_date": 1632421224,
-      "nlp_sentiment_label": "positive",
-      "nlp_sentiment_score": 0.1,
-      "nlp_sentiment_magnitude": 5.8,
-      "nlp_entities": "Cauliflower Casserole|weeknight casserole|Ground Beef",
-      "nlp_payload": "",
-      "nlp_categories": "/Food & Drink/Cooking & Recipes|/Food & Drink/Food",
-      "primary_purpose": "traffic-and-acquisition",
-      "publish_date": "2021-09-23T18:20:24Z",
-      "shown_on_platform": "own",
-      "syndicated": "do-not-syndicate",
-      "taxonomy_id": [
-        "11721",
-        "12449",
-        "12860",
-        "11865",
-        "13025",
-        "12979",
-        "13761",
-        "12019",
-        "12213",
-        "10688",
-        "16753",
-        "10054"
-      ],
-      "uuid": "2c0a4dd7-a77c-4388-91fd-a41e0b49e95e",
-      "content_graph_id": "cms/onecms_posts_etg_7919044",
-      "brand": "etg",
-      "path": "/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/",
-      "url": "https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/",
-      "content_type": "recipe",
-      "created_date": "2021-09-23T15:19:08Z",
-      "auth": {
-        "auth0_config": {
-          "domain": "accounts.eatingwell.com",
-          "clientId": "wARAmQRFGRiLu3hWFu3Z2fPBMY53tFwL",
-          "socialDomain": "accounts.eatingwell.com",
-          "socialClientId": "wARAmQRFGRiLu3hWFu3Z2fPBMY53tFwL",
-          "database": "ar-idp",
-          "customDomain": true
+        const preferenceCenterTrigger = document.querySelector('.ot-pref-trigger');
+        preferenceCenterTrigger.addEventListener('click', (e) => {
+            e.preventDefault();
+            Mntl.utilities.loadExternalJS(
+                externalJS
+            , () => {
+                Mntl.CMP.onSdkLoaded(() => {
+                    OneTrust.ToggleInfoDisplay();
+                })
+            });
         },
-        "default_regsource": "27629",
-        "brand_domain": "https://www.eatingwell.com",
-        "bypass_page_auth": false
-      }
+        { once: true });
     });
-      })(window) </script> <script> function getQueryParam(paramName) {
-        var query = window.location.search.substring(1);
-        var params = query.split('&');
-        for (var i = 0; i < params.length; i += 1) {
-          var pair = params[i].split('=');
-          if (pair[0] === paramName) {
-            return pair[1];
-          }
-        }
-        return false;
-      };
-      function removeURLParameter(url, param) {
-        var urlParts = url.split('?');
-        if (urlParts.length >= 2) {
-          var prefix = "".concat(encodeURIComponent(param), "=");
-          var params = urlParts[1].split(/[&;]/g);
-          for (var i = params.length - 1; i >= 0; i -= 1) {
-            if (params[i].lastIndexOf(prefix, 0) !== -1) {
-              params.splice(i, 1);
-            }
-          }
-          url = urlParts[0];
-          if (params.length > 0) {
-            url += "?".concat(params.join('&'));
-          }
-          return url;
-        }
-        return url;
-      };
-      function setCookie(cookieName, value, daysToExpire) {
-        var expires = '';
-        if (daysToExpire) {
-          var date = new Date();
-          date.setTime(date.getTime() + daysToExpire * 24 * 60 * 60 * 1000);
-          expires = "; expires=".concat(date.toGMTString());
-        }
-        if (expires !== '') {
-          document.cookie = "".concat(cookieName, "=").concat(value).concat(expires, "; path=/");
-        }
-        return true;
-      };
-      (function(){
-        var hid = getQueryParam('hid');
-        if (!hid) {
-          return;
-        }
-        setCookie('hid', hid, 90);
+    Mntl.CMP.init(true, 'ccpa', false, 3000);
+})();
+window.Mntl = window.Mntl || {};
+Mntl.RTB = Mntl.RTB || {};
+Mntl.RTB.setTaxonomyStampValues({"tax1":"etg_healthy-recipes","tax2":"etg_healthy-main-dish-recipes","tax0":"etg_homepage","tax3":"etg_healthy-casserole-recipes"});
+Mntl.RTB.setTimeoutLength([750,1250]);
+Mntl.RTB.Plugins.amazon.amazonConfigs = {"mapTaxValues":{"tax1":"etg_healthy-recipes","tax2":"etg_healthy-main-dish-recipes","si_section":"etg_healthy-main-dish-recipes","tax0":"etg_homepage","tax3":"etg_healthy-casserole-recipes"},"mapFBValues":{"adunitid":"mapFBID"},"amazonSlotName":false,"amazonSection":"Healthy Casserole Recipes"};
+Mntl.RTB.Plugins.prebid.setPriceGranularity({"buckets":[{"max":"20","increment":"0.05"},{"max":"100","increment":"0.5"}]});
+Mntl.RTB.initVideoBidders([{ type: 'amazon', id: '3446' }, { type: 'prebid', id: 'true' } ]);
+Mntl.RTB.initDisplayAndOutstreamBidders([{ type: "amazon", id: '3446'},{ type: "msg", id: 'true'},{ type: "ixid", id: 'true'},{ type: "prebid", id: 'true'}]);
+Mntl.RTB.Plugins.prebid.setConfig({"square-fixed\/tier1":[{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_square_fixed_tier1_300x250"}},{"bidder":"trustx","params":{"uid":"21950","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441206","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"443226","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060384","type":"display"}}],"leaderboardac\/tier3":[{"bidder":"ix","params":{"siteId":"443169","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier2_728x90"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21947","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060381","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441204","type":"display"}}],"leaderboard-fixed\/tier2":[{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_fixed_tier2_728x90"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441198","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060376","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"trustx","params":{"uid":"21942","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"443210","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}}],"leaderboard-fixed\/tier1":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441196","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"ix","params":{"siteId":"443209","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"trustx","params":{"uid":"21941","useNewFormat":true,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060375","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_fixed_tier1_728x90"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}}],"square-fixed\/tier2":[{"bidder":"ix","params":{"siteId":"443227","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441208","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21951","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_square_fixed_tier2_300x250"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060385","type":"display"}}],"leaderboardac\/tier2":[{"bidder":"ix","params":{"siteId":"443168","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"trustx","params":{"uid":"21944","useNewFormat":true,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060378","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441202","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier1_728x90"}}],"square-fixed\/tier3":[{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_square_fixed_tier3_300x250"}},{"bidder":"ix","params":{"siteId":"443228","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060386","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21952","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441210","type":"display"}}],"leaderboard-fixed\/tier3":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441200","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_fixed_tier3_728x90"}},{"bidder":"ix","params":{"siteId":"443211","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060377","type":"display"}},{"bidder":"trustx","params":{"uid":"21943","useNewFormat":true,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}}],"square-fixed\/tier4":[{"bidder":"ix","params":{"siteId":"443229","type":"display"}},{"bidder":"trustx","params":{"uid":"21953","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441212","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060387","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_square_fixed_tier4_300x250"}}],"preroll":[{"bidder":"ix","params":{"siteId":"829690","type":"instream"}},{"bidder":"trustx","params":{"uid":"351797","useNewFormat":true,"type":"instream"}},{"bidder":"appnexus","params":{"placementId":"25482194","type":"instream"}},{"bidder":"roundel","params":{"siteId":578566,"type":"instream"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441218","type":"instream"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"instream"}}],"leaderboardfooter-flex\/tier2":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441204","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"443169","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060381","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier2_728x90"}},{"bidder":"trustx","params":{"uid":"21947","useNewFormat":true,"type":"display"}}],"leaderboardfooter-flex\/tier1":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ix","params":{"siteId":"443168","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier1_728x90"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21944","useNewFormat":true,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060378","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441202","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"leaderboardfooter-flex\/tier4":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441204","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"443169","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060381","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier2_728x90"}},{"bidder":"trustx","params":{"uid":"21947","useNewFormat":true,"type":"display"}}],"leaderboardfooter-flex\/tier3":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier1_728x90"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21944","useNewFormat":true,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060378","type":"display"}},{"bidder":"ix","params":{"siteId":"443168","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441202","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"square-flex\/tier1":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060388","type":"display"}},{"bidder":"trustx","params":{"uid":"21954","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"443176","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_square_flex_tier1_300x250"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441214","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"square-flex\/tier2":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441216","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060392","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_square_flex_tier2_300x250"}},{"bidder":"trustx","params":{"uid":"21957","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"443175","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"leaderboard-flex\/tier2":[{"bidder":"ix","params":{"siteId":"443169","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441204","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060381","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21947","useNewFormat":true,"type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier2_728x90"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboard-flex\/tier1":[{"bidder":"ix","params":{"siteId":"443168","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426744","zoneId":"2441202","type":"display"}},{"bidder":"trustx","params":{"uid":"21944","useNewFormat":true,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060378","type":"display"}},{"bidder":"onemobile","params":{"dcn":"8a9698a4017a7ae782afe89dbff7003f","pos":"ew_leadrbrd_flex_tier1_728x90"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}]});
+Mntl.RTB.setLatencyBuffer(0);
+(function(){
+const pageTargeting = {
+customSeries: ''
+,tax0: 'EatingWell'
+,rid: 'n0d67930b103440e6811a95e3ef3c23a218'
+,custom: ''
+,sid: 'nf77991515d454c899d99b480b3173c5117'
+}
+;
+const baseSlotTargeting = {
+leaid: '1017375'
+,docId: '7165416'
+,viewtype: ''
+,type: 'recipe'
+,ptax: 'etg_healthy-main-dish-recipes'
+,vid: '1'
+,tax1: 'etg_healthy-recipes'
+,tax2: 'etg_healthy-main-dish-recipes'
+,tier: 'L'
+,leuid: '153546959002053'
+,id: '7165416'
+,tax3: 'etg_healthy-casserole-recipes'
+,tax4: ''
+,inf: '0'
+,entryType: 'direct'
+,gtemplate: 'recipe'
+,revenueGroup: ''
+,chpg: '1'
+,t: '120'
+,au: '1017375'
+,jny: '0'
+,sbj: ''
+,aid: ''
+,jnyroot: ''
+}
+;
+pageTargeting.mtax = ['12373','16752','11184','16751','12550','13042','12979','25281','10439','11807','10054','13761','12213','13025','16753','11865','12019','11721','11270','12384','11252','11053','12449','11870','11595','16426','11132','11374','12860','11871','12425','10688','11710'];
+pageTargeting.sentiment = 'neutral';
+pageTargeting.concepts = ['Cauliflower Casserole','weeknight casserole','Ground Beef','cauliflower','kids','tortilla chips','sour cream','adults','casserole','tomatoes'];
+pageTargeting.taxons = '\/Food & Drink/Cooking & Recipes'.split(/\/|\|/).filter((n) => n),
+pageTargeting.w = Mntl.utilities.getW();
+const initialSlots = [];
+initialSlots.push({
+config: {
+id: 'oop',
+sizes: [[1, 1]],
+type: 'outofpage',
+rtb: false,
+timedRefresh: 0,
+waitForThirdParty: true
+},
+targeting: Mntl.fnUtilities.deepExtend({}, {
+pos: 'atf',
+priority: 0
+,floor_id: 'f941fb56a16a440c933d5c11223730cb'
+,floor: '5'
+})
+});
+initialSlots.push({
+config: {
+id: 'square-flex-1',
+sizes: [[300, 250],[299, 251],[300, 600],[300, 1050],[160, 600]],
+type: 'billboard',
+rtb: true,
+timedRefresh: 0,
+waitForThirdParty: false
+},
+targeting: Mntl.fnUtilities.deepExtend({}, {
+pos: 'atf',
+priority: 2
+,floor_id: '33fd2fbc784c42b5b2793c2129b70c59'
+,floor: '75'
+})
+});
+initialSlots.push({
+config: {
+id: 'leaderboard-fixed-0',
+sizes: [[728, 90]],
+type: 'leaderboard',
+rtb: true,
+timedRefresh: 30000,
+waitForThirdParty: false
+},
+targeting: Mntl.fnUtilities.deepExtend({}, {
+pos: 'atf',
+priority: 99
+,floor_id: 'defd075479484e9b8cc95dcfe7876b91'
+,floor: '60'
+})
+});
+const testIds = Mntl.GPT.getTestIds();
+pageTargeting.ab = testIds;
+pageTargeting.bts = testIds;
+Mntl.utilities.onLoad(function() {
+Mntl.utilities.loadExternalJS({
+src: '//securepubads.g.doubleclick.net/tag/js/gpt.js',
+async: false
+});
+});
+const options = {
+domain: 'www.eatingwell.com',
+templateName: 'recipesc',
+isMobile: false,
+dfpId: '3865',
+publisherProvidedId: '4b63c4fc-c0aa-4388-acfc-3011ea0a5703',
+singleRequest: false,
+useLmdFormat: true,
+useOxygen: true,
+useInfiniteRightRail: true,
+useAuctionFloorSearch: false,
+bundlePrebid: false,
+lmdSiteCode: 'hlt',
+pageTargeting,
+baseSlotTargeting,
+geo: {
+isInEurope: false,
+isInUsa: true
+},
+initialSlots,
+utils: {
+generateSlotId: Eatingwell.GPT.generateSlotId
+},
+displayOnScroll: false,
+displayOnConsent: true
+};
+if (Mntl.AdMetrics) {
+Mntl.AdMetrics.init("7165416", "n0d67930b103440e6811a95e3ef3c23a218", initialSlots.map(slot => slot.config.id), Date.now());
+} else {
+Mntl.AdMetrics = { pushMetrics: () => {} };
+}
+Mntl.GPT.init(options);
+}());// moved from gtm.ftl so we can initialize GTM only onLoad. From https://support.google.com/tagmanager/answer/6103696?hl=en
+Mntl.utilities.onLoad(function() {
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;defer=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-P3X3VT7');
+});
+var dataLayer = dataLayer || [];
+dataLayer.push({
+event: 'ab-proctor',
+'abTests-proctor': {
+"99-0"
+: "rtbTracking | control | | 0"
+,
+"99-1"
+: "useOxygen | useOxygen | use the Oxygenated ad unit format and slot names | 1"
+,
+"56"
+: "pushly | control | pushly disabled | 0"
+,
+"99-3"
+: "vanillaJWPlayer | active | | 1"
+,
+"99-4"
+: "jumpToRecipe | active | Hide Jump to Recipe Button | 1"
+,
+"99-5"
+: "useRTBforVideoAds | active | | 1"
+}
+});
+dataLayer.push({
+envData: {
+environment: {
+environment: "k8s-prod",
+application: "eatingwell",
+dataCenter: "us-west-1"
+},
+server: {
+version: "1.6.0",
+title: "eatingwell-launcher"
+},
+client : {
+browserUA: navigator.userAgent,
+serverUA: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
+deviceType: "pc",
+usStateCode: "FL"
+},
+mantle: "3.14.56",
+commerce: ""
+}
+});
+(function(win, fnUtils, CMP) {
+var pageViewDataAsJSON = {"country":"US","description":"This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream.","authorId":"1017375","documentId":7165416,"muid":"4b63c4fc-c0aa-4388-acfc-3011ea0a5703","templateName":"RECIPESC","contentGroup":"Other","revenueGroup":"","title":"Cheesy Ground Beef & Cauliflower Casserole" || document.title || '',"lastEditingAuthorId":"1017375","lastEditingUserId":"153546959002053","templateId":"120","viewType":"","fullUrl":"https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"internalSessionId":"nf77991515d454c899d99b480b3173c5117","internalRequestId":"n0d67930b103440e6811a95e3ef3c23a218","hid":"","experienceTypeName":"","recircDocIdsFooter":"S-7159848|S-7160204|S-7156105|S-7154068|S-7159526|S-7155130|S-7165852|S-7162604","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"3.14.56","commerceVersion":"","primaryTaxonomyIds":"6744898|7186545|7186551|7186481","primaryTaxonomyNames":"EatingWell|Healthy Recipes|Healthy Main Dish Recipes|Healthy Casserole Recipes"};
+var deferLoadTime = 5000;
+var readyForThirdPartyTrackingEvent = new CustomEvent('readyForThirdPartyTracking', { bubbles: true });
+var readyForThirdPartyTracking = fnUtils.once(function() {
+dataLayer.push({event: 'readyForThirdPartyTracking'});
+window.dispatchEvent(readyForThirdPartyTrackingEvent);
+});
+var readyForDeferredScriptsEvent = new CustomEvent('readyForDeferredScripts', { bubbles: true });
+var readyForDeferredScripts = fnUtils.once(function() {
+dataLayer.push({event: 'readyForDeferredScripts'});
+window.dispatchEvent(readyForDeferredScriptsEvent);
+});
+var hasTargetingConsentHandler = function() {
+const hasConsent = CMP.hasTargetingConsent();
+if (hasConsent) {
+readyForThirdPartyTracking();
+}
+// if there is consent or the user has closed the banner(AlertBox) in EU then trigger readyForDeferredScripts
+if (hasConsent || CMP.isAlertBoxClosed()) {
+readyForDeferredScripts();
+}
+return hasConsent;
+};
+var onRequiredDomEvent = fnUtils.once(function() {
+if (!CMP) {
+readyForThirdPartyTracking();
+readyForDeferredScripts();
+return;
+}
+if (!CMP.isLoading()) {
+hasTargetingConsentHandler();
+}
+CMP.onConsentChange(hasTargetingConsentHandler);
+});
+[
+['adRendered', onRequiredDomEvent],
+['beforeunload', onRequiredDomEvent],
+['load', function() { setTimeout(onRequiredDomEvent, deferLoadTime); }]
+].forEach(function(event) {
+win.addEventListener(event[0], event[1], { once: true });
+});
+pageViewDataAsJSON.breakpointName = Eatingwell.utilities.getW();
+pageViewDataAsJSON.bounceExchangeId = '2548';
+pageViewDataAsJSON.descriptiveTaxonomy = '12373,16752,11184,16751,12550,13042,12979,25281,10439,11807,10054,13761,12213,13025,16753,11865,12019,11721,11270,12384,11252,11053,12449,11870,11595,16426,11132,11374,12860,11871,12425,10688,11710';
+Mntl.utilities.onLoad(function() {
+Mntl.PageView.init(pageViewDataAsJSON);
+});
+})(window || {}, Mntl.fnUtilities || {}, Mntl.CMP);</script>
+					
+					<link rel="shortcut icon" href="/favicon.ico">
+<link rel="icon" type="image/x-icon" href="/favicon.ico">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon-precomposed" sizes="60x60" href="/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon-precomposed" sizes="76x76" href="/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon-precomposed" sizes="120x120" href="/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon-precomposed" sizes="152x152" href="/apple-touch-icon-152x152.png">
+<link rel="apple-touch-icon-precomposed" sizes="180x180" href="/apple-touch-icon-180x180.png">
 
-        // Set hid to server on Hermes for 90 days
-        const request = new XMLHttpRequest();
-        request.withCredentials = true;
-        const url = '/hermes/?keys=hid&max-age=90';
-        request.open('GET', url, true);
-        request.send();
+<meta name="msapplication-TileColor" content="#F4F4F4"/>
+<meta name="msapplication-TileImage" content="/static/1.6.0/icons/favicons/mstile-144x144.png">
+<meta name="msapplication-square70x70logo" content="/static/1.6.0/icons/favicons/mstile-70x70.png">
+<meta name="msapplication-square150x150logo" content="/static/1.6.0/icons/favicons/mstile-150x150.png">
+<meta name="msapplication-square310x310logo" content="/static/1.6.0/icons/favicons/mstile-310x310.png">
+<meta name="msapplication-wide310x150logo" content="/static/1.6.0/icons/favicons/mstile-310x150.png">
 
-        window.location.replace(removeURLParameter(window.location.href, 'hid'));
-      })(); </script> <script> window.mdp = window.mdp || {};
-      window.mdp.getCookieValue = function getCookieValue(name) {
-        var cookie = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
-        return cookie ? decodeURIComponent(cookie.pop()) : '';
-      } </script><script id="karma-loader">function loadKarma(w,d){
-      const isMobile = !!window.navigator.userAgent.match(/Mobi/) && !window.navigator.userAgent.match(/iPad/);
-      w.karma = window.karma || {};
-      w.karma.config = {
-        apiVersion: 3,
-        bypassDOMReady: false,
-        isMobile: isMobile,
-        site: 'ew.mdp.' + (isMobile ? 'mob' : 'com'),
-        targeting: {
-          channel: "HealthyRecipes",
-          sch: "",
-          ctype: null,
-          tags: [],
-          id: "2c0a4dd7-a77c-4388-91fd-a41e0b49e95e",
-          r: "7919044",
-          type: "recipe",
-          parent: "healthy_main_dish_recipes",
-          child: "healthy_casserole_recipes",
-          abTest: "mdextest",
-          collapseall: (window.mdpKarmaNoAds ? true : ''),
-        },
-      };
-      w.karma.gaAdBlockReportData = {
-        contentChannel: udl.get('channel'),
-        contentCmsCategory: udl.get('category'),
-        contentCmsId: udl.get('cms_id'),
-        contentGraphId: udl.get('content_graph_id'),
-        referrer: d.referrer || null,
-        search: location.search || null, // eslint-disable-line no-restricted-globals
-        url: d.location.href,
-        path: w.location.pathname,
-        fullurl: udl.get('url'),
-      };
-      window.karma.config.callback = window.karma.config.callback || [];
-      function r(){if(null===d.querySelector('img[src$="/kismet/spacer.png"]')){const e=d.createElement("img");e.src="/kismet/spacer.png",d.head.appendChild(e);if(w.analytics){analytics.track('Ad Blocker Detected', w.karma.gaAdBlockReportData);}const s=document.createElement('script');s.src="/moksa/js-min/moksa.js";s.async=true;d.head.appendChild(s);
-      }}w.karma.cmd=w.karma.cmd||[],w.karma.config.go=function(){w.karma.cmd.push("go")};const n=d.createElement("script");n.src="https://karma.mdpcdn.com/service/js-min/karma.js",n.async=false,n.onload=n.onreadystatechange=function(){const e=this.readyState;e&&"complete"!=e&&"loaded"!=e&&r()},n.onerror=r;document.head.appendChild(n);};loadKarma(window,document);</script><script defer="defer" src="/dist/main.js"></script><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" crossorigin><script>!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.async=!1;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";document.head.appendChild(e)};analytics.SNIPPET_VERSION="4.0.0";analytics.load('BSQ3jJmPdZb0oZHrcrfMei2vGkpY4TyL');}}();</script><script>window.ELEMENT_CLIENT_CONFIG = {
-      brand_public_folder:null}; </script><script> var _sf_async_config = _sf_async_config || {};
-        /** CONFIGURATION START **/
-        _sf_async_config.uid = 63768;
-        _sf_async_config.domain = 'eatingwell.com';
-        _sf_async_config.flickerControl = false;
-        _sf_async_config.useCanonical = true;
-        _sf_async_config.useCanonicalDomain = true;
-        /** CONFIGURATION END **/ </script> <script async src="//static.chartbeat.com/js/chartbeat_mab.js"></script><script id="auth0config" data-client-id="wARAmQRFGRiLu3hWFu3Z2fPBMY53tFwL" data-domain="accounts.eatingwell.com" data-social-client-id="wARAmQRFGRiLu3hWFu3Z2fPBMY53tFwL" data-social-domain="accounts.eatingwell.com" data-regsource="27629" data-nonce="randomStrings" data-state="qwerty" data-brand-domain="https://www.eatingwell.com"></script> <link rel="stylesheet" href="/dist/fontWoff2.css" as="style" crossorigin> <link rel="stylesheet" type="text/css" href="/dist/style.css"> <script> var linkElement = document.querySelector("link[href='/dist/style.css']");
-        linkElement.onload = function(){
-      var evt = new Event('global:blocking-css-loaded');window.dispatchEvent(evt);};</script> <link rel="stylesheet" type="text/css" media="print" href="/dist/print.css"> </head> <body class="template-recipe node- mdex-test karma-site-container etg no-js" data-content-graph-id="cms/onecms_posts_etg_7919044" data-uuid="2c0a4dd7-a77c-4388-91fd-a41e0b49e95e" data-current-env="production" data-add-slash="true" data-caas-sitename="etg" data-element-login-registration="true" data-recommendations-proximity-url="https://recommendation.meredith.services/v2/Proximity" data-recommendations-aggregates-url="https://recommendation.meredith.services/v2/Aggregates" data-recommendations-contains-url="https://recommendation.meredith.services/v2/Contains" data-search-api-url="https://search.meredith.services/v2/search" data-faceted-search-api-url="" data-dynamic-nav-id="cms/onecms_posts_etg_explore" data-content-router-site="www.eatingwell.com" data-content-type="recipe"> <header class="component navigation-test"><a class="skipLink elementFont__button skipLink--skipNav" href="#main-content">Skip to content</a> <div class="component adhesion-ad mobile-ad"><div class="adhesion-ad-container"> <div id="div-gpt-mob-adhesive-banner-fixed" data-tier="1" class="ad ad-container ad-wrapper type-320-flex mobile-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> </div></div> <div class="ad-wrapper outer tablet-ad desktop-ad full-column karma-leaderboard-docking-element"><div class="ad-sticky-container desktop-ad tablet-ad karma-ad"><div id="div-gpt-leaderboard-flex-1" data-tier="1" class="ad ad-container ad-wrapper type-banner type-970x90-flex margin-16-tb desktop-ad tablet-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div></div> </div> <nav aria-label="Top" data-tracking-zone="nav-bar" class="main-new new-navigation karma-below-banner no-secondary-ribbon no-utility-ribbon"> <h2 id="top-nav-heading" class="sr-heading">Top Navigation</h2> <div class="container primary"><div class="subcontainer"> <button class="menu" aria-label="Explore EatingWell"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path d="M3 6h18v2.016H3V6zm0 6.984v-1.969h18v1.969H3zM3 18v-2.016h18V18H3z"/></svg> <span class="menu-explore elementFont__details--navigation" aria-hidden="true">Explore</span> </button> <div class="logo"> <a class="full-logo mobile-only" data-action="primary-nav-logo" data-tracking-label="brand logo" href="/"><span class="svg-label">EatingWell</span> <span class="svg-logo" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="215" height="64" viewBox="0 0 215 64"><defs><path id="eating-well-logo-a" d="M0 63.847h214.497V0H0z"/></defs><g fill="none" fill-rule="evenodd"><path fill="#639A3A" d="M61.203 9.883a3.707 3.707 0 1 0 7.413 0 3.707 3.707 0 0 0-7.413 0z"/><mask id="eating-well-logo-b" fill="#fff"><use xlink:href="#eating-well-logo-a"/></mask><path fill="#639A3A" d="M188.897 52.697h6.502V.387h-6.502zm11.129.047h6.5V.434h-6.5z" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.01 48.097c-1.323 0-2.331 1.008-2.331 2.332 0 1.324 1.008 2.332 2.332 2.332 1.324 0 2.332-1.008 2.332-2.332 0-1.387-1.008-2.332-2.332-2.332m.01 4.296c-1.135 0-1.954-.82-1.954-1.954 0-1.135.82-1.954 1.954-1.954s1.954.82 1.954 1.954-.82 1.954-1.954 1.954" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.956 50.05c0-.503-.378-.755-.819-.755h-1.072v2.269h.505v-.82h.252l.693.82h.567V51.5l-.693-.694c.315-.189.567-.378.567-.756m-.819.315h-.504v-.693h.504c.19 0 .378.126.378.378-.063.189-.189.315-.378.315" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" d="M113.13 39.451c-.064-.001-.124-.008-.187-.008.063-.034.124-.027.186.008m-2.93-1.58c-2.974 0-5.804-2.757-5.804-8.996 0-5.441 2.395-8.851 5.803-8.851 3.556 0 5.879 3.41 5.879 8.923 0 5.441-2.25 8.924-5.879 8.924m-4.797 1.287c.02-.033.046-.042.085-.021l-.085.021m11.698.965c3.314-1.838 5.423-5.764 5.423-10.668 0-3.984-1.333-7.306-3.265-9.308 2.519.182 4.267-.396 4.267-.396l-1.118-4.748s-1.91.45-4.608.45c-2.792 0-4.933-.653-7.6-.653-7.775 0-11.94 5.25-11.94 13.371 0 5.048 1.891 9.569 5.261 11.714-1.6.855-3.161 2.205-4.097 3.203l3.667 4.07c1.57-1.714 4.362-3.553 7.994-3.553 4.468 0 7.878 3.048 7.878 7.471 0 4.608-3.69 7.122-8.437 7.122-5.492 0-9.328-3.742-9.328-3.742l-3.739 4.02c2.85 3.003 7.761 5.371 13.283 5.371 7.93 0 14.365-4.533 14.365-12.26 0-5.619-3.305-9.88-8.006-11.464M30.4 48.151c-2.649 0-4.977-2.01-4.977-8.104 0-5.168 1.71-8.103 4.839-8.103 3.41 0 5.513 3.377 5.513 8.031 0 4.172-2.375 8.176-5.376 8.176m13.508-.984c-1.396-.28-2.19-1.071-2.19-3.491V27.859c0-9.926-3.462-13.422-11.23-13.422-4.672 0-8.138 1.98-8.138 1.98l.107 5.312s3.712-1.756 7.061-1.756c4.507 0 6.258 2.99 6.258 7.088v2.756c-1.523-2.248-4.23-3.046-6.696-3.046-5.659 0-10.157 4.498-10.157 13.204 0 8.851 4.883 13.566 10.397 13.566 2.283 0 5.396-1.25 7.478-4.643.5 2.109 2.066 4.134 5.993 4.134 2.164 0 3.328-.35 3.328-.35v-5.47s-.814.234-2.211-.045M54.22 7.958l-6.502 2.039v5.456h-3.982v5.993h3.982v22.157c0 6.746 2.874 9.503 8.532 9.503.871 0 1.379-.073 2.25-.362V47.28c-.508.145-.726.145-1.161.145-2.612 0-3.12-.798-3.12-4.498V21.446h4.28v-5.993h-4.28V7.958m7.451 44.786h6.5V15.453h-6.5zm24.877-38.307c-2.55 0-5.777 1.357-8.002 4.896v-3.88h-5.97v37.29h6.5V28.7c0-4.28 3.4-8.56 6.49-8.56 2.56 0 3.333 1.852 3.333 5.03v27.574h6.5v-27.86c0-3.627-.798-5.949-2.321-7.69-1.524-1.814-3.918-2.757-6.53-2.757M159.177.435l-7.028 34.277L145.99 0h-5.066l-6.24 34.687-7.24-34.252h-6.573l12.045 52.889h3.858l6.701-36.209 6.52 36.209h3.931L165.968.434zm15.369 19.392c3.202 0 4.818 3.446 4.818 10.716h-10.215c0-7.402 2.385-10.716 5.397-10.716m.592 27.961c-3.731 0-6.232-4.06-6.232-10.283 0-.926-.005-1.29-.005-1.508l16.49-.007c.072-2.22.11-2.907.11-4.068 0-10.834-3.213-17.485-10.955-17.485-7.948 0-11.825 7.247-11.825 19.734 0 12.536 5.043 19.37 12.234 19.37 4.958 0 8.524-3.061 10.618-8.364l-4.61-2.64c-1.523 2.978-3.046 5.251-5.825 5.251M0 52.744h18.271v-6.427H6.646v-17.37h10.04v-6.428H6.647V6.863H18.41V.435H0z" mask="url(#eating-well-logo-b)"/></g></svg> </span> </a> <a class="full-logo desktop-only" href="/" data-action="primary-nav-logo" data-tracking-label="brand logo"><span class="svg-label">EatingWell</span> <span class="svg-logo" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="215" height="64" viewBox="0 0 215 64"><defs><path id="eating-well-logo-a" d="M0 63.847h214.497V0H0z"/></defs><g fill="none" fill-rule="evenodd"><path fill="#639A3A" d="M61.203 9.883a3.707 3.707 0 1 0 7.413 0 3.707 3.707 0 0 0-7.413 0z"/><mask id="eating-well-logo-b" fill="#fff"><use xlink:href="#eating-well-logo-a"/></mask><path fill="#639A3A" d="M188.897 52.697h6.502V.387h-6.502zm11.129.047h6.5V.434h-6.5z" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.01 48.097c-1.323 0-2.331 1.008-2.331 2.332 0 1.324 1.008 2.332 2.332 2.332 1.324 0 2.332-1.008 2.332-2.332 0-1.387-1.008-2.332-2.332-2.332m.01 4.296c-1.135 0-1.954-.82-1.954-1.954 0-1.135.82-1.954 1.954-1.954s1.954.82 1.954 1.954-.82 1.954-1.954 1.954" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.956 50.05c0-.503-.378-.755-.819-.755h-1.072v2.269h.505v-.82h.252l.693.82h.567V51.5l-.693-.694c.315-.189.567-.378.567-.756m-.819.315h-.504v-.693h.504c.19 0 .378.126.378.378-.063.189-.189.315-.378.315" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" d="M113.13 39.451c-.064-.001-.124-.008-.187-.008.063-.034.124-.027.186.008m-2.93-1.58c-2.974 0-5.804-2.757-5.804-8.996 0-5.441 2.395-8.851 5.803-8.851 3.556 0 5.879 3.41 5.879 8.923 0 5.441-2.25 8.924-5.879 8.924m-4.797 1.287c.02-.033.046-.042.085-.021l-.085.021m11.698.965c3.314-1.838 5.423-5.764 5.423-10.668 0-3.984-1.333-7.306-3.265-9.308 2.519.182 4.267-.396 4.267-.396l-1.118-4.748s-1.91.45-4.608.45c-2.792 0-4.933-.653-7.6-.653-7.775 0-11.94 5.25-11.94 13.371 0 5.048 1.891 9.569 5.261 11.714-1.6.855-3.161 2.205-4.097 3.203l3.667 4.07c1.57-1.714 4.362-3.553 7.994-3.553 4.468 0 7.878 3.048 7.878 7.471 0 4.608-3.69 7.122-8.437 7.122-5.492 0-9.328-3.742-9.328-3.742l-3.739 4.02c2.85 3.003 7.761 5.371 13.283 5.371 7.93 0 14.365-4.533 14.365-12.26 0-5.619-3.305-9.88-8.006-11.464M30.4 48.151c-2.649 0-4.977-2.01-4.977-8.104 0-5.168 1.71-8.103 4.839-8.103 3.41 0 5.513 3.377 5.513 8.031 0 4.172-2.375 8.176-5.376 8.176m13.508-.984c-1.396-.28-2.19-1.071-2.19-3.491V27.859c0-9.926-3.462-13.422-11.23-13.422-4.672 0-8.138 1.98-8.138 1.98l.107 5.312s3.712-1.756 7.061-1.756c4.507 0 6.258 2.99 6.258 7.088v2.756c-1.523-2.248-4.23-3.046-6.696-3.046-5.659 0-10.157 4.498-10.157 13.204 0 8.851 4.883 13.566 10.397 13.566 2.283 0 5.396-1.25 7.478-4.643.5 2.109 2.066 4.134 5.993 4.134 2.164 0 3.328-.35 3.328-.35v-5.47s-.814.234-2.211-.045M54.22 7.958l-6.502 2.039v5.456h-3.982v5.993h3.982v22.157c0 6.746 2.874 9.503 8.532 9.503.871 0 1.379-.073 2.25-.362V47.28c-.508.145-.726.145-1.161.145-2.612 0-3.12-.798-3.12-4.498V21.446h4.28v-5.993h-4.28V7.958m7.451 44.786h6.5V15.453h-6.5zm24.877-38.307c-2.55 0-5.777 1.357-8.002 4.896v-3.88h-5.97v37.29h6.5V28.7c0-4.28 3.4-8.56 6.49-8.56 2.56 0 3.333 1.852 3.333 5.03v27.574h6.5v-27.86c0-3.627-.798-5.949-2.321-7.69-1.524-1.814-3.918-2.757-6.53-2.757M159.177.435l-7.028 34.277L145.99 0h-5.066l-6.24 34.687-7.24-34.252h-6.573l12.045 52.889h3.858l6.701-36.209 6.52 36.209h3.931L165.968.434zm15.369 19.392c3.202 0 4.818 3.446 4.818 10.716h-10.215c0-7.402 2.385-10.716 5.397-10.716m.592 27.961c-3.731 0-6.232-4.06-6.232-10.283 0-.926-.005-1.29-.005-1.508l16.49-.007c.072-2.22.11-2.907.11-4.068 0-10.834-3.213-17.485-10.955-17.485-7.948 0-11.825 7.247-11.825 19.734 0 12.536 5.043 19.37 12.234 19.37 4.958 0 8.524-3.061 10.618-8.364l-4.61-2.64c-1.523 2.978-3.046 5.251-5.825 5.251M0 52.744h18.271v-6.427H6.646v-17.37h10.04v-6.428H6.647V6.863H18.41V.435H0z" mask="url(#eating-well-logo-b)"/></g></svg> </span> </a></div><div class="primary-links desktop-only"> <ul class="primary-text-links elementFont__resetList"> <li data-nav-pos="pos-1" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-1" href="#">Healthy Recipes</a></li> <li data-nav-pos="pos-2" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-2" href="#">Special Diets</a></li> <li data-nav-pos="pos-3" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-3" href="#">Diabetes</a></li> <li data-nav-pos="pos-4" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-4" href="#">Healthy Meal Plans</a></li> <li data-nav-pos="pos-5" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-5" href="#">Healthy Eating</a></li> <li data-nav-pos="pos-6" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-6" href="#">Healthy Lifestyle</a></li> <li data-nav-pos="pos-7" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-7" href="#">Healthy Cooking</a></li> <li data-nav-pos="pos-8" class="header-primary-links heading-list menu-list-item has-submenu"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" aria-controls="submenu-8" href="#">Shop</a></li> <li data-nav-pos="pos-9" class="header-primary-links heading-list menu-list-item"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" href="https://www.eatingwell.com/category/4328/news/">News</a></li> <li data-nav-pos="pos-10" class="header-primary-links heading-list menu-list-item"> <a class="elementFont__button elementButton__defaultFocus--noOffset elementFont__resetLink--hover" href="https://www.eatingwell.com/category/videos/">Videos</a></li> </ul></div> <div class="auth-icons mobile-only"> <a href="https://www.eatingwell.com/account/signup?regSource=27629" class="logged-out profile-image-container"> <img alt="Log In" class="profile-img" src="/img/profile.png"> </a> <a href="https://www.eatingwell.com/profile/my/profile-settings/" class="logged-in profile-image-container"> <img alt="Account Details" class="profile-img" src="/img/profile.png"> </a> </div> <div class="menu-search"> <div class="buttons"> <button class="icon search js-activate" aria-label="Open search box" data-action="nav-close-search"> <span class="icon icon-search utility-icon color-navigation"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg></span> </button><div class="component site-search search-container"> <form class="header-search-form" method="GET" data-tracking-zone="search-form" action="/search/"><label class="hidden-label" for="search-a">Search</label> <input type="text" class="search-field" value="" id="search-a" name="q" placeholder="Search EatingWell" aria-label="Search"> </form> <button class="icon close close-search" aria-label="Close search box" data-action="nav-close-search"><span class="svg-label">Close</span><span class="icon icon-close utility-icon color-navigation"><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></span> </button></div> </div> <section class="container secondary-links secondary-menu"> <h2 class="sr-heading">Profile Menu</h2> <div class="secondary-text-links"> <div data-action="secondary-nav-pos-1" class="heading-menu menu-list-item secondary-item has-submenu logged-out euDisabled"> <button data-tracking-label="join now" class="menu-link elementFont__details--navigation elementFont__resetLink expand-trigger has-auth" aria-expanded="false"> <span class="profile-image-container logged-out"><img alt="Log In" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="profile-image-container logged-in"><img alt="Account Details" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="secondary-menu-label">Join Now</span><span class="icon desktop-only"><span class="icon icon-down-triangle utility-icon color-gray-6"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 255 255"><path d="M0 63.75l127.5 127.5L255 63.75z"/></svg></span> </span> <span class="icon accordion-arrow mobile-only"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span> </button><div class="submenu-children-wrapper"><div class="sub-menu-header"> <button aria-label="Close" class="icon back-button mobile-only"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <span class="main-channel mobile-only elementFont__subhead">Join Now</span></div> <div class="dropdown-links-list"><h3 class="sub-menu__heading-label elementFont__details--navigation">Account</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu euDisabled logged-out join-now"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signup?regSource&#x3D;27688&amp;returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="join now > join now">Join Now</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/profile/my/profile-settings/" data-tracking-label="join now > my profile">My Profile</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://secure.eatingwell.com/common/profile/member/optout/" data-tracking-label="join now > email preferences">Email Preferences</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/profile/my/" data-tracking-label="join now > favorites">Favorites</a> </li> <li class="menu-item heading-menu logged-out"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://x.specialoffers.meredith.com/ats/show.aspx?cr&#x3D;588&amp;fm&#x3D;301&amp;regSource&#x3D;27538" data-tracking-label="join now > newsletters">Newsletters</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code&#x3D;ETG" target="_blank" data-tracking-label="join now > manage your subscription">Manage Your Subscription<span class="hidden-label"> this link opens in a new tab</span></a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/article/290690/customer-service/" data-tracking-label="join now > help">Help</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signout?successPage=https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="join now > logout">Logout</a> </li> </ul><hr class="secondary-nav-divider desktop-only"><h3 class="sub-menu__heading-label elementFont__details--navigation">More</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.magazine.store/eatingwell/" data-tracking-label="join now > give a gift subscription">Give a Gift Subscription</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://learn.cookinglightdiet.com/?utm_source&#x3D;un_display_etg_b907etr1b204" data-tracking-label="join now > cooking light diet">Cooking Light Diet</a> </li> </ul></div></div></div> <div data-action="secondary-nav-pos-2" class="heading-menu menu-list-item secondary-item has-submenu logged-in euDisabled"> <button data-tracking-label="your account" class="menu-link elementFont__details--navigation elementFont__resetLink expand-trigger has-auth" aria-expanded="false"> <span class="profile-image-container logged-out"><img alt="Log In" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="profile-image-container logged-in"><img alt="Account Details" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="secondary-menu-label">Your Account</span><span class="icon desktop-only"><span class="icon icon-down-triangle utility-icon color-gray-6"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 255 255"><path d="M0 63.75l127.5 127.5L255 63.75z"/></svg></span> </span> <span class="icon accordion-arrow mobile-only"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span> </button><div class="submenu-children-wrapper"><div class="sub-menu-header"> <button aria-label="Close" class="icon back-button mobile-only"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <span class="main-channel mobile-only elementFont__subhead">Your Account</span></div> <div class="dropdown-links-list"><h3 class="sub-menu__heading-label elementFont__details--navigation">Account</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu euDisabled logged-out join-now"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signup?regSource&#x3D;27688&amp;returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="your account > join now">Join Now</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/profile/my/profile-settings/" data-tracking-label="your account > my profile">My Profile</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://secure.eatingwell.com/common/profile/member/optout/" data-tracking-label="your account > email preferences">Email Preferences</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/profile/my/" data-tracking-label="your account > favorites">Favorites</a> </li> <li class="menu-item heading-menu logged-out"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://x.specialoffers.meredith.com/ats/show.aspx?cr&#x3D;588&amp;fm&#x3D;301&amp;regSource&#x3D;27538" data-tracking-label="your account > newsletters">Newsletters</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code&#x3D;ETG" target="_blank" data-tracking-label="your account > manage your subscription">Manage Your Subscription<span class="hidden-label"> this link opens in a new tab</span></a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/article/290690/customer-service/" data-tracking-label="your account > help">Help</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signout?successPage=https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="your account > logout">Logout</a> </li> </ul><hr class="secondary-nav-divider desktop-only"><h3 class="sub-menu__heading-label elementFont__details--navigation">More</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.magazine.store/eatingwell/" data-tracking-label="your account > give a gift subscription">Give a Gift Subscription</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://learn.cookinglightdiet.com/?utm_source&#x3D;un_display_etg_b907etr1b204" data-tracking-label="your account > cooking light diet">Cooking Light Diet</a> </li> </ul></div></div></div> <div data-action="secondary-nav-pos-3" class="heading-menu menu-list-item secondary-item logged-out euDisabled"> <a href="/account/signin?regSource&#x3D;27688&amp;returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="login" class="menu-link elementFont__details--navigation elementFont__resetLink"> <span class="secondary-menu-label">Login</span></a></div></div></section></div> <div class="menu-subscribe" id="homepageHeaderMonetateTargeter"> <span class="subscribe-link"> <a class="elementFont__button elementFont__resetLink" href="https://www.magazine.store/eatingwell/?utm_source&#x3D;eatingwell.com&amp;utm_medium&#x3D;owned&amp;utm_campaign&#x3D;i907etr1w1657" aria-describedby="external-disclaimer"> Subscribe </a> </span> </div> <div class="contextual-social-links mobile-only"> <div data-tracking-zone="sticky nav" class="component share-new square"> <span class="icon icon-pinterest social-icon padding-8-right" data-social-service="pinterest"><a href="https://www.pinterest.com/pin/create/link/?url&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;pinterest.com%26utm_medium&#x3D;social%26utm_campaign&#x3D;social-share-recipe%26utm_content&#x3D;20211014&amp;media&#x3D;https%3A%2F%2Fimagesvc.meredithcorp.io%2Fv3%2Fmm%2Fimage%3Furl%3Dhttps%253A%252F%252Fstatic.onecms.io%252Fwp-content%252Fuploads%252Fsites%252F44%252F2021%252F08%252F16%252Fcheesy-ground-beef-and-cauliflower-casserole.jpg&amp;description&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole%20" class="display-block allowPopup popup share-new__link" aria-label="Pin (opens in a new window)" target="_blank" title="pinterest share (opens in a new window)" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-pinterest" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M11.018 14.094l-.028.096c-.455 1.786-.506 2.183-.975 3.011a9.21 9.21 0 0 1-.753 1.126c-.031.04-.061.092-.124.08-.068-.015-.074-.077-.08-.131a9.552 9.552 0 0 1-.1-1.635c.025-.714.113-.959 1.033-4.827a.267.267 0 0 0-.022-.162c-.22-.594-.263-1.197-.071-1.808.416-1.32 1.912-1.42 2.173-.331.162.673-.265 1.554-.592 2.856-.27 1.075.994 1.84 2.075 1.054.997-.723 1.385-2.456 1.311-3.685-.144-2.45-2.832-2.98-4.536-2.191-1.955.904-2.398 3.326-1.516 4.432.112.142.198.227.16.37-.056.222-.106.445-.167.666-.046.164-.183.224-.349.156a2.005 2.005 0 0 1-.816-.611c-.75-.928-.964-2.764.027-4.317 1.098-1.721 3.139-2.417 5.004-2.206 2.226.253 3.632 1.774 3.896 3.5.12.786.034 2.724-1.07 4.094-1.27 1.575-3.327 1.679-4.277.713-.073-.074-.132-.162-.203-.25"/></svg><span class="icon-text">Pin</span></a></span> <span class="icon icon-favorite default-icon padding-8-right" data-social-service="favorite" data-tracking-zone="save-heart"><a href="javascript:void(0);" class="display-block shareicon-favorite-link-tag shareicon-favorite-link" aria-label="Save this" title="favorite share" data-content-login-url="/account/signin?returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F&amp;regSource&#x3D;27687"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-favorite" width="36" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg> <span class="icon-text">Save</span></a></span> </div> </div></div></div> </nav> <div class="docking-nav-placeholder"></div> <div class="main has-promo-tout notification-banner-wrapper" data-embed-type="notification-banner"></div> <div class="partial modal hamburger static modal--hideHeading" aria-hidden="true" id="dialog-52f04f84-867b-45ee-83f3-abf90d1cfe51" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="hamburger_dialog"> <button class="close close--outside" type="button" data-a11y-dialog-hide data-tracking-zone="nav-hamburger" data-action="close-hamburger-menu"> <span class="visually-hidden">Close this dialog window</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="hamburger_dialog" class="visually-hidden">Explore EatingWell</h2> <div class="content modalContent content--noPadding"> <div class="hamburger-header modal-header" data-tracking-zone="nav-hamburger"><div class="logo"> <a class="full-logo mobile-only" data-action="primary-nav-logo" data-tracking-label="brand logo" href="/"><span class="svg-label">EatingWell</span> <span class="svg-logo" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="215" height="64" viewBox="0 0 215 64"><defs><path id="eating-well-logo-a" d="M0 63.847h214.497V0H0z"/></defs><g fill="none" fill-rule="evenodd"><path fill="#639A3A" d="M61.203 9.883a3.707 3.707 0 1 0 7.413 0 3.707 3.707 0 0 0-7.413 0z"/><mask id="eating-well-logo-b" fill="#fff"><use xlink:href="#eating-well-logo-a"/></mask><path fill="#639A3A" d="M188.897 52.697h6.502V.387h-6.502zm11.129.047h6.5V.434h-6.5z" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.01 48.097c-1.323 0-2.331 1.008-2.331 2.332 0 1.324 1.008 2.332 2.332 2.332 1.324 0 2.332-1.008 2.332-2.332 0-1.387-1.008-2.332-2.332-2.332m.01 4.296c-1.135 0-1.954-.82-1.954-1.954 0-1.135.82-1.954 1.954-1.954s1.954.82 1.954 1.954-.82 1.954-1.954 1.954" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.956 50.05c0-.503-.378-.755-.819-.755h-1.072v2.269h.505v-.82h.252l.693.82h.567V51.5l-.693-.694c.315-.189.567-.378.567-.756m-.819.315h-.504v-.693h.504c.19 0 .378.126.378.378-.063.189-.189.315-.378.315" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" d="M113.13 39.451c-.064-.001-.124-.008-.187-.008.063-.034.124-.027.186.008m-2.93-1.58c-2.974 0-5.804-2.757-5.804-8.996 0-5.441 2.395-8.851 5.803-8.851 3.556 0 5.879 3.41 5.879 8.923 0 5.441-2.25 8.924-5.879 8.924m-4.797 1.287c.02-.033.046-.042.085-.021l-.085.021m11.698.965c3.314-1.838 5.423-5.764 5.423-10.668 0-3.984-1.333-7.306-3.265-9.308 2.519.182 4.267-.396 4.267-.396l-1.118-4.748s-1.91.45-4.608.45c-2.792 0-4.933-.653-7.6-.653-7.775 0-11.94 5.25-11.94 13.371 0 5.048 1.891 9.569 5.261 11.714-1.6.855-3.161 2.205-4.097 3.203l3.667 4.07c1.57-1.714 4.362-3.553 7.994-3.553 4.468 0 7.878 3.048 7.878 7.471 0 4.608-3.69 7.122-8.437 7.122-5.492 0-9.328-3.742-9.328-3.742l-3.739 4.02c2.85 3.003 7.761 5.371 13.283 5.371 7.93 0 14.365-4.533 14.365-12.26 0-5.619-3.305-9.88-8.006-11.464M30.4 48.151c-2.649 0-4.977-2.01-4.977-8.104 0-5.168 1.71-8.103 4.839-8.103 3.41 0 5.513 3.377 5.513 8.031 0 4.172-2.375 8.176-5.376 8.176m13.508-.984c-1.396-.28-2.19-1.071-2.19-3.491V27.859c0-9.926-3.462-13.422-11.23-13.422-4.672 0-8.138 1.98-8.138 1.98l.107 5.312s3.712-1.756 7.061-1.756c4.507 0 6.258 2.99 6.258 7.088v2.756c-1.523-2.248-4.23-3.046-6.696-3.046-5.659 0-10.157 4.498-10.157 13.204 0 8.851 4.883 13.566 10.397 13.566 2.283 0 5.396-1.25 7.478-4.643.5 2.109 2.066 4.134 5.993 4.134 2.164 0 3.328-.35 3.328-.35v-5.47s-.814.234-2.211-.045M54.22 7.958l-6.502 2.039v5.456h-3.982v5.993h3.982v22.157c0 6.746 2.874 9.503 8.532 9.503.871 0 1.379-.073 2.25-.362V47.28c-.508.145-.726.145-1.161.145-2.612 0-3.12-.798-3.12-4.498V21.446h4.28v-5.993h-4.28V7.958m7.451 44.786h6.5V15.453h-6.5zm24.877-38.307c-2.55 0-5.777 1.357-8.002 4.896v-3.88h-5.97v37.29h6.5V28.7c0-4.28 3.4-8.56 6.49-8.56 2.56 0 3.333 1.852 3.333 5.03v27.574h6.5v-27.86c0-3.627-.798-5.949-2.321-7.69-1.524-1.814-3.918-2.757-6.53-2.757M159.177.435l-7.028 34.277L145.99 0h-5.066l-6.24 34.687-7.24-34.252h-6.573l12.045 52.889h3.858l6.701-36.209 6.52 36.209h3.931L165.968.434zm15.369 19.392c3.202 0 4.818 3.446 4.818 10.716h-10.215c0-7.402 2.385-10.716 5.397-10.716m.592 27.961c-3.731 0-6.232-4.06-6.232-10.283 0-.926-.005-1.29-.005-1.508l16.49-.007c.072-2.22.11-2.907.11-4.068 0-10.834-3.213-17.485-10.955-17.485-7.948 0-11.825 7.247-11.825 19.734 0 12.536 5.043 19.37 12.234 19.37 4.958 0 8.524-3.061 10.618-8.364l-4.61-2.64c-1.523 2.978-3.046 5.251-5.825 5.251M0 52.744h18.271v-6.427H6.646v-17.37h10.04v-6.428H6.647V6.863H18.41V.435H0z" mask="url(#eating-well-logo-b)"/></g></svg> </span> </a> <a class="full-logo desktop-only" href="/" data-action="primary-nav-logo" data-tracking-label="brand logo"><span class="svg-label">EatingWell</span> <span class="svg-logo" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="215" height="64" viewBox="0 0 215 64"><defs><path id="eating-well-logo-a" d="M0 63.847h214.497V0H0z"/></defs><g fill="none" fill-rule="evenodd"><path fill="#639A3A" d="M61.203 9.883a3.707 3.707 0 1 0 7.413 0 3.707 3.707 0 0 0-7.413 0z"/><mask id="eating-well-logo-b" fill="#fff"><use xlink:href="#eating-well-logo-a"/></mask><path fill="#639A3A" d="M188.897 52.697h6.502V.387h-6.502zm11.129.047h6.5V.434h-6.5z" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.01 48.097c-1.323 0-2.331 1.008-2.331 2.332 0 1.324 1.008 2.332 2.332 2.332 1.324 0 2.332-1.008 2.332-2.332 0-1.387-1.008-2.332-2.332-2.332m.01 4.296c-1.135 0-1.954-.82-1.954-1.954 0-1.135.82-1.954 1.954-1.954s1.954.82 1.954 1.954-.82 1.954-1.954 1.954" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.956 50.05c0-.503-.378-.755-.819-.755h-1.072v2.269h.505v-.82h.252l.693.82h.567V51.5l-.693-.694c.315-.189.567-.378.567-.756m-.819.315h-.504v-.693h.504c.19 0 .378.126.378.378-.063.189-.189.315-.378.315" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" d="M113.13 39.451c-.064-.001-.124-.008-.187-.008.063-.034.124-.027.186.008m-2.93-1.58c-2.974 0-5.804-2.757-5.804-8.996 0-5.441 2.395-8.851 5.803-8.851 3.556 0 5.879 3.41 5.879 8.923 0 5.441-2.25 8.924-5.879 8.924m-4.797 1.287c.02-.033.046-.042.085-.021l-.085.021m11.698.965c3.314-1.838 5.423-5.764 5.423-10.668 0-3.984-1.333-7.306-3.265-9.308 2.519.182 4.267-.396 4.267-.396l-1.118-4.748s-1.91.45-4.608.45c-2.792 0-4.933-.653-7.6-.653-7.775 0-11.94 5.25-11.94 13.371 0 5.048 1.891 9.569 5.261 11.714-1.6.855-3.161 2.205-4.097 3.203l3.667 4.07c1.57-1.714 4.362-3.553 7.994-3.553 4.468 0 7.878 3.048 7.878 7.471 0 4.608-3.69 7.122-8.437 7.122-5.492 0-9.328-3.742-9.328-3.742l-3.739 4.02c2.85 3.003 7.761 5.371 13.283 5.371 7.93 0 14.365-4.533 14.365-12.26 0-5.619-3.305-9.88-8.006-11.464M30.4 48.151c-2.649 0-4.977-2.01-4.977-8.104 0-5.168 1.71-8.103 4.839-8.103 3.41 0 5.513 3.377 5.513 8.031 0 4.172-2.375 8.176-5.376 8.176m13.508-.984c-1.396-.28-2.19-1.071-2.19-3.491V27.859c0-9.926-3.462-13.422-11.23-13.422-4.672 0-8.138 1.98-8.138 1.98l.107 5.312s3.712-1.756 7.061-1.756c4.507 0 6.258 2.99 6.258 7.088v2.756c-1.523-2.248-4.23-3.046-6.696-3.046-5.659 0-10.157 4.498-10.157 13.204 0 8.851 4.883 13.566 10.397 13.566 2.283 0 5.396-1.25 7.478-4.643.5 2.109 2.066 4.134 5.993 4.134 2.164 0 3.328-.35 3.328-.35v-5.47s-.814.234-2.211-.045M54.22 7.958l-6.502 2.039v5.456h-3.982v5.993h3.982v22.157c0 6.746 2.874 9.503 8.532 9.503.871 0 1.379-.073 2.25-.362V47.28c-.508.145-.726.145-1.161.145-2.612 0-3.12-.798-3.12-4.498V21.446h4.28v-5.993h-4.28V7.958m7.451 44.786h6.5V15.453h-6.5zm24.877-38.307c-2.55 0-5.777 1.357-8.002 4.896v-3.88h-5.97v37.29h6.5V28.7c0-4.28 3.4-8.56 6.49-8.56 2.56 0 3.333 1.852 3.333 5.03v27.574h6.5v-27.86c0-3.627-.798-5.949-2.321-7.69-1.524-1.814-3.918-2.757-6.53-2.757M159.177.435l-7.028 34.277L145.99 0h-5.066l-6.24 34.687-7.24-34.252h-6.573l12.045 52.889h3.858l6.701-36.209 6.52 36.209h3.931L165.968.434zm15.369 19.392c3.202 0 4.818 3.446 4.818 10.716h-10.215c0-7.402 2.385-10.716 5.397-10.716m.592 27.961c-3.731 0-6.232-4.06-6.232-10.283 0-.926-.005-1.29-.005-1.508l16.49-.007c.072-2.22.11-2.907.11-4.068 0-10.834-3.213-17.485-10.955-17.485-7.948 0-11.825 7.247-11.825 19.734 0 12.536 5.043 19.37 12.234 19.37 4.958 0 8.524-3.061 10.618-8.364l-4.61-2.64c-1.523 2.978-3.046 5.251-5.825 5.251M0 52.744h18.271v-6.427H6.646v-17.37h10.04v-6.428H6.647V6.863H18.41V.435H0z" mask="url(#eating-well-logo-b)"/></g></svg> </span> </a></div></div> <div class="modal-wrapper" data-tracking-zone="nav-hamburger"><div class="modal-navigation"> <nav aria-label="main" class="hamburger-menu"> <ul class="top-menu"><li class="menu-item-main search-menu-item"> <div class="search-form-container search-open"> <form method="GET" data-tracking-zone="search-form" action="/search"> <label class="search-label" for="explore-search">Search</label><div class="search-container"> <input id="explore-search" name="q" type="text" class="search-field" value="" placeholder="Enter search term" title="Enter search term"> <button type="submit" class="icon search js-activate" title="Search" aria-label="Search"><span class="icon icon-search utility-icon color-navigation"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg></span> </button> </div></form></div></li> <li class="menu-item-main heading-menu parent-menu pos-0 has-submenu" data-nav-pos="pos-0"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-0"> <span id="submenu-label-0">Explore</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a> <div class="submenu-children-wrapper" id="submenu-0"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Explore</h3></div> <ul class="navigation-content explore navigation-recirc" aria-labelledby="submenu-label-0"> <li class="tile navigation__tile"><a class="media-img" href="https://www.eatingwell.com/article/7895606/what-should-you-eat-before-and-after-getting-the-covid-vaccine-heres-what-the-experts-say/" data-tracking-label="Explore &gt; What Should You Eat Before and After Getting the COVID Vaccine? Here&#x27;s What the Experts Say" aria-hidden="true" tabindex="-1"> <div class="component lazy-image lazy-image-udf aspect_1x1 cache-only align-default" data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url&#x3D;https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F03%2F25%2Fwhat-to-eat-before-and-after-getting-the-covid-vaccine-v3.jpg" data-special-crop="rect&#x3D;438,0,1563,1125" data-alt="What Should You Eat Before and After Getting the COVID Vaccine? Here&#x27;s What the Experts Say" data-title="what-to-eat-before-and-after-getting-the-covid-vaccine-v2" data-shop-image="false" data-original-width="2000" data-original-height="1125" data-high-density="true" data-crop-percentage="100" data-width="230" data-height="230" data-tracking-zone="image" data-orientation="default"> <noscript><img src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F03%2F25%2Fwhat-to-eat-before-and-after-getting-the-covid-vaccine-v3.jpg" alt="What Should You Eat Before and After Getting the COVID Vaccine? Here&#x27;s What the Experts Say" width="230" height="230"></noscript> <div class="inner-container js-inner-container"> <span class="placeholderText visually-hidden">What Should You Eat Before and After Getting the COVID Vaccine? Here&#x27;s What the Experts Say</span> </div><div class="lazy-image__loadingPlaceholder"><img class="loadingPlaceholder" alt="" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20100%20100'%3E%3C/svg%3E" width="2000" height="1125"></div></div></a> <div class="media-body article-info bucket-margin margin-24-bottom clearfix"> <h4 class="headline"><a href="https://www.eatingwell.com/article/7895606/what-should-you-eat-before-and-after-getting-the-covid-vaccine-heres-what-the-experts-say/" class="heading-3 heading-content margin-8-bottom media-heading headline" data-tracking-label="Explore &gt; What Should You Eat Before and After Getting the COVID Vaccine? Here&#x27;s What the Experts Say"> What Should You Eat Before and After Getting the COVID Vaccine? Here's What the Experts Say</a></h4> <span class="summary margin-8-bottom">Don&#x27;t worry, you don&#x27;t need a special diet to get your vaccine. But we talked to the CDC and doctors to learn more about drinking alcohol and if there were any foods it would be a good idea to eat or avoid before and after your shot.</span> <a class="read-more" href="https://www.eatingwell.com/article/7895606/what-should-you-eat-before-and-after-getting-the-covid-vaccine-heres-what-the-experts-say/" data-tracking-label="Explore &gt; What Should You Eat Before and After Getting the COVID Vaccine? Here&#x27;s What the Experts Say" aria-hidden="true" tabindex="-1">Read More <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="icon-arrow-right"><path d="M12 3.984l8.016 8.016-8.016 8.016-1.406-1.406 5.578-5.625h-12.188v-1.969h12.188l-5.578-5.625z"/></svg></a></div></li> <li class="tile navigation__tile"><a class="media-img" href="https://www.eatingwell.com/article/7917692/ways-to-help-support-your-immune-system-naturally/" data-tracking-label="Explore &gt; 8 Ways to Help Support Your Immune System Naturally" aria-hidden="true" tabindex="-1"> <div class="component lazy-image lazy-image-udf aspect_1x1 cache-only align-default" data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url&#x3D;https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F09%2F20%2F8-ways-to-help-support-your-immune-system-naturally.jpg" data-special-crop="rect&#x3D;334,0,1667,1333" data-alt="8 Ways to Help Support Your Immune System Naturally" data-title="8-ways-to-help-support-your-immune-system-naturally" data-shop-image="false" data-original-width="2000" data-original-height="1333" data-high-density="true" data-crop-percentage="100" data-width="230" data-height="230" data-tracking-zone="image" data-orientation="default" data-focal-point-x="1000" data-focal-point-y="439"> <noscript><img src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F09%2F20%2F8-ways-to-help-support-your-immune-system-naturally.jpg" alt="8 Ways to Help Support Your Immune System Naturally" width="230" height="230"></noscript> <div class="inner-container js-inner-container"> <span class="placeholderText visually-hidden">8 Ways to Help Support Your Immune System Naturally</span> </div><div class="lazy-image__loadingPlaceholder"><img class="loadingPlaceholder" alt="" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20100%20100'%3E%3C/svg%3E" width="2000" height="1333"></div></div></a> <div class="media-body article-info bucket-margin margin-24-bottom clearfix"> <h4 class="headline"><a href="https://www.eatingwell.com/article/7917692/ways-to-help-support-your-immune-system-naturally/" class="heading-3 heading-content margin-8-bottom media-heading headline" data-tracking-label="Explore &gt; 8 Ways to Help Support Your Immune System Naturally"> 8 Ways to Help Support Your Immune System Naturally</a></h4> <span class="summary margin-8-bottom">Staying healthy and keeping your immune system in tip-top shape is top of mind for many of us, especially during cold and flu season. And when it comes to supporting our health, natural (aka complementary and alternative medicine) is a route we like to explore. Read on for 8 ways to naturally fuel your immune system.</span> <a class="read-more" href="https://www.eatingwell.com/article/7917692/ways-to-help-support-your-immune-system-naturally/" data-tracking-label="Explore &gt; 8 Ways to Help Support Your Immune System Naturally" aria-hidden="true" tabindex="-1">Read More <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="icon-arrow-right"><path d="M12 3.984l8.016 8.016-8.016 8.016-1.406-1.406 5.578-5.625h-12.188v-1.969h12.188l-5.578-5.625z"/></svg></a></div></li> <li class="tile navigation__tile"><a class="media-img" href="https://www.eatingwell.com/gallery/7917721/fall-casserole-recipes-for-sunday-dinner/" data-tracking-label="Explore &gt; 20 Fall Casseroles for a Delicious Sunday Dinner" aria-hidden="true" tabindex="-1"> <div class="component lazy-image lazy-image-udf aspect_1x1 cache-only align-default" data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url&#x3D;https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F09%2F03%2F3x2-cheesy-spinach-artichoke-casserole.jpg" data-special-crop="" data-alt="20 Fall Casseroles for a Delicious Sunday Dinner" data-title="3x2-cheesy-spinach-artichoke-casserole" data-shop-image="false" data-original-width="2000" data-original-height="1333" data-high-density="true" data-crop-percentage="100" data-width="230" data-height="230" data-tracking-zone="image" data-orientation="default" data-focal-point-x="940" data-focal-point-y="613"> <noscript><img src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F09%2F03%2F3x2-cheesy-spinach-artichoke-casserole.jpg" alt="20 Fall Casseroles for a Delicious Sunday Dinner" width="230" height="230"></noscript> <div class="inner-container js-inner-container"> <span class="placeholderText visually-hidden">20 Fall Casseroles for a Delicious Sunday Dinner</span> </div><div class="lazy-image__loadingPlaceholder"><img class="loadingPlaceholder" alt="" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20100%20100'%3E%3C/svg%3E" width="2000" height="1333"></div></div></a> <div class="media-body article-info bucket-margin margin-24-bottom clearfix"> <h4 class="headline"><a href="https://www.eatingwell.com/gallery/7917721/fall-casserole-recipes-for-sunday-dinner/" class="heading-3 heading-content margin-8-bottom media-heading headline" data-tracking-label="Explore &gt; 20 Fall Casseroles for a Delicious Sunday Dinner"> 20 Fall Casseroles for a Delicious Sunday Dinner</a></h4> <span class="summary margin-8-bottom">End the weekend on a high note with these comforting fall casseroles. Whether you choose a classic creamy chicken casserole, a veggie-packed potpie or a baked lasagna, these filling dinners are sure to satisfy everyone at the table. Recipes like our Spinach &amp; Artichoke Casserole with Chicken and Cauliflower Rice and Kale &amp; White Bean Potpie with Chive Biscuits are healthy meals that will leave you ready to face a new week.</span> <a class="read-more" href="https://www.eatingwell.com/gallery/7917721/fall-casserole-recipes-for-sunday-dinner/" data-tracking-label="Explore &gt; 20 Fall Casseroles for a Delicious Sunday Dinner" aria-hidden="true" tabindex="-1">Read More <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" class="icon-arrow-right"><path d="M12 3.984l8.016 8.016-8.016 8.016-1.406-1.406 5.578-5.625h-12.188v-1.969h12.188l-5.578-5.625z"/></svg></a></div></li> </ul></div></li> <li data-nav-pos="pos-1" class="menu-item-main heading-menu parent-menu pos-1 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-1"> <span id="submenu-label-1">Healthy Recipes</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-1" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Healthy Recipes</h3> <a href="https://www.eatingwell.com/recipes/" class="see-all-heading">See All Healthy Recipes</a></div> <ul aria-labelledby="submenu-label-1" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17916/mealtimes/breakfast-brunch/" data-tracking-label="healthy recipes > healthy breakfast &amp; brunch recipes">Healthy Breakfast & Brunch Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17963/mealtimes/lunch/" data-tracking-label="healthy recipes > healthy lunch recipes">Healthy Lunch Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17947/mealtimes/dinner/" data-tracking-label="healthy recipes > healthy dinner recipes">Healthy Dinner Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17990/mealtimes/snacks/" data-tracking-label="healthy recipes > healthy snack recipes">Healthy Snack Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18044/desserts/" data-tracking-label="healthy recipes > healthy dessert recipes">Healthy Dessert Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18042/soup/" data-tracking-label="healthy recipes > healthy soup recipes">Healthy Soup Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17981/salad/" data-tracking-label="healthy recipes > healthy salad recipes">Healthy Salad Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17989/drinks/smoothies/" data-tracking-label="healthy recipes > healthy smoothie recipes">Healthy Smoothie Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18258/cooking-methods-styles/quick-easy/" data-tracking-label="healthy recipes > healthy quick &amp; easy recipes">Healthy Quick & Easy Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17987/cooking-methods-styles/slow-cooker-crockpot/" data-tracking-label="healthy recipes > healthy slow-cooker &amp; crockpot recipes">Healthy Slow-Cooker & Crockpot Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18049/healthy-kids/" data-tracking-label="healthy recipes > healthy kids recipes">Healthy Kids Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17959/holidays-occasions/" data-tracking-label="healthy recipes > healthy holiday recipes">Healthy Holiday Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18003/lifestyle-diets/vegan/" data-tracking-label="healthy recipes > healthy vegan recipes">Healthy Vegan Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18005/lifestyle-diets/vegetarian/" data-tracking-label="healthy recipes > healthy vegetarian recipes">Healthy Vegetarian Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18314/cuisines-regions/mediterranean/" data-tracking-label="healthy recipes > healthy mediterranean diet recipes">Healthy Mediterranean Diet Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17899/health-condition/diabetic/" data-tracking-label="healthy recipes > healthy diabetes-friendly recipes">Healthy Diabetes-Friendly Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18012/low-calorie/" data-tracking-label="healthy recipes > healthy low-calorie recipes">Healthy Low-Calorie Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18045/weight-loss-diet/" data-tracking-label="healthy recipes > healthy weight loss &amp; diet recipes">Healthy Weight Loss & Diet Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/18024/lifestyle-diets/" data-tracking-label="healthy recipes > more lifestyle diet recipes">More Lifestyle Diet Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/22823/health-condition/" data-tracking-label="healthy recipes > more health condition recipes">More Health Condition Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/22824/dietary-restrictions/" data-tracking-label="healthy recipes > more dietary restriction recipes">More Dietary Restriction Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/22825/nutrient-focused-diets/" data-tracking-label="healthy recipes > more nutrient focused recipes">More Nutrient Focused Recipes</a></li></ul></div></li> <li data-nav-pos="pos-2" class="menu-item-main heading-menu parent-menu pos-2 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-2"> <span id="submenu-label-2">Special Diets</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-2" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Special Diets</h3> <a href="https://www.eatingwell.com/category/4243/special-diets/" class="see-all-heading">See All Special Diets</a></div> <ul aria-labelledby="submenu-label-2" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4244/clean-eating-diet-center/" data-tracking-label="special diets > clean eating diet center">Clean Eating Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4274/mediterranean-diet-center/" data-tracking-label="special diets > mediterranean diet center">Mediterranean Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4267/low-carb-diet-center/" data-tracking-label="special diets > low-carb diet center">Low-Carb Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4236/weight-loss/" data-tracking-label="special diets > weight loss center">Weight Loss Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4247/dairy-free-diet-center/" data-tracking-label="special diets > dairy-free diet center">Dairy-Free Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4251/gluten-free-diet-center/" data-tracking-label="special diets > gluten-free diet center">Gluten-Free Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4262/high-fiber-diet-center/" data-tracking-label="special diets > high-fiber diet center">High-Fiber Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4280/vegan-diet-center/" data-tracking-label="special diets > vegan diet center">Vegan Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4283/vegetarian-diet-center/" data-tracking-label="special diets > vegetarian diet center">Vegetarian Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4256/heart-healthy-diet-center/" data-tracking-label="special diets > heart-healthy diet center">Heart-Healthy Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4268/cholesterol-diet-center/" data-tracking-label="special diets > cholesterol diet center">Cholesterol Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4248/diabetes-diet-center/" data-tracking-label="special diets > diabetes diet center">Diabetes Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4259/high-blood-pressure-diet-center/" data-tracking-label="special diets > high blood pressure diet center">High Blood Pressure Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4271/low-sodium-diet-center/" data-tracking-label="special diets > low sodium diet center">Low Sodium Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4254/healthy-aging-diet-center/" data-tracking-label="special diets > healthy aging diet center">Healthy Aging Diet Center</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4277/pregnancy-diet-center/" data-tracking-label="special diets > pregnancy diet center">Pregnancy Diet Center</a></li></ul></div></li> <li data-nav-pos="pos-3" class="menu-item-main heading-menu parent-menu pos-3 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-3"> <span id="submenu-label-3">Diabetes</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-3" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Diabetes</h3> <a href="https://www.eatingwell.com/category/4248/diabetes-diet-center/" class="see-all-heading">See All Diabetes</a></div> <ul aria-labelledby="submenu-label-3" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4291/meal-plans-for-diabetes/" data-tracking-label="diabetes > meal plans for diabetes">Meal Plans for Diabetes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/recipes/17899/health-condition/diabetic/" data-tracking-label="diabetes > diabetes-friendly recipes">Diabetes-Friendly Recipes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4248/diabetes-diet-center/" data-tracking-label="diabetes > diabetes diet center">Diabetes Diet Center</a></li></ul></div></li> <li data-nav-pos="pos-4" class="menu-item-main heading-menu parent-menu pos-4 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-4"> <span id="submenu-label-4">Healthy Meal Plans</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-4" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Healthy Meal Plans</h3> <a href="https://www.eatingwell.com/category/4286/meal-plans/" class="see-all-heading">See All Healthy Meal Plans</a></div> <ul aria-labelledby="submenu-label-4" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4287/meal-planning-101/" data-tracking-label="healthy meal plans > meal planning 101">Meal Planning 101</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4288/dinner-plans/" data-tracking-label="healthy meal plans > dinner plans">Dinner Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4289/clean-eating-meal-plans/" data-tracking-label="healthy meal plans > clean eating meal plans">Clean Eating Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4300/mediterranean-diet-meal-plans/" data-tracking-label="healthy meal plans > mediterranean diet meal plans">Mediterranean Diet Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4298/low-carb-meal-plans/" data-tracking-label="healthy meal plans > low-carb meal plans">Low-Carb Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4305/weight-loss-meal-plans/" data-tracking-label="healthy meal plans > weight-loss meal plans">Weight-Loss Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4290/dairy-free-meal-plans/" data-tracking-label="healthy meal plans > dairy-free meal plans">Dairy-Free Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4294/gluten-free-meal-plans/" data-tracking-label="healthy meal plans > gluten-free meal plans">Gluten-Free Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4293/high-fiber-meal-plans/" data-tracking-label="healthy meal plans > high-fiber meal plans">High-Fiber Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4303/vegan-meal-plans/" data-tracking-label="healthy meal plans > vegan meal plans">Vegan Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4304/vegetarian-meal-plans/" data-tracking-label="healthy meal plans > vegetarian meal plans">Vegetarian Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4297/heart-healthy-meal-plans/" data-tracking-label="healthy meal plans > heart-healthy meal plans">Heart-Healthy Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4299/low-cholesterol-meal-plans/" data-tracking-label="healthy meal plans > low cholesterol meal plans">Low Cholesterol Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4291/meal-plans-for-diabetes/" data-tracking-label="healthy meal plans > meal plans for diabetes">Meal Plans for Diabetes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4292/blood-pressure-meal-plans/" data-tracking-label="healthy meal plans > blood pressure meal plans">Blood Pressure Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4302/low-sodium-meal-plans/" data-tracking-label="healthy meal plans > low sodium meal plans">Low Sodium Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4295/healthy-aging-meal-plans/" data-tracking-label="healthy meal plans > anti-aging meal plans">Anti-Aging Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4301/pregnancy-meal-plans/" data-tracking-label="healthy meal plans > pregnancy meal plans">Pregnancy Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4296/healthy-kids-meal-plans/" data-tracking-label="healthy meal plans > healthy kids meal plans">Healthy Kids Meal Plans</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4330/theprep/" data-tracking-label="healthy meal plans > theprep">ThePrep</a></li></ul></div></li> <li data-nav-pos="pos-5" class="menu-item-main heading-menu parent-menu pos-5 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-5"> <span id="submenu-label-5">Healthy Eating</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-5" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Healthy Eating</h3> <a href="https://www.eatingwell.com/category/4306/healthy-eating-101/" class="see-all-heading">See All Healthy Eating</a></div> <ul aria-labelledby="submenu-label-5" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4306/healthy-eating-101/" data-tracking-label="healthy eating > healthy eating 101">Healthy Eating 101</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4319/eat-more-vegetables/" data-tracking-label="healthy eating > eat more vegetables">Eat More Vegetables</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4317/30-day-challenges/" data-tracking-label="healthy eating > 30-day challenges">30-Day Challenges</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4325/good-food-fast/" data-tracking-label="healthy eating > good food fast">Good Food Fast</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4311/healthy-eating-for-kids/" data-tracking-label="healthy eating > healthy eating for kids">Healthy Eating for Kids</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4308/best-healthy-foods/" data-tracking-label="healthy eating > best healthy foods">Best Healthy Foods</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4316/green-and-sustainable-eating/" data-tracking-label="healthy eating > green and sustainable eating">Green and Sustainable Eating</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4331/the-beet/" data-tracking-label="healthy eating > the beet">The Beet</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4322/transformed/" data-tracking-label="healthy eating > transformed">Transformed</a></li></ul></div></li> <li data-nav-pos="pos-6" class="menu-item-main heading-menu parent-menu pos-6 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-6"> <span id="submenu-label-6">Healthy Lifestyle</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-6" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Healthy Lifestyle</h3> <a href="https://www.eatingwell.com/category/4318/eatingwell-in-real-life/" class="see-all-heading">See All Healthy Lifestyle</a></div> <ul aria-labelledby="submenu-label-6" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4313/wine-beer-spirits-guide/" data-tracking-label="healthy lifestyle > wine, beer &amp; spirits guide">Wine, Beer & Spirits Guide</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4310/entertaining/" data-tracking-label="healthy lifestyle > entertaining">Entertaining</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4318/eatingwell-in-real-life/" data-tracking-label="healthy lifestyle > eatingwell in real life">EatingWell in Real Life</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4320/plant-your-plate/" data-tracking-label="healthy lifestyle > plant your plate">Plant Your Plate</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4315/healthy-pets/" data-tracking-label="healthy lifestyle > healthy pets">Healthy Pets</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4323/american-food-heroes/" data-tracking-label="healthy lifestyle > american food heroes">American Food Heroes</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4327/future-of-food/" data-tracking-label="healthy lifestyle > future of food">Future of Food</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4321/food-with-purpose/" data-tracking-label="healthy lifestyle > food with purpose">Food with Purpose</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4329/obsessed/" data-tracking-label="healthy lifestyle > obsessed">Obsessed</a></li></ul></div></li> <li data-nav-pos="pos-7" class="menu-item-main heading-menu parent-menu pos-7 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-7"> <span id="submenu-label-7">Healthy Cooking</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-7" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Healthy Cooking</h3> <a href="https://www.eatingwell.com/category/4309/healthy-cooking-how-tos/" class="see-all-heading">See All Healthy Cooking</a></div> <ul aria-labelledby="submenu-label-7" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4309/healthy-cooking-how-tos/" data-tracking-label="healthy cooking > healthy cooking how-to&#x27;s">Healthy Cooking How-To's</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4312/ask-the-test-kitchen/" data-tracking-label="healthy cooking > ask the test kitchen">Ask the Test Kitchen</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4314/budget-cooking-guide/" data-tracking-label="healthy cooking > budget cooking guide">Budget Cooking Guide</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4332/thrifty/" data-tracking-label="healthy cooking > thrifty">Thrifty</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/category/4333/family-heritage-cooking/" data-tracking-label="healthy cooking > heritage cooking">Heritage Cooking</a></li></ul></div></li> <li data-nav-pos="pos-8" class="menu-item-main heading-menu parent-menu pos-8 has-submenu"> <a class="submenu-link main-link expand-trigger" href="#" aria-controls="submenu-8"> <span id="submenu-label-8">Shop</span> <span class="icon accordion accordion-arrow"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span></a><div id="submenu-8" class="submenu-children-wrapper"> <div class="sub-menu-header"> <button class="back-button mobile-only" type="button" aria-label="Back to main menu"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <h3 class="main-channel elementFont__subhead">Shop</h3> <a href="https://www.eatingwell.com/article/283588/the-eatingwell-bookstore-cookbooks-more/" class="see-all-heading">See All Shop</a></div> <ul aria-labelledby="submenu-label-8" class="submenu-children"> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="https://www.eatingwell.com/article/283588/the-eatingwell-bookstore-cookbooks-more/" data-tracking-label="shop > eatingwell cookbooks &amp; more">EatingWell Cookbooks & More</a></li> <li class="menu-item-main heading-menu"><a class="submenu-link child-link" href="http://frozenfresh.eatingwell.com/" data-tracking-label="shop > eatingwell frozen meals">EatingWell Frozen Meals</a></li></ul></div></li> <li data-nav-pos="pos-9" class="menu-item-main heading-menu parent-menu pos-9"> <a class="submenu-link main-link" href="https://www.eatingwell.com/category/4328/news/"> <span id="submenu-label-9">News</span> </a></li> <li data-nav-pos="pos-10" class="menu-item-main heading-menu parent-menu pos-10"> <a class="submenu-link main-link" href="https://www.eatingwell.com/category/videos/"> <span id="submenu-label-10">Videos</span> </a></li> </ul></nav></div> <div class="hamburger-auth-section"> <section class="container secondary-links hamburger static"> <h2 class="sr-heading">Profile Menu</h2> <div class="secondary-text-links"><div class="heading-menu menu-list-item secondary-item"> <a class="menu-link external-link-warning elementFont__details--navigation elementFont__resetLink" href="https://www.magazine.store/eatingwell/?utm_source&#x3D;eatingwell.com&amp;utm_medium&#x3D;owned&amp;utm_campaign&#x3D;i907etr5w1657" target="_blank" aria-describedby="external-disclaimer" data-tracking-label="subscribe"> <span>Subscribe <span class="hidden-label"> this link opens in a new tab</span> <span class="external-link-icon" aria-hidden="true"> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M8 16h8v-3h1v4H7V7h4v1H8v8zm5-10h5v5h-1V8l-5 5-1-1 5-5h-3V6z"/></svg> </span> </span> </a></div> <div data-action="secondary-nav-pos-1" class="heading-menu menu-list-item secondary-item has-submenu logged-out euDisabled"> <button data-tracking-label="join now" class="menu-link elementFont__details--navigation elementFont__resetLink expand-trigger has-auth" aria-expanded="false"> <span class="profile-image-container logged-out"><img alt="Log In" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="profile-image-container logged-in"><img alt="Account Details" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="secondary-menu-label">Join Now</span><span class="icon desktop-only"><span class="icon icon-down-triangle utility-icon color-gray-6"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 255 255"><path d="M0 63.75l127.5 127.5L255 63.75z"/></svg></span> </span> <span class="icon accordion-arrow mobile-only"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span> </button><div class="submenu-children-wrapper"><div class="sub-menu-header"> <button aria-label="Close" class="icon back-button mobile-only"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <span class="main-channel mobile-only elementFont__subhead">Join Now</span></div> <div class="dropdown-links-list"><h3 class="sub-menu__heading-label elementFont__details--navigation">Account</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu euDisabled logged-out join-now"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signup?regSource&#x3D;27688&amp;returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="join now > join now">Join Now</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/profile/my/profile-settings/" data-tracking-label="join now > my profile">My Profile</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://secure.eatingwell.com/common/profile/member/optout/" data-tracking-label="join now > email preferences">Email Preferences</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/profile/my/" data-tracking-label="join now > favorites">Favorites</a> </li> <li class="menu-item heading-menu logged-out"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://x.specialoffers.meredith.com/ats/show.aspx?cr&#x3D;588&amp;fm&#x3D;301&amp;regSource&#x3D;27538" data-tracking-label="join now > newsletters">Newsletters</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code&#x3D;ETG" target="_blank" data-tracking-label="join now > manage your subscription">Manage Your Subscription<span class="hidden-label"> this link opens in a new tab</span></a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/article/290690/customer-service/" data-tracking-label="join now > help">Help</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signout?successPage=https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="join now > logout">Logout</a> </li> </ul><hr class="secondary-nav-divider desktop-only"><h3 class="sub-menu__heading-label elementFont__details--navigation">More</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.magazine.store/eatingwell/" data-tracking-label="join now > give a gift subscription">Give a Gift Subscription</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://learn.cookinglightdiet.com/?utm_source&#x3D;un_display_etg_b907etr1b204" data-tracking-label="join now > cooking light diet">Cooking Light Diet</a> </li> </ul></div></div></div> <div data-action="secondary-nav-pos-2" class="heading-menu menu-list-item secondary-item has-submenu logged-in euDisabled"> <button data-tracking-label="your account" class="menu-link elementFont__details--navigation elementFont__resetLink expand-trigger has-auth" aria-expanded="false"> <span class="profile-image-container logged-out"><img alt="Log In" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="profile-image-container logged-in"><img alt="Account Details" aria-hidden="true" class="profile-img" src="/img/profile.png"></span> <span class="secondary-menu-label">Your Account</span><span class="icon desktop-only"><span class="icon icon-down-triangle utility-icon color-gray-6"><svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 255 255"><path d="M0 63.75l127.5 127.5L255 63.75z"/></svg></span> </span> <span class="icon accordion-arrow mobile-only"><span class="icon icon-down utility-icon"><svg width="12" height="8" viewBox="0 0 12 8" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L10.59.59 6 5.17 1.41.59 0 2l6 6z"/></svg></span> </span> </button><div class="submenu-children-wrapper"><div class="sub-menu-header"> <button aria-label="Close" class="icon back-button mobile-only"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg></button> <span class="main-channel mobile-only elementFont__subhead">Your Account</span></div> <div class="dropdown-links-list"><h3 class="sub-menu__heading-label elementFont__details--navigation">Account</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu euDisabled logged-out join-now"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signup?regSource&#x3D;27688&amp;returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="your account > join now">Join Now</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/profile/my/profile-settings/" data-tracking-label="your account > my profile">My Profile</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://secure.eatingwell.com/common/profile/member/optout/" data-tracking-label="your account > email preferences">Email Preferences</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/profile/my/" data-tracking-label="your account > favorites">Favorites</a> </li> <li class="menu-item heading-menu logged-out"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://x.specialoffers.meredith.com/ats/show.aspx?cr&#x3D;588&amp;fm&#x3D;301&amp;regSource&#x3D;27538" data-tracking-label="your account > newsletters">Newsletters</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code&#x3D;ETG" target="_blank" data-tracking-label="your account > manage your subscription">Manage Your Subscription<span class="hidden-label"> this link opens in a new tab</span></a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.eatingwell.com/article/290690/customer-service/" data-tracking-label="your account > help">Help</a> </li> <li class="menu-item heading-menu logged-in"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="/account/signout?successPage=https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="your account > logout">Logout</a> </li> </ul><hr class="secondary-nav-divider desktop-only"><h3 class="sub-menu__heading-label elementFont__details--navigation">More</h3><ul class="secondary-nav-submenu-children"> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://www.magazine.store/eatingwell/" data-tracking-label="your account > give a gift subscription">Give a Gift Subscription</a> </li> <li class="menu-item heading-menu"> <a class="menu-link elementFont__subtitle--navigation elementFont__resetLink" href="https://learn.cookinglightdiet.com/?utm_source&#x3D;un_display_etg_b907etr1b204" data-tracking-label="your account > cooking light diet">Cooking Light Diet</a> </li> </ul></div></div></div> <div data-action="secondary-nav-pos-3" class="heading-menu menu-list-item secondary-item logged-out euDisabled"> <a href="/account/signin?regSource&#x3D;27688&amp;returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-tracking-label="login" class="menu-link elementFont__details--navigation elementFont__resetLink"> <span class="secondary-menu-label">Login</span></a></div> <div class="heading-menu menu-list-item secondary-item sweepstakes" data-action="secondary-nav-pos-4"> <a href="https://www.eatingwell.com/sweepstakes/" class="menu-link elementFont__details--navigation elementFont__resetLink" data-tracking-label="sweepstakes"> <span class="secondary-menu-label">Sweepstakes</span> </a> </div></div></section> <section class="social-share"><h3 class="heading-follow-up">Follow Us</h3> <div class="menu-item-styled social-items no-pad-top"> <link href="https://www.facebook.com/EatingWell/" rel="dns-prefetch"><span class="icon icon-facebook social-icon margin-4-right" data-social-service="facebook"><a href="https://www.facebook.com/EatingWell/" class="display-block" aria-label="Share on facebook (opens in a new window)" target="_blank" title="facebook share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-facebook" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M13.774 8.824c.355-.012.71-.003 1.066-.003h.147V7.079c-.19-.018-.388-.043-.587-.052-.364-.015-.73-.033-1.094-.025-.557.01-1.084.139-1.544.45-.528.358-.818.86-.928 1.454a4.708 4.708 0 0 0-.064.747c-.01.39-.002.78-.002 1.172v.146H9v1.945h1.758v4.889h2.148v-4.88h1.752l.27-1.955h-.394c-.498.002-1.643 0-1.643 0s.006-.964.018-1.382c.017-.573.378-.748.865-.764"/></svg></a></span> <link href="https://twitter.com/EatingWell" rel="dns-prefetch"><span class="icon icon-twitter social-icon margin-4-right" data-social-service="twitter"><a href="https://twitter.com/EatingWell" class="display-block" aria-label="Share on twitter (opens in a new window)" target="_blank" title="twitter share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-twitter" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M9.793 15.25c-1.336-.049-2.17-1.041-2.392-1.847.372.073.739.058 1.103-.035.009-.002.018-.009.036-.017a2.571 2.571 0 0 1-1.669-1.222 2.65 2.65 0 0 1-.376-1.415c.36.2.738.311 1.144.323-.545-.406-.91-.937-1.059-1.615a2.72 2.72 0 0 1 .276-1.928c1.392 1.697 3.153 2.628 5.301 2.781-.016-.105-.031-.197-.041-.291a2.65 2.65 0 0 1 .375-1.74c.41-.664.993-1.077 1.743-1.204.864-.146 1.619.109 2.25.742.042.042.077.056.137.042a5.05 5.05 0 0 0 1.494-.595c.012-.006.023-.013.035-.018.002-.002.006-.001.017-.001a2.709 2.709 0 0 1-1.1 1.448 4.769 4.769 0 0 0 1.43-.399l.01.012c-.097.134-.193.27-.295.399a5.128 5.128 0 0 1-.933.92c-.03.022-.044.044-.044.084.015.395 0 .79-.047 1.182a8.026 8.026 0 0 1-.663 2.37 7.686 7.686 0 0 1-1.388 2.098 6.815 6.815 0 0 1-3.533 2.038 7.4 7.4 0 0 1-1.431.177 7.069 7.069 0 0 1-4.113-1.144l-.06-.04a5.039 5.039 0 0 0 3.793-1.105"/></svg></a></span> <link href="https://www.pinterest.com/eatingwell/" rel="dns-prefetch"><span class="icon icon-pinterest social-icon margin-4-right" data-social-service="pinterest"><a href="https://www.pinterest.com/eatingwell/" class="display-block" aria-label="Share on pinterest (opens in a new window)" target="_blank" title="pinterest share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-pinterest" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M11.018 14.094l-.028.096c-.455 1.786-.506 2.183-.975 3.011a9.21 9.21 0 0 1-.753 1.126c-.031.04-.061.092-.124.08-.068-.015-.074-.077-.08-.131a9.552 9.552 0 0 1-.1-1.635c.025-.714.113-.959 1.033-4.827a.267.267 0 0 0-.022-.162c-.22-.594-.263-1.197-.071-1.808.416-1.32 1.912-1.42 2.173-.331.162.673-.265 1.554-.592 2.856-.27 1.075.994 1.84 2.075 1.054.997-.723 1.385-2.456 1.311-3.685-.144-2.45-2.832-2.98-4.536-2.191-1.955.904-2.398 3.326-1.516 4.432.112.142.198.227.16.37-.056.222-.106.445-.167.666-.046.164-.183.224-.349.156a2.005 2.005 0 0 1-.816-.611c-.75-.928-.964-2.764.027-4.317 1.098-1.721 3.139-2.417 5.004-2.206 2.226.253 3.632 1.774 3.896 3.5.12.786.034 2.724-1.07 4.094-1.27 1.575-3.327 1.679-4.277.713-.073-.074-.132-.162-.203-.25"/></svg></a></span> <link href="https://instagram.com/eatingwell/" rel="dns-prefetch"><span class="icon icon-instagram social-icon margin-4-right" data-social-service="instagram"><a href="https://instagram.com/eatingwell/" class="display-block" aria-label="Share on instagram (opens in a new window)" target="_blank" title="instagram share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M11.998 6c1.63 0 1.833.007 2.473.036.639.03 1.075.13 1.456.279a2.94 2.94 0 0 1 1.063.692c.333.333.538.668.691 1.062.149.382.25.818.28 1.456.028.64.035.844.035 2.473 0 1.63-.007 1.833-.036 2.473-.029.639-.13 1.075-.279 1.456a2.94 2.94 0 0 1-.692 1.063 2.94 2.94 0 0 1-1.062.691c-.381.149-.817.25-1.456.28-.64.028-.844.035-2.473.035s-1.833-.007-2.473-.036c-.638-.029-1.074-.13-1.456-.279a2.94 2.94 0 0 1-1.062-.692 2.94 2.94 0 0 1-.692-1.062c-.148-.381-.25-.817-.279-1.456-.03-.64-.036-.844-.036-2.473s.007-1.833.036-2.473c.03-.638.13-1.074.279-1.456a2.94 2.94 0 0 1 .692-1.062 2.94 2.94 0 0 1 1.062-.692c.382-.148.818-.25 1.456-.279.64-.03.844-.036 2.473-.036zm0 1.08c-1.601 0-1.791.007-2.424.036-.584.026-.902.124-1.113.206-.28.109-.48.239-.69.449-.21.21-.34.41-.449.69-.082.211-.18.529-.206 1.113-.03.633-.035.823-.035 2.424 0 1.602.006 1.791.035 2.424.026.585.124.902.206 1.114.109.28.239.48.449.69.21.21.41.34.69.448.211.082.529.18 1.113.207.633.028.822.034 2.424.034 1.602 0 1.791-.006 2.424-.034.585-.027.902-.125 1.114-.207.28-.109.48-.239.69-.449.21-.21.34-.41.448-.69.082-.21.18-.528.207-1.113.028-.633.034-.822.034-2.424 0-1.601-.006-1.791-.034-2.424-.027-.584-.125-.902-.207-1.113a1.858 1.858 0 0 0-.449-.69c-.21-.21-.41-.34-.69-.449-.21-.082-.528-.18-1.113-.206-.633-.03-.822-.035-2.424-.035zm0 1.838a3.08 3.08 0 1 1 0 6.16 3.08 3.08 0 0 1 0-6.16zm0 5.08a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm3.922-5.202a.72.72 0 1 1-1.44 0 .72.72 0 0 1 1.44 0z"/></svg></a></span> <link href="https://www.youtube.com/user/eatingwell" rel="dns-prefetch"><span class="icon icon-youtube social-icon margin-4-right" data-social-service="youtube"><a href="https://www.youtube.com/user/eatingwell" class="display-block" aria-label="Share on youtube (opens in a new window)" target="_blank" title="youtube share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M10.227 13.95l4.307-2.233-4.307-2.248v4.482zm-3.8 2.487a1.613 1.613 0 0 1-1.064-1.035c-.462-1.268-.598-6.57.29-7.615a1.718 1.718 0 0 1 1.158-.616c2.393-.257 9.784-.22 10.636.086.5.18.854.506 1.046 1.006.505 1.31.522 6.079-.066 7.34-.16.344-.42.585-.75.758-.892.468-10.077.462-11.25.076z"/></svg> </a></span> </div></section></div></div> </div></div></div> <div class="menu-overlay" data-tracking-zone="nav-hamburger" data-action="close-hamburger-menu"></div> <div class="monetate" id="underNavMonetateTargeter" role="complementary" aria-hidden="true"></div> <a class="skipLink__destination skipLink__destination--headerOffset" id="main-content"></a></header> <div aria-live="assertive" class="component alert-banner type-auth-modal auth-modal-banner hidden"> <div class="alert-wrapper"><div class="alert-icon"></div> <div class="alert-text"> </div> <button class="alert-close" aria-label="Close this alert"><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button></div></div> <div class="docked-sharebar-content-container"> <div class="container-full-width template-two-col with-sidebar-right karma-below-banner karma-site-container recipe-wrapper"> <main class="inner-container two-col-inner"> <div class="recipe-container two-col-container"> <div class="content content-breadcrumbs"> <div class="component breadcrumbs" data-tracking-zone="breadcrumbs"><nav class="breadcrumbs__container" aria-label="Breadcrumb"><ol class="breadcrumbs__list"> <li class="breadcrumbs__item"><a class="breadcrumbs__link" href="https://www.eatingwell.com"><span class="breadcrumbs__title">Home</span></a><span class="icon breadcrumbs__icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M8.578 16.359l4.594-4.594-4.594-4.594 1.406-1.406 6 6-6 6z"/></svg> </span></li> <li class="breadcrumbs__item"><a class="breadcrumbs__link" href="https://www.eatingwell.com/recipes/"><span class="breadcrumbs__title">Healthy Recipes</span></a><span class="icon breadcrumbs__icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M8.578 16.359l4.594-4.594-4.594-4.594 1.406-1.406 6 6-6 6z"/></svg> </span></li> <li class="breadcrumbs__item"><a class="breadcrumbs__link" href="https://www.eatingwell.com/recipes/17965/main-dishes/"><span class="breadcrumbs__title">Healthy Main Dish Recipes</span></a><span class="icon breadcrumbs__icon"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M8.578 16.359l4.594-4.594-4.594-4.594 1.406-1.406 6 6-6 6z"/></svg> </span></li> <li class="breadcrumbs__item breadcrumbs__item--last"><a class="breadcrumbs__link breadcrumbs__link--last" href="https://www.eatingwell.com/recipes/17923/main-dishes/casseroles/"><span class="breadcrumbs__title">Healthy Casserole Recipes</span></a><span class="icon breadcrumbs__icon breadcrumbs__icon--last"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M8.578 16.359l4.594-4.594-4.594-4.594 1.406-1.406 6 6-6 6z"/></svg> </span></li> <li class="breadcrumbs__item visually-hidden" aria-current="page">Cheesy Ground Beef & Cauliflower Casserole</li></ol></nav><span class="breadcrumbs-align-shift"></span></div> </div> <div class="content two-col-main-content karma-content-container"> <div class="recipe-content two-col-content karma-main-column"> <div class="main-header recipe-main-header" data-path="/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/"><div class="intro article-info"><div class="headline-wrapper"><h1 class="headline heading-content elementFont__display">Cheesy Ground Beef & Cauliflower Casserole</h1> <div id="karma-lazy-sponsorLogo" class="sponsor-logo"></div> </div></div> <div class="recipe-review-container euDisabled"> <div class="component recipe-ratings"> <a href="#" class="add-rating-reviews-link ugc-ratings-link review-stars-container embedded-auth-modal-trigger" data-login-url="
-                                /account/signup?returnURL&#x3D;https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F
-                      "> <span class="review-star-text">Rating: Unrated</span> <span class="rating-star" aria-hidden="true" data-rating="1"><svg width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="1 – Couldn&#x27;t eat it" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-opacity=".95"><path class="rating-star-filled" d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></g></svg></span> <span class="rating-star" aria-hidden="true" data-rating="2"><svg width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="2 – Didn&#x27;t like it" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-opacity=".95"><path class="rating-star-filled" d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></g></svg></span> <span class="rating-star" aria-hidden="true" data-rating="3"><svg width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="3 – It was OK" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-opacity=".95"><path class="rating-star-filled" d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></g></svg></span> <span class="rating-star" aria-hidden="true" data-rating="4"><svg width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="4 – Liked it" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-opacity=".95"><path class="rating-star-filled" d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></g></svg></span> <span class="rating-star" aria-hidden="true" data-rating="5"><svg width="24" height="24" viewBox="0 0 24 24" role="img" aria-label="5 – Loved it" xmlns="http://www.w3.org/2000/svg"><g fill="#000" fill-opacity=".95"><path class="rating-star-filled" d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></g></svg></span> </a> </div> <div class="partial ugc-ratings"> <ul class="ugc-ratings-list"> <li class="partial ugc-ratings-list-item"> <a class="ugc-ratings-link elementFont__detailsLink--underlined no-ratings" href="#reviewSection"> Be the first to rate &amp; review! </a> </li> </ul> </div> </div> <div class="recipe-summary elementFont__dek--paragraphWithin elementFont__dek--linkWithin"> <p class="margin-0-auto">Ground beef and cauliflower combine to create a hearty weeknight casserole that both kids and adults will love. Serve with tortilla chips and sour cream. </p> </div> <div class="author authorItem authorItem-1"> <div class="author-text" data-tracking-zone="author"> <span class="author-block authorBlock elementFont__subtitle"> <svg xmlns="http://www.w3.org/2000/svg" class="profile-pic author-svg" width="48" height="48" viewBox="0 0 24 24"><path d="M2 12c0 5.52 4.48 10 10 10s10-4.48 10-10S17.52 2 12 2 2 6.48 2 12zm10-7c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/></svg> <span class="author-name-title"> <span class="author-name authorName linkHoverStyle">Carolyn Casner</span> </span> </span> </div> </div> <div class="original-source elementFont__fine"> EatingWell.com, September 2021 </div> </div> <div class="two-col-content-wrapper"> <div class="two-col-social docked-sharebar-docking-container"> <div class="component docked-sharebar" data-tracking-zone="share"><div data-tracking-zone="share bar" class="component share-new vertical square"> <span class="icon icon-favorite default-icon padding-8-right" data-social-service="favorite" data-tracking-zone="save-heart"><a href="javascript:void(0);" class="display-block shareicon-favorite-link-tag shareicon-favorite-link" aria-label="Save this" title="favorite share" data-content-login-url="/account/signin?returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F&amp;regSource&#x3D;27687"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-favorite" width="36" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg> <span class="icon-text">Save</span></a></span> <span class="icon icon-pinterest social-icon padding-8-right" data-social-service="pinterest"><a href="https://www.pinterest.com/pin/create/link/?url&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;pinterest.com%26utm_medium&#x3D;social%26utm_campaign&#x3D;social-share-recipe%26utm_content&#x3D;20211014&amp;media&#x3D;https%3A%2F%2Fimagesvc.meredithcorp.io%2Fv3%2Fmm%2Fimage%3Furl%3Dhttps%253A%252F%252Fstatic.onecms.io%252Fwp-content%252Fuploads%252Fsites%252F44%252F2021%252F08%252F16%252Fcheesy-ground-beef-and-cauliflower-casserole.jpg&amp;description&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole%20" class="display-block allowPopup popup share-new__link" aria-label="Pin (opens in a new window)" target="_blank" title="pinterest share (opens in a new window)" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-pinterest" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M11.018 14.094l-.028.096c-.455 1.786-.506 2.183-.975 3.011a9.21 9.21 0 0 1-.753 1.126c-.031.04-.061.092-.124.08-.068-.015-.074-.077-.08-.131a9.552 9.552 0 0 1-.1-1.635c.025-.714.113-.959 1.033-4.827a.267.267 0 0 0-.022-.162c-.22-.594-.263-1.197-.071-1.808.416-1.32 1.912-1.42 2.173-.331.162.673-.265 1.554-.592 2.856-.27 1.075.994 1.84 2.075 1.054.997-.723 1.385-2.456 1.311-3.685-.144-2.45-2.832-2.98-4.536-2.191-1.955.904-2.398 3.326-1.516 4.432.112.142.198.227.16.37-.056.222-.106.445-.167.666-.046.164-.183.224-.349.156a2.005 2.005 0 0 1-.816-.611c-.75-.928-.964-2.764.027-4.317 1.098-1.721 3.139-2.417 5.004-2.206 2.226.253 3.632 1.774 3.896 3.5.12.786.034 2.724-1.07 4.094-1.27 1.575-3.327 1.679-4.277.713-.073-.074-.132-.162-.203-.25"/></svg><span class="icon-text">Pin</span></a></span> <span class="icon icon-print social-icon padding-8-right" data-social-service="print"><a href="?printview" class="display-block" aria-label="Print this page" title="print share" data-tracking-label="print preview" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole" data-tracking-event-name="content action taken"> <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M19 8h-2V5H7v3H5v7h2v4h10v-4h2V8zM8 6h8v2H8V6zm0 12v-5h8v5H8zm9-7c-.533 0-1-.467-1-1 0-.533.467-1 1-1s1 .467 1 1c0 .533-.467 1-1 1zm-2 4v1H9v-1h6z"/></svg> <span class="icon-text">Print</span></a></span> <button class="icon shareicon-modal-toggle" aria-label="More Share Options" data-tracking-do-not-track="1"><span class="icon icon-ellipsis default-icon"><svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 20 20" aria-hidden="true"><path d="M10.001 7.8c-1.215 0-2.201 0.985-2.201 2.2s0.986 2.2 2.201 2.2c1.215 0 2.199-0.985 2.199-2.2s-0.984-2.2-2.199-2.2zM3.001 7.8c-1.215 0-2.201 0.985-2.201 2.2s0.986 2.2 2.201 2.2c1.215 0 2.199-0.986 2.199-2.2s-0.984-2.2-2.199-2.2zM17.001 7.8c-1.215 0-2.201 0.985-2.201 2.2s0.986 2.2 2.201 2.2c1.215 0 2.199-0.985 2.199-2.2s-0.984-2.2-2.199-2.2z"/></svg> <span class="icon-text">More</span></span> </button></div> <div class="sharebar-modal hidden"><div data-tracking-zone="share bar" class="component share-new square"> <span class="icon icon-facebook social-icon padding-8-right" data-social-service="facebook"><a href="https://www.facebook.com/sharer/sharer.php?u&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;facebook.com%26utm_medium&#x3D;social%26utm_campaign&#x3D;social-share-recipe%26utm_content&#x3D;20211014" class="display-block allowPopup popup" aria-label="Share this on Facebook (opens in a new window)" target="_blank" title="facebook share (opens in a new window)" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-facebook" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M13.774 8.824c.355-.012.71-.003 1.066-.003h.147V7.079c-.19-.018-.388-.043-.587-.052-.364-.015-.73-.033-1.094-.025-.557.01-1.084.139-1.544.45-.528.358-.818.86-.928 1.454a4.708 4.708 0 0 0-.064.747c-.01.39-.002.78-.002 1.172v.146H9v1.945h1.758v4.889h2.148v-4.88h1.752l.27-1.955h-.394c-.498.002-1.643 0-1.643 0s.006-.964.018-1.382c.017-.573.378-.748.865-.764"/></svg><span class="icon-text">Facebook</span></a></span> <span class="icon icon-twitter social-icon" data-social-service="twitter"><a href="https://www.twitter.com/intent/tweet?text&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole%20https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;twitter.com%26utm_medium&#x3D;social%26utm_campaign&#x3D;social-share-recipe" class="display-block allowPopup popup" aria-label="Tweet this (opens in a new window)" target="_blank" title="twitter share (opens in a new window)" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-twitter" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M9.793 15.25c-1.336-.049-2.17-1.041-2.392-1.847.372.073.739.058 1.103-.035.009-.002.018-.009.036-.017a2.571 2.571 0 0 1-1.669-1.222 2.65 2.65 0 0 1-.376-1.415c.36.2.738.311 1.144.323-.545-.406-.91-.937-1.059-1.615a2.72 2.72 0 0 1 .276-1.928c1.392 1.697 3.153 2.628 5.301 2.781-.016-.105-.031-.197-.041-.291a2.65 2.65 0 0 1 .375-1.74c.41-.664.993-1.077 1.743-1.204.864-.146 1.619.109 2.25.742.042.042.077.056.137.042a5.05 5.05 0 0 0 1.494-.595c.012-.006.023-.013.035-.018.002-.002.006-.001.017-.001a2.709 2.709 0 0 1-1.1 1.448 4.769 4.769 0 0 0 1.43-.399l.01.012c-.097.134-.193.27-.295.399a5.128 5.128 0 0 1-.933.92c-.03.022-.044.044-.044.084.015.395 0 .79-.047 1.182a8.026 8.026 0 0 1-.663 2.37 7.686 7.686 0 0 1-1.388 2.098 6.815 6.815 0 0 1-3.533 2.038 7.4 7.4 0 0 1-1.431.177 7.069 7.069 0 0 1-4.113-1.144l-.06-.04a5.039 5.039 0 0 0 3.793-1.105"/></svg><span class="icon-text">Tweet</span></a></span> <span class="icon icon-email-solid default-icon padding-8-right" data-social-service="email"><a href="mailto:?subject&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole%20&amp;body&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;emailshare%26utm_medium&#x3D;email%26utm_campaign&#x3D;email-share-recipe%26utm_content&#x3D;20211014" class="display-block" aria-label="Email this" title="email share" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.016 8.016v-2.016l-8.016 5.016-8.016-5.016v2.016l8.016 4.969zM20.016 3.984c1.078 0 1.969 0.938 1.969 2.016v12c0 1.078-0.891 2.016-1.969 2.016h-16.031c-1.078 0-1.969-0.938-1.969-2.016v-12c0-1.078 0.891-2.016 1.969-2.016h16.031z"/></svg> <span class="icon-text">Email</span></a></span> <span class="icon icon-sms utility-icon" data-social-service="sms"><a href="sms://?&amp;body&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/?utm_source&#x3D;smsshare&amp;utm_medium&#x3D;sms&amp;utm_campaign&#x3D;sms-share-recipe&amp;utm_content&#x3D;20211014" class="display-block" aria-label="Text message this" title="sms share"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-sms" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M15.984 18v-14.016h-9v14.016h9zM11.484 21.984c0.844 0 1.5-0.656 1.5-1.5s-0.656-1.5-1.5-1.5-1.5 0.656-1.5 1.5 0.656 1.5 1.5 1.5zM15.516 0.984c1.359 0 2.484 1.172 2.484 2.531v16.969c0 1.359-1.125 2.531-2.484 2.531h-8.016c-1.359 0-2.484-1.172-2.484-2.531v-16.969c0-1.359 1.125-2.531 2.484-2.531h8.016z"/></svg> <span class="icon-text">Send Text Message</span></a></span> </div> </div></div> </div> <div class="recipe-content-container" data-tracking-zone="body"> <div class="lead-content-wrapper two-col-style"> <div class="primary-media-section"> <h2 class="hidden-label">Gallery</h2> <div class="image-container"> <div class="component lazy-image lazy-image-udf lead-media ugc-photos-link aspect_1x1 cache-only align-default" data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url&#x3D;https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg" data-use-imagesvc-to-cache="true" data-special-crop="rect&#x3D;0,0,2000,2000" data-alt="Cheesy Ground Beef &amp; Cauliflower Casserole " data-title="cheesy-ground-beef-and-cauliflower-casserole" data-shop-image="false" data-original-width="2000" data-original-height="2000" data-high-density="true" data-main-recipe="true" data-crop-percentage="100" data-tracking-zone="image" data-orientation="default" data-focal-point-x="1160" data-focal-point-y="700"> <noscript><img src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg" alt="Cheesy Ground Beef &amp; Cauliflower Casserole "></noscript> <div class="inner-container js-inner-container image-overlay"> <span class="placeholderText visually-hidden">Cheesy Ground Beef &amp; Cauliflower Casserole </span> <span class="icon icon-pinterest-circle-solid social-icon pinterest-transparent" data-social-service="pinterest"><a href="https://www.pinterest.com/pin/create/link/?url&#x3D;https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F%3Futm_source%3Dpinterest.com%26utm_medium%3Dsocial%26utm_campaign%3Dsocial-share-recipe%26utm_content%3D20211014%26utm_term%3Dundefined&amp;media&#x3D;https%3A%2F%2Fimagesvc.meredithcorp.io%2Fv3%2Fmm%2Fimage%3Furl%3Dhttps%253A%252F%252Fstatic.onecms.io%252Fwp-content%252Fuploads%252Fsites%252F44%252F2021%252F08%252F16%252Fcheesy-ground-beef-and-cauliflower-casserole.jpg&amp;description&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole" class="display-block allowPopup popup" aria-label="Pin this Cheesy Ground Beef &amp; Cauliflower Casserole  image" title="pinterest share"> <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><g fill="none" fill-rule="evenodd"><path d="M32 16c0 8.837-7.163 16-16 16S0 24.837 0 16 7.163 0 16 0s16 7.163 16 16" fill="#E54A59"/><path d="M15.164 18.532c-.011.039-.022.072-.03.106-.503 1.97-.56 2.408-1.076 3.322-.246.436-.524.847-.832 1.242-.034.044-.067.102-.136.088-.076-.016-.082-.084-.09-.145-.083-.599-.128-1.2-.108-1.803.026-.788.123-1.058 1.139-5.327a.295.295 0 0 0-.024-.178c-.244-.656-.291-1.32-.079-1.995.459-1.456 2.11-1.567 2.398-.366.178.743-.292 1.716-.653 3.152-.299 1.186 1.097 2.03 2.29 1.163 1.1-.798 1.527-2.71 1.446-4.067-.16-2.703-3.125-3.287-5.005-2.417-2.157.997-2.647 3.67-1.673 4.891.123.156.219.25.177.408-.062.245-.117.49-.185.734-.05.182-.202.247-.385.173a2.212 2.212 0 0 1-.9-.675c-.827-1.024-1.064-3.049.03-4.763 1.21-1.9 3.463-2.668 5.52-2.435 2.457.28 4.01 1.958 4.3 3.863.133.867.038 3.006-1.18 4.518-1.402 1.737-3.672 1.852-4.72.786-.08-.082-.145-.178-.224-.275" fill="#FFF"/></g></svg> </a></span> <button class="icon icon-image-zoom" data-image="https://imagesvc.meredithcorp.io/v3/mm/image?url&#x3D;https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg" data-caption="" data-credit="Credit: Jason Donnelly" data-alt="Cheesy Ground Beef &amp; Cauliflower Casserole " data-title="cheesy-ground-beef-and-cauliflower-casserole" aria-label="Make image larger cheesy-ground-beef-and-cauliflower-casserole" data-tracking-do-not-track="1"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M2.667 21.333h8v2.667h-10.667v-10.667h2.667v8zM21.333 0h2.667v10.667h-2.667v-8h-8v-2.667h8z"/></svg> </button> </div><div class="lazy-image__loadingPlaceholder"><img class="loadingPlaceholder" alt="" src="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20100%20100'%3E%3C/svg%3E" width="2000" height="2000"></div></div> <div class="credit scale-12 elementFont__fine--credit"> Credit: Jason Donnelly </div> </div> </div> <div class="lead-content-aside-wrapper"> <div class="recipe-info-section"> <h2 class="hidden-label">Recipe Summary test</h2> <span class="time-stats icon-background-round" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="32px" height="32px" aria-hidden="true"><path fill="#000" d="M11.026 13.974V9.25a4.724 4.724 0 0 1 4.724 4.724h-4.724zm0 5.833a5.834 5.834 0 1 0 0-11.667 5.834 5.834 0 0 0 0 11.667zm9.103-10.975a.562.562 0 0 1-.121.785l-.283.207a.561.561 0 0 1-.784-.121l-.39-.533-.73.534A8.026 8.026 0 1 1 9.97 6.02V4.69H8.3a.561.561 0 0 1-.562-.562V2.561c0-.31.252-.561.561-.561h5.456c.31 0 .56.251.56.561v1.566a.56.56 0 0 1-.56.561h-1.67V6.02a8.01 8.01 0 0 1 5.051 2.752l.73-.535-.39-.533a.561.561 0 0 1 .12-.785l.283-.207a.561.561 0 0 1 .784.121l1.467 2z"/></svg> </span> <section class="recipe-meta-container two-subcol-content clearfix"> <div class="two-subcol-content-wrapper"> <div class="recipe-meta-item"> <div class="recipe-meta-item-header elementFont__subtitle--bold elementFont__transformCapitalize">active:</div> <div class="recipe-meta-item-body elementFont__subtitle">30 mins </div> </div> <div class="recipe-meta-item"> <div class="recipe-meta-item-header elementFont__subtitle--bold elementFont__transformCapitalize">total:</div> <div class="recipe-meta-item-body elementFont__subtitle">30 mins </div> </div> </div> <div class="two-subcol-content-wrapper"> <div class="recipe-meta-item"><div class="recipe-meta-item-header elementFont__subtitle--bold elementFont__transformCapitalize">Servings:</div> <div class="recipe-meta-item-body elementFont__subtitle">6 </div> </div> </div> </section> <div class="nutrition-profile"> <h3 class="nutrition-profile-header elementFont__subtitle--bold">Nutrition Profile:</h3> <ul class="nutrition-profile__itemList elementFont__details"> <li class="nutrition-profile-item elementFont__details--linkWithin"><a href="https://www.eatingwell.com/recipes/18048/dietary-restrictions/egg-free/">Egg Free</a></li> <li class="nutrition-profile-item elementFont__details--linkWithin"><a href="https://www.eatingwell.com/recipes/17900/dietary-restrictions/gluten-free/">Gluten-Free</a></li> <li class="nutrition-profile-item elementFont__details--linkWithin"><a href="https://www.eatingwell.com/recipes/22762/nutrient-focused-diets/high-protein/">High-Protein</a></li> <li class="nutrition-profile-item elementFont__details--linkWithin"><a href="https://www.eatingwell.com/recipes/18051/dietary-restrictions/nut-free/">Nut-Free</a></li> <li class="nutrition-profile-item elementFont__details--linkWithin"><a href="https://www.eatingwell.com/recipes/18050/dietary-restrictions/soy-free/">Soy-Free</a></li> </ul> </div> <div class="nutrition-info"><a class="nutrition-link elementFont__detailsLink--underlined" href="#nutrition" data-label="nutritional value clicked" data-tracking-zone="recipe-interaction">Nutrition Info</a></div> </div> </div> </div> <div class="recipe-ad-container mobile-ad"><div id="div-gpt-mob-square-flex-1" data-tier="1" class="ad ad-container ad-wrapper mobile-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> </div> <div class="recipe-ad-container tablet-ad"><div id="div-gpt-square-fixed-1" data-tier="1" class="ad ad-container ad-wrapper tablet-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-2" data-tier="2" class="ad ad-container ad-wrapper tablet-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> </div> <div class="recipe-ad-container ad-title mobile-ad tablet-ad">Advertisement</div> <a class="skipLink__destination skipLink__destination--headerOffset" id="recipe-body"></a> <div class="recipe-shopper-wrapper"> <section class="component recipe-ingredients recipeIngredients container" data-login-url="/account/signup?context_action&#x3D;View%20Shopping%20List&amp;custom_dek&#x3D;Sign%20up%20to%20view%20your%20account%27s%20shopping%20list.&amp;returnURL&#x3D;https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F" data-regsource="" data-servings="6" data-recipe-id="7919044" data-tracking-zone="recipe-ingredients"> <div class="section-headline"> <h2 class="elementFont__subhead">Ingredients</h2> </div> <fieldset class="ingredients-section__fieldset"> <legend class="visually-hidden ingredients-section__legend">Ingredient Checklist</legend> <ul class="ingredients-section" data-tracking-label="ingredients section"> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="31628"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-0"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="1" data-init-quantity="1" data-unit="tablespoon" data-ingredient="extra-virgin olive oil" data-unit_family="volumetric" type="checkbox" value=" extra-virgin olive oil" id="recipe-ingredients-label-7919044-0-0"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">1 tablespoon extra-virgin olive oil </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="4397"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-1"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="½" data-init-quantity="0.5" data-unit="cup" data-ingredient="chopped onion" data-unit_family="volumetric" type="checkbox" value=" onions" id="recipe-ingredients-label-7919044-0-1"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">½ cup chopped onion </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="4432"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-2"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="1" data-init-quantity="1" data-unit="medium" data-ingredient="green bell pepper, chopped" data-unit_family="each" type="checkbox" value="large green bell pepper" id="recipe-ingredients-label-7919044-0-2"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">1 medium green bell pepper, chopped </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="30014"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-3"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="1" data-init-quantity="1" data-unit="pound" data-ingredient="lean ground beef" data-unit_family="weight" type="checkbox" value=" beef, ground, raw, 10% fat" id="recipe-ingredients-label-7919044-0-3"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">1 pound lean ground beef </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="4286"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-4"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="3" data-init-quantity="3" data-unit="cups" data-ingredient="bite-size cauliflower florets" data-unit_family="volumetric" type="checkbox" value="head cauliflower" id="recipe-ingredients-label-7919044-0-4"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">3 cups bite-size cauliflower florets </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="4342"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-5"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="3" data-init-quantity="3" data-unit="cloves" data-ingredient="garlic, minced" data-unit_family="each" type="checkbox" value="clove garlic, whole" id="recipe-ingredients-label-7919044-0-5"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">3 cloves garlic, minced </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="30929"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-6"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="2" data-init-quantity="2" data-unit="tablespoons" data-ingredient="chili powder" data-unit_family="volumetric" type="checkbox" value=" chili powder" id="recipe-ingredients-label-7919044-0-6"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">2 tablespoons chili powder </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="20551"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-7"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="2" data-init-quantity="2" data-unit="teaspoons" data-ingredient="ground cumin" data-unit_family="volumetric" type="checkbox" value=" ground cumin" id="recipe-ingredients-label-7919044-0-7"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">2 teaspoons ground cumin </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="30307"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-8"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="1" data-init-quantity="1" data-unit="teaspoon" data-ingredient="dried oregano" data-unit_family="volumetric" type="checkbox" value=" chopped fresh oregano" id="recipe-ingredients-label-7919044-0-8"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">1 teaspoon dried oregano </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="33513"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-9"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="½" data-init-quantity="0.5" data-unit="teaspoon" data-ingredient="salt" data-unit_family="volumetric" type="checkbox" value=" salt" id="recipe-ingredients-label-7919044-0-9"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">½ teaspoon salt </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="23729"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-10"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="¼" data-init-quantity="0.25" data-unit="teaspoon" data-ingredient="ground chipotle " data-unit_family="volumetric" type="checkbox" value="pinch ground chipotle " id="recipe-ingredients-label-7919044-0-10"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">¼ teaspoon ground chipotle </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="10498"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-11"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="1" data-init-quantity="1" data-unit="(15 ounce) can" data-ingredient="no-salt-added petite-diced tomatoes" data-unit_family="each" type="checkbox" value="(14.5 ounce) can peeled and diced tomatoes" id="recipe-ingredients-label-7919044-0-11"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">1 (15 ounce) can no-salt-added petite-diced tomatoes </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="22106"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-12"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="2" data-init-quantity="2" data-unit="cups" data-ingredient="shredded extra-sharp Cheddar cheese" data-unit_family="volumetric" type="checkbox" value="slice sharp Cheddar cheese" id="recipe-ingredients-label-7919044-0-12"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">2 cups shredded extra-sharp Cheddar cheese </span> </span> </label> </li> <li class="ingredients-item" data-tracking-zone="recipe-interaction" data-id="4634"> <label class="checkbox-list" for="recipe-ingredients-label-7919044-0-13"> <input class="checkbox-list-input" data-tracking-label="ingredient clicked" data-quantity="⅓" data-init-quantity="0.333" data-unit="cup" data-ingredient="sliced pickled jalapeños" data-unit_family="volumetric" type="checkbox" value="(4 ounce) can jalapeno peppers" id="recipe-ingredients-label-7919044-0-13"> <span class="checkbox-list-checkmark"> <span class="ingredients-item-name elementFont__body">⅓ cup sliced pickled jalapeños </span> </span> </label> </li> </ul> </fieldset> </section> <section class="recipe-shopper-container"> <div id="recipe-shopper" class="recipe-shopper"></div> </section> </div> <section class="component recipe-instructions recipeInstructions container"> <h2 class="section-headline elementFont__subhead"> <span class="section-icon icon-background-round" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" aria-hidden="true"><path d="M21.616 13.945c.663 0 1.175.651 1.068 1.37C21.958 20.22 18.514 24 11.85 24c-6.664 0-10.108-3.78-10.835-8.685-.106-.719.405-1.37 1.068-1.37h19.534zM5.894 15.947h-2.72c.406 1.662 1.207 3.046 2.348 4.042.919.802 2.057 1.364 3.399 1.687-1.95-1.138-2.655-3.543-3.027-5.729zm9.857-9.09l.048-.14.009-.028 1.323-.876.05.077c.143.215.429.28.65.148l5.425-3.228A1.511 1.511 0 1 0 21.589.293l-5.09 3.734a.483.483 0 0 0-.117.656l.05.076-1.267.84a13.78 13.78 0 0 0-.112-.01l-.15-.01c-1.716-.119-6.94-.273-8.355 2.079-.634 1.054-.426 2.388.618 3.965 1.044 1.576 2.191 2.289 3.409 2.116 2.717-.385 4.615-5.255 5.176-6.881M7.58 8.278c.539-.896 2.251-1.327 4.075-1.481l-.12.046C9.542 7.63 8.19 8.55 7.491 9.59c-.15-.522-.122-.96.089-1.31zm2.826 4.269c-.404.057-.819-.087-1.24-.43 1.23-.237 2.604-1.123 4.106-2.652l.09-.092c-.855 1.62-1.92 3.028-2.956 3.174zM8.181 10.95c.374-1.63 3.075-2.832 5.32-3.522-1.512 1.797-3.672 3.815-5.32 3.522z"/></svg> </span>Directions</h2> <fieldset class="instructions-section__fieldset"> <legend class="visually-hidden instructions-section__legend elementFont__title">Instructions Checklist</legend> <ul class="instructions-section" data-tracking-label="instructions section"> <li class="subcontainer instructions-section-item" data-tracking-zone="recipe-interaction"> <label class="checkbox-list" for="recipe-instructions-label-0-0"> <input class="checkbox-list-input" type="checkbox" value="" data-tracking-label="directions clicked" id="recipe-instructions-label-0-0"> <span class="checkbox-list-checkmark"> <span class="checkbox-list-text elementFont__subtitle--bold">Step 1</span> </span> </label> <div class="section-body elementFont__body--paragraphWithin elementFont__body--linkWithin"><div class="paragraph"><p>Position rack in upper third of oven. Preheat broiler to high.</p> </div> </div> <div id="div-gpt-mob-square-fixed-1" data-tier="2" class="ad ad-container ad-wrapper mobile-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div class="ad-title mobile-ad">Advertisement</div> </li> <li class="subcontainer instructions-section-item" data-tracking-zone="recipe-interaction"> <label class="checkbox-list" for="recipe-instructions-label-0-1"> <input class="checkbox-list-input" type="checkbox" value="" data-tracking-label="directions clicked" id="recipe-instructions-label-0-1"> <span class="checkbox-list-checkmark"> <span class="checkbox-list-text elementFont__subtitle--bold">Step 2</span> </span> </label> <div class="section-body elementFont__body--paragraphWithin elementFont__body--linkWithin"><div class="paragraph"><p>Heat oil in a large oven-safe skillet over medium heat. Add onion and bell pepper; cook, stirring, until softened, about 5 minutes. Add beef and cauliflower; cook, stirring and breaking the beef up into smaller pieces, until it is no longer pink, 5 to 7 minutes. Stir in garlic, chili powder, cumin, oregano, salt and chipotle; cook until fragrant, about 1 minute. Add tomatoes and their juices; bring to a simmer and cook, stirring occasionally, until liquid is reduced and the cauliflower is tender, about 3 minutes more. Remove from heat.</p> </div> </div> </li> <li class="subcontainer instructions-section-item" data-tracking-zone="recipe-interaction"> <label class="checkbox-list" for="recipe-instructions-label-0-2"> <input class="checkbox-list-input" type="checkbox" value="" data-tracking-label="directions clicked" id="recipe-instructions-label-0-2"> <span class="checkbox-list-checkmark"> <span class="checkbox-list-text elementFont__subtitle--bold">Step 3</span> </span> </label> <div class="section-body elementFont__body--paragraphWithin elementFont__body--linkWithin"><div class="paragraph"><p>Sprinkle cheese over the beef mixture and top with sliced jalapeños. Broil until the cheese is melted and browned in spots, 2 to 3 minutes.</p> </div> </div> </li> </ul> </fieldset> </section> <section class="nutrition-section container"> <h2 class="section-headline elementFont__subhead"> <a id="nutrition"></a> <span class="section-icon icon-background-round" aria-hidden="true"> <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" aria-hidden="true"><path d="M5 9.2h3V19H5V9.2zM10.6 5h2.8v14h-2.8V5zm5.6 8H19v6h-2.8v-6z"/></svg> </span> Nutrition Facts </h2> <div class="partial recipe-nutrition-section elementFont__subtitle elementFont__subtitle--linkWithin"> <div class="section-label">Serving Size: <span class="section-body">about 1 cup</span></div> <div class="section-label">Per Serving:</div> <div class="section-body"> 351 calories; fat 23g; cholesterol 86mg; sodium 672mg; carbohydrates 11g; dietary fiber 3g; protein 26g; sugars 4g; niacin equivalents 5mg; saturated fat 11g; vitamin a iu 1522IU; potassium 639mg. </div> </div> </section> <div class="karma-lazy-seriesDetails"></div> </div> </div> <div class="div-sm-inStream"></div> </div> <div class="recipe-right-rail two-col-right-rail karma-sticky-rail"> <div class="monetate" id="Reciperightrail" role="complementary" aria-hidden="true"></div> <div class="karma-rail-docking-element"> <div class="recipe-ad-wrapper"><div id="div-gpt-square-flex-1" data-tier="1" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-3" data-tier="2" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> </div> <div class="recipe-ad-wrapper ad-title">Advertisement</div> </div> </div> </div> <div class="content last"> <div class="recirculation-wrapper"> <div class="component recirculation loading recirculation__cards" data-recirc="closed" data-show-toaster="" data-endpoint="/element-api/content-proxy/recommendations" data-recommendations-request-data="%7B%22provider%22%3A%22cms%22%2C%22brand%22%3A%22etg%22%2C%22id%22%3A%227919044%22%2C%22matchFactor%22%3A%22%22%2C%22contentType%22%3A%22recipe%22%2C%22parent%22%3A%22cms%2Fonecms_terms_etg_735%22%2C%22entity%22%3A%22cms%2Fonecms_terms_etg_736%22%2C%22category%22%3A%22Healthy%20Casserole%20Recipes%22%2C%22content_graph_id%22%3A%22cms%2Fonecms_posts_etg_7919044%22%7D" data-inject-content="recipe-in-recirc-outbrain" data-content-graph-id="cms/onecms_posts_etg_7919044"> </div> </div> </div> </div> <div class="div-sm-highImpact"></div> <div class="component feedback karma-content-container reviews recipe" data-render-template="feedback/partials/reviews" data-type="reviews" data-items-per-page="99" data-items-to-render="9" data-get-endpoint="/element-api/content-proxy/getreviewsbycontent" data-get-user-endpoint="/user-proxy/getreviewbyuserandcontent?mappingType&#x3D;myReview&amp;renderTemplate&#x3D;feedback/partials/my-review" data-post-endpoint="/user-proxy/savereview" data-post-reaction-endpoint="/user-proxy/savereaction" data-post-generate-signed-url-endpoint="/user-proxy/generatesignedurl" data-content-graph-id="cms/onecms_posts_etg_7919044" data-total="0" data-brand="etg" data-cms-id="7919044" data-content-type="recipe" data-url="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/" data-sort="-publishDate" data-sort-options="{
-  &quot;Newest&quot;: &quot;-publishDate&quot;,
-  &quot;Oldest&quot;: &quot;+publishDate&quot;
-}" data-is-demo="" data-provider="" data-provider-id=""> <div class="feedback__sharebar docked-sharebar-docking-container"> <div class="component docked-sharebar" data-tracking-zone="share"><div data-tracking-zone="share bar" class="component share-new vertical square"> <span class="icon icon-favorite default-icon padding-8-right" data-social-service="favorite" data-tracking-zone="save-heart"><a href="javascript:void(0);" class="display-block shareicon-favorite-link-tag shareicon-favorite-link" aria-label="Save this" title="favorite share" data-content-login-url="/account/signin?returnURL&#x3D;%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F&amp;regSource&#x3D;27687"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-favorite" width="36" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg> <span class="icon-text">Save</span></a></span> <span class="icon icon-pinterest social-icon padding-8-right" data-social-service="pinterest"><a href="https://www.pinterest.com/pin/create/link/?url&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;pinterest.com%26utm_medium&#x3D;social%26utm_campaign&#x3D;social-share-recipe%26utm_content&#x3D;20211014&amp;media&#x3D;https%3A%2F%2Fimagesvc.meredithcorp.io%2Fv3%2Fmm%2Fimage%3Furl%3Dhttps%253A%252F%252Fstatic.onecms.io%252Fwp-content%252Fuploads%252Fsites%252F44%252F2021%252F08%252F16%252Fcheesy-ground-beef-and-cauliflower-casserole.jpg&amp;description&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole%20" class="display-block allowPopup popup share-new__link" aria-label="Pin (opens in a new window)" target="_blank" title="pinterest share (opens in a new window)" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-pinterest" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M11.018 14.094l-.028.096c-.455 1.786-.506 2.183-.975 3.011a9.21 9.21 0 0 1-.753 1.126c-.031.04-.061.092-.124.08-.068-.015-.074-.077-.08-.131a9.552 9.552 0 0 1-.1-1.635c.025-.714.113-.959 1.033-4.827a.267.267 0 0 0-.022-.162c-.22-.594-.263-1.197-.071-1.808.416-1.32 1.912-1.42 2.173-.331.162.673-.265 1.554-.592 2.856-.27 1.075.994 1.84 2.075 1.054.997-.723 1.385-2.456 1.311-3.685-.144-2.45-2.832-2.98-4.536-2.191-1.955.904-2.398 3.326-1.516 4.432.112.142.198.227.16.37-.056.222-.106.445-.167.666-.046.164-.183.224-.349.156a2.005 2.005 0 0 1-.816-.611c-.75-.928-.964-2.764.027-4.317 1.098-1.721 3.139-2.417 5.004-2.206 2.226.253 3.632 1.774 3.896 3.5.12.786.034 2.724-1.07 4.094-1.27 1.575-3.327 1.679-4.277.713-.073-.074-.132-.162-.203-.25"/></svg><span class="icon-text">Pin</span></a></span> <span class="icon icon-print social-icon padding-8-right" data-social-service="print"><a href="?printview" class="display-block" aria-label="Print this page" title="print share" data-tracking-label="print preview" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole" data-tracking-event-name="content action taken"> <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M19 8h-2V5H7v3H5v7h2v4h10v-4h2V8zM8 6h8v2H8V6zm0 12v-5h8v5H8zm9-7c-.533 0-1-.467-1-1 0-.533.467-1 1-1s1 .467 1 1c0 .533-.467 1-1 1zm-2 4v1H9v-1h6z"/></svg> <span class="icon-text">Print</span></a></span> <button class="icon shareicon-modal-toggle" aria-label="More Share Options" data-tracking-do-not-track="1"><span class="icon icon-ellipsis default-icon"><svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 20 20" aria-hidden="true"><path d="M10.001 7.8c-1.215 0-2.201 0.985-2.201 2.2s0.986 2.2 2.201 2.2c1.215 0 2.199-0.985 2.199-2.2s-0.984-2.2-2.199-2.2zM3.001 7.8c-1.215 0-2.201 0.985-2.201 2.2s0.986 2.2 2.201 2.2c1.215 0 2.199-0.986 2.199-2.2s-0.984-2.2-2.199-2.2zM17.001 7.8c-1.215 0-2.201 0.985-2.201 2.2s0.986 2.2 2.201 2.2c1.215 0 2.199-0.985 2.199-2.2s-0.984-2.2-2.199-2.2z"/></svg> <span class="icon-text">More</span></span> </button></div> <div class="sharebar-modal hidden"><div data-tracking-zone="share bar" class="component share-new square"> <span class="icon icon-facebook social-icon padding-8-right" data-social-service="facebook"><a href="https://www.facebook.com/sharer/sharer.php?u&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;facebook.com%26utm_medium&#x3D;social%26utm_campaign&#x3D;social-share-recipe%26utm_content&#x3D;20211014" class="display-block allowPopup popup" aria-label="Share this on Facebook (opens in a new window)" target="_blank" title="facebook share (opens in a new window)" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-facebook" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M13.774 8.824c.355-.012.71-.003 1.066-.003h.147V7.079c-.19-.018-.388-.043-.587-.052-.364-.015-.73-.033-1.094-.025-.557.01-1.084.139-1.544.45-.528.358-.818.86-.928 1.454a4.708 4.708 0 0 0-.064.747c-.01.39-.002.78-.002 1.172v.146H9v1.945h1.758v4.889h2.148v-4.88h1.752l.27-1.955h-.394c-.498.002-1.643 0-1.643 0s.006-.964.018-1.382c.017-.573.378-.748.865-.764"/></svg><span class="icon-text">Facebook</span></a></span> <span class="icon icon-twitter social-icon" data-social-service="twitter"><a href="https://www.twitter.com/intent/tweet?text&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole%20https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;twitter.com%26utm_medium&#x3D;social%26utm_campaign&#x3D;social-share-recipe" class="display-block allowPopup popup" aria-label="Tweet this (opens in a new window)" target="_blank" title="twitter share (opens in a new window)" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-twitter" width="36" height="36" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M9.793 15.25c-1.336-.049-2.17-1.041-2.392-1.847.372.073.739.058 1.103-.035.009-.002.018-.009.036-.017a2.571 2.571 0 0 1-1.669-1.222 2.65 2.65 0 0 1-.376-1.415c.36.2.738.311 1.144.323-.545-.406-.91-.937-1.059-1.615a2.72 2.72 0 0 1 .276-1.928c1.392 1.697 3.153 2.628 5.301 2.781-.016-.105-.031-.197-.041-.291a2.65 2.65 0 0 1 .375-1.74c.41-.664.993-1.077 1.743-1.204.864-.146 1.619.109 2.25.742.042.042.077.056.137.042a5.05 5.05 0 0 0 1.494-.595c.012-.006.023-.013.035-.018.002-.002.006-.001.017-.001a2.709 2.709 0 0 1-1.1 1.448 4.769 4.769 0 0 0 1.43-.399l.01.012c-.097.134-.193.27-.295.399a5.128 5.128 0 0 1-.933.92c-.03.022-.044.044-.044.084.015.395 0 .79-.047 1.182a8.026 8.026 0 0 1-.663 2.37 7.686 7.686 0 0 1-1.388 2.098 6.815 6.815 0 0 1-3.533 2.038 7.4 7.4 0 0 1-1.431.177 7.069 7.069 0 0 1-4.113-1.144l-.06-.04a5.039 5.039 0 0 0 3.793-1.105"/></svg><span class="icon-text">Tweet</span></a></span> <span class="icon icon-email-solid default-icon padding-8-right" data-social-service="email"><a href="mailto:?subject&#x3D;Cheesy%20Ground%20Beef%20%26%20Cauliflower%20Casserole%20&amp;body&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/%3Futm_source&#x3D;emailshare%26utm_medium&#x3D;email%26utm_campaign&#x3D;email-share-recipe%26utm_content&#x3D;20211014" class="display-block" aria-label="Email this" title="email share" data-tracking-content-headline="Cheesy Ground Beef &amp; Cauliflower Casserole"> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.016 8.016v-2.016l-8.016 5.016-8.016-5.016v2.016l8.016 4.969zM20.016 3.984c1.078 0 1.969 0.938 1.969 2.016v12c0 1.078-0.891 2.016-1.969 2.016h-16.031c-1.078 0-1.969-0.938-1.969-2.016v-12c0-1.078 0.891-2.016 1.969-2.016h16.031z"/></svg> <span class="icon-text">Email</span></a></span> <span class="icon icon-sms utility-icon" data-social-service="sms"><a href="sms://?&amp;body&#x3D;https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/?utm_source&#x3D;smsshare&amp;utm_medium&#x3D;sms&amp;utm_campaign&#x3D;sms-share-recipe&amp;utm_content&#x3D;20211014" class="display-block" aria-label="Text message this" title="sms share"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-sms" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path d="M15.984 18v-14.016h-9v14.016h9zM11.484 21.984c0.844 0 1.5-0.656 1.5-1.5s-0.656-1.5-1.5-1.5-1.5 0.656-1.5 1.5 0.656 1.5 1.5 1.5zM15.516 0.984c1.359 0 2.484 1.172 2.484 2.531v16.969c0 1.359-1.125 2.531-2.484 2.531h-8.016c-1.359 0-2.484-1.172-2.484-2.531v-16.969c0-1.359 1.125-2.531 2.484-2.531h8.016z"/></svg> <span class="icon-text">Send Text Message</span></a></span> </div> </div></div> </div> <div class="feedback__wrapper karma-main-column"> <div class="feedback__header"> <h2 class="feedback__heading"> <a id="reviewSection"></a> Reviews </h2> </div> <div class="feedback__headerContainer euDisabled"> <div class="feedback__headerContainerInner"> <div class="feedback__reviewContainer feedback__reviewContainer--myReview"> </div> <div class="feedback__addContainer"> <div class="feedback__addContainerIcon"> <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="160" height="160" viewBox="0 0 160 160"> <circle class="ugc-avatar-background-color ugc-avatar-background-color-1" cx="80" cy="80" r="80"/> <g class="ugc-avatar-color ugc-avatar-color-1"> <path d="m 56.601,68.942 c 0,1.023 0.83,1.853 1.854,1.853 1.024,0 1.853,-0.83 1.853,-1.853 0,-1.024 -0.83,-1.854 -1.853,-1.854 -1.024,0 -1.854,0.83 -1.854,1.854 z"/> <path d="m 120.448,90.348 h 3.251 V 64.194 h -3.251 z m 5.565,0.024 h 3.25 V 64.217 h -3.25 z"/> <path d="m 131.505,88.048 c -0.661,0 -1.166,0.505 -1.166,1.167 0,0.661 0.505,1.166 1.166,1.166 0.662,0 1.167,-0.505 1.167,-1.166 0,-0.694 -0.505,-1.167 -1.167,-1.167 m 0.005,2.148 c -0.567,0 -0.977,-0.41 -0.977,-0.977 0,-0.567 0.41,-0.977 0.977,-0.977 0.568,0 0.977,0.41 0.977,0.977 0,0.568 -0.41,0.977 -0.977,0.977"/> <path d="m 131.978,89.025 c 0,-0.252 -0.189,-0.378 -0.41,-0.378 h -0.535 v 1.135 h 0.252 v -0.41 h 0.126 l 0.347,0.41 h 0.283 V 89.75 l -0.346,-0.346 c 0.157,-0.095 0.283,-0.19 0.283,-0.379 m -0.41,0.158 h -0.252 v -0.347 h 0.252 c 0.095,0 0.19,0.063 0.19,0.19 -0.032,0.094 -0.095,0.157 -0.19,0.157"/> <path d="m 82.565,83.726 c -0.032,-0.001 -0.062,-0.004 -0.093,-0.004 0.03,-0.017 0.062,-0.014 0.093,0.004 m -1.466,-0.79 c -1.487,0 -2.901,-1.379 -2.901,-4.499 0,-2.72 1.197,-4.425 2.901,-4.425 1.778,0 2.94,1.705 2.94,4.461 0,2.721 -1.126,4.463 -2.94,4.463 M 78.7,83.579 c 0.01,-0.017 0.023,-0.021 0.043,-0.01 -0.014,0.002 -0.028,0.007 -0.043,0.01 m 5.85,0.483 c 1.656,-0.92 2.711,-2.883 2.711,-5.335 0,-1.992 -0.667,-3.652 -1.633,-4.653 1.26,0.09 2.134,-0.199 2.134,-0.199 l -0.559,-2.373 c 0,0 -0.955,0.224 -2.304,0.224 -1.396,0 -2.466,-0.326 -3.8,-0.326 -3.888,0 -5.97,2.625 -5.97,6.686 0,2.523 0.946,4.784 2.63,5.857 -0.8,0.427 -1.58,1.102 -2.048,1.6 l 1.833,2.036 c 0.786,-0.857 2.182,-1.776 3.998,-1.776 2.233,0 3.939,1.524 3.939,3.735 0,2.304 -1.845,3.56 -4.219,3.56 -2.746,0 -4.664,-1.87 -4.664,-1.87 l -1.87,2.01 c 1.426,1.501 3.881,2.685 6.642,2.685 3.965,0 7.183,-2.266 7.183,-6.13 0,-2.809 -1.653,-4.94 -4.003,-5.731 M 41.2,88.076 c -1.324,0 -2.488,-1.005 -2.488,-4.052 0,-2.584 0.855,-4.052 2.419,-4.052 1.705,0 2.757,1.689 2.757,4.016 0,2.085 -1.188,4.088 -2.688,4.088 m 6.753,-0.493 c -0.698,-0.14 -1.094,-0.535 -1.094,-1.745 V 77.93 c 0,-4.964 -1.732,-6.711 -5.615,-6.711 -2.336,0 -4.07,0.99 -4.07,0.99 l 0.054,2.655 c 0,0 1.856,-0.878 3.53,-0.878 2.254,0 3.13,1.496 3.13,3.545 v 1.378 c -0.762,-1.125 -2.115,-1.523 -3.348,-1.523 -2.83,0 -5.079,2.248 -5.079,6.602 0,4.425 2.441,6.783 5.199,6.783 1.141,0 2.698,-0.626 3.738,-2.322 0.25,1.054 1.034,2.067 2.997,2.067 1.082,0 1.664,-0.175 1.664,-0.175 v -2.735 c 0,0 -0.407,0.117 -1.106,-0.023 M 53.11,67.98 49.86,68.998 v 2.728 h -1.992 v 2.997 h 1.991 V 85.8 c 0,3.374 1.437,4.752 4.266,4.752 0.436,0 0.69,-0.036 1.125,-0.181 V 87.64 c -0.254,0.073 -0.363,0.073 -0.58,0.073 -1.307,0 -1.56,-0.4 -1.56,-2.25 v -10.74 h 2.14 V 71.726 H 53.11 V 67.98 m 3.725,22.392 h 3.25 V 71.726 h -3.25 z M 69.274,71.218 c -1.275,0 -2.889,0.679 -4.002,2.448 v -1.94 h -2.985 v 18.646 h 3.25 V 78.35 c 0,-2.14 1.7,-4.28 3.245,-4.28 1.28,0 1.667,0.926 1.667,2.515 v 13.787 h 3.25 v -13.93 c 0,-1.813 -0.399,-2.974 -1.16,-3.845 -0.763,-0.907 -1.96,-1.379 -3.265,-1.379 M 105.588,64.217 102.075,81.356 98.994,64 h -2.532 l -3.12,17.344 -3.62,-17.127 h -3.287 l 6.023,26.445 h 1.929 l 3.35,-18.105 3.26,18.105 h 1.966 l 6.021,-26.445 z m 7.685,9.697 c 1.6,0 2.409,1.722 2.409,5.358 h -5.108 c 0,-3.702 1.193,-5.358 2.7,-5.358 m 0.295,13.98 c -1.866,0 -3.116,-2.03 -3.116,-5.141 0,-0.464 -0.003,-0.645 -0.003,-0.755 l 8.245,-0.003 c 0.037,-1.11 0.056,-1.453 0.056,-2.034 0,-5.417 -1.607,-8.742 -5.478,-8.742 -3.974,0 -5.913,3.623 -5.913,9.867 0,6.268 2.522,9.685 6.118,9.685 2.478,0 4.261,-1.531 5.308,-4.182 l -2.305,-1.32 c -0.761,1.489 -1.522,2.625 -2.912,2.625 M 26,90.372 h 9.136 v -3.214 h -5.813 v -8.685 h 5.02 V 75.26 h -5.02 v -7.829 h 5.883 V 64.217 H 26 Z"/> </g> </svg> </div> <button class="feedback__addContainerButton elementButton__big elementButton__contained embedded-auth-modal-trigger" data-login-url="/account/signup" data-regsource="27634" data-context-action="Rate & Review" data-context-dek="Join now to rate and review Cheesy Ground Beef &amp; Cauliflower Casserole">Add Rating &amp; Review</button> </div> <div class="feedback__topRatingsContainer"> </div> </div> </div> <div class="feedback__contentWrapper loading"> <div class="feedback__bodyContainer feedback__bodyContainer--noFeedback"> <span class="euDisabled">Be the first to rate and review!</span> <span class="euEnabled">No ratings or reviews yet.</span> </div> </div> </div> <div class="feedback__rightRail karma-sticky-rail"> <div class="karma-rail-docking-element"> <div class="feedback__rightRailAdWrapper"> <div id="div-gpt-square-fixed-4" data-tier="3" data-scroll-load="true" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-5" data-tier="4" data-scroll-load="true" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> </div> <div class="desktop-ad ad-title">Advertisement</div> </div> </div> </div><div class="partial modal feedback__modal static" aria-hidden="true" id="dialog-aff516ae-7a29-4408-81ef-2ddad6abb225" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="feedback-modal-close"> <button class="close" type="button" data-a11y-dialog-hide data-tracking-zone="do-not-track" data-action="close-hamburger-menu"> <span class="visually-hidden">Close this dialog window</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="feedback-modal-close" class="dialogTitle elementFont__title"> <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path fill="#FFF" d="M26.667 2.667H5.333c-1.466 0-2.653 1.2-2.653 2.666l-.013 24L8 24h18.667c1.466 0 2.666-1.2 2.666-2.667v-16c0-1.466-1.2-2.666-2.666-2.666zm-2.667 16H8V16h16v2.667zm0-4H8V12h16v2.667zm0-4H8V8h16v2.667z"/></svg> Review this recipe</h2> <div class="content modalContent content--noPadding"><div aria-live="assertive" class="component alert-banner type-error hidden"> <div class="alert-wrapper"><div class="alert-icon"></div> <div class="alert-text"> </div> <button class="alert-close" aria-label="Close this alert"><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button></div></div> <div class="feedback__modalContainer"> <div class="feedback__modalInner"> <form class="feedback__modalContent"> <div class="feedback__modalHeader"> <div class="feedback__modalPlaceholder"></div> <div class="feedback__modalHeadline">Cheesy Ground Beef & Cauliflower Casserole</div> </div> <div class="feedback__modalBody"> <div class="feedback__modalUserInput"> <div class="feedback__modalRating"> <div class="component recipe-ratings interactive"> <fieldset class="ratings-text ratings-input"> <legend class="ratings-legend">Rate this recipe</legend> <input name="ugc-rating" type="radio" value="" id="star0" class="rating-star-input visually-hidden star0" checked="checked"> <label for="star0" class="rating-star rating-star-label"> <span class="ratings-text-label" data-rating="0">Your rating</span> </label> <input name="ugc-rating" type="radio" value="1" id="star1" class="rating-star-input visually-hidden star1"> <label for="star1" class="rating-star rating-star-label"> <span class="visually-hidden">Rate this a 1: </span> <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path class="rating-star-filled" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg> <span class="ratings-text-label" data-rating="1">Couldn&#x27;t eat it</span> </label> <input name="ugc-rating" type="radio" value="2" id="star2" class="rating-star-input visually-hidden star2"> <label for="star2" class="rating-star rating-star-label"> <span class="visually-hidden">Rate this a 2: </span> <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path class="rating-star-filled" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg> <span class="ratings-text-label" data-rating="2">Didn&#x27;t like it</span> </label> <input name="ugc-rating" type="radio" value="3" id="star3" class="rating-star-input visually-hidden star3"> <label for="star3" class="rating-star rating-star-label"> <span class="visually-hidden">Rate this a 3: </span> <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path class="rating-star-filled" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg> <span class="ratings-text-label" data-rating="3">It was OK</span> </label> <input name="ugc-rating" type="radio" value="4" id="star4" class="rating-star-input visually-hidden star4"> <label for="star4" class="rating-star rating-star-label"> <span class="visually-hidden">Rate this a 4: </span> <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path class="rating-star-filled" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg> <span class="ratings-text-label" data-rating="4">Liked it</span> </label> <input name="ugc-rating" type="radio" value="5" id="star5" class="rating-star-input visually-hidden star5"> <label for="star5" class="rating-star rating-star-label"> <span class="visually-hidden">Rate this a 5: </span> <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true" xmlns="http://www.w3.org/2000/svg"><path class="rating-star-filled" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg> <span class="ratings-text-label" data-rating="5">Loved it</span> </label> </fieldset> </div> </div> <div class="feedback__modalText"> <label class="visually-hidden" for="feedback-text">What did you think about this recipe? Did you make any changes or notes?</label> <textarea id="feedback-text" name="feedback-text" placeholder="What did you think about this recipe? Did you make any changes or notes?"></textarea> </div> </div> </div> <div class="feedback__modalButtons"> <button class="feedback__modalCancel elementButton__cancel" type="cancel" data-tracking-zone="cancel-review" data-tracking-label="cancel review">Cancel</button> <button class="feedback__modalSubmit elementButton__big elementButton__contained" type="submit">Submit</button> </div></form></div> <div class="feedback__modalThankyou"> <svg xmlns="http://www.w3.org/2000/svg" width="112" height="112" aria-hidden="true"><path d="M56 9.333C30.24 9.333 9.333 30.24 9.333 56S30.24 102.667 56 102.667 102.667 81.76 102.667 56 81.76 9.333 56 9.333zm-9.333 70L23.333 56l6.58-6.58 16.754 16.707 35.42-35.42 6.58 6.626-42 42z"/></svg> <div class="feedback__modalThankyouText"> <div class="feedback__modalThankyouDefault">Success!</div> Thanks for adding your feedback.</div></div></div> </div></div></div> <div class="partial modal review__modal static" aria-hidden="true" id="dialog-80ed94ab-4e3c-43e1-81e9-c2d0163d01ba" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="review-modal-close"> <button class="close" type="button" data-a11y-dialog-hide data-tracking-zone="do-not-track" data-action="close-hamburger-menu"> <span class="visually-hidden">Close this dialog window</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="review-modal-close" class="dialogTitle elementFont__title">Recipe Reviews & Photos</h2> <div class="content modalContent"><div class="reviewModal__content"> <div class="reviewModal__contentWrapper"> <h2 class="reviewModal__header">Review for <span class="reviewModal__recipeTitle"></span></h2> <div class="reviewModalContent__review"></div> </div> <div class="reviewModal__adColumn"> <div class="reviewModal__adWrapper"> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper desktop-ad desktop-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="desktop" tabindex="-1" data-tier="1"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper desktop-ad desktop-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="desktop" tabindex="-1" data-tier="2"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper tablet-ad tablet-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="tablet" tabindex="-1" data-tier="3"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper tablet-ad tablet-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="tablet" tabindex="-1" data-tier="4"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper mobile-ad mobile-ad" data-karma-lazy-type="div-gpt-lazy-mob-square-fixed" data-breakpoints="mobile" tabindex="-1" data-tier="1"></div> <div class="ad-title">Advertisement</div> </div> </div> </div></div></div> </div></main> </div> </div> <div class="component recipe-reviews container-full-width template-two-col with-sidebar-right hidden" data-id="7919044" data-page="" data-reviews-sort="" data-reviews-count="" data-ratings-average="" data-ratings-average-display="" data-rating-counts="" data-ratings-count="" data-headline="Cheesy Ground Beef &amp; Cauliflower Casserole" role="region" aria-label="Ratings and Reviews Page"> <div class="inner-container two-col-inner"> <div class="content two-col-main-content karma-content-container"> <div class="two-col-content karma-main-column"> <div class="two-col-content-wrapper"> <div class="recipe-content-container"><div class="component loader hidden" role="alert" aria-label="Loading" aria-live="assertive"></div> <section class="recipes-reviews-container container"> <a href="#" class="recipe-review-back elementFont__detailsLink"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.016 11.016v1.969h-12.188l5.578 5.625-1.406 1.406-8.016-8.016 8.016-8.016 1.406 1.406-5.578 5.625h12.188z"/></svg><span class="recipe-review-back-text">Back to Cheesy Ground Beef &amp; Cauliflower Casserole</span> </a> <div class="recipe-review-overall-rating"> <h2 class="section-headline elementFont__subhead"> <span class="review-headline">All Reviews for <span class="review-page-title">Cheesy Ground Beef &amp; Cauliflower Casserole</span></span></h2> <div class="component recipe-ratings"></div> </div> <div class="recipe-reviews-info"> <div class="recipe-reviews-counter elementFont__subtitle">- of Reviews</div> <div class="component recipe-reviews-sort sort-dropdown"> <div class="sort-title"> <span class="sort-title-reviews">Reviews: </span> <a class="sort-title-trigger" href="#" aria-label="Select a sort option" aria-expanded="false" role="button"> <span class="sort-title-selected">Most Helpful </span> <svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 255 255"><path d="M0 63.75l127.5 127.5L255 63.75z"/></svg> </a> </div> <div class="sort-options"> <a href="#" class="sort-option active" data-sort="helpful_count,desc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Most Helpful (Selected)">Most Helpful</span> </a> <a href="#" class="sort-option" data-sort="rating,desc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Sort by Most Positive">Most Positive</span> </a> <a href="#" class="sort-option" data-sort="rating,asc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Sort by Least Positive">Least Positive</span> </a> <a href="#" class="sort-option" data-sort="last_updated,desc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Sort by Newest">Newest</span> </a> </div> </div> </div> </section> </div> </div> </div> <div class="recipe-reviews-right-rail two-col-right-rail karma-sticky-rail"> <div class="karma-rail-docking-element"> <div class="recipe-ad-wrapper"><div id="div-gpt-square-fixed-6" data-tier="3" data-scroll-load="true" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-7" data-tier="4" data-scroll-load="true" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> </div> </div> </div> </div> </div> </div> <div class="recipe-ad-region" role="complementary"> <div class="recipe-ad-wrapper full-width recipe-main-ad"> <div id="div-gpt-mob-square-fixed-2" data-tier="3" class="ad ad-container ad-wrapper mobile-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-mob-square-fixed-3" data-tier="4" class="ad ad-container ad-wrapper mobile-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-8" data-tier="3" class="ad ad-container ad-wrapper tablet-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-9" data-tier="4" class="ad ad-container ad-wrapper tablet-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-10" data-tier="3" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> <div id="div-gpt-square-fixed-11" data-tier="4" class="ad ad-container ad-wrapper desktop-ad karma-ad" role="complementary" aria-hidden="true" tabindex="-1"></div> </div> <div class="recipe-ad-wrapper ad-title">Advertisement</div> </div> <div class="partial modal share-icons" aria-hidden="true" id="dialog-1acb34ac-0c39-48c7-a833-00700ff0ebf3" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="share_dialog"> <button class="close" type="button" data-a11y-dialog-hide data-tracking-zone="do-not-track" data-action="close-hamburger-menu"> <span class="visually-hidden">Close this dialog window</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="share_dialog" class="dialogTitle elementFont__title">Share & More</h2> <div class="content modalContent"></div></div></div> <div class="partial modal ugc-modal static" aria-hidden="true" id="dialog-5f2ffddb-da8a-4b66-a503-c1afe8b0d938" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="ugc_reviews"> <button class="close" type="button" data-a11y-dialog-hide data-tracking-zone="do-not-track" data-action="close-hamburger-menu"> <span class="visually-hidden">Back to Recipe</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="ugc_reviews" class="dialogTitle elementFont__title"><span class="ugc-heading">Recipe <span class="ugc-heading-reviews reviews-content-heading">Reviews</span> <span class="photos-content-heading">Photos</span></span></h2> <div class="content modalContent content--noPadding"> <div class="component ugc-reviews" data-id="7919044" data-page="" data-legacy-cms-id="" data-reviews-count="" data-photos-count="0" data-headline="Cheesy Ground Beef &amp; Cauliflower Casserole" data-author=""> <div class="ugc-content"> <h3 class="ugc-heading elementFont__headline"> <span class="ugc-heading-variant reviews-content"> Reviews for </span> <span class="ugc-heading-variant photos-content"> Photos of </span> Cheesy Ground Beef & Cauliflower Casserole</h3> <div class="component recipe-reviews-sort sort-dropdown"> <div class="sort-title"> <span class="sort-title-reviews">Reviews: </span> <a class="sort-title-trigger" href="#" aria-label="Select a sort option" aria-expanded="false" role="button"> <span class="sort-title-selected">Most Helpful </span> <svg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 255 255"><path d="M0 63.75l127.5 127.5L255 63.75z"/></svg> </a> </div> <div class="sort-options"> <a href="#" class="sort-option active" data-sort="helpful_count,desc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Most Helpful (Selected)">Most Helpful</span> </a> <a href="#" class="sort-option" data-sort="rating,desc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Sort by Most Positive">Most Positive</span> </a> <a href="#" class="sort-option" data-sort="rating,asc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Sort by Least Positive">Least Positive</span> </a> <a href="#" class="sort-option" data-sort="last_updated,desc" role="button"> <span class="sort-option-check"><svg xmlns="http://www.w3.org/2000/svg" class="icon-check icon-share-check" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 16.172L19.594 5.578 21 6.984l-12 12-5.578-5.578L4.828 12z"/></svg> </span> <span class="sort-option-title" aria-label="Sort by Newest">Newest</span> </a> </div> </div> <div class="ugc-recipe-reviews"> <div class="recipe-review-index reviews-content"> <span class="recipe-review-index-of"> <span class="review-index">1</span> of </span> <span class="recipe-review-sort"></span> </div> <div class="ugc-review-nav"> <span class="ugc-review-prev"> <span class="icon"> <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" aria-hidden="true"><polygon points="15.41 7.41 14 6 8 12 14 18 15.41 16.59 10.83 12"></polygon></svg> </span> </span> <div class="ugc-review-all-link photos-content"> </div> <span class="ugc-review-next"> <span class="icon"> <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" aria-hidden="true"><polygon points="10 6 8.59 7.41 13.17 12 8.59 16.59 10 18 16 12"></polygon></svg> </span> </span> </div> <div class="js-container reviews-content" data-type="reviews"> </div> <div class="js-container photos-content" data-type="photos"> </div> </div> </div> <div class="right-column"> <div class="recipe-ad-wrapper"> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper desktop-ad desktop-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="desktop" tabindex="-1" data-tier="1"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper desktop-ad desktop-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="desktop" tabindex="-1" data-tier="2"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper tablet-ad tablet-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="tablet" tabindex="-1" data-tier="3"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper tablet-ad tablet-ad" data-karma-lazy-type="div-gpt-lazy-square-fixed" data-breakpoints="tablet" tabindex="-1" data-tier="4"></div> <div class="karma-lazy-loaded-ad ad-container karma-ad ad-wrapper ad-wrapper mobile-ad mobile-ad" data-karma-lazy-type="div-gpt-lazy-mob-square-fixed" data-breakpoints="mobile" tabindex="-1" data-tier="1"></div> </div> </div> </div> </div></div></div> <div class="partial modal embedded-auth-modal static" aria-hidden="true" id="dialog-53f8ba5e-d6fe-4fbf-90d9-067726c605ae" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="embedded_auth"> <button class="close" type="button" data-a11y-dialog-hide data-tracking-zone="do-not-track" data-action="close-hamburger-menu"> <span class="visually-hidden">Close</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="embedded_auth" class="dialogTitle elementFont__title">Sign in</h2> <div class="content modalContent"> <div class="component embedded-auth embeddedAuth embedded-auth-modal static"> <div class="embeddedAuth__frame"></div> <div class="component loader" role="alert" aria-label="Loading" aria-live="assertive"></div> <div class="embeddedAuth__success hidden"> <h2 class="embeddedAuth__successHeading"> </h2> <p class="embeddedAuth__successBody"> </p> </div> </div> </div></div></div><footer class="component footer-test"> <div class="footer-test main" data-tracking-zone="mdex-footer"> <div class="footer-links-wrapper"><div class="footer-logo"><a class="full-logo" href="/" data-action="footer-logo"><span class="svg-label">EatingWell</span> <span class="svg-logo" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="215" height="64" viewBox="0 0 215 64"><defs><path id="eating-well-logo-a" d="M0 63.847h214.497V0H0z"/></defs><g fill="none" fill-rule="evenodd"><path fill="#639A3A" d="M61.203 9.883a3.707 3.707 0 1 0 7.413 0 3.707 3.707 0 0 0-7.413 0z"/><mask id="eating-well-logo-b" fill="#fff"><use xlink:href="#eating-well-logo-a"/></mask><path fill="#639A3A" d="M188.897 52.697h6.502V.387h-6.502zm11.129.047h6.5V.434h-6.5z" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.01 48.097c-1.323 0-2.331 1.008-2.331 2.332 0 1.324 1.008 2.332 2.332 2.332 1.324 0 2.332-1.008 2.332-2.332 0-1.387-1.008-2.332-2.332-2.332m.01 4.296c-1.135 0-1.954-.82-1.954-1.954 0-1.135.82-1.954 1.954-1.954s1.954.82 1.954 1.954-.82 1.954-1.954 1.954" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" fill-rule="nonzero" d="M211.956 50.05c0-.503-.378-.755-.819-.755h-1.072v2.269h.505v-.82h.252l.693.82h.567V51.5l-.693-.694c.315-.189.567-.378.567-.756m-.819.315h-.504v-.693h.504c.19 0 .378.126.378.378-.063.189-.189.315-.378.315" mask="url(#eating-well-logo-b)"/><path fill="#639A3A" d="M113.13 39.451c-.064-.001-.124-.008-.187-.008.063-.034.124-.027.186.008m-2.93-1.58c-2.974 0-5.804-2.757-5.804-8.996 0-5.441 2.395-8.851 5.803-8.851 3.556 0 5.879 3.41 5.879 8.923 0 5.441-2.25 8.924-5.879 8.924m-4.797 1.287c.02-.033.046-.042.085-.021l-.085.021m11.698.965c3.314-1.838 5.423-5.764 5.423-10.668 0-3.984-1.333-7.306-3.265-9.308 2.519.182 4.267-.396 4.267-.396l-1.118-4.748s-1.91.45-4.608.45c-2.792 0-4.933-.653-7.6-.653-7.775 0-11.94 5.25-11.94 13.371 0 5.048 1.891 9.569 5.261 11.714-1.6.855-3.161 2.205-4.097 3.203l3.667 4.07c1.57-1.714 4.362-3.553 7.994-3.553 4.468 0 7.878 3.048 7.878 7.471 0 4.608-3.69 7.122-8.437 7.122-5.492 0-9.328-3.742-9.328-3.742l-3.739 4.02c2.85 3.003 7.761 5.371 13.283 5.371 7.93 0 14.365-4.533 14.365-12.26 0-5.619-3.305-9.88-8.006-11.464M30.4 48.151c-2.649 0-4.977-2.01-4.977-8.104 0-5.168 1.71-8.103 4.839-8.103 3.41 0 5.513 3.377 5.513 8.031 0 4.172-2.375 8.176-5.376 8.176m13.508-.984c-1.396-.28-2.19-1.071-2.19-3.491V27.859c0-9.926-3.462-13.422-11.23-13.422-4.672 0-8.138 1.98-8.138 1.98l.107 5.312s3.712-1.756 7.061-1.756c4.507 0 6.258 2.99 6.258 7.088v2.756c-1.523-2.248-4.23-3.046-6.696-3.046-5.659 0-10.157 4.498-10.157 13.204 0 8.851 4.883 13.566 10.397 13.566 2.283 0 5.396-1.25 7.478-4.643.5 2.109 2.066 4.134 5.993 4.134 2.164 0 3.328-.35 3.328-.35v-5.47s-.814.234-2.211-.045M54.22 7.958l-6.502 2.039v5.456h-3.982v5.993h3.982v22.157c0 6.746 2.874 9.503 8.532 9.503.871 0 1.379-.073 2.25-.362V47.28c-.508.145-.726.145-1.161.145-2.612 0-3.12-.798-3.12-4.498V21.446h4.28v-5.993h-4.28V7.958m7.451 44.786h6.5V15.453h-6.5zm24.877-38.307c-2.55 0-5.777 1.357-8.002 4.896v-3.88h-5.97v37.29h6.5V28.7c0-4.28 3.4-8.56 6.49-8.56 2.56 0 3.333 1.852 3.333 5.03v27.574h6.5v-27.86c0-3.627-.798-5.949-2.321-7.69-1.524-1.814-3.918-2.757-6.53-2.757M159.177.435l-7.028 34.277L145.99 0h-5.066l-6.24 34.687-7.24-34.252h-6.573l12.045 52.889h3.858l6.701-36.209 6.52 36.209h3.931L165.968.434zm15.369 19.392c3.202 0 4.818 3.446 4.818 10.716h-10.215c0-7.402 2.385-10.716 5.397-10.716m.592 27.961c-3.731 0-6.232-4.06-6.232-10.283 0-.926-.005-1.29-.005-1.508l16.49-.007c.072-2.22.11-2.907.11-4.068 0-10.834-3.213-17.485-10.955-17.485-7.948 0-11.825 7.247-11.825 19.734 0 12.536 5.043 19.37 12.234 19.37 4.958 0 8.524-3.061 10.618-8.364l-4.61-2.64c-1.523 2.978-3.046 5.251-5.825 5.251M0 52.744h18.271v-6.427H6.646v-17.37h10.04v-6.428H6.647V6.863H18.41V.435H0z" mask="url(#eating-well-logo-b)"/></g></svg> </span> </a></div> <nav class="footer-sections" aria-label="Footer"><section class="footer-section footer-magazines-more"><h2 class="footer-title elementFont__subhead">Magazines &amp; More</h2><div id="footermagmore"></div></section> <section class="footer-section footer-learn-more"><h2 class="footer-title elementFont__subhead">Learn More</h2><ul class="footer-learn-more-links elementFont__resetList"> <li class="footer-link-item"><a href="https://www.eatingwell.com/article/14869/about-eatingwell/" class="footer-link elementFont__details" data-tracking-label="about us">About Us</a></li> <li class="footer-link-item"><a href="https://www.magazine.store/eatingwell/" target="_blank" rel="noopener" class="footer-link elementFont__details" data-tracking-label="subscribe">Subscribe<span class="hidden-label"> this link opens in a new tab</span></a></li> <li class="footer-link-item"><a href="https://www.eatingwell.com/article/14867/contact-us/" class="footer-link elementFont__details" data-tracking-label="contact us">Contact Us</a></li> <li class="footer-link-item"><a href="https://www.meredith.com/national-media/digital" class="footer-link elementFont__details" data-tracking-label="advertise">Advertise</a></li> <li class="footer-link-item"><a href="https://www.meredithcontentlicensing.com" class="footer-link elementFont__details" data-tracking-label="content licensing">Content Licensing</a></li> <li class="footer-link-item"><a href="https://www.eatingwell.com/article/290682/eatingwells-annual-recipe-index-archive/" class="footer-link elementFont__details" data-tracking-label="recipe index">Recipe Index</a></li> <li class="footer-link-item"><a href="https://www.eatingwell.com/article/14865/jobs-internships/" class="footer-link elementFont__details" data-tracking-label="jobs">Jobs</a></li> </ul></section> <section class="footer-section footer-connect"><h2 class="footer-title elementFont__subhead">Connect</h2> <div class="footer-follow-us elementFont__details">Follow Us</div> <div class="footer-social-container"> <span class="icon icon-facebook social-icon margin-4-right" data-social-service="facebook"><a href="https://www.facebook.com/EatingWell/" class="display-block" aria-label="Share on facebook (opens in a new window)" target="_blank" title="facebook share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-facebook" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M13.774 8.824c.355-.012.71-.003 1.066-.003h.147V7.079c-.19-.018-.388-.043-.587-.052-.364-.015-.73-.033-1.094-.025-.557.01-1.084.139-1.544.45-.528.358-.818.86-.928 1.454a4.708 4.708 0 0 0-.064.747c-.01.39-.002.78-.002 1.172v.146H9v1.945h1.758v4.889h2.148v-4.88h1.752l.27-1.955h-.394c-.498.002-1.643 0-1.643 0s.006-.964.018-1.382c.017-.573.378-.748.865-.764"/></svg></a></span> <span class="icon icon-twitter social-icon margin-4-right" data-social-service="twitter"><a href="https://twitter.com/EatingWell" class="display-block" aria-label="Share on twitter (opens in a new window)" target="_blank" title="twitter share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-twitter" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M9.793 15.25c-1.336-.049-2.17-1.041-2.392-1.847.372.073.739.058 1.103-.035.009-.002.018-.009.036-.017a2.571 2.571 0 0 1-1.669-1.222 2.65 2.65 0 0 1-.376-1.415c.36.2.738.311 1.144.323-.545-.406-.91-.937-1.059-1.615a2.72 2.72 0 0 1 .276-1.928c1.392 1.697 3.153 2.628 5.301 2.781-.016-.105-.031-.197-.041-.291a2.65 2.65 0 0 1 .375-1.74c.41-.664.993-1.077 1.743-1.204.864-.146 1.619.109 2.25.742.042.042.077.056.137.042a5.05 5.05 0 0 0 1.494-.595c.012-.006.023-.013.035-.018.002-.002.006-.001.017-.001a2.709 2.709 0 0 1-1.1 1.448 4.769 4.769 0 0 0 1.43-.399l.01.012c-.097.134-.193.27-.295.399a5.128 5.128 0 0 1-.933.92c-.03.022-.044.044-.044.084.015.395 0 .79-.047 1.182a8.026 8.026 0 0 1-.663 2.37 7.686 7.686 0 0 1-1.388 2.098 6.815 6.815 0 0 1-3.533 2.038 7.4 7.4 0 0 1-1.431.177 7.069 7.069 0 0 1-4.113-1.144l-.06-.04a5.039 5.039 0 0 0 3.793-1.105"/></svg></a></span> <span class="icon icon-pinterest social-icon margin-4-right" data-social-service="pinterest"><a href="https://www.pinterest.com/eatingwell/" class="display-block" aria-label="Share on pinterest (opens in a new window)" target="_blank" title="pinterest share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" class="icon-share icon-share-pinterest" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M11.018 14.094l-.028.096c-.455 1.786-.506 2.183-.975 3.011a9.21 9.21 0 0 1-.753 1.126c-.031.04-.061.092-.124.08-.068-.015-.074-.077-.08-.131a9.552 9.552 0 0 1-.1-1.635c.025-.714.113-.959 1.033-4.827a.267.267 0 0 0-.022-.162c-.22-.594-.263-1.197-.071-1.808.416-1.32 1.912-1.42 2.173-.331.162.673-.265 1.554-.592 2.856-.27 1.075.994 1.84 2.075 1.054.997-.723 1.385-2.456 1.311-3.685-.144-2.45-2.832-2.98-4.536-2.191-1.955.904-2.398 3.326-1.516 4.432.112.142.198.227.16.37-.056.222-.106.445-.167.666-.046.164-.183.224-.349.156a2.005 2.005 0 0 1-.816-.611c-.75-.928-.964-2.764.027-4.317 1.098-1.721 3.139-2.417 5.004-2.206 2.226.253 3.632 1.774 3.896 3.5.12.786.034 2.724-1.07 4.094-1.27 1.575-3.327 1.679-4.277.713-.073-.074-.132-.162-.203-.25"/></svg></a></span> <span class="icon icon-instagram social-icon margin-4-right" data-social-service="instagram"><a href="https://instagram.com/eatingwell/" class="display-block" aria-label="Share on instagram (opens in a new window)" target="_blank" title="instagram share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M11.998 6c1.63 0 1.833.007 2.473.036.639.03 1.075.13 1.456.279a2.94 2.94 0 0 1 1.063.692c.333.333.538.668.691 1.062.149.382.25.818.28 1.456.028.64.035.844.035 2.473 0 1.63-.007 1.833-.036 2.473-.029.639-.13 1.075-.279 1.456a2.94 2.94 0 0 1-.692 1.063 2.94 2.94 0 0 1-1.062.691c-.381.149-.817.25-1.456.28-.64.028-.844.035-2.473.035s-1.833-.007-2.473-.036c-.638-.029-1.074-.13-1.456-.279a2.94 2.94 0 0 1-1.062-.692 2.94 2.94 0 0 1-.692-1.062c-.148-.381-.25-.817-.279-1.456-.03-.64-.036-.844-.036-2.473s.007-1.833.036-2.473c.03-.638.13-1.074.279-1.456a2.94 2.94 0 0 1 .692-1.062 2.94 2.94 0 0 1 1.062-.692c.382-.148.818-.25 1.456-.279.64-.03.844-.036 2.473-.036zm0 1.08c-1.601 0-1.791.007-2.424.036-.584.026-.902.124-1.113.206-.28.109-.48.239-.69.449-.21.21-.34.41-.449.69-.082.211-.18.529-.206 1.113-.03.633-.035.823-.035 2.424 0 1.602.006 1.791.035 2.424.026.585.124.902.206 1.114.109.28.239.48.449.69.21.21.41.34.69.448.211.082.529.18 1.113.207.633.028.822.034 2.424.034 1.602 0 1.791-.006 2.424-.034.585-.027.902-.125 1.114-.207.28-.109.48-.239.69-.449.21-.21.34-.41.448-.69.082-.21.18-.528.207-1.113.028-.633.034-.822.034-2.424 0-1.601-.006-1.791-.034-2.424-.027-.584-.125-.902-.207-1.113a1.858 1.858 0 0 0-.449-.69c-.21-.21-.41-.34-.69-.449-.21-.082-.528-.18-1.113-.206-.633-.03-.822-.035-2.424-.035zm0 1.838a3.08 3.08 0 1 1 0 6.16 3.08 3.08 0 0 1 0-6.16zm0 5.08a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm3.922-5.202a.72.72 0 1 1-1.44 0 .72.72 0 0 1 1.44 0z"/></svg></a></span> <span class="icon icon-youtube social-icon margin-4-right" data-social-service="youtube"><a href="https://www.youtube.com/user/eatingwell" class="display-block" aria-label="Share on youtube (opens in a new window)" target="_blank" title="youtube share (opens in a new window)"> <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"><path fill="#685F55" d="M10.227 13.95l4.307-2.233-4.307-2.248v4.482zm-3.8 2.487a1.613 1.613 0 0 1-1.064-1.035c-.462-1.268-.598-6.57.29-7.615a1.718 1.718 0 0 1 1.158-.616c2.393-.257 9.784-.22 10.636.086.5.18.854.506 1.046 1.006.505 1.31.522 6.079-.066 7.34-.16.344-.42.585-.75.758-.892.468-10.077.462-11.25.076z"/></svg> </a></span> </div> <div class="footer-newsletter-signup"><a class="footer-newsletter-signup-heading elementFont__details--footer" href="https://x.specialoffers.meredith.com/ats/show.aspx?cr=588&fm=301&regSource=27512" target="_blank">Subscribe to Our Newsletters</a><div id="signup"></div></div></section></nav></div> <div class="container-full-width footer-other-sites"><div class="footer-other-sites-wrapper"> <a id="otherMeredithSites" class="footer-other-sites-link elementButton__standard elementButton__outlined" role="button" href="#">Other Meredith Sites</a> <div class="partial modal other-sites static footer-modal" aria-hidden="true" id="dialog-7dbe835b-5736-44b3-b80a-6747f826a145" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="other_dialog"> <button class="close" type="button" data-a11y-dialog-hide data-tracking-zone="do-not-track" data-action="close-hamburger-menu"> <span class="visually-hidden">Close this dialog window</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="other_dialog" class="dialogTitle elementFont__title">Other Meredith Sites</h2> <div class="content modalContent"><ul class="elementFont__resetList"> <li><a target="_blank" rel="noopener" href="https://www.4yourhealth.com/" class="elementFont__details--footer elementFont__resetLink--hover">4 Your Health <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.allrecipes.com/" class="elementFont__details--footer elementFont__resetLink--hover">Allrecipes <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="http://www.allpeoplequilt.com/" class="elementFont__details--footer elementFont__resetLink--hover">All People Quilt <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.bhg.com/" class="elementFont__details--footer elementFont__resetLink--hover">Better Homes &amp; Gardens <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.bizrateinsights.com/" class="elementFont__details--footer elementFont__resetLink--hover">Bizrate Insights <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.bizratesurveys.com/" class="elementFont__details--footer elementFont__resetLink--hover">Bizrate Surveys <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.cookinglight.com/" class="elementFont__details--footer elementFont__resetLink--hover">Cooking Light <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.dailypaws.com/" class="elementFont__details--footer elementFont__resetLink--hover">Daily Paws <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.eatthis.com/" class="elementFont__details--footer elementFont__resetLink--hover">Eat This, Not That <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://ew.com/" class="elementFont__details--footer elementFont__resetLink--hover">Entertainment Weekly <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.foodandwine.com/" class="elementFont__details--footer elementFont__resetLink--hover">Food &amp; Wine <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.health.com/" class="elementFont__details--footer elementFont__resetLink--hover">Health <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://hellogiggles.com/" class="elementFont__details--footer elementFont__resetLink--hover">Hello Giggles <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.instyle.com/" class="elementFont__details--footer elementFont__resetLink--hover">Instyle <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.marthastewart.com/" class="elementFont__details--footer elementFont__resetLink--hover">Martha Stewart <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="http://www.midwestliving.com/" class="elementFont__details--footer elementFont__resetLink--hover">Midwest Living <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.more.com/" class="elementFont__details--footer elementFont__resetLink--hover">More <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.myrecipes.com/" class="elementFont__details--footer elementFont__resetLink--hover">MyRecipes <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="http://www.mywedding.com/" class="elementFont__details--footer elementFont__resetLink--hover">MyWedding <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.myfoodandfamily.com" class="elementFont__details--footer elementFont__resetLink--hover">My Food and Family <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.my.life" class="elementFont__details--footer elementFont__resetLink--hover">MyLife <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.parenting.com/" class="elementFont__details--footer elementFont__resetLink--hover">Parenting <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.parents.com/" class="elementFont__details--footer elementFont__resetLink--hover">Parents <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://people.com/" class="elementFont__details--footer elementFont__resetLink--hover">People <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://peopleenespanol.com/" class="elementFont__details--footer elementFont__resetLink--hover">People en Español <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.rachaelraymag.com/" class="elementFont__details--footer elementFont__resetLink--hover">Rachael Ray Magazine <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.realsimple.com/" class="elementFont__details--footer elementFont__resetLink--hover">Real Simple <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="http://serpadres.com/" class="elementFont__details--footer elementFont__resetLink--hover">Ser Padres <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.shape.com/" class="elementFont__details--footer elementFont__resetLink--hover">Shape <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="http://siempremujer.com/" class="elementFont__details--footer elementFont__resetLink--hover">Siempre Mujer <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.southernliving.com/" class="elementFont__details--footer elementFont__resetLink--hover">Southern Living <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://swearby.com/" class="elementFont__details--footer elementFont__resetLink--hover">SwearBy <span class="hidden-label"> this link opens in a new tab</span> </a></li> <li><a target="_blank" rel="noopener" href="https://www.travelandleisure.com/" class="elementFont__details--footer elementFont__resetLink--hover">Travel &amp; Leisure <span class="hidden-label"> this link opens in a new tab</span> </a></li> </ul></div></div></div></div><div class="footer-copyright"><span class="footer-copyright-logo"><span class="visually-hidden">Meredith</span><svg xmlns="http://www.w3.org/2000/svg" width="104" height="24" viewBox="0 4 139 24"><path fill="#695E4A" d="M59.26 16.047V16c0-3.604 2.533-6.562 6.107-6.562 3.977 0 5.99 3.148 5.99 6.776 0 .264-.025.527-.048.811h-9.186c.31 2.053 1.753 3.198 3.6 3.198 1.396 0 2.39-.525 3.386-1.503l1.68 1.503c-1.184 1.432-2.818 2.364-5.114 2.364-3.622 0-6.416-2.649-6.416-6.539zm9.256-.931c-.19-1.861-1.279-3.318-3.173-3.318-1.752 0-2.984 1.361-3.243 3.318h6.416zm13.502.931V16c0-3.604 2.532-6.562 6.107-6.562 3.977 0 5.99 3.148 5.99 6.776 0 .264-.025.527-.048.811h-9.185c.306 2.053 1.75 3.198 3.597 3.198 1.397 0 2.392-.525 3.386-1.503l1.68 1.503c-1.183 1.432-2.817 2.364-5.112 2.364-3.622 0-6.415-2.649-6.415-6.539zm9.255-.931c-.189-1.861-1.278-3.318-3.172-3.318-1.752 0-2.984 1.361-3.243 3.318h6.415zm4.453.906v-.048c0-4.176 2.818-6.537 5.8-6.537 2.798 0 4.097 1.54 4.262 1.7v-6.24h2.862V22.3h-2.862v-1.456c-.238.242-1.51 1.72-4.263 1.72-2.934 0-5.799-2.365-5.799-6.542zm10.109 0v-.048c0-2.433-1.706-4.032-3.623-4.032-1.965 0-3.599 1.527-3.599 4.032v.048c0 2.435 1.658 4.034 3.6 4.034 1.916 0 3.622-1.624 3.622-4.034zm18.233 6.537c-3.681 0-5.704-1.15-5.704-4.701V4.898h2.864v4.801h2.841v2.481h-2.841v5.39c0 2.32 1.351 2.507 2.84 2.507v2.482zm2.514-17.662h2.864v6.252c.158-.2 1.259-1.712 3.59-1.712 3.018 0 4.767 2.003 4.767 4.843v8.02h-2.864v-7.137c0-1.891-1.04-3.102-2.745-3.102-1.657 0-2.748 1.146-2.748 3.102V22.3h-2.865V4.897h.001zM112.075 9.7h2.863v12.6h-2.863zM114.919 6.627v1.12h-2.844v-2.85h2.844zM38.002 9.7h2.864v1.493c.135-.16 1.407-1.756 3.692-1.756 2.6 0 3.531 1.63 3.835 2.218.215-.351 1.417-2.218 3.94-2.218 2.72 0 4.678 2.003 4.678 4.82V22.3h-2.864v-7.137c0-1.924-.995-3.102-2.604-3.102-1.563 0-2.604 1.129-2.604 3.102V22.3h-2.865v-7.137c0-1.956-1.017-3.102-2.604-3.102-1.58 0-2.604 1.146-2.604 3.102V22.3h-2.864V9.7zm35.75 0h2.863v2.042c.249-.424 1.224-2.283 4.428-2.283v2.97h-.61c-2.48 0-3.818 1.593-3.818 3.95v5.922h-2.862V9.699z"/><path fill="#009BDA" d="M15.918 7.413l-3.232 3.232-2.082-2.082 3.232-3.232zM21.207 19.258l2.066 2.082 3.232-3.258-2.066-2.083zM19.628 3.65a2.265 2.265 0 0 1 3.232 0c.941.949.856 2.395 0 3.26l-1.653 1.666 2.065 2.082 1.654-1.666c1.016-1.025 2.454-.785 3.233 0 .979.987.805 2.447 0 3.257l-1.654 1.668 2.065 2.082 1.654-1.667c2.09-2.107 1.989-5.417 0-7.422a5.183 5.183 0 0 0-3.775-1.537 5.236 5.236 0 0 0-1.523-3.806c-1.954-1.97-5.26-2.12-7.363 0l-1.654 1.668 2.066 2.082 1.653-1.667zM15.91 13.917l2.065 2.082 3.232-3.258-2.066-2.083z"/><path fill="#6FBE44" d="M10.611 23.422l3.233 3.26 2.065-2.083-3.232-3.259zM28.57 16l-2.066 2.082 1.654 1.667c.805.811.98 2.27 0 3.258-.778.785-2.217 1.025-3.232 0l-1.654-1.667-2.066 2.082 1.653 1.666c.857.864.942 2.311 0 3.26a2.265 2.265 0 0 1-3.232 0l-1.654-1.668-2.065 2.083 1.654 1.667c2.102 2.12 5.408 1.97 7.362 0a5.239 5.239 0 0 0 1.524-3.805 5.182 5.182 0 0 0 3.775-1.537c1.988-2.006 2.09-5.315 0-7.423L28.57 16zM15.91 18.082l3.232 3.258 2.065-2.082-3.232-3.259zM23.273 10.658l-2.066 2.083 3.232 3.258 2.066-2.082-3.232-3.259z"/><path fill="#F7901E" d="M15.9 24.584l3.233-3.232 2.081 2.081-3.232 3.233zM12.19 28.348c-.805.811-2.253.987-3.232 0-.778-.784-1.016-2.234 0-3.258v-.002l1.653-1.666-2.066-2.082-1.653 1.666c-.856.863-2.291.949-3.232 0a2.31 2.31 0 0 1 0-3.259l1.652-1.666-2.064-2.082-1.653 1.667c-2.103 2.12-1.954 5.452 0 7.422a5.146 5.146 0 0 0 3.774 1.536c-.015.768.143 2.414 1.524 3.806 1.99 2.006 5.273 2.108 7.362 0l1.654-1.667-2.065-2.082-1.654 1.667zM13.844 16l-3.233 3.258 2.066 2.082 3.232-3.258L13.844 16zM8.546 10.658l-3.232 3.259 2.065 2.082 3.232-3.258z"/><path fill="#ED174C" d="M10.611 19.258l-3.232-3.26-2.066 2.083 3.233 3.259zM3.66 12.25a2.31 2.31 0 0 1 0-3.258c.942-.95 2.377-.864 3.233 0l1.653 1.666 2.066-2.082L8.959 6.91v-.001c-1.016-1.023-.778-2.474 0-3.259.979-.987 2.427-.81 3.231 0l1.654 1.667 2.066-2.081-1.654-1.667c-2.09-2.107-5.373-2.006-7.362 0C5.512 2.96 5.354 4.607 5.37 5.374A5.145 5.145 0 0 0 1.595 6.91c-1.953 1.97-2.102 5.303 0 7.424L3.25 16l2.065-2.082L3.66 12.25zM17.983 5.33l3.232 3.232-2.082 2.081L15.9 7.412zM13.844 15.999l2.066-2.082-3.233-3.259-2.066 2.083 3.233 3.258z"/><path fill="#583357" d="M17.985 5.324L15.92 7.39l-2.082-2.083 2.065-2.064z"/><path fill="#BF272E" d="M5.323 13.926l2.065 2.065-2.082 2.082-2.066-2.065z"/><path fill="#008F4C" d="M26.5 18.074l-2.066-2.065 2.083-2.082 2.065 2.065z"/><path fill="#7A783E" d="M13.833 26.675L15.9 24.61l2.081 2.081-2.065 2.066z"/><path fill="#443639" d="M23.281 10.667l-2.064 2.065-2.083-2.082L21.2 8.585z"/><path fill="#803136" d="M10.618 19.263l2.066 2.066L10.6 23.41l-2.065-2.065z"/><path fill="#5A3438" d="M10.62 8.585l2.066 2.065-2.083 2.083-2.066-2.065z"/><path fill="#443639" d="M13.835 15.992l2.066-2.066 2.081 2.082-2.065 2.066z"/><path fill="#2B6442" d="M23.283 21.35l-2.065 2.065-2.083-2.083 2.066-2.065z"/></svg></span><span class="footer-copyright-text"><span class="footer-copyright-prefix">&copy; 2021 EatingWell.com is part of the Allrecipes Food Group. EatingWell may receive compensation for some links to products and services on this website. Offers may be subject to change without notice. All Right Reserved. Use of this site constitutes acceptance of our</span> <span class="footer__legalLinks-wrapper"> <span class="footer__legalLinks-link"><a href="https://www.meredith.com/nmg/privacy" target="_blank" data-tracking-label="Privacy Policy"> Privacy Policy<span class="hidden-label">this link opens in a new tab</span></a></span> <span class="footer__legalLinks-link"><a href="https://www.meredith.com/adchoices" target="_blank" data-tracking-label="Ad Choices"> Ad Choices<span class="hidden-label">this link opens in a new tab</span></a></span> <span class="footer__legalLinks-link"><a href="https://www.meredith.com/legal/terms" target="_blank" data-tracking-label="Terms of Service"> Terms of Service<span class="hidden-label">this link opens in a new tab</span></a></span> <span class="footer__legalLinks-link ot-sdk-show-settings-parent"> <a class="ot-sdk-show-settings" href="javascript:void(0)" data-tracking-label="California Do Not Sell">California Do Not Sell<span class="hidden-label">this link opens a modal window</span></a></span> <span class="footer__legalLinks-link"><a href="https://www.meredith.com/legal/web-accessibility" target="_blank" data-tracking-label="Web Accessibility"> Web Accessibility<span class="hidden-label">this link opens in a new tab</span></a></span> </span></span></div></div></div></footer> <div class="print-footer" role="region" aria-label="Print Footer"><span class="print-footer-copyright elementFont__fine">&copy; Copyright 2021 <span class="recipe-copyright-text__brand">eatingwell.com</span>. All rights reserved.</span> <span class="print-footer-from elementFont__fine">Printed from <span class="recipe-copyright-text__brand">https://www.eatingwell.com</span> 10/14/2021</span> </div> <div id="page-segment-values"><div class="keyvals" data-content_author_name="carolyn casner" data-content_cms_sub_category="healthy casserole recipes" data-content_cms_id="7919044" data-content_featured_image="https://static.onecms.io/wp-content/uploads/sites/44/2021/08/16/cheesy-ground-beef-and-cauliflower-casserole.jpg" data-content_modified_date="2021/09/23" data-content_published_date="2021/09/23" data-content_shown_on_platform="own" data-content_type="recipe" data-path="/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/" data-referrer="" data-content_is_post="post" data-affiliate_link_count="0" data-karma_id="2c0a4dd7-a77c-4388-91fd-a41e0b49e95e" data-karma_type="recipe" data-video_id="" data-video_version="v4" data-content_headline="cheesy ground beef  cauliflower casserole" data-title="cheesy ground beef  cauliflower casserole" data-content_life_cycle="evergreen-annual" data-content_primary_purpose="traffic-and-acquisition" data-content_graph_id="cms/onecms_posts_etg_7919044" data-internalcampaign="" data-emaillaunchid="" data-content_channel="healthy recipes" data-content_cms_category="healthy main dish recipes" data-content_cms_tags="" data-content_taxonomy="11721,16426,11710,11053,12449,12860,11865,13025,11595,11132,12979,11270,11870,11374,13761,10439,11807,12019,12384,25281,12213,12550,10688,11184,16753,16751,11252,10054,16752" data-meredith_brand="eatingwell.com" data-meredith_application="front end" data-recipe_convenience="" data-recipe_courses="" data-recipe_cuisine="" data-recipe_dietary_considerations="" data-recipe_food_main_ingredients="extra-virgin olive oil,chopped onion,green bell pepper, chopped,lean ground beef,bite-size cauliflower florets,garlic, minced,chili powder,ground cumin,dried oregano,salt,ground chipotle,no-salt-added petite-diced tomatoes,shredded extra-sharp cheddar cheese,sliced pickled jalapeños" data-content_ad_keys="" data-content_published_date_formatted="20210923" data-content_modified_date_formatted="20210923" data-content_source="0" data-submission_type="editorial" data-content_syndicated="do-not-syndicate" data-content_syndicated_brand="" data-content_syndicated_url="" data-content_nlp_sentiment_label="positive" data-content_nlp_sentiment_score="0.1" data-content_nlp_sentiment_magnitude="5.8" data-content_nlp_entities="cauliflower casserole|weeknight casserole|ground beef" data-content_nlp_categories="/food &amp; drink/cooking &amp; recipes|/food &amp; drink/food" data-adtaxonomy="11721,16426,11710,11053,12449,12860,11865,13025,11595,11132,12979,11270,11870,11374,13761,10439,11807,12019,12384,25281,12213,12550,10688,11184,16753,16751,11252,10054,16752"></div> </div> <div id="site-components" data-brand-sync="auth" data-brand-async="" data-core-sync="lazy-image,atg,user-auth,registration-login,eu-disable-links,newsletter-unsubscribe" data-core-async="video,feed,gallery-test,add-product,add-recipe,swears,breadcrumbs,product-detail,one-tap,docked-sharebar,gallery-view-all,gallery-everything-in,dropdown,autofill-content-container,expander,outbrain,font-size-slider,newsletter-signup-modal,search-results-form,pinterest-pin,topic-sub-nav,embed-facebook,embed-instagram,embed-twitter,embed-pinterest,build-a-meal,ecommerce-hub,content-loader,before-after,burst-text,bucket,progress-bar,amazon-price,image-zoom,glossary-header,recirculation,share-new,circular-countdown,fancy-chart,navigation-test,filmstrip-slide,footer-test,topics-carousel,circular-carousel,category-page-videos,auto-advance,category-page-list-load-more,recipe-ratings,ugc-reviews,ugc-upload,recipe-reviews,recipe-reviews-sort,recipe-ingredients,recipe-instructions,recipe-nutrition,print-preview,faceted-search-filters,image-link,saga,saga-ribbon,slider,search-results,alert-banner,entity-summary,sticky-action-bar,faceted-search-widget,ugc-comments,project-ratings,ugc-photo-upload,button-pdf,buying-information,recirculation-toaster,social-stories,call-to-action,category-page-promo-entity,node-interactive-content,profile-management-page,tout-cards,entity-full,quick-registration,poll-template,embedded-auth,manage-push-notifications,sweepstakes-entry-page,selectable,sweepstakes-description,sweepstakes-confirmation,feedback,entity-table-of-contents,line-clamp,search-by-ingredient,video-transcript,audio,embed-tiktok,user-profile-management,add-swearby-story,gallery-right-rail-video,assistive-text,sitewide-alerts,table-of-contents,favorite,listicle,shop-go,init-auth,user-profile-registration,favorite-collections"></div><div class="partial modal zoom-image image-modal static modal--hideHeading" aria-hidden="true" id="dialog-64c467a1-2180-4659-b8a1-47866a2c2474" role="dialog"> <div tabindex="0" data-a11y-dialog-hide></div> <div class="dialog-wrap" role="dialog" aria-labelledby="overlays_zoom_image"> <button class="close close--outside" type="button" data-a11y-dialog-hide data-tracking-zone="do-not-track" data-action="close-hamburger-menu"> <span class="visually-hidden">Close this dialog window</span><svg width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg"><path d="M14 1.41L12.59 0 7 5.59 1.41 0 0 1.41 5.59 7 0 12.59 1.41 14 7 8.41 12.59 14 14 12.59 8.41 7z"/></svg></button> <h2 id="overlays_zoom_image" class="visually-hidden">View image</h2> <div class="content modalContent content--noPadding"><div class="component image-zoom"><div class="inner-container"><div class="media-img"></div><div class="image-wrap-container clearfix"><div class="credit body-caption padding-4-top elementFont__fine--caption">Cheesy Ground Beef & Cauliflower Casserole</div></div></div></div> </div></div></div><div class="component external-disclaimer" id="external-disclaimer" aria-hidden="true">this link is to an external site that may or may not meet accessibility guidelines.</div> </body> </html>
+
+					
+					<script id="eatingwell-schema_1-0" class="comp  eatingwell-schema mntl-schema-unified" type="application/ld+json">				
+[
+{
+"@context": "http://schema.org",
+"@type": ["Recipe","NewsArticle"]
+,"headline": "Cheesy Ground Beef &amp; Cauliflower Casserole"
+,"datePublished": "2021-09-23T14:20:24.000-04:00"
+,"dateModified": "2021-09-23T14:20:24.000-04:00"
+,"author": [
+{"@type": "Person"
+,"name": "Carolyn Casner"
+,"url": "https://www.eatingwell.com/author/carolyn-casner/"
+}
+]
+,"description": "This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream."
+,"image": {
+"@type": "ImageObject",
+"url": "https://www.eatingwell.com/thmb/32d8L6W6cwt652tjjXAHosP3ViE=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg",
+"height": 1500,
+"width": 1500
+}
+,"video": {
+"@type": "VideoObject",
+"embedUrl": "https://players.brightcove.net/5118192885001/default_default/index.html?videoId=6307528357112",
+"description": "Searching for new casserole recipes? In this video, learn how to make cheesy casserole with ground beef and cauliflower for a gluten-free dish that everyone will love. Serve as a hearty dinner for your family, or prepare a larger serving for guests!",
+"duration": "PT1M53S",
+"name": "Cheesy Ground Beef & Cauliflower Casserole Recipe",
+"thumbnailUrl": "https://cf-images.us-east-1.prod.boltdns.net/v1/static/5118192885001/a77e5407-0f3d-42b2-9aa0-7e0b13c61f5e/77d7ea97-b2db-49c9-839d-b6d919deace2/1280x720/match/image.jpg",
+"uploadDate": "2022-06-21T17:38:56.601-04:00"}
+,"publisher": {
+"@type": "Organization",
+"name": "EatingWell",
+"url": "https://www.eatingwell.com",
+"logo": {
+"@type": "ImageObject",
+"url": "https://www.eatingwell.com/thmb/cr0OO5bIhN4hn9zmchZ_ZSKGUuQ=/112x112/filters:no_upscale():max_bytes(150000):strip_icc()/eatingwell_brand_logo_schema-b4e06815bfc2449ebe240453e3b47d48.png",
+"width": 112,
+"height": 112
+},
+"brand": "EatingWell"
+, "publishingPrinciples": "https://www.eatingwell.com/about-us-6743412#toc-editorial-policies"
+, "sameAs" : [
+"https://www.facebook.com/EatingWell/",
+"https://twitter.com/EatingWell/",
+"https://www.instagram.com/eatingwell/",
+"https://www.pinterest.com/eatingwell/",
+"https://flipboard.com/@EatingWell",
+"https://www.youtube.com/@eatingwell",
+"https://www.linkedin.com/company/eatingwell-media-group/",
+"https://www.tiktok.com/@eatingwell"
+]
+}
+,"name": "Cheesy Ground Beef &amp; Cauliflower Casserole"
+,"aggregateRating": {
+"@type": "AggregateRating",
+"ratingValue": "4.3",
+"ratingCount": "24"
+}
+,"nutrition": {
+"@type": "NutritionInformation"
+,"calories": "351 kcal"
+,"carbohydrateContent": "11 g"
+,"cholesterolContent": "86 mg"
+,"fiberContent": "3 g"
+,"proteinContent": "26 g"
+,"saturatedFatContent": "11 g"
+,"sodiumContent": "672 mg"
+,"sugarContent": "4 g"
+,"fatContent": "23 g"
+,"unsaturatedFatContent": "0 g"
+}
+,"recipeIngredient": [
+"1 tablespoon extra-virgin olive oil",
+"0.5 cup chopped onion",
+"1 medium green bell pepper, chopped",
+"1 pound lean ground beef",
+"3 cups bite-size cauliflower florets",
+"3 cloves garlic, minced",
+"2 tablespoons chili powder",
+"2 teaspoons ground cumin",
+"1 teaspoon dried oregano",
+"0.5 teaspoon salt",
+"0.25 teaspoon ground chipotle",
+"1 (15 ounce) can no-salt-added petite-diced tomatoes",
+"2 cups shredded extra-sharp Cheddar cheese",
+"0.333 cup sliced pickled jalapeños" ]
+,"recipeInstructions": [
+{
+"@type": "HowToStep"
+,"text": "Position rack in upper third of oven. Preheat broiler to high."
+} ,{
+"@type": "HowToStep"
+,"text": "Heat oil in a large oven-safe skillet over medium heat. Add onion and bell pepper; cook, stirring, until softened, about 5 minutes. Add beef and cauliflower; cook, stirring and breaking the beef up into smaller pieces, until it is no longer pink, 5 to 7 minutes. Stir in garlic, chili powder, cumin, oregano, salt and chipotle; cook until fragrant, about 1 minute. Add tomatoes and their juices; bring to a simmer and cook, stirring occasionally, until liquid is reduced and the cauliflower is tender, about 3 minutes more. Remove from heat."
+} ,{
+"@type": "HowToStep"
+,"image": [
+{
+"@type": "ImageObject",
+"url": "https://www.eatingwell.com/thmb/32d8L6W6cwt652tjjXAHosP3ViE=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+}
+]
+,"text": "Sprinkle cheese over the beef mixture and top with sliced jalapeños. Broil until the cheese is melted and browned in spots, 2 to 3 minutes."
+} ]
+,"recipeYield": ["6"]
+,"totalTime": "PT30M"
+,"mainEntityOfPage": {
+"@type": ["WebPage"]
+,"@id": "https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/"
+,"breadcrumb": {
+"@type": "BreadcrumbList",
+"itemListElement": [
+{
+"@type": "ListItem",
+"position": 1,
+"item": {
+"@id": "https://www.eatingwell.com/recipes/17965/main-dishes/",
+"name": "Healthy Main Dish Recipes"
+}
+}
+,
+{
+"@type": "ListItem",
+"position": 2,
+"item": {
+"@id": "https://www.eatingwell.com/recipes/17923/main-dishes/casseroles/",
+"name": "Healthy Casserole Recipes"
+}
+}
+,
+{
+"@type": "ListItem",
+"position": 3,
+"item": {
+"@id": "https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/",
+"name": "Cheesy Ground Beef &amp; Cauliflower Casserole"
+}
+}
+]
+}
+}
+, "about": [
+]
+}
+]</script><!-- end: comp eatingwell-schema mntl-schema-unified -->		
+
+					
+					<meta property="fb:pages" content="10053803772" />
+</head>		
+<body>
+<svg class="mntl-svg-resource is-hidden">
+<defs>
+<symbol id="icon-chevron_right">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M10 6L8.59003 7.41L13.17 12L8.59003 16.59L10 18L16 12L10 6Z"/></svg> </symbol>
+<symbol id="light-box-arrow">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="2575 18840 48 48"><g transform="translate(1355 18464)"><circle cx="24" cy="24" r="24" transform="translate(1220 376)" fill="#fff"/><path d="M1248.675 390l9.38 9.38M1258.055 399.38l-9.38 9.553M1232 399.38h25.186" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3"/></g></svg> </symbol>
+<symbol id="icon-star-empty">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 9.24L14.81 8.62L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27L18.18 21L16.55 13.97L22 9.24ZM12 15.4L8.24 17.67L9.24 13.39L5.92 10.51L10.3 10.13L12 6.1L13.71 10.14L18.09 10.52L14.77 13.4L15.77 17.68L12 15.4Z"/></svg> </symbol>
+<symbol id="icon-print">
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.8337 6.66667H4.16699C2.78366 6.66667 1.66699 7.78333 1.66699 9.16667V14.1667H5.00033V17.5H15.0003V14.1667H18.3337V9.16667C18.3337 7.78333 17.217 6.66667 15.8337 6.66667ZM13.3337 15.8333H6.66699V11.6667H13.3337V15.8333ZM15.8337 10C15.3753 10 15.0003 9.625 15.0003 9.16667C15.0003 8.70833 15.3753 8.33333 15.8337 8.33333C16.292 8.33333 16.667 8.70833 16.667 9.16667C16.667 9.625 16.292 10 15.8337 10ZM15.0003 2.5H5.00033V5.83333H15.0003V2.5Z"/></svg> </symbol>
+<symbol id="icon-star">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 17.27L18.18 21L16.54 13.97L22 9.24L14.81 8.63L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27Z"/></svg> </symbol>
+<symbol id="icon-star-half">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 9.74L14.81 9.12L12 2.5L9.19 9.13L2 9.74L7.46 14.47L5.82 21.5L12 17.77L18.18 21.5L16.55 14.47L22 9.74ZM12 15.9V6.6L13.71 10.64L18.09 11.02L14.77 13.9L15.77 18.18L12 15.9Z"/></svg> </symbol>
+<symbol id="reviewer-icon">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m15.73975,0.45073l-3.73975,1.6059l-3.73866,-1.6059l-2.07997,3.50878l-3.97075,0.89094l0.37398,4.06865l-2.68383,3.07975l2.68383,3.06885l-0.37398,4.07091l3.97075,0.90079l2.07997,3.50987l3.73866,-1.61694l3.73975,1.60593l2.07889,-3.50987l3.97182,-0.90079l-0.37508,-4.0599l2.68385,-3.06885l-2.68385,-3.06875l0.37508,-4.05874l-3.97182,-0.90195l-2.07889,-3.51868zm0.59395,7.02856l1.62795,1.6279l-8.06252,8.08344l-4.17974,-4.18972l1.6279,-1.62787l2.55184,2.5629l6.43457,-6.45665z"/></svg> </symbol>
+<symbol id="reviewer-icon">
+<svg viewBox="0 0 153.4 122.3"><path d="M150.1,7.2l-3.9-3.9c-4.3-4.3-11.4-4.3-15.8,0L55.2,87.4L22.9,55.2c-4.3-4.3-11.5-4.3-15.8,0l-3.9,3.9c-4.3,4.3-4.3,11.4,0,15.8L43.1,115c0.1,0.1,0.1,0.1,0.2,0.2l3.9,3.9c4.3,4.3,11.4,4.3,15.8,0l87.2-96.1C154.5,18.6,154.5,11.5,150.1,7.2z"/></svg> </symbol>
+<symbol id="icon-facebook">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.282 8.46782H13.12V6.39482C13.12 5.61682 13.637 5.43482 14 5.43482H16.23V2.01182L13.157 1.99982C9.748 1.99982 8.972 4.55382 8.972 6.18682V8.46782H7V11.9938H8.972V21.9728H13.12V11.9938H15.919L16.282 8.46782Z"/></svg> </symbol>
+<symbol id="icon-flipboard">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M8 0H0V24H8V0Z"/><path d="M16.0533 0H7.97858V8.01068H16.0533 23.9999V0H16.0533ZM15.9893 8.01074H7.97858V16.0214H15.9893V8.01074Z"/></svg> </symbol>
+<symbol id="icon-instagram">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8.27326 3.05416C9.23411 3.01036 9.54091 3 11.9876 3C14.4343 3 14.7411 3.01036 15.7019 3.05416C16.6608 3.09785 17.3157 3.25001 17.8888 3.47247C18.4812 3.70247 18.9836 4.01021 19.4844 4.51055C19.9852 5.01092 20.2933 5.51283 20.5235 6.10466C20.7462 6.67712 20.8985 7.33137 20.9423 8.28931C20.9861 9.24926 20.9965 9.55575 20.9965 12C20.9965 14.4443 20.9861 14.7507 20.9423 15.7107C20.8985 16.6686 20.7462 17.3229 20.5235 17.8953C20.2933 18.4872 19.9852 18.9891 19.4844 19.4895C18.9836 19.9898 18.4812 20.2975 17.8888 20.5275C17.3157 20.75 16.6608 20.9021 15.7019 20.9458C14.7411 20.9896 14.4343 21 11.9876 21C9.54091 21 9.23411 20.9896 8.27326 20.9458C7.31433 20.9021 6.65948 20.75 6.08642 20.5275C5.494 20.2975 4.9916 19.9898 4.49077 19.4895C3.98994 18.9891 3.6819 18.4872 3.45167 17.8953C3.22895 17.3229 3.07668 16.6686 3.03291 15.7107C2.98907 14.7507 2.9787 14.4443 2.9787 12C2.9787 9.55575 2.98907 9.24926 3.03291 8.28931C3.07668 7.33137 3.22895 6.67712 3.45167 6.10466C3.6819 5.51283 3.98994 5.01092 4.49077 4.51055C4.9916 4.01021 5.494 3.70247 6.08642 3.47247C6.65948 3.25001 7.31433 3.09785 8.27326 3.05416ZM15.6279 4.6741C14.678 4.6308 14.3931 4.62162 11.9876 4.62162C9.5821 4.62162 9.2972 4.6308 8.34721 4.6741C7.46889 4.71411 6.99184 4.86073 6.6744 4.98398C6.25392 5.14725 5.95382 5.34227 5.63855 5.65723C5.32332 5.97215 5.12806 6.27196 4.96464 6.69206C4.8413 7.00919 4.69454 7.48574 4.65445 8.36323C4.61111 9.31224 4.60195 9.5969 4.60195 12C4.60195 14.4031 4.61111 14.6878 4.65445 15.6368C4.69454 16.5143 4.8413 16.9908 4.96464 17.3079C5.12806 17.728 5.32332 18.0278 5.63855 18.3428C5.95382 18.6577 6.25392 18.8528 6.6744 19.016C6.99184 19.1393 7.46889 19.2859 8.34725 19.3259C9.29705 19.3692 9.58196 19.3784 11.9876 19.3784C14.3932 19.3784 14.6781 19.3692 15.6279 19.3259C16.5063 19.2859 16.9833 19.1393 17.3008 19.016C17.7213 18.8528 18.0214 18.6577 18.3366 18.3428C18.6519 18.0278 18.8471 17.728 19.0105 17.3079C19.1339 16.9908 19.2806 16.5143 19.3207 15.6368C19.3641 14.6878 19.3732 14.4031 19.3732 12C19.3732 9.5969 19.3641 9.31224 19.3207 8.36323C19.2806 7.48574 19.1339 7.00919 19.0105 6.69206C18.8471 6.27196 18.6519 5.97215 18.3366 5.65723C18.0214 5.34227 17.7213 5.14725 17.3008 4.98398C16.9833 4.86073 16.5063 4.71411 15.6279 4.6741ZM8.99787 12.009C8.99787 13.6324 10.3424 14.9485 12.0008 14.9485C13.6593 14.9485 15.0038 13.6324 15.0038 12.009C15.0038 10.3855 13.6593 9.06948 12.0008 9.06948C10.3424 9.06948 8.99787 10.3855 8.99787 12.009ZM7.37466 12.009C7.37466 9.50799 9.44588 7.48056 12.0008 7.48056C14.5558 7.48056 16.627 9.50799 16.627 12.009C16.627 14.51 14.5558 16.5374 12.0008 16.5374C9.44588 16.5374 7.37466 14.51 7.37466 12.009ZM16.1487 8.49799C16.7457 8.49799 17.2297 8.02423 17.2297 7.43978C17.2297 6.85533 16.7457 6.38157 16.1487 6.38157C15.5516 6.38157 15.0676 6.85533 15.0676 7.43978C15.0676 8.02423 15.5516 8.49799 16.1487 8.49799Z"/></svg> </symbol>
+<symbol id="icon-linkedin">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5.90187 7.78789C4.8515 7.78789 4 6.98834 4 5.8944C4 4.8003 4.8515 4 5.90187 4C6.95223 4 7.80373 4.8003 7.80373 5.8944C7.80373 6.98834 6.95223 7.78789 5.90187 7.78789ZM4.25243 19.7198H7.55133V9.24009H4.25243V19.7198ZM16.4144 19.7279H19.7132V13.2463C19.7132 10.0453 17.724 8.95331 15.8832 8.95331C14.1812 8.95331 13.0668 10.0549 12.7477 10.6999H12.7056V9.24802H9.53307V19.7279H12.8318V14.046C12.8318 12.5311 13.7917 11.7943 14.7704 11.7943C15.6964 11.7943 16.4144 12.3151 16.4144 14.004V19.7279Z"/></svg> </symbol>
+<symbol id="icon-pinterest">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.00043 9.157C4.00043 11.129 4.74543 12.882 6.34643 13.535C6.60843 13.642 6.84443 13.539 6.91943 13.249C6.97343 13.048 7.09743 12.54 7.15343 12.329C7.23043 12.041 7.20143 11.941 6.98943 11.69C6.52743 11.146 6.23343 10.441 6.23343 9.443C6.23343 6.548 8.39943 3.955 11.8744 3.955C14.9504 3.955 16.6424 5.835 16.6424 8.347C16.6424 11.651 15.1794 14.439 13.0084 14.439C11.8094 14.439 10.9134 13.447 11.2004 12.231C11.5454 10.78 12.2114 9.214 12.2114 8.166C12.2114 7.228 11.7094 6.445 10.6674 6.445C9.44143 6.445 8.45643 7.713 8.45643 9.411C8.45643 10.493 8.82243 11.224 8.82243 11.224C8.82243 11.224 7.56843 16.538 7.34843 17.468C6.91043 19.321 7.28243 21.593 7.31443 21.823C7.33243 21.958 7.50743 21.991 7.58743 21.888C7.69943 21.74 9.15843 19.938 9.65543 18.138C9.79543 17.629 10.4614 14.988 10.4614 14.988C10.8604 15.748 12.0234 16.417 13.2604 16.417C16.9444 16.417 19.4434 13.059 19.4434 8.564C19.4434 5.165 16.5644 2 12.1894 2C6.74443 2 4.00043 5.903 4.00043 9.157Z"/></svg> </symbol>
+<symbol id="icon-tiktok">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M20.4761 9.49649C20.3086 9.5129 20.1411 9.52165 19.9736 9.52293C18.1346 9.52293 16.4192 8.5702 15.4105 6.98779V15.6201C15.4105 19.1431 12.6324 22 9.20399 22C5.77554 22 3 19.1431 3 15.6201C3 12.097 5.77798 9.24008 9.20644 9.24008C9.33604 9.24008 9.4632 9.25266 9.59036 9.26023V12.4037C9.4632 12.3886 9.33727 12.3635 9.20644 12.3635C7.45675 12.3635 6.03964 13.8215 6.03964 15.6188C6.03964 17.4174 7.45798 18.8741 9.20644 18.8741C10.9561 18.8741 12.5016 17.4576 12.5016 15.659L12.5322 1H15.4581C15.7344 3.69727 17.8497 5.8038 20.481 6.00113V9.4953"/></svg> </symbol>
+<symbol id="icon-twitter">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M21.689 5.894C20.966 6.215 20.187 6.432 19.37 6.53C20.204 6.03 20.843 5.238 21.146 4.295C20.365 4.758 19.499 5.094 18.58 5.275C17.844 4.49 16.793 4 15.632 4C13.401 4 11.592 5.808 11.592 8.039C11.592 8.356 11.628 8.664 11.697 8.96C8.34 8.791 5.362 7.183 3.371 4.739C3.024 5.336 2.824 6.03 2.824 6.77C2.824 8.171 3.537 9.408 4.621 10.132C3.959 10.111 3.336 9.929 2.791 9.627V9.678C2.791 11.635 4.185 13.267 6.031 13.638C5.693 13.731 5.336 13.78 4.967 13.78C4.706 13.78 4.454 13.755 4.208 13.708C4.721 15.312 6.213 16.481 7.98 16.513C6.598 17.596 4.858 18.242 2.964 18.242C2.638 18.242 2.317 18.223 2 18.186C3.788 19.332 5.91 20 8.192 20C15.623 20 19.686 13.845 19.686 8.508C19.686 8.332 19.682 8.158 19.674 7.985C20.463 7.415 21.148 6.704 21.689 5.894Z"/></svg> </symbol>
+<symbol id="icon-website">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2V2ZM11 19.93C7.05 19.44 4 16.08 4 12C4 11.38 4.08 10.79 4.21 10.21L9 15V16C9 17.1 9.9 18 11 18V19.93V19.93ZM17.9 17.39C17.64 16.58 16.9 16 16 16H15V13C15 12.45 14.55 12 14 12H8V10H10C10.55 10 11 9.55 11 9V7H13C14.1 7 15 6.1 15 5V4.59C17.93 5.78 20 8.65 20 12C20 14.08 19.2 15.97 17.9 17.39V17.39Z"/></svg> </symbol>
+<symbol id="icon-youtube">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.8139 5.42068C20.6744 5.65216 21.352 6.3342 21.582 7.20034C22 8.77011 22 12.0455 22 12.0455C22 12.0455 22 15.3207 21.582 16.8907C21.352 17.7567 20.6744 18.4387 19.8139 18.6703C18.2542 19.0909 12 19.0909 12 19.0909C12 19.0909 5.7458 19.0909 4.18614 18.6703C3.32568 18.4387 2.64795 17.7567 2.41795 16.8907C2 15.3207 2 12.0455 2 12.0455C2 12.0455 2 8.77011 2.41795 7.20034C2.64795 6.3342 3.32568 5.65216 4.18614 5.42068C5.7458 5 12 5 12 5C12 5 18.2542 5 19.8139 5.42068ZM15.1818 12.0456L9.95455 15.0192V9.0717L15.1818 12.0456Z"/></svg> </symbol>
+<symbol id="icon-share">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 9V5L21 12L14 19V14.9C9 14.9 5.5 16.5 3 20C4 15 7 10 14 9Z"/></svg> </symbol>
+<symbol id="icon-email">
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.667 3.33334H3.33366C2.41699 3.33334 1.67533 4.08334 1.67533 5.00001L1.66699 15C1.66699 15.9167 2.41699 16.6667 3.33366 16.6667H16.667C17.5837 16.6667 18.3337 15.9167 18.3337 15V5.00001C18.3337 4.08334 17.5837 3.33334 16.667 3.33334ZM16.667 6.66668L10.0003 10.8333L3.33366 6.66668V5.00001L10.0003 9.16668L16.667 5.00001V6.66668Z"/></svg> </symbol>
+<symbol id="icon-time">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11.99 22C6.47 22 2 17.52 2 12C2 6.48 6.47 2 11.99 2C17.52 2 22 6.48 22 12C22 17.52 17.52 22 11.99 22ZM12 4C7.58 4 4 7.58 4 12C4 16.42 7.58 20 12 20C16.42 20 20 16.42 20 12C20 7.58 16.42 4 12 4ZM12.5 17H11V11L16.25 7.85L17 9.08L12.5 11.75V17Z"/></svg> </symbol>
+<symbol id="icon-menu">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 18h18v-2H3v2Zm0-5h18v-2H3v2Zm0-7v2h18V6H3Z"/></svg> </symbol>
+<symbol id="icon-close">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 5.61143L18.3886 4L12 10.3886L5.61143 4L4 5.61143L10.3886 12L4 18.3886L5.61143 20L12 13.6114L18.3886 20L20 18.3886L13.6114 12L20 5.61143Z"/></svg> </symbol>
+<symbol id="icon-logo">
+<svg viewBox="0 0 640 191" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M182.185 29.4201C182.185 35.5142 187.125 40.4536 193.222 40.4536C199.315 40.4536 204.255 35.5142 204.255 29.4201C204.255 23.3237 199.315 18.3843 193.222 18.3843C187.125 18.3843 182.185 23.3237 182.185 29.4201Z" fill="#619E45"/><mask id="a" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="639" height="191"><path fill-rule="evenodd" clip-rule="evenodd" d="M0 190.056H638.503V0H0V190.056Z" fill="#fff"/></mask><g mask="url(#a)" fill-rule="evenodd" clip-rule="evenodd" fill="#619E45"><path d="M562.298 156.865H581.651V1.15466H562.298V156.865ZM595.425 157.005H614.776V1.29431H595.425V157.005ZM621.183 150.114C621.183 146.174 624.185 143.172 628.125 143.172 632.066 143.172 635.068 145.987 635.068 150.114 635.068 154.055 632.066 157.057 628.125 157.057 624.185 157.057 621.183 154.055 621.183 150.114ZM622.338 150.143C622.338 153.521 624.777 155.96 628.154 155.96 631.532 155.96 633.971 153.521 633.971 150.143 633.971 146.766 631.532 144.327 628.154 144.327 624.777 144.327 622.338 146.766 622.338 150.143Z"/><path d="M628.501 146.737C629.814 146.737 630.94 147.488 630.94 148.989 630.94 150.115 630.189 150.677 629.251 151.24L631.315 153.304V153.492H629.626L627.563 151.053H626.812V153.492H625.311V146.737H628.501ZM627 149.927H628.501C629.064 149.927 629.439 149.552 629.626 148.989 629.626 148.238 629.064 147.863 628.501 147.863H627V149.927ZM336.757 117.437C336.57 117.432 336.391 117.412 336.204 117.412 336.389 117.311 336.572 117.333 336.757 117.437ZM328.032 112.733C319.181 112.733 310.758 104.526 310.758 85.9525 310.758 69.7567 317.887 59.6054 328.032 59.6054 338.615 59.6054 345.53 69.7567 345.53 86.1673 345.53 102.365 338.833 112.733 328.032 112.733ZM313.751 116.564C313.809 116.464 313.888 116.438 314.006 116.5 313.924 116.519 313.836 116.544 313.751 116.564ZM348.574 119.436C358.438 113.966 364.717 102.278 364.717 87.6787 364.717 75.8196 360.747 65.9327 354.997 59.9737 362.495 60.5152 367.698 58.7937 367.698 58.7937L364.372 44.6612C364.372 44.6612 358.688 45.9994 350.654 45.9994 342.343 45.9994 335.97 44.0562 328.032 44.0562 304.887 44.0562 292.486 59.6862 292.486 83.8581 292.486 98.8842 298.119 112.342 308.151 118.729 303.389 121.272 298.74 125.291 295.954 128.261L306.869 140.375C311.543 135.277 319.855 129.801 330.666 129.801 343.965 129.801 354.117 138.876 354.117 152.042 354.117 165.758 343.135 173.239 329.002 173.239 312.653 173.239 301.234 162.102 301.234 162.102L290.105 174.069C298.591 183.006 313.207 190.056 329.645 190.056 353.249 190.056 372.406 176.563 372.406 153.563 372.406 136.835 362.567 124.15 348.574 119.436ZM90.4908 143.334C82.6082 143.334 75.6782 137.351 75.6782 119.211 75.6782 103.827 80.7689 95.0886 90.082 95.0886 100.233 95.0886 106.494 105.142 106.494 118.996 106.494 131.414 99.4229 143.334 90.4908 143.334ZM130.699 140.403C126.544 139.573 124.182 137.216 124.182 130.011V82.9294C124.182 53.3816 113.874 42.9762 90.754 42.9762 76.8455 42.9762 66.5267 48.8705 66.5267 48.8705L66.8454 64.6807C66.8454 64.6807 77.8962 59.4537 87.8652 59.4537 101.281 59.4537 106.494 68.357 106.494 80.5543V88.7579C101.96 82.0657 93.9038 79.6907 86.5616 79.6907 69.7158 79.6907 56.3257 93.0796 56.3257 118.996 56.3257 145.343 70.8611 159.379 87.2763 159.379 94.0712 159.379 103.338 155.656 109.534 145.556 111.022 151.833 115.686 157.862 127.374 157.862 133.818 157.862 137.282 156.822 137.282 156.822V140.54C137.282 140.54 134.857 141.235 130.699 140.403ZM161.397 23.6893 142.046 29.758V45.9988H130.19V63.8388H142.046V129.794C142.046 149.876 150.6 158.082 167.443 158.082 170.035 158.082 171.546 157.866 174.138 157.005V140.743C172.628 141.174 171.979 141.174 170.684 141.174 162.907 141.174 161.397 138.799 161.397 127.785V63.8388H174.138V45.9988H161.397V23.6893ZM183.575 157.005H202.925V45.9988H183.575V157.005ZM257.628 42.9751C250.04 42.9751 240.431 47.0139 233.807 57.5487V45.999H216.034V157.005H235.383V85.4338C235.383 72.6926 245.507 59.9491 254.705 59.9491 262.324 59.9491 264.625 65.4659 264.625 74.9256V157.005H283.974V74.0758C283.974 63.2767 281.6 56.3652 277.065 51.1821 272.529 45.7831 265.402 42.9751 257.628 42.9751ZM473.828 1.29384 452.91 103.328 434.571-.000488281H419.493L400.92 103.255 379.368 1.29384H359.8L395.655 158.731H407.14L427.087 50.9469 446.491 158.731H458.195L494.045 1.29384H473.828ZM519.579 59.0213C529.11 59.0213 533.92 69.2777 533.92 90.9199H503.512C503.512 68.884 510.613 59.0213 519.579 59.0213ZM521.34 142.254C510.234 142.254 502.79 130.166 502.79 111.643 502.79 108.886 502.774 107.805 502.774 107.154L551.861 107.133C552.077 100.525 552.19 98.4803 552.19 95.0222 552.19 62.7749 542.624 42.9756 519.579 42.9756 495.919 42.9756 484.377 64.5473 484.377 101.719 484.377 139.036 499.39 159.379 520.797 159.379 535.555 159.379 546.169 150.266 552.403 134.481L538.68 126.619C534.147 135.487 529.614 142.254 521.34 142.254ZM0 157.005H54.3893V137.873H19.7832V86.1667H49.6727V67.0335H19.7832V20.4286H54.805V1.29431H0V157.005Z"/></g></svg> </symbol>
+<symbol id="icon-account">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2C6.48 2 2 6.48 2 12ZM12 5C13.66 5 15 6.34 15 8C15 9.66 13.66 11 12 11C10.34 11 9 9.66 9 8C9 6.34 10.34 5 12 5ZM12 19.2C9.5 19.2 7.29 17.92 6 15.98C6.03 13.99 10 12.9 12 12.9C13.99 12.9 17.97 13.99 18 15.98C16.71 17.92 14.5 19.2 12 19.2Z"/></svg> </symbol>
+<symbol id="icon-search">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.5 14H14.71L14.43 13.73C15.41 12.59 16 11.11 16 9.5C16 5.91 13.09 3 9.5 3C5.91 3 3 5.91 3 9.5C3 13.09 5.91 16 9.5 16C11.11 16 12.59 15.41 13.73 14.43L14 14.71V15.5L19 20.49L20.49 19L15.5 14ZM9.5 14C7.01 14 5 11.99 5 9.5C5 7.01 7.01 5 9.5 5C11.99 5 14 7.01 14 9.5C14 11.99 11.99 14 9.5 14Z"/></svg> </symbol>
+<symbol id="icon-info">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V11H13V17ZM13 9H11V7H13V9Z"/></svg> </symbol>
+<symbol id="icon-arrow_left">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z"/></svg> </symbol>
+<symbol id="mntl-dotdash-universal-nav__logo">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="5 2.8 290 69"><circle cx="39.6" cy="37.4" r="34.3" fill="#f44b34"/><path fill="#fff" d="M50.4 17.9c-1.7-1.8-4-2.6-7-2.6-9.1-.1-12.4-.1-13.2-.1L27.3 22h8.1L30 28v21h-.1l.1.1v6.7l-3.6 4h18.5L53 51V25c0-.1.1-4.3-2.6-7.1zm-5.2 19.6-7.4 7.8V41l7.4-7.8v4.3zm-7.4-15.4h3c.9 0 2.1-.1 3.1.9s1.4 2.5 1.4 4.9v3.6l-7.4 7.8-.1-17.2zm-4.9 30.1 3.3-3.6 9-9.5v13.1c0 .1-12.3.1-12.3 0z"/><path fill="#009ad9" d="m99.645 22.637 6.505-6.506 4.172 4.172-6.505 6.506zM121 44l4.2 4.2 6.5-6.5-4.2-4.2zm-3.2-31.2c1.8-1.8 4.7-1.8 6.5 0 1.9 1.9 1.7 4.8 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c2-2 4.9-1.6 6.5 0 2 2 1.6 4.9 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c4.2-4.2 4-10.8 0-14.8-2.8-2.8-6.1-3.1-7.6-3.1.1-1.5-.3-4.8-3.1-7.6-3.9-3.9-10.6-4.2-14.8 0l-3.3 3.3 4.2 4.2 3.2-3.4zm-7.5 20.6 4.2 4.1L121 31l-4.2-4.1-6.5 6.5z"/><path fill="#6ebd44" d="m99.6 52.4 6.6 6.5 4.1-4.2-6.5-6.5zm36.3-14.9-4.2 4.2L135 45c1.6 1.6 2 4.5 0 6.5-1.6 1.6-4.5 2.1-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c1.7 1.7 1.9 4.6 0 6.5-1.8 1.8-4.7 1.8-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c4.2 4.2 10.9 3.9 14.8 0 2.8-2.8 3.1-6.1 3.1-7.6 1.5 0 4.8-.3 7.6-3.1 4-4 4.2-10.6 0-14.8l-3.2-3.4zm-25.6 4.2 6.5 6.5L121 44l-6.5-6.5zm14.9-14.8L121 31l6.5 6.5 4.2-4.1-6.5-6.5z"/><path fill="#f68f1e" d="m110.332 54.607 6.506-6.506 4.172 4.172-6.506 6.505zM102.8 62.2c-1.6 1.6-4.5 2-6.5 0-1.6-1.6-2.1-4.5 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-1.7 1.7-4.6 1.9-6.5 0-1.8-1.8-1.8-4.7 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-4.2 4.2-3.9 10.9 0 14.8 2.8 2.8 6.1 3.1 7.6 3.1 0 1.5.3 4.8 3.1 7.6 4 4 10.6 4.2 14.8 0l3.3-3.3-4.2-4.2-3.2 3.4zm3.4-24.7L99.6 44l4.2 4.2 6.5-6.5zM95.5 26.9 89 33.4l4.1 4.1 6.5-6.5z"/><path fill="#ec174c" d="m99.6 44-6.5-6.5-4.1 4.2 6.5 6.5zm-14-14c-1.8-1.8-1.8-4.7 0-6.5 1.9-1.9 4.8-1.7 6.5 0l3.3 3.3 4.2-4.2-3.3-3.3c-2-2-1.6-4.9 0-6.5 2-2 4.9-1.6 6.5 0l3.3 3.3 4.2-4.2-3.3-3.2c-4.2-4.2-10.8-4-14.8 0-2.8 2.8-3.1 6.1-3.1 7.6-1.5-.1-4.9.3-7.6 3.1-3.9 3.9-4.2 10.6 0 14.8l3.3 3.3 4.2-4.2-3.4-3.3zm24.73-9.682 4.172-4.172 6.505 6.505-4.172 4.172zM106.2 37.5l4.1-4.1-6.5-6.5-4.2 4.1 6.6 6.5z"/><path fill="#573357" d="m106.142 16.042 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#be272d" d="m84.81 37.543 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#008e4c" d="m127.497 37.555 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#7a773e" d="m106.172 58.866 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#443639" d="m116.856 26.74 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#803136" d="m95.455 48.169 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#593438" d="m95.446 26.753 4.172-4.172 4.172 4.173-4.172 4.171z"/><path fill="#443639" d="m106.155 37.456 4.172-4.172 4.172 4.171-4.172 4.172z"/><path fill="#2a6442" d="m116.871 48.153 4.172-4.172 4.172 4.172-4.172 4.172z"/><path d="M170.4 13.5c-2.5-2.2-5.7-3.3-9.6-3.3h-7.2v23.6h7.6c3.8 0 7-1.1 9.4-3.3s3.6-5 3.6-8.5-1.3-6.3-3.8-8.5zm.1 8.5c0 2.6-.9 4.7-2.6 6.2-1.7 1.6-4.1 2.3-7 2.3h-3.8V13.4h3.8c2.9 0 5.2.8 7 2.3 1.7 1.5 2.6 3.7 2.6 6.3zm14.6-6.3c-2.5 0-4.7.9-6.4 2.7s-2.6 4-2.6 6.6.9 4.8 2.6 6.6c1.7 1.8 3.9 2.7 6.4 2.7h.1v-.1c2.5 0 4.7-.9 6.4-2.7s2.6-4 2.6-6.6c0-2.5-.9-4.8-2.6-6.6-1.8-1.7-3.9-2.6-6.5-2.6zm4.1 13.7c-.5.6-1.1 1-1.8 1.3s-1.4.3-2.2.3c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 3 .6 4 1.7 1.1 1.2 1.6 2.6 1.6 4.3 0 1.9-.5 3.4-1.6 4.6zm16.9.8c-.5.6-1.3.9-2.3.9-1.6 0-2.4-.9-2.4-2.7v-9.2h5v-3h-5v-4.4h-3.3v4.4h-2.9l.1 3h2.9v9.3c0 1.9.5 3.3 1.4 4.3s2.2 1.5 3.9 1.5c1.8 0 3.2-.5 4.2-1.5l-1.6-2.6zm38.1-11.6c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V16.1h-3.4v2.5h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-.5.6-1.1 1-1.8 1.3s-1.4.4-2.2.4c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6.1 2.9.6 4 1.8zm17.9 3.6c-.9-.3-1.9-.6-3-.9-1-.3-1.9-.6-2.5-1-.7-.4-1-1-1-1.6l.1-.1c0-.7.3-1.2.9-1.6.6-.4 1.4-.6 2.3-.6 2 0 3.4.7 4.5 2l2-2c-1.3-1.8-3.5-2.7-6.6-2.7-1.9 0-3.5.5-4.7 1.4-1.2 1-1.7 2.1-1.7 3.5 0 1.2.3 2.1 1 2.9s1.5 1.3 2.6 1.7c1.1.4 2 .7 2.9 1 1 .3 1.8.7 2.4 1.1.7.5 1 1 1 1.8s-.3 1.4-.9 1.8c-.6.5-1.4.7-2.5.7-2.3 0-4.1-.8-5.3-2.3l-2 2.2c1.5 1.9 3.9 2.9 7.1 2.9 2.2 0 3.9-.5 5.1-1.5s1.8-2.3 1.8-3.8c0-1.2-.3-2.2-1-3-.6-.9-1.5-1.4-2.5-1.9zm14.9-8.6c-2.3 0-4.1.8-5.2 2.5V8.4h-3.4v25.4h3.4l.1-10.3c0-1.4.4-2.6 1.2-3.4.8-.8 1.8-1.2 3.2-1.2 1.3 0 2.4.4 3.2 1.3.8.8 1.2 2 1.2 3.4v10.3h3.4V23c0-2.3-.6-4-1.9-5.4-1.4-1.4-3.1-2-5.2-2zm-52.2 3c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V8.4h-3.4v10.2h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-1.1 1.2-2.4 1.8-4 1.8-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 2.9.5 4 1.7zm48.8 19.9h-3.6v19.1c0 2.4.7 4.1 2.1 5.1 1.2.9 3.1 1.4 5.6 1.4h.1v-3h-.1c-1.2 0-2.1-.2-2.7-.6-.9-.6-1.4-1.7-1.4-3.3V51h4.1v-3h-4.1v-7.5zm-96.2 7c-1.4 0-2.6.3-3.7 1-1 .6-1.7 1.5-2.3 2.6-1.2-2.4-3.2-3.6-6-3.6-2.2 0-4 .9-5.2 2.6V48h-3.5v18.2h3.5l.2-10.7c0-1.5.4-2.6 1.1-3.5.7-.9 1.8-1.3 3.1-1.3s2.3.4 3.1 1.3c.8.9 1.2 2 1.2 3.5v10.6h3.4V55.5c0-1.5.4-2.6 1.2-3.5s1.8-1.3 3.2-1.3c1.3 0 2.3.4 3.1 1.3.7.9 1.1 2 1.1 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5-1.3-1.3-3-2-5.1-2zm18.9 0c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7 1-.9 2.2-1.4 3.6-1.4zm22.5-2.3c-.6-.5-1.6-.8-2.8-.8-1.9 0-3.4.9-4.5 2.6v-2H205v18.2h3.5l-.1-10.5c0-1.5.3-2.7.9-3.6.6-.9 1.5-1.3 2.6-1.3.9 0 1.7.2 2.3.7h.1l1.4-3.3zm9-.7c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7.9-.9 2.1-1.4 3.6-1.4zm26.1 0c-1.5-2-3.6-3.1-6.3-3.1-2.5 0-4.6.9-6.3 2.7s-2.5 4.1-2.5 6.8.9 5 2.5 6.8c1.7 1.8 3.8 2.7 6.3 2.7 2.6 0 4.7-1.1 6.3-3.2v2.7h3.5V40.5h-3.5v10zm-1.7 2c1.1 1.2 1.6 2.7 1.6 4.5 0 1.7-.6 3.3-1.6 4.5-1.1 1.2-2.4 1.8-4.2 1.8-1.7 0-3.1-.6-4.2-1.8-1.1-1.2-1.7-2.7-1.7-4.5s.6-3.3 1.7-4.5c1.1-1.2 2.5-1.8 4.2-1.8 1.8.1 3.1.7 4.2 1.8zm43.5-3c-1.3-1.4-3-2.1-5.2-2.1-2.4 0-4.2.9-5.4 2.6v-9.6h-3.5v25.7h3.5l.1-10.5c0-1.5.4-2.6 1.2-3.5.8-.9 1.8-1.3 3.2-1.3 1.4 0 2.5.4 3.3 1.3.8.9 1.2 2 1.2 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5zM259.1 48h3.5v18.2h-3.5zm0-7.5h3.4v3.4h-3.4z"/></svg> </symbol>
+<symbol id="icon-close">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 5.61143L18.3886 4L12 10.3886L5.61143 4L4 5.61143L10.3886 12L4 18.3886L5.61143 20L12 13.6114L18.3886 20L20 18.3886L13.6114 12L20 5.61143Z"/></svg> </symbol>
+</defs>
+</svg>
+<!-- Google Tag Manager (Testing) -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-P3X3VT7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager -->
+<a
+href="#main"
+rel="nocaes"
+id="skip-to-content_1-0"
+class=" skip-to-content mntl-text-link"
+data-tracking-container="true"
+><span class="link__wrapper">Skip to content</span></a><!-- end: skip-to-content mntl-text-link -->
+<header id="header_1-0" class="comp header" role="banner" data-tracking-container="true">
+<div class="header__menu-top">
+<div class="header__menu-button-container">
+<button class="header__menu-button" aria-label="Main menu for EatingWell">
+<div class="header__menu-button-inner">
+<svg class="icon icon-menu ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-menu"></use>
+</svg>
+<svg class="icon icon-close ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+</svg>
+<div>
+</button>
+</div>
+<div class="header__logo-wrapper">
+<a id="logo_1-0" class="comp logo mntl-block" rel="home" href="/" aria-label="Home">
+<div id="mntl-text-block_1-0" class="comp is-screenreader-only mntl-text-block">
+EatingWell</div><!-- end: comp is-screenreader-only mntl-text-block -->
+<svg class="icon icon-logo ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo"></use>
+</svg>
+</a><!-- end: comp logo mntl-block -->
+</div>
+<div id="utility-nav_1-0" class="comp utility-nav">
+<ul class="utility-nav__list type--rabbit">
+<li class="loc search-bar utility-nav__search utility-nav__partial-menu-item">
+<div id="general-search_1-0" class="comp type--cat general-search" data-tracking-container="true">
+<button class="general-search__icon-button" aria-label="search">
+<svg class="icon icon-search ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
+</svg>
+</button>
+<form class="general-search__form" role="search" action="/search" method="get">
+<div class="general-search__input-group input-group">
+<label for="general-search__search-input" class="type--cat-bold">Search</label>
+<input type="text" name="q" id="general-search__search-input" class="general-search__input" placeholder="What are you looking for?" type="text" required="required" value="" autocomplete="off">
+<button class="general-search__button type--squirrel button--contained-standard-square">
+<span class="is-vishidden">Search</span>
+<svg class="icon icon-search ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
+</svg>
+</button>
+<button class="general-search__close" aria-label="Close search bar">
+<svg class="icon icon-close ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+</svg>
+</button>
+</div>
+</form>
+<div class="loc validation-message">
+<div id="general-search__validation-message_1-0" class="comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational">
+<svg class="icon icon-info message-banner__prefix-icon message-banner__icon ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-info"></use>
+</svg>
+<span class="message-banner__text ">
+Please fill out this field.
+</span>
+<button class="message-banner__close-button js-message-banner-close" aria-label="Close informational Banner">
+<svg class="icon icon-close message-banner__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+</svg>
+</button>
+</div><!-- end: comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational -->
+</div>
+</div><!-- end: comp type--cat general-search -->
+</li>
+<li class="loc sign-in utility-nav__signin utility-nav__full-menu-item">
+<a id="mntl-auth0_1-0" class="comp mntl-auth0" data-auth0-logout-url="https://www.eatingwell.com:443/auth0/logout" data-auth0-audience="platform-services-prod" data-auth0-domain="etg-prod.auth0.com" data-auth0-type="signin" data-auth0-client-id="BNT3QoETBtD7OTDvCd0uMfEG90dwqXft" data-auth0-enabled="true" data-auth0-regsource="27520">
+<svg class="icon icon-account ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+</svg>
+Log In
+</a><!-- end: comp mntl-auth0 -->
+</li>
+<li class="utility-nav__account utility-nav__full-menu-item utility-nav__list-item mntl-auth0-sign-out">
+<button class="utility-nav__title type--rabbit">
+<svg class="icon icon-account ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+</svg>
+<span>My Account</span>
+<svg class="icon ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#"></use>
+</svg>
+</button>
+<div class="utility-nav__sublist-container">
+<ul class="utility-nav__link-list">
+<li class="loc sign-out utility-nav__sublist-list-item utility-nav__sublist-list-item--signout">
+<a id="mntl-auth0-sign-out_1-0" class="comp mntl-auth0-sign-out mntl-auth0" data-auth0-logout-url="https://www.eatingwell.com:443/auth0/logout" data-auth0-client-id="BNT3QoETBtD7OTDvCd0uMfEG90dwqXft" data-auth0-audience="platform-services-prod" data-auth0-enabled="true" data-auth0-domain="etg-prod.auth0.com" data-auth0-type="signout">
+Log Out
+</a><!-- end: comp mntl-auth0-sign-out mntl-auth0 -->
+</li>
+</ul>
+</div>
+</li>
+<li class="loc newsletter-link-wrapper utility-nav__newsletter utility-nav__full-menu-item">
+<a
+href="#"
+rel="nocaes"
+data-a11y-dialog-show="newsletter-dialog-header"
+id="newsletter-dialog-header-link_1-0"
+class=" newsletter-dialog-header-link dialog-link mntl-text-link"
+data-tracking-container="true"
+><span class="link__wrapper">Newsletter</span></a><!-- end: newsletter-dialog-header-link dialog-link mntl-text-link -->
+</li>
+<li class="utility-nav__sweepstakes utility-nav__full-menu-item">
+<a
+href="https://www.eatingwell.com/sweepstakes/"
+rel="nocaes"
+> Sweepstakes
+</a><!-- end: --> </li>
+</ul>
+</div><!-- end: comp utility-nav -->
+</div>
+<div class="header__nav-panel">
+<nav id="fullscreen-nav_1-0" class="comp fullscreen-nav" role="navigation" data-tracking-container="true">
+<div id="fullscreen-nav__search_1-0" class="comp type--cat fullscreen-nav__search general-search" data-tracking-container="true">
+<form class="fullscreen-nav__search__form" role="search" action="/search" method="get">
+<div class="general-search__input-group input-group">
+<label for="fullscreen-nav__search__search-input" class="type--cat-bold">Search</label>
+<input type="text" name="q" id="fullscreen-nav__search__search-input" class="general-search__input" placeholder="What are you looking for?" type="text" required="required" value="" autocomplete="off">
+<button class="general-search__button type--squirrel button--contained-standard-square">
+<span class="is-vishidden">Search</span>
+<svg class="icon icon-search ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
+</svg>
+</button>
+</div>
+</form>
+<div class="loc validation-message">
+<div id="general-search__validation-message_2-0" class="comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational">
+<svg class="icon icon-info message-banner__prefix-icon message-banner__icon ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-info"></use>
+</svg>
+<span class="message-banner__text ">
+Please fill out this field.
+</span>
+<button class="message-banner__close-button js-message-banner-close" aria-label="Close informational Banner">
+<svg class="icon icon-close message-banner__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+</svg>
+</button>
+</div><!-- end: comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational -->
+</div>
+</div><!-- end: comp type--cat fullscreen-nav__search general-search -->
+<ul class="fullscreen-nav__list">
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/recipes/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-healthy-recipes-fullscreen-nav">
+Healthy Recipes
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-healthy-recipes-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">Healthy Recipes</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17947/mealtimes/dinner/"
+rel="nocaes"
+> Dinner
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/18258/cooking-methods-styles/quick-easy/"
+rel="nocaes"
+> Quick & Easy
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17916/mealtimes/breakfast-brunch/"
+rel="nocaes"
+> Breakfast & Brunch
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17963/mealtimes/lunch/"
+rel="nocaes"
+> Lunch
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/18041/appetizer/"
+rel="nocaes"
+> Appetizers
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17986/side-dishes/"
+rel="nocaes"
+> Side Dishes
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17981/salad/"
+rel="nocaes"
+> Salads
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/18042/soup/"
+rel="nocaes"
+> Soup
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/18044/desserts/"
+rel="nocaes"
+> Desserts
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17989/drinks/smoothies/"
+rel="nocaes"
+> Smoothies
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17990/mealtimes/snacks/"
+rel="nocaes"
+> Snacks
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/recipes/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/category/4243/special-diets/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-special-diets-fullscreen-nav">
+Special Diets
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-special-diets-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">Special Diets</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4274/mediterranean-diet-center/"
+rel="nocaes"
+> Mediterranean Diet
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4236/weight-loss/"
+rel="nocaes"
+> Weight Loss
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4256/heart-healthy-diet-center/"
+rel="nocaes"
+> Heart Health
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4251/gluten-free-diet-center/"
+rel="nocaes"
+> Gluten-Free
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4283/vegetarian-diet-center/"
+rel="nocaes"
+> Vegetarian
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4280/vegan-diet-center/"
+rel="nocaes"
+> Vegan
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/category/4243/special-diets/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/category/4248/diabetes-diet-center/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-diabetes-fullscreen-nav">
+Diabetes
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-diabetes-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">Diabetes</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4291/meal-plans-for-diabetes/"
+rel="nocaes"
+> Meal Plans for Diabetes
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/recipes/17899/health-condition/diabetic/"
+rel="nocaes"
+> Diabetes-Friendly Recipes
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/category/4248/diabetes-diet-center/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/category/4328/news/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-news-fullscreen-nav">
+News
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-news-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">News</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/7908969/features/"
+rel="nocaes"
+> Features
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/category/4328/news/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/category/4286/meal-plans/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-meal-plans-fullscreen-nav">
+Meal Plans
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-meal-plans-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">Meal Plans</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4288/dinner-plans/"
+rel="nocaes"
+> Dinner Plans
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4305/weight-loss-meal-plans/"
+rel="nocaes"
+> Weight-Loss Meal Plans
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4298/low-carb-meal-plans/"
+rel="nocaes"
+> Low-Carb Meal Plans
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4299/low-cholesterol-meal-plans/"
+rel="nocaes"
+> Low-Cholesterol Meal Plans
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4300/mediterranean-diet-meal-plans/"
+rel="nocaes"
+> Mediterranean Diet Meal Plans
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4302/low-sodium-meal-plans/"
+rel="nocaes"
+> Low-Sodium Meal Plans
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4330/theprep/"
+rel="nocaes"
+> ThePrep
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/category/4286/meal-plans/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/category/4306/healthy-eating-101/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-healthy-eating-fullscreen-nav">
+Healthy Eating
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-healthy-eating-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">Healthy Eating</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4307/how-to-eat-healthy/"
+rel="nocaes"
+> How to Eat Healthy
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4308/best-healthy-foods/"
+rel="nocaes"
+> Best Healthy Foods
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4309/healthy-cooking-how-tos/"
+rel="nocaes"
+> Healthy Cooking How-Tos
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4311/healthy-eating-for-kids/"
+rel="nocaes"
+> Healthy Eating for Kids
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4325/good-food-fast/"
+rel="nocaes"
+> Good Food Fast
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4313/wine-beer-spirits-guide/"
+rel="nocaes"
+> Beer, Wine & Spirits Guide
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/category/4306/healthy-eating-101/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/category/7886691/healthy-lifestyle/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-healthy-lifestyle-fullscreen-nav">
+Healthy Lifestyle
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-healthy-lifestyle-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">Healthy Lifestyle</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4318/eatingwell-in-real-life/"
+rel="nocaes"
+> EatingWell in Real Life
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4310/entertaining/"
+rel="nocaes"
+> Entertaining
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/7904359/kitchen-essentials/"
+rel="nocaes"
+> Kitchen Essentials
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/category/4316/green-and-sustainable-eating/"
+rel="nocaes"
+> Sustainability
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/category/7886691/healthy-lifestyle/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+<li class="fullscreen-nav__list-item">
+<a href="https://www.eatingwell.com/about-us-6743412" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-about-us-fullscreen-nav">
+About Us
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</a>
+<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-about-us-fullscreen-nav">
+<div class="fullscreen-nav__sublist-header">
+<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="fullscreen-nav__sublist-header-text type--goat-bold">About Us</span>
+</div>
+<ul class="fullscreen-nav__sublist">
+<li class="fullscreen-nav__sublist-item type--rabbit">
+<a
+href="https://www.eatingwell.com/our-food-and-nutrition-philosophy-6746110"
+rel="nocaes"
+> Nutrition Guidelines
+</a><!-- end: --> </li>
+<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+<a
+href="https://www.eatingwell.com/about-us-6743412"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</div>
+</li>
+</ul>
+<div id="utility-nav_2-0" class="comp utility-nav">
+<ul class="utility-nav__list type--rabbit">
+<li class="loc sign-in utility-nav__signin utility-nav__full-menu-item">
+<a id="mntl-auth0_2-0" class="comp mntl-auth0" data-auth0-logout-url="https://www.eatingwell.com:443/auth0/logout" data-auth0-audience="platform-services-prod" data-auth0-domain="etg-prod.auth0.com" data-auth0-type="signin" data-auth0-client-id="BNT3QoETBtD7OTDvCd0uMfEG90dwqXft" data-auth0-enabled="true" data-auth0-regsource="27520">
+<svg class="icon icon-account ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+</svg>
+Log In
+</a><!-- end: comp mntl-auth0 -->
+</li>
+<li class="utility-nav__account utility-nav__full-menu-item utility-nav__list-item mntl-auth0-sign-out">
+<button class="utility-nav__title type--rabbit">
+<svg class="icon icon-account ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+</svg>
+<span>My Account</span>
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</button>
+<div class="utility-nav__sublist-container">
+<div class="utility-nav__sublist-header">
+<button class="utility-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow_left ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+</svg>
+</button>
+<span class="type--goat-bold">My Account</span>
+</div>
+<ul class="utility-nav__link-list">
+<li class="loc sign-out utility-nav__sublist-list-item utility-nav__sublist-list-item--signout">
+<a id="mntl-auth0-sign-out_2-0" class="comp mntl-auth0-sign-out mntl-auth0" data-auth0-logout-url="https://www.eatingwell.com:443/auth0/logout" data-auth0-client-id="BNT3QoETBtD7OTDvCd0uMfEG90dwqXft" data-auth0-audience="platform-services-prod" data-auth0-enabled="true" data-auth0-domain="etg-prod.auth0.com" data-auth0-type="signout">
+Log Out
+</a><!-- end: comp mntl-auth0-sign-out mntl-auth0 -->
+</li>
+</ul>
+</div>
+</li>
+<li class="loc newsletter-link-wrapper utility-nav__newsletter utility-nav__full-menu-item">
+<a
+href="#"
+rel="nocaes"
+data-a11y-dialog-show="newsletter-dialog-header"
+id="newsletter-dialog-header-link_2-0"
+class=" newsletter-dialog-header-link dialog-link mntl-text-link"
+data-tracking-container="true"
+><span class="link__wrapper">Newsletter</span></a><!-- end: newsletter-dialog-header-link dialog-link mntl-text-link -->
+</li>
+<li class="utility-nav__sweepstakes utility-nav__full-menu-item">
+<a
+href="https://www.eatingwell.com/sweepstakes/"
+rel="nocaes"
+> Sweepstakes
+</a><!-- end: --> </li>
+</ul>
+</div><!-- end: comp utility-nav -->
+<div class="loc fullscreen-nav__social">
+<nav id="fullscreen-nav__social-nav_1-0" class="comp fullscreen-nav__social-nav eatingwell-social-nav mntl-social-nav" role="navigation" data-tracking-container="true">
+<div class="social-nav__title">Follow Us</div>
+<ul class="social-nav__list">
+<li class="social-nav__item social-nav__item--facebook">
+<a
+href="https://www.facebook.com/EatingWell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--facebook"
+> <svg class="icon icon-facebook social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
+</svg>
+<span class="social-nav__accessible-label">Facebook</span>
+</a><!-- end: social-nav__link social-nav__link--facebook --> </li>
+<li class="social-nav__item social-nav__item--flipboard">
+<a
+href="https://flipboard.com/@EatingWell"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--flipboard"
+> <svg class="icon icon-flipboard social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard"></use>
+</svg>
+<span class="social-nav__accessible-label">Flipboard</span>
+</a><!-- end: social-nav__link social-nav__link--flipboard --> </li>
+<li class="social-nav__item social-nav__item--instagram">
+<a
+href="https://www.instagram.com/eatingwell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--instagram"
+> <svg class="icon icon-instagram social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram"></use>
+</svg>
+<span class="social-nav__accessible-label">Instagram</span>
+</a><!-- end: social-nav__link social-nav__link--instagram --> </li>
+<li class="social-nav__item social-nav__item--pinterest">
+<a
+href="https://www.pinterest.com/eatingwell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--pinterest"
+> <svg class="icon icon-pinterest social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest"></use>
+</svg>
+<span class="social-nav__accessible-label">Pinterest</span>
+</a><!-- end: social-nav__link social-nav__link--pinterest --> </li>
+<li class="social-nav__item social-nav__item--twitter">
+<a
+href="https://twitter.com/EatingWell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--twitter"
+> <svg class="icon icon-twitter social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use>
+</svg>
+<span class="social-nav__accessible-label">Twitter</span>
+</a><!-- end: social-nav__link social-nav__link--twitter --> </li>
+<li class="social-nav__item social-nav__item--youtube">
+<a
+href="https://www.youtube.com/@eatingwell"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--youtube"
+> <svg class="icon icon-youtube social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube"></use>
+</svg>
+<span class="social-nav__accessible-label">YouTube</span>
+</a><!-- end: social-nav__link social-nav__link--youtube --> </li>
+</ul>
+</nav><!-- end: comp fullscreen-nav__social-nav eatingwell-social-nav mntl-social-nav -->
+</div>
+</nav><!-- end: comp fullscreen-nav -->
+</div>
+<nav id="header-nav_1-0" class="comp header-nav" role="navigation">
+<div class="header-nav__list-wrapper">
+<ul class="header-nav__list">
+<li class="header-nav__list-item">
+<a
+href="https://www.eatingwell.com/recipes/"
+rel="nocaes"
+> Healthy Recipes
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17947/mealtimes/dinner/"
+rel="nocaes"
+> Dinner
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/18258/cooking-methods-styles/quick-easy/"
+rel="nocaes"
+> Quick & Easy
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17916/mealtimes/breakfast-brunch/"
+rel="nocaes"
+> Breakfast & Brunch
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17963/mealtimes/lunch/"
+rel="nocaes"
+> Lunch
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/18041/appetizer/"
+rel="nocaes"
+> Appetizers
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17986/side-dishes/"
+rel="nocaes"
+> Side Dishes
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17981/salad/"
+rel="nocaes"
+> Salads
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/18042/soup/"
+rel="nocaes"
+> Soup
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/18044/desserts/"
+rel="nocaes"
+> Desserts
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17989/drinks/smoothies/"
+rel="nocaes"
+> Smoothies
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17990/mealtimes/snacks/"
+rel="nocaes"
+> Snacks
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item type--squirrel-bold view-all">
+<a
+href="https://www.eatingwell.com/recipes/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</li>
+<li class="header-nav__list-item">
+<a
+href="https://www.eatingwell.com/category/4243/special-diets/"
+rel="nocaes"
+> Special Diets
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4274/mediterranean-diet-center/"
+rel="nocaes"
+> Mediterranean Diet
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4236/weight-loss/"
+rel="nocaes"
+> Weight Loss
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4256/heart-healthy-diet-center/"
+rel="nocaes"
+> Heart Health
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4251/gluten-free-diet-center/"
+rel="nocaes"
+> Gluten-Free
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4283/vegetarian-diet-center/"
+rel="nocaes"
+> Vegetarian
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4280/vegan-diet-center/"
+rel="nocaes"
+> Vegan
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item type--squirrel-bold view-all">
+<a
+href="https://www.eatingwell.com/category/4243/special-diets/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</li>
+<li class="header-nav__list-item">
+<a
+href="https://www.eatingwell.com/category/4248/diabetes-diet-center/"
+rel="nocaes"
+> Diabetes
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4291/meal-plans-for-diabetes/"
+rel="nocaes"
+> Meal Plans for Diabetes
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/recipes/17899/health-condition/diabetic/"
+rel="nocaes"
+> Diabetes-Friendly Recipes
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item type--squirrel-bold view-all">
+<a
+href="https://www.eatingwell.com/category/4248/diabetes-diet-center/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</li>
+<li class="header-nav__list-item">
+<a
+href="https://www.eatingwell.com/category/4286/meal-plans/"
+rel="nocaes"
+> Meal Plans
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4288/dinner-plans/"
+rel="nocaes"
+> Dinner Plans
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4305/weight-loss-meal-plans/"
+rel="nocaes"
+> Weight-Loss Meal Plans
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4298/low-carb-meal-plans/"
+rel="nocaes"
+> Low-Carb Meal Plans
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4299/low-cholesterol-meal-plans/"
+rel="nocaes"
+> Low-Cholesterol Meal Plans
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4300/mediterranean-diet-meal-plans/"
+rel="nocaes"
+> Mediterranean Diet Meal Plans
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4302/low-sodium-meal-plans/"
+rel="nocaes"
+> Low-Sodium Meal Plans
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4330/theprep/"
+rel="nocaes"
+> ThePrep
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item type--squirrel-bold view-all">
+<a
+href="https://www.eatingwell.com/category/4286/meal-plans/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</li>
+<li class="header-nav__list-item">
+<a
+href="https://www.eatingwell.com/category/4328/news/"
+rel="nocaes"
+> News
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/7908969/features/"
+rel="nocaes"
+> Features
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item type--squirrel-bold view-all">
+<a
+href="https://www.eatingwell.com/category/4328/news/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</li>
+<li class="header-nav__list-item">
+<a
+href="https://www.eatingwell.com/category/4306/healthy-eating-101/"
+rel="nocaes"
+> Healthy Eating
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4307/how-to-eat-healthy/"
+rel="nocaes"
+> How to Eat Healthy
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4308/best-healthy-foods/"
+rel="nocaes"
+> Best Healthy Foods
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4309/healthy-cooking-how-tos/"
+rel="nocaes"
+> Healthy Cooking How-Tos
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4311/healthy-eating-for-kids/"
+rel="nocaes"
+> Healthy Eating for Kids
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4325/good-food-fast/"
+rel="nocaes"
+> Good Food Fast
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4313/wine-beer-spirits-guide/"
+rel="nocaes"
+> Beer, Wine & Spirits Guide
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item type--squirrel-bold view-all">
+<a
+href="https://www.eatingwell.com/category/4306/healthy-eating-101/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</li>
+<li class="header-nav__list-item">
+<a
+href="https://www.eatingwell.com/category/7886691/healthy-lifestyle/"
+rel="nocaes"
+> Healthy Lifestyle
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4318/eatingwell-in-real-life/"
+rel="nocaes"
+> EatingWell in Real Life
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4310/entertaining/"
+rel="nocaes"
+> Entertaining
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/7904359/kitchen-essentials/"
+rel="nocaes"
+> Kitchen Essentials
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/category/4316/green-and-sustainable-eating/"
+rel="nocaes"
+> Sustainability
+</a><!-- end: --> </li>
+<li class="header-nav__sublist-item type--squirrel-bold view-all">
+<a
+href="https://www.eatingwell.com/category/7886691/healthy-lifestyle/"
+rel="nocaes"
+> View All
+</a><!-- end: --> </li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="header-nav__list-item header-nav__list-item-about-us">
+<a
+href="/about-us-6743412"
+rel="nocaes"
+> About Us
+</a><!-- end: -->
+<ul class="header-nav__sublist">
+<li class="header-nav__sublist-item">
+<a
+href="https://www.eatingwell.com/our-food-and-nutrition-philosophy-6746110"
+rel="nocaes"
+> Our Food &amp; Nutrition Philosophy
+</a><!-- end: --> </li>
+</ul>
+</div>
+</nav><!-- end: comp header-nav -->
+</header><!-- end: comp header -->
+<div id="mntl-leaderboard-header_1-0" class="comp has-right-label leaderboard mntl-leaderboard-header mntl-leaderboard-fixed-0 mntl-leaderboard-fixed mntl-gpt-adunit gpt leaderboard ">
+<div id="leaderboard-fixed-0" class="wrapper"
+data-timed-refresh="30000"
+></div>
+</div><!-- end: comp has-right-label leaderboard mntl-leaderboard-header mntl-leaderboard-fixed-0 mntl-leaderboard-fixed mntl-gpt-adunit gpt leaderboard -->
+<div id="mntl-leaderboard-spacer_1-0" class="comp mntl-leaderboard-spacer mntl-block"></div><!-- end: comp mntl-leaderboard-spacer mntl-block -->
+<main id="main" class="loc main" role="main">
+<iframe id="height-change-listener" role="none" tabindex="-1" src="about:blank" aria-hidden="true"></iframe>
+<article id="eatingwell-article_1-0" class="comp mntl-article--two-column-right-rail sc-ad-container adjusted-right-rail eatingwell-article mntl-article" data-content-graph-id="cms__onecms_posts_etg_7919044" data-tracking-container="true">
+<div class="loc article-header">
+<div id="article-preheading_1-0" class="comp article-preheading mntl-block">
+<ul id="breadcrumbs_1-0" class="comp type--squirrel breadcrumbs mntl-breadcrumbs mntl-block" data-tracking-container="true">
+<li id="mntl-breadcrumbs__item_1-0" class="comp mntl-breadcrumbs__item mntl-block">
+<a
+href="https://www.eatingwell.com/recipes/"
+rel="nocaes"
+id="mntl-text-link_2-0"
+class=" mntl-text-link mntl-breadcrumbs__link"
+data-tracking-container="true"
+><span class="link__wrapper">Healthy Recipes</span></a><!-- end: mntl-text-link mntl-breadcrumbs__link -->
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</li><!-- end: comp mntl-breadcrumbs__item mntl-block -->
+<li id="mntl-breadcrumbs__item_1-0-1" class="comp mntl-breadcrumbs__item mntl-block">
+<a
+href="https://www.eatingwell.com/recipes/17965/main-dishes/"
+rel="nocaes"
+id="mntl-text-link_2-0-1"
+class=" mntl-text-link mntl-breadcrumbs__link"
+data-tracking-container="true"
+><span class="link__wrapper">Healthy Main Dish Recipes</span></a><!-- end: mntl-text-link mntl-breadcrumbs__link -->
+<svg class="icon icon-chevron_right ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+</svg>
+</li><!-- end: comp mntl-breadcrumbs__item mntl-block -->
+<li id="mntl-breadcrumbs__item_1-0-2" class="comp mntl-breadcrumbs__item mntl-block">
+<a
+href="https://www.eatingwell.com/recipes/17923/main-dishes/casseroles/"
+rel="nocaes"
+id="mntl-text-link_2-0-2"
+class=" mntl-text-link mntl-breadcrumbs__link"
+data-tracking-container="true"
+><span class="link__wrapper">Healthy Casserole Recipes</span></a><!-- end: mntl-text-link mntl-breadcrumbs__link -->
+</li><!-- end: comp mntl-breadcrumbs__item mntl-block -->
+</ul><!-- end: comp type--squirrel breadcrumbs mntl-breadcrumbs mntl-block -->
+</div><!-- end: comp article-preheading mntl-block -->
+</div>
+<div class="loc article-post-header">
+<h1 id="article-heading_1-0" class="comp type--lion article-heading mntl-text-block">
+Cheesy Ground Beef &amp; Cauliflower Casserole</h1><!-- end: comp type--lion article-heading mntl-text-block -->
+<div id="review-header-component_1-0" class="comp review-header-component mntl-block">
+<div id="mntl-recipe-review-bar_1-0" class="comp has-ratings has-comments js-recipe-review-bar mntl-recipe-review-bar mntl-block">
+<div id="mntl-recipe-review-bar__star-rating_1-0" class="comp mntl-recipe-review-bar__star-rating mntl-recipe-star-rating">
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-half ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
+</svg>
+</div><!-- end: comp mntl-recipe-review-bar__star-rating mntl-recipe-star-rating -->
+<div id="mntl-recipe-review-bar__rating_1-0" class="comp type--squirrel-link mntl-recipe-review-bar__rating mntl-text-block">
+4.3</div><!-- end: comp type--squirrel-link mntl-recipe-review-bar__rating mntl-text-block -->
+<div id="mntl-recipe-review-bar__rating-count_1-0" class="comp type--cat mntl-recipe-review-bar__rating-count mntl-text-block">
+(24)</div><!-- end: comp type--cat mntl-recipe-review-bar__rating-count mntl-text-block -->
+<div id="mntl-recipe-review-bar__comment-count_1-0" class="comp type--squirrel-link mntl-recipe-review-bar__comment-count mntl-text-block">
+24 Reviews</div><!-- end: comp type--squirrel-link mntl-recipe-review-bar__comment-count mntl-text-block -->
+</div><!-- end: comp has-ratings has-comments js-recipe-review-bar mntl-recipe-review-bar mntl-block -->
+</div><!-- end: comp review-header-component mntl-block -->
+<p id="article-subheading_1-0" class="comp type--dog article-subheading">
+Ground beef and cauliflower combine to create a hearty weeknight casserole that both kids and adults will love. Serve with tortilla chips and sour cream.</p><!-- end: comp type--dog article-subheading -->
+<div id="article-meta-dynamic_1-0" class="comp article-meta-dynamic article-meta mntl-block" data-tracking-container="true">
+<div id="eatingwell-bylines_1-0" class="comp type--rabbit eatingwell-bylines mntl-bylines">
+<div id="mntl-bylines__group_1-0" class="comp mntl-bylines__group--author mntl-bylines__group mntl-block">
+<div id="mntl-bylines__item_1-0" class="comp mntl-bylines__item mntl-attribution__item mntl-attribution__item--has-date">
+<span class="mntl-attribution__item-descriptor">By</span>
+<div data-tooltip="<p>Carolyn Casner is a longtime recipe tester and contributor for EatingWell. Over the years, she has tested and developed hundreds of recipes for the magazine and website.</p>" data-inline-tooltip="true">
+<a
+href="https://www.eatingwell.com/author/carolyn-casner/"
+rel="nocaes"
+data-trigger-link="true"
+class="mntl-attribution__item-name"
+>Carolyn Casner</a><!-- end: mntl-attribution__item-name -->
+<div id="mntl-author-tooltip_1-0" class="comp mntl-author-tooltip mntl-tooltip mntl-group">
+<div class="mntl-author-tooltip__top mntl-author-tooltip__top--no-image">
+<div id="mntl-author-tooltip__name_1-0" class="comp mntl-author-tooltip__name mntl-attribution__item">
+<a
+href="https://www.eatingwell.com/author/carolyn-casner/"
+rel="nocaes"
+class="mntl-attribution__item-name"
+>Carolyn Casner</a><!-- end: mntl-attribution__item-name -->
+</div><!-- end: comp mntl-author-tooltip__name mntl-attribution__item -->
+<div class="mntl-author-tooltip__bio">
+<p>Carolyn Casner is a longtime recipe tester and contributor for EatingWell. Over the years, she has tested and developed hundreds of recipes for the magazine and website.</p>
+</div>
+</div>
+<div class="mntl-author-tooltip__bottom">
+<a
+href="/about-us-6743412#toc-editorial-policies"
+rel="nocaes"
+class="mntl-author-tooltip__learn-more-link"
+>EatingWell's Editorial Guidelines</a><!-- end: mntl-author-tooltip__learn-more-link -->
+</div>
+</div><!-- end: comp mntl-author-tooltip mntl-tooltip mntl-group -->
+</div>
+</div><!-- end: comp mntl-bylines__item mntl-attribution__item mntl-attribution__item--has-date -->
+<div class="mntl-attribution__item-date">Published on September 23, 2021</div>
+</div><!-- end: comp mntl-bylines__group--author mntl-bylines__group mntl-block -->
+</div><!-- end: comp type--rabbit eatingwell-bylines mntl-bylines -->
+<div id="recipe-social-share_1-0" class="comp recipe-social-share">
+<div class="recipe-social-share__inner">
+<div class="loc print">
+<form id="print-button_1-0" class="comp print-button mntl-print-button" method="POST" action="/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/?print" target="_blank" aria-label="Print this article." data-tracking-container="true">
+<button class="mntl-print-button__btn" aria-label="Print this article.">
+Print
+<svg class="icon icon-print mntl-print-button__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use>
+</svg>
+</button>
+<input type="hidden" value="true" name="print" />
+<input type="hidden" value="3730b9db8c61022102fa843c5968bd25" name="CSRFToken" />
+</form><!-- end: comp print-button mntl-print-button -->
+</div>
+<div class="recipe-social-share__rate-wrapper">
+<button aria-label="Rate It" class="recipe-social-share__rate-button" data-click-tracked="false">
+<span class="recipe-social-share__rate-label">Rate It</span>
+<svg class="icon icon-star-empty ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty"></use>
+</svg>
+</button>
+</div>
+<div class="recipe-social-share__share-wrapper">
+<button aria-label="Share" aria-expanded="false" class="recipe-social-share__share-button">
+<span class="recipe-social-share__share-label">Share</span>
+<svg class="icon icon-share ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-share"></use>
+</svg>
+</button>
+</div>
+<div class="loc social-share">
+<ul id="social-share_1-0" class="comp social-share mntl-social-share share" data-title="Cheesy Ground Beef &amp; Cauliflower Casserole" data-description="This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream." data-tracking-container="true">
+<li class="share-item share-item-facebook">
+<span data-href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F%3Futm_source%3Dfacebook.com%26utm_medium%3Dsocial%26utm_campaign%3Dsocial-share-article"
+data-network="facebook"
+data-click-tracked="true"
+class="share-link share-link-facebook"
+tabindex="0"
+title="Share on Facebook">
+<svg class="icon icon-facebook ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
+</svg>
+Share
+</span>
+</li>
+<li class="share-item share-item-twitter">
+<span data-href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F%3Futm_source%3Dtwitter%26utm_medium%3Dsocial%26utm_campaign%3Dshareurlbuttons&via=EatingWell&text=Cheesy+Ground+Beef+%26+Cauliflower+Casserole"
+data-network="twitter"
+data-click-tracked="true"
+class="share-link share-link-twitter"
+tabindex="0"
+title="Share on Twitter">
+<svg class="icon icon-twitter ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use>
+</svg>
+Tweet
+</span>
+</li>
+<li class="share-item share-item-pinterest">
+<span data-href="http://pinterest.com/pin/create/button/?url=https%3A%2F%2Fwww.eatingwell.com%2Frecipe%2F7919044%2Fcheesy-ground-beef-cauliflower-casserole%2F%3Futm_source%3Dpinterest%26utm_medium%3Dsocial%26utm_campaign%3Dshareurlbuttons&description=Cheesy+Ground+Beef+%26+Cauliflower+Casserole&media=https%3A%2F%2Fwww.eatingwell.com%2Fthmb%2FGfO5QDo7pRM4F1mWQP9nCHyFLak%3D%2F750x0%2Fcheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+data-network="pinterest"
+data-click-tracked="true"
+class="share-link share-link-pinterest"
+tabindex="0"
+title="Share on Pinterest">
+<svg class="icon icon-pinterest ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest"></use>
+</svg>
+Pin
+</span>
+</li>
+<li class="share-item share-item-emailshare">
+<span data-href="https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/?utm_source=emailshare&utm_medium=social&utm_campaign=shareurlbuttons"
+data-network="emailshare"
+data-click-tracked="true"
+class="share-link share-link-emailshare"
+tabindex="0"
+title="Email this article">
+<svg class="icon icon-email ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-email"></use>
+</svg>
+Email
+</span>
+</li>
+</ul><!-- end: comp social-share mntl-social-share share -->
+</div>
+</div>
+</div><!-- end: comp recipe-social-share -->
+</div><!-- end: comp article-meta-dynamic article-meta mntl-block -->
+</div>
+<div class="loc article-content">
+<div id="article__primary-video_1-0" class="comp right-rail__offset article__primary-video video-player--bc mntl-bcplayer-deferred mntl-bcplayer">
+<div class="jumpstart-js-wrapper jumpstart-js-wrapper--lazy ">
+<video class="jumpstart-js jumpstart-video-muted"
+data-brand="etg"
+data-carbon="true"
+data-click-load="false"
+data-account="5118192885001"
+data-video-id="6307528357112"
+data-preventstart="true"
+data-autoplay="true"
+data-mobile-autoplay="true"
+data-stickyplay="true"
+data-is-lead="true"
+data-metadata="{&quot;accountId&quot;:&quot;5118192885001&quot;,&quot;dates&quot;:{&quot;created&quot;:1654785716160,&quot;updated&quot;:1655847536601,&quot;firstPublished&quot;:1654789065522},&quot;description&quot;:&quot;Searching for new casserole recipes? In this video, learn how to make cheesy casserole with ground beef and cauliflower for a gluten-free dish that everyone will love. Serve as a hearty dinner for your family, or prepare a larger serving for guests!&quot;,&quot;documentState&quot;:{&quot;state&quot;:&quot;ACTIVE&quot;},&quot;duration&quot;:113813,&quot;economics&quot;:&quot;AD_SUPPORTED&quot;,&quot;franchise&quot;:&quot;Recipe Demos&quot;,&quot;name&quot;:&quot;Cheesy Ground Beef \u0026 Cauliflower Casserole Recipe&quot;,&quot;syndicate&quot;:&quot;1&quot;,&quot;tags&quot;:[&quot;eatingwell&quot;,&quot;casserole&quot;,&quot;casserole ideas&quot;,&quot;casserole recipes&quot;,&quot;casseroles&quot;,&quot;cauliflower&quot;,&quot;cheese&quot;,&quot;cheesy&quot;,&quot;cooking&quot;,&quot;dinner&quot;,&quot;dinner ideas&quot;,&quot;dinner recipes&quot;,&quot;easy&quot;,&quot;eatingwell.com&quot;,&quot;fast&quot;,&quot;food&quot;,&quot;gluten free&quot;,&quot;gluten free recipes&quot;,&quot;ground beef&quot;,&quot;healthy&quot;,&quot;healthy recipes&quot;,&quot;high protein&quot;,&quot;how to&quot;,&quot;how to make&quot;,&quot;kitchen&quot;,&quot;low carb&quot;,&quot;quick&quot;,&quot;recipe&quot;,&quot;recipes&quot;,&quot;simple&quot;,&quot;what to make&quot;],&quot;textTracks&quot;:true,&quot;videoId&quot;:&quot;6307528357112&quot;,&quot;vertical&quot;:&quot;EATINGWELL&quot;}"
+data-dynamic-embed=""
+data-is-broad="false"
+poster="https://imagesvc.meredithcorp.io/v3/jumpstartpure/image/?url=https%3A%2F%2Fcf-images.us-east-1.prod.boltdns.net%2Fv1%2Fstatic%2F5118192885001%2Fa77e5407-0f3d-42b2-9aa0-7e0b13c61f5e%2F77d7ea97-b2db-49c9-839d-b6d919deace2%2F1280x720%2Fmatch%2Fimage.jpg&w=640&h=360&q=90&c=cc"
+>
+</video>
+</div>
+</div><!-- end: comp right-rail__offset article__primary-video video-player--bc mntl-bcplayer-deferred mntl-bcplayer -->
+<div id="article-content_1-0" class="comp article-content mntl-block">
+<div id="recipe-details_1-0" class="comp recipe-details mntl-recipe-details">
+<div class="mntl-recipe-details__content">
+<div class="mntl-recipe-details__item">
+<div class="mntl-recipe-details__label">Active Time:</div>
+<div class="mntl-recipe-details__value">30 mins</div>
+</div>
+<div class="mntl-recipe-details__item">
+<div class="mntl-recipe-details__label">Total Time:</div>
+<div class="mntl-recipe-details__value">30 mins</div>
+</div>
+<div class="mntl-recipe-details__item">
+<div class="mntl-recipe-details__label">Servings:</div>
+<div class="mntl-recipe-details__value">6 </div>
+</div>
+</div>
+<div class="mntl-recipe-details__nutrition-profile">
+<div class="mntl-recipe-details__label">Nutrition Profile:</div>
+<div class="mntl-recipe-details__nutrition-profile-items">
+<a
+href="https://www.eatingwell.com/recipes/18048/dietary-restrictions/egg-free/"
+rel="nocaes"
+class="mntl-recipe-details__nutrition-profile-item"
+>Egg Free</a><!-- end: mntl-recipe-details__nutrition-profile-item -->
+<a
+href="https://www.eatingwell.com/recipes/17900/dietary-restrictions/gluten-free/"
+rel="nocaes"
+class="mntl-recipe-details__nutrition-profile-item"
+>Gluten-Free</a><!-- end: mntl-recipe-details__nutrition-profile-item -->
+<a
+href="https://www.eatingwell.com/recipes/22762/nutrient-focused-diets/high-protein/"
+rel="nocaes"
+class="mntl-recipe-details__nutrition-profile-item"
+>High-Protein</a><!-- end: mntl-recipe-details__nutrition-profile-item -->
+<a
+href="https://www.eatingwell.com/recipes/18013/lifestyle-diets/low-carb/"
+rel="nocaes"
+class="mntl-recipe-details__nutrition-profile-item"
+>Low Carbohydrate</a><!-- end: mntl-recipe-details__nutrition-profile-item -->
+<a
+href="https://www.eatingwell.com/recipes/18051/dietary-restrictions/nut-free/"
+rel="nocaes"
+class="mntl-recipe-details__nutrition-profile-item"
+>Nut-Free</a><!-- end: mntl-recipe-details__nutrition-profile-item -->
+<a
+href="https://www.eatingwell.com/recipes/18050/dietary-restrictions/soy-free/"
+rel="nocaes"
+class="mntl-recipe-details__nutrition-profile-item"
+>Soy-Free</a><!-- end: mntl-recipe-details__nutrition-profile-item -->
+</div>
+</div>
+<div class="loc nutrition-link mntl-recipe-details__nutrition-link-container">
+<span id="mntl-recipe-details__nutrition-link_1-0" class="comp mntl-recipe-details__nutrition-link mntl-text-block">
+Jump to Nutrition Facts</span><!-- end: comp mntl-recipe-details__nutrition-link mntl-text-block -->
+</div>
+</div><!-- end: comp recipe-details mntl-recipe-details -->
+<div id="mntl-recipe-intro_1-0" class="comp mntl-recipe-intro mntl-block">
+<div id="mntl-recipe-intro__content_1-0" class="comp mntl-recipe-intro__content mntl-sc-page mntl-block" data-sc-sticky-offset="190" data-sc-ad-label-height="24" data-sc-ad-track-spacing="100" data-sc-min-track-height="250" data-sc-max-track-height="600" data-sc-breakpoint="50em" data-sc-load-immediate="4" data-sc-content-positions="[1, 1250, 1550, 1950, 2350, 2750, 3150, 3550, 3950]" data-bind-scroll-on-start="true"></div><!-- end: comp mntl-recipe-intro__content mntl-sc-page mntl-block -->
+</div><!-- end: comp mntl-recipe-intro mntl-block -->
+<div id="mntl-native-fluid_1-0" class="comp mntl-native-fluid mntl-native" style="--native-ad-height: auto">
+<div id="mntl-native__adunit_1-0" class="comp scads-to-load mntl-native__adunit mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt native dynamic">
+<div id="native" class="wrapper"
+data-type="native" data-pos="native" data-priority="4" data-sizes="[[1, 3],&quot;fluid&quot;]" data-rtb="false" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div><!-- end: comp scads-to-load mntl-native__adunit mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt native dynamic -->
+</div><!-- end: comp mntl-native-fluid mntl-native -->
+<div id="mntl-lrs-ingredients_1-0" class="comp mntl-lrs-ingredients mntl-block" data-content-modified-date="2023-02-09T00:09:56.000Z" data-load-offset="300" data-vertical-prefix="ew">
+<div id="mntl-structured-ingredients_1-0" class="comp mntl-structured-ingredients">
+<div class="loc heading">
+<h2 id="mntl-structured-ingredients__heading_1-0" class="comp mntl-structured-ingredients__heading mntl-text-block">
+Ingredients</h2><!-- end: comp mntl-structured-ingredients__heading mntl-text-block -->
+</div>
+<ul class="mntl-structured-ingredients__list">
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="31628"
+>
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">tablespoon</span> <span data-ingredient-name="true">extra-virgin olive oil</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="4397"
+>
+<p><span data-ingredient-quantity="true">½</span> <span data-ingredient-unit="true">cup</span> <span data-ingredient-name="true">chopped onion</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="4432"
+>
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">medium</span> <span data-ingredient-name="true">green bell pepper, chopped</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="30014"
+>
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">pound</span> <span data-ingredient-name="true">lean ground beef</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="4286"
+>
+<p><span data-ingredient-quantity="true">3</span> <span data-ingredient-unit="true">cups</span> <span data-ingredient-name="true">bite-size cauliflower florets</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="4342"
+>
+<p><span data-ingredient-quantity="true">3</span> <span data-ingredient-unit="true">cloves</span> <span data-ingredient-name="true">garlic, minced</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="30929"
+>
+<p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">tablespoons</span> <span data-ingredient-name="true">chili powder</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="20551"
+>
+<p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">teaspoons</span> <span data-ingredient-name="true">ground cumin</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="30307"
+>
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">teaspoon</span> <span data-ingredient-name="true">dried oregano</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="33513"
+>
+<p><span data-ingredient-quantity="true">½</span> <span data-ingredient-unit="true">teaspoon</span> <span data-ingredient-name="true">salt</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="23729"
+>
+<p><span data-ingredient-quantity="true">¼</span> <span data-ingredient-unit="true">teaspoon</span> <span data-ingredient-name="true">ground chipotle </span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="10498"
+>
+<p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">(15 ounce) can</span> <span data-ingredient-name="true">no-salt-added petite-diced tomatoes</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="22106"
+>
+<p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">cups</span> <span data-ingredient-name="true">shredded extra-sharp Cheddar cheese</span></p>
+</li>
+<li
+class="mntl-structured-ingredients__list-item "
+data-id="4634"
+>
+<p><span data-ingredient-quantity="true">⅓</span> <span data-ingredient-unit="true">cup</span> <span data-ingredient-name="true">sliced pickled jalapeños</span></p>
+</li>
+</ul>
+</div><!-- end: comp mntl-structured-ingredients -->
+</div><!-- end: comp mntl-lrs-ingredients mntl-block -->
+<div id="recipe__steps_1-0" class="comp recipe__steps mntl-block">
+<h2 id="recipe__steps-heading_1-0" class="comp recipe__steps-heading mntl-text-block">
+Directions</h2><!-- end: comp recipe__steps-heading mntl-text-block -->
+<div id="recipe__steps-content_1-0" class="comp recipe__steps-content mntl-sc-page mntl-block">
+<OL id="mntl-sc-block_2-0" class="comp mntl-sc-block-group--OL mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--OL mntl-sc-block mntl-sc-block-startgroup -->
+<LI id="mntl-sc-block_2-0-1" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup -->
+<p id="mntl-sc-block_2-0-2" class="comp mntl-sc-block mntl-sc-block-html">
+Position rack in upper third of oven. Preheat broiler to high.
+</p><!-- end: comp mntl-sc-block mntl-sc-block-html -->
+<div id="mntl-sc-block_2-0-3" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div><!-- end: comp mntl-sc-block mntl-sc-block-adslot mntl-block -->
+</LI>
+<LI id="mntl-sc-block_2-0-5" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup -->
+<p id="mntl-sc-block_2-0-6" class="comp mntl-sc-block mntl-sc-block-html">
+Heat oil in a large oven-safe skillet over medium heat. Add onion and bell pepper; cook, stirring, until softened, about 5 minutes. Add beef and cauliflower; cook, stirring and breaking the beef up into smaller pieces, until it is no longer pink, 5 to 7 minutes. Stir in garlic, chili powder, cumin, oregano, salt and chipotle; cook until fragrant, about 1 minute. Add tomatoes and their juices; bring to a simmer and cook, stirring occasionally, until liquid is reduced and the cauliflower is tender, about 3 minutes more. Remove from heat.
+</p><!-- end: comp mntl-sc-block mntl-sc-block-html -->
+<div id="mntl-sc-block_2-0-7" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div><!-- end: comp mntl-sc-block mntl-sc-block-adslot mntl-block -->
+</LI>
+<LI id="mntl-sc-block_2-0-9" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup -->
+<p id="mntl-sc-block_2-0-10" class="comp mntl-sc-block mntl-sc-block-html">
+Sprinkle cheese over the beef mixture and top with sliced jalapeños. Broil until the cheese is melted and browned in spots, 2 to 3 minutes.
+</p><!-- end: comp mntl-sc-block mntl-sc-block-html -->
+<figure id="mntl-sc-block_2-0-11" class="comp mntl-sc-block-image--no-theme mntl-sc-block-image mntl-sc-block eatingwell-sc-block-image mntl-sc-block-universal-image figure-square figure-high-res">
+<div class="figure-media">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+data-src="https://www.eatingwell.com/thmb/ucM6BcWh4Npbovra71Pta4b48Vg=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+width="2000"
+height="2000"
+data-srcset="https://www.eatingwell.com/thmb/pjFTh-0rFzcGolqh8LicHUKeFRc=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg 750w"
+data-sizes="750px"
+alt="Cheesy Ground Beef &amp; Cauliflower Casserole"
+class="lazyload universal-image__image"
+data-expand="300"
+id=mntl-sc-block-image_1-0-1
+data-click-tracked="true"
+data-tracking-container="true"
+data-img-lightbox="true"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/ucM6BcWh4Npbovra71Pta4b48Vg=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+width="2000"
+height="2000"
+class="img--noscript universal-image__image"
+srcset="https://www.eatingwell.com/thmb/pjFTh-0rFzcGolqh8LicHUKeFRc=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg 750w"
+sizes="750px"
+alt="Cheesy Ground Beef &amp; Cauliflower Casserole"
+/>
+</noscript>
+</div>
+</div>
+<figcaption id="mntl-figure-caption_1-0" class="comp type--mouse mntl-figure-caption figure-article-caption">
+<span class="figure-article-caption-owner">Jason Donnelly</span>
+</figcaption><!-- end: comp type--mouse mntl-figure-caption figure-article-caption -->
+</figure><!-- end: comp mntl-sc-block-image--no-theme mntl-sc-block-image mntl-sc-block eatingwell-sc-block-image mntl-sc-block-universal-image figure-square figure-high-res -->
+<div id="mntl-sc-block_2-0-12" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div><!-- end: comp mntl-sc-block mntl-sc-block-adslot mntl-block -->
+</LI>
+</OL>
+</div><!-- end: comp recipe__steps-content mntl-sc-page mntl-block -->
+</div><!-- end: comp recipe__steps mntl-block -->
+<div id="recipe-rate-print_1-0" class="comp recipe-rate-print mntl-block">
+<button id="recipe-rate-print__rate-button_1-0" class="comp recipe-rate-print__rate-button mntl-button" data-click-tracked="false" aria-label="Rate it">
+Rate it
+<svg class="icon icon-star-empty mntl-button__icon ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty"></use>
+</svg>
+</button><!-- end: comp recipe-rate-print__rate-button mntl-button -->
+<form id="recipe-rate-print__print-button_1-0" class="comp recipe-rate-print__print-button print-button mntl-print-button" method="POST" action="/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/?print" target="_blank" aria-label="Print this article." data-tracking-container="true">
+<button class="mntl-print-button__btn" aria-label="Print this article.">
+Print
+<svg class="icon icon-print mntl-print-button__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use>
+</svg>
+</button>
+<input type="hidden" value="true" name="print" />
+<input type="hidden" value="3730b9db8c61022102fa843c5968bd25" name="CSRFToken" />
+</form><!-- end: comp recipe-rate-print__print-button print-button mntl-print-button -->
+</div><!-- end: comp recipe-rate-print mntl-block -->
+<div id="recipe__nutrition-facts_1-0" class="comp recipe__nutrition-facts mntl-nutrition-facts mntl-block">
+<div id="mntl-nutrition-facts-summary_1-0" class="comp mntl-nutrition-facts-summary">
+<h2 class="mntl-nutrition-facts-summary__heading type--zebra" colspan="2">Nutrition Facts <span class="mntl-nutrition-facts-summary__heading-aside type--dog">(per serving)</h2>
+<table class="mntl-nutrition-facts-summary__table">
+<tbody class="mntl-nutrition-facts-summary__table-body">
+<tr class="mntl-nutrition-facts-summary__table-row">
+<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">351</td>
+<td class="mntl-nutrition-facts-summary__table-cell type--dogg">Calories</td>
+</tr>
+<tr class="mntl-nutrition-facts-summary__table-row">
+<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">23g </td>
+<td class="mntl-nutrition-facts-summary__table-cell type--dog">Fat</td>
+</tr>
+<tr class="mntl-nutrition-facts-summary__table-row">
+<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">11g </td>
+<td class="mntl-nutrition-facts-summary__table-cell type--dog">Carbs</td>
+</tr>
+<tr class="mntl-nutrition-facts-summary__table-row">
+<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">26g </td>
+<td class="mntl-nutrition-facts-summary__table-cell type--dog">Protein</td>
+</tr>
+</tbody>
+</table>
+</div><!-- end: comp mntl-nutrition-facts-summary -->
+<!-- daily values taken from https://www.fda.gov/food/new-nutrition-facts-label/daily-value-new-nutrition-and-supplement-facts-labels as of Feb 2023-->
+<div id="mntl-nutrition-facts-label_1-0" class="comp mntl-nutrition-facts-label eatingwell-nutrition-facts-label" data-tracking-container="true">
+<button class="mntl-nutrition-facts-label__button mntl-nutrition-facts-label__button--show type--dog">
+<span class="mntl-nutrition-facts-label__button-text">Show Full Nutrition Label</span>
+<span class="mntl-nutrition-facts-label__button-text">Hide Full Nutrition Label</span>
+</button>
+<div class="mntl-nutrition-facts-label__wrapper mntl-nutrition-facts-label__wrapper--collapsed">
+<div class="mntl-nutrition-facts-label__contents">
+<table class="mntl-nutrition-facts-label__table">
+<thead class="mntl-nutrition-facts-label__table-head">
+<tr>
+<th class="mntl-nutrition-facts-label__table-head-title type--goat-bold" colspan="2">Nutrition Facts</th>
+</tr>
+<tr class="mntl-nutrition-facts-label__servings">
+<th class="mntl-nutrition-facts-label__table-head-subtitle" colspan="2">
+<span class="mntl-nutrition-facts-label__table-head-pretext">Servings Per Recipe</span>
+<span>6</span>
+</th>
+</tr>
+<tr class="mntl-nutrition-facts-label__calories">
+<th class="mntl-nutrition-facts-label__table-head-subtitle" colspan="2">
+<span class="mntl-nutrition-facts-label__table-head-pretext">Calories</span>
+<span>351</span>
+</th>
+</tr>
+</thead>
+<tbody class="mntl-nutrition-facts-label__table-body type--cat">
+<tr class="mntl-nutrition-facts-label__table-dv-row type--dog">
+<td colspan="2">% Daily Value *</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Total Carbohydrate</span>
+11g
+</td>
+<td>
+4%
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Dietary Fiber</span>
+3g
+</td>
+<td>
+11%
+</td>
+</tr>
+<tr>
+<td colspan="2">
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Total Sugars</span>
+4g
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Protein</span>
+26g
+</td>
+<td>
+52%
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Total Fat</span>
+23g
+</td>
+<td>
+29%
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Saturated Fat</span>
+11g
+</td>
+<td>
+55%
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Cholesterol</span>
+86mg
+</td>
+<td>
+29%
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Vitamin A</span>
+1522IU
+</td>
+<td>
+30%
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Sodium</span>
+672mg
+</td>
+<td>
+29%
+</td>
+</tr>
+<tr>
+<td >
+<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Potassium</span>
+639mg
+</td>
+<td>
+14%
+</td>
+</tr>
+</tbody>
+</table>
+<div id="recipe__nutrition-facts-label-disclaimer_1-0" class="comp type--cat recipe__nutrition-facts-label-disclaimer mntl-block">
+<p id="mntl-text-block_3-0" class="comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block">
+Nutrition information is calculated by a registered dietitian using an ingredient database but should be considered an estimate.</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block -->
+<p id="mntl-text-block_4-0" class="comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block">
+* Daily Values (DVs) are the recommended amounts of nutrients to consume each day. Percent Daily Value (%DV) found on nutrition labels tells you how much a serving of a particular food or recipe contributes to each of those total recommended amounts. Per the Food and Drug Administration (FDA), the daily value is based on a standard 2,000 calorie diet. Depending on your calorie needs or if you have a health condition, you may need more or less of particular nutrients. (For example, it’s recommended that people following a heart-healthy diet eat less sodium on a daily basis compared to those following a standard diet.)</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block -->
+<p id="mntl-text-block_5-0" class="comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block">
+(-) Information is not currently available for this nutrient. If you are following a special diet for medical reasons, be sure to consult with your primary care provider or a registered dietitian to better understand your personal nutrition needs.</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block -->
+<p id="mntl-text-block_6-0" class="comp recipe__nutrition-facts-label-disclaimer-copyright mntl-text-block">
+Powered by the ESHA Research Database © 2018, <a href="https://www.esha.com/" target="_blank">ESHA Research, Inc.</a> All Rights Reserved</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-copyright mntl-text-block -->
+</div><!-- end: comp type--cat recipe__nutrition-facts-label-disclaimer mntl-block -->
+</div>
+</div>
+</div><!-- end: comp mntl-nutrition-facts-label eatingwell-nutrition-facts-label -->
+</div><!-- end: comp recipe__nutrition-facts mntl-nutrition-facts mntl-block -->
+<div id="recipe-ugc-wrapper_1-0" class="comp recipe-ugc-wrapper mntl-ugc-vue-with-auth mntl-block" data-scroll-defer-offset="800" data-defer="load" data-defer-params></div><!-- end: comp recipe-ugc-wrapper mntl-ugc-vue-with-auth mntl-block -->
+</div><!-- end: comp article-content mntl-block -->
+</div>
+<div class="loc article-right-rail">
+<div id="mntl-right-rail_1-0" class="comp mntl-right-rail mntl-block">
+<div id="recipe-billboard-group_3-0" class="comp js-scads-inline-content recipe-billboard-group mntl-block">
+<div id="mntl-block_18-0" class="comp mntl-block">
+<div id="mntl-squareFlex1-sticky_3-0" class="comp scads-to-load right-rail__item mntl-squareFlex1-sticky mntl-sc-sticky-billboard" data-height="1090" style="height: 1090px;">
+<div id="mntl-sc-sticky-billboard-ad_34-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard ">
+<div id="square-flex-1" class="wrapper"
+></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFlex1-sticky mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+<div id="mntl-block_19-0" class="comp mntl-block">
+<div id="mntl-squareFlex2-sticky-dynamic_3-0" class="comp scads-to-load right-rail__item mntl-squareFlex2-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_36-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-flex-2" class="wrapper"
+data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[300, 251],[300, 600],[300, 601],[2, 1],[160, 600],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="011af2910716423bb58abe8e63ea5ef1" data-auction-floor-value="60"></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFlex2-sticky-dynamic mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+<div id="mntl-block_20-0" class="comp mntl-block">
+<div id="mntl-squareFixed-sticky-dynamic_13-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_38-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper"
+data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="2e94cf33034341da8af46929f25dcc71" data-auction-floor-value="50"></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+<div id="mntl-block_21-0" class="comp mntl-block">
+<div id="mntl-squareFixed-sticky-dynamic_14-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_40-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper"
+data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="2e94cf33034341da8af46929f25dcc71" data-auction-floor-value="50"></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+<div id="mntl-block_22-0" class="comp mntl-block">
+<div id="mntl-squareFixed-sticky-dynamic_15-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_42-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper"
+data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="2e94cf33034341da8af46929f25dcc71" data-auction-floor-value="50"></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+<div id="mntl-block_23-0" class="comp mntl-block">
+<div id="mntl-squareFixed-sticky-dynamic_16-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_44-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper"
+data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="2e94cf33034341da8af46929f25dcc71" data-auction-floor-value="50"></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+<div id="mntl-block_24-0" class="comp mntl-block">
+<div id="mntl-squareFixed-sticky-dynamic_17-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_46-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper"
+data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="2e94cf33034341da8af46929f25dcc71" data-auction-floor-value="50"></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+<div id="mntl-block_25-0" class="comp mntl-block">
+<div id="mntl-squareFixed-sticky-dynamic_18-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
+<div id="mntl-sc-sticky-billboard-ad_48-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+<div id="square-fixed" class="wrapper"
+data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="2e94cf33034341da8af46929f25dcc71" data-auction-floor-value="50"></div>
+</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
+</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
+</div><!-- end: comp mntl-block -->
+</div><!-- end: comp js-scads-inline-content recipe-billboard-group mntl-block -->
+</div><!-- end: comp mntl-right-rail mntl-block -->
+</div>
+</article><!-- end: comp mntl-article--two-column-right-rail sc-ad-container adjusted-right-rail eatingwell-article mntl-article -->
+<div id="leaderboard-post-content_1-0" class="comp js-lazy-ad has-right-label leaderboard leaderboard-post-content mntl-leaderboardac mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
+<div id="leaderboardac" class="wrapper"
+data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], &quot;fluid&quot;, [970, 250], [1, 11], [1200, 450]]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="3b966d781d4e443a86f77a5395b993f5" data-auction-floor-value="60"></div>
+</div><!-- end: comp js-lazy-ad has-right-label leaderboard leaderboard-post-content mntl-leaderboardac mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic -->
+<section id="recirc-section_1-0" class="comp recirc-section" data-tracking-container="true">
+<span class="recirc-section__header type--camel">
+Related Articles
+</span>
+<div class="loc recirc-content">
+<div id="recirc-section__card-list-1_1-0" class="comp recirc-section__card-list-1 card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36">
+<a id="mntl-card-list-items_1-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7159848" data-tax-levels href="https://www.eatingwell.com/gallery/8026868/comforting-creamy-dinner-casseroles-with-three-steps-or-less/" data-cta data-ordinal="1">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/R-95HophwnNPDbFH9pzePW2TYHE=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Salmon-Noodle-Casseroles-Beauty-1x1-BG-3192-479f2efa39004c68a08f83793611ff2e.jpg"
+width="282"
+height="188"
+alt="a recipe photo of the Salmon Noodle Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/R-95HophwnNPDbFH9pzePW2TYHE=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Salmon-Noodle-Casseroles-Beauty-1x1-BG-3192-479f2efa39004c68a08f83793611ff2e.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="a recipe photo of the Salmon Noodle Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">21 Comforting, Creamy Dinner Casseroles with Three Steps or Less</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Danielle DeAngelis"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_1-0-1" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7160204" data-tax-levels href="https://www.eatingwell.com/gallery/8014689/best-casseroles-of-2022/" data-cta data-ordinal="2">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/NlFNnalHqkC0GobpsLCBCrG3Nrc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/chicken-and-zucchini-casserole--e4e64845ddf54daf86ea88ec0ca5431f.jpg"
+width="282"
+height="188"
+alt="Chicken &amp; Zucchini Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/NlFNnalHqkC0GobpsLCBCrG3Nrc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/chicken-and-zucchini-casserole--e4e64845ddf54daf86ea88ec0ca5431f.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Chicken &amp; Zucchini Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Our 20 Most Popular Casseroles of 2022</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Danielle DeAngelis"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_1-0-2" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7156105" data-tax-levels href="https://www.eatingwell.com/gallery/8000083/high-protein-dinner-casserole-recipes/" data-cta data-ordinal="3">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/MSV4LrWiu5ENg270Ag-YNocgKQk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/philly-chicken-cheesesteak-casserole-step-12-2000-9efd2759a7eb4b59a2c4d8c8ef2c8e13.jpg"
+width="282"
+height="188"
+alt="Philly Chicken Cheesesteak Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/MSV4LrWiu5ENg270Ag-YNocgKQk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/philly-chicken-cheesesteak-casserole-step-12-2000-9efd2759a7eb4b59a2c4d8c8ef2c8e13.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Philly Chicken Cheesesteak Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">26 High-Protein Casseroles That Are Perfect for Dinner</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Danielle DeAngelis"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_1-0-3" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7154068" data-tax-levels href="https://www.eatingwell.com/gallery/7957934/family-friendly-dinner-recipes-with-ground-beef/" data-cta data-ordinal="4">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/k0QFFBJ1LAr-SBrA_l__J7q7tt8=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/taco-stuffed-peppers-1244-043ffd0abb0f44e788beba624464a2f9.jpg"
+width="282"
+height="188"
+alt="Cheesy Tex-Mex Taco Stuffed Peppers"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/k0QFFBJ1LAr-SBrA_l__J7q7tt8=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/taco-stuffed-peppers-1244-043ffd0abb0f44e788beba624464a2f9.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Cheesy Tex-Mex Taco Stuffed Peppers"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Family & Kids Dinner Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">25 Family-Friendly Dinners That Start with Ground Beef</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Leah Goggins"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_1-0-4" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7159526" data-tax-levels href="https://www.eatingwell.com/gallery/7924062/healthy-ground-beef-casseroles-for-dinner/" data-cta data-ordinal="5">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/eiQzc1wehCxBds40Y_cIiLIqL4M=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+width="282"
+height="188"
+alt="Cheesy Ground Beef &amp; Cauliflower Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/eiQzc1wehCxBds40Y_cIiLIqL4M=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Cheesy Ground Beef &amp; Cauliflower Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Ground Beef Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">23 Healthy Ground Beef Casseroles for a Cozy Dinner</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Leah Goggins"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_1-0-5" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7155130" data-tax-levels href="https://www.eatingwell.com/gallery/8031365/most-popular-recipes-in-february-2023/" data-cta data-ordinal="6">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/xh1XaYkLzuoquvFKLQZqh7ctT2I=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Creamy-Jalapeno-Skillet-Chicken-Beauty-1x1-4542-1-415b40ab3a3748bdac6be8ba2ed05478.jpeg"
+width="282"
+height="188"
+alt="a recipe photo of the Creamy Jalapeño Skillet Chicken"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/xh1XaYkLzuoquvFKLQZqh7ctT2I=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Creamy-Jalapeno-Skillet-Chicken-Beauty-1x1-4542-1-415b40ab3a3748bdac6be8ba2ed05478.jpeg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="a recipe photo of the Creamy Jalapeño Skillet Chicken"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Best of the Best">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Our 25 Most Popular Recipes in February</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Danielle DeAngelis"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_1-0-6" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7165852" data-tax-levels href="https://www.eatingwell.com/recipe/8030699/french-onion-stuffed-spaghetti-squash/" data-cta data-ordinal="7">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/uZ6DymjQidO7pVcgHPsyKIe3MN0=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/French-Onion-Stuffed-Spaghetti-Squash-BG-Beauty-1x1-4809-91845bf26acd432faa5f02a45e69893e.jpg"
+width="282"
+height="188"
+alt="a recipe photo of the French Onion-Stuffed Spaghetti Squash"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/uZ6DymjQidO7pVcgHPsyKIe3MN0=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/French-Onion-Stuffed-Spaghetti-Squash-BG-Beauty-1x1-4809-91845bf26acd432faa5f02a45e69893e.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="a recipe photo of the French Onion-Stuffed Spaghetti Squash"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Spaghetti Squash Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">French Onion-Stuffed Spaghetti Squash</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Carolyn Casner"></div>
+<div id="recipe-card-meta_1-0" class="comp recipe-card-meta">
+<div class="recipe-card-meta__time">
+<svg class="icon icon-time ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-time"></use>
+</svg>
+<span class="recipe-card-meta__time-text type--rabbit">
+45 mins
+</span>
+</div>
+</div><!-- end: comp recipe-card-meta -->
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_1-0-7" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7162604" data-tax-levels href="https://www.eatingwell.com/gallery/7924194/cozy-beef-dinner-recipes-for-fall/" data-cta data-ordinal="8">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/eiQzc1wehCxBds40Y_cIiLIqL4M=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+width="282"
+height="188"
+alt="Cheesy Ground Beef &amp; Cauliflower Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/eiQzc1wehCxBds40Y_cIiLIqL4M=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Cheesy Ground Beef &amp; Cauliflower Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Fall Dinner Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">25 Cozy Beef Dinners That Are Perfect for Fall</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Leah Goggins"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+</div><!-- end: comp recirc-section__card-list-1 card-list mntl-document-card-list mntl-card-list mntl-block -->
+<div id="leaderboard-deferred-footer_1-0" class="comp js-lazy-ad has-right-label leaderboard leaderboard-deferred-footer mntl-leaderboardfooter-flex-1-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
+<div id="leaderboardfooter-flex-1" class="wrapper"
+data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="8138561b59f64d4c882c185a20b972a7" data-auction-floor-value="70"></div>
+</div><!-- end: comp js-lazy-ad has-right-label leaderboard leaderboard-deferred-footer mntl-leaderboardfooter-flex-1-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic -->
+<div id="recirc-section__card-list-2_1-0" class="comp recirc-section__card-list-2 card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36">
+<a id="mntl-card-list-items_3-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7164219" data-tax-levels href="https://www.eatingwell.com/recipe/8028323/turkey-chili/" data-cta data-ordinal="1">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/KR4RFyqsxEu7Jr1pPJgbfYv3itQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Turkey-Chili-ddmfs-baeuty-02-857c1225511a4a7c9d027875d0e2f98a.jpg"
+width="282"
+height="188"
+alt="a recipe photo of the Turkey Chili"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/KR4RFyqsxEu7Jr1pPJgbfYv3itQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Turkey-Chili-ddmfs-baeuty-02-857c1225511a4a7c9d027875d0e2f98a.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="a recipe photo of the Turkey Chili"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Chili Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Turkey Chili</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Julia Levy"></div>
+<div id="recipe-card-meta_3-0" class="comp recipe-card-meta">
+<div class="recipe-card-meta__time">
+<svg class="icon icon-time ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-time"></use>
+</svg>
+<span class="recipe-card-meta__time-text type--rabbit">
+30 mins
+</span>
+</div>
+</div><!-- end: comp recipe-card-meta -->
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_3-0-1" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7159299" data-tax-levels href="https://www.eatingwell.com/gallery/8024636/comforting-creamy-skillet-casseroles/" data-cta data-ordinal="2">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/O4Bz22ME8AyzW9h9U7SI6liD-yU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Cheesy-Roasted-Eggplant-Skillet-Casserole-v2-1x1-1-3ffd8a768f5e4157acc59bc780d1ffc6.jpg"
+width="282"
+height="188"
+alt="Cheesy Roasted Eggplant Skillet Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/O4Bz22ME8AyzW9h9U7SI6liD-yU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Cheesy-Roasted-Eggplant-Skillet-Casserole-v2-1x1-1-3ffd8a768f5e4157acc59bc780d1ffc6.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Cheesy Roasted Eggplant Skillet Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">18 Comforting, Creamy Skillet Casseroles</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Danielle DeAngelis"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_3-0-2" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7185106" data-tax-levels href="https://www.eatingwell.com/recipe/8012781/nacho-cauliflower-casserole/" data-cta data-ordinal="3">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/gPoPt8WZg2AhvQWb39YvFr2rmDg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Nacho-Cauliflower-Casserole-0069-54b55359c5514c7e8fe8c9722405836e.jpg"
+width="282"
+height="188"
+alt="a recipe photo of the Nacho Cauliflower Casserole served in a dish"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/gPoPt8WZg2AhvQWb39YvFr2rmDg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Nacho-Cauliflower-Casserole-0069-54b55359c5514c7e8fe8c9722405836e.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="a recipe photo of the Nacho Cauliflower Casserole served in a dish"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Nacho Cauliflower Casserole</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Nicole Hopper"></div>
+<div id="recipe-card-meta_3-0-1" class="comp recipe-card-meta">
+<div id="mntl-recipe-star-rating_3-0" class="comp mntl-recipe-star-rating">
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-empty ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty"></use>
+</svg>
+</div><!-- end: comp mntl-recipe-star-rating -->
+<div class="recipe-card-meta__time">
+<svg class="icon icon-time ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-time"></use>
+</svg>
+<span class="recipe-card-meta__time-text type--rabbit">
+1 hrs 15 mins
+</span>
+</div>
+</div><!-- end: comp recipe-card-meta -->
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_3-0-3" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7183820" data-tax-levels href="https://www.eatingwell.com/recipe/250376/healthy-green-bean-casserole/" data-cta data-ordinal="4">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/cvKj-kFzJJ-c4fEvn4zvDxWddaU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/3757873-f459bebc55a7444488c2b57a592219e9.jpg"
+width="282"
+height="188"
+alt="3757873.jpg"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/cvKj-kFzJJ-c4fEvn4zvDxWddaU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/3757873-f459bebc55a7444488c2b57a592219e9.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="3757873.jpg"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Healthy Green Bean Casserole</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By EatingWell Test Kitchen"></div>
+<div id="recipe-card-meta_3-0-2" class="comp recipe-card-meta">
+<div id="mntl-recipe-star-rating_3-0-1" class="comp mntl-recipe-star-rating">
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+</div><!-- end: comp mntl-recipe-star-rating -->
+<div class="recipe-card-meta__time">
+<svg class="icon icon-time ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-time"></use>
+</svg>
+<span class="recipe-card-meta__time-text type--rabbit">
+1 hrs
+</span>
+</div>
+</div><!-- end: comp recipe-card-meta -->
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_3-0-4" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7164554" data-tax-levels href="https://www.eatingwell.com/recipe/8018819/beef-black-bean-nacho-casserole/" data-cta data-ordinal="5">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/5hfWlPbqWtbWyjn8JZ8PxPiSa78=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Tex-Mex-Cheeseburger-Casserole-2-430b0c8edec4480d8deb893aca384482.jpg"
+width="282"
+height="188"
+alt="a recipe image of the Tex-Mex Cheeseburger Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/5hfWlPbqWtbWyjn8JZ8PxPiSa78=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/Tex-Mex-Cheeseburger-Casserole-2-430b0c8edec4480d8deb893aca384482.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="a recipe image of the Tex-Mex Cheeseburger Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Beef &amp; Black Bean Nacho Casserole</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Sara Haas, RDN"></div>
+<div id="recipe-card-meta_3-0-3" class="comp recipe-card-meta">
+<div id="mntl-recipe-star-rating_3-0-2" class="comp mntl-recipe-star-rating">
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+</div><!-- end: comp mntl-recipe-star-rating -->
+<div class="recipe-card-meta__time">
+<svg class="icon icon-time ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-time"></use>
+</svg>
+<span class="recipe-card-meta__time-text type--rabbit">
+1 hrs 20 mins
+</span>
+</div>
+</div><!-- end: comp recipe-card-meta -->
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_3-0-5" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7164321" data-tax-levels href="https://www.eatingwell.com/recipe/7989666/cheesy-ground-beef-broccoli-casserole/" data-cta data-ordinal="6">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/-huM6bHvdmPVpUVIVUPpFG0UB8g=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-broccoli-casserole-hero-01-1-5fd40df69c644bb69308fb6ec999d1ff.jpg"
+width="282"
+height="188"
+alt="cheesy ground beef broccoli casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/-huM6bHvdmPVpUVIVUPpFG0UB8g=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/cheesy-ground-beef-broccoli-casserole-hero-01-1-5fd40df69c644bb69308fb6ec999d1ff.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="cheesy ground beef broccoli casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Ground Beef Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Cheesy Ground Beef &amp; Broccoli Casserole</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Carolyn Malcoun"></div>
+<div id="recipe-card-meta_3-0-4" class="comp recipe-card-meta">
+<div id="mntl-recipe-star-rating_3-0-3" class="comp mntl-recipe-star-rating">
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+</svg>
+</div><!-- end: comp mntl-recipe-star-rating -->
+<div class="recipe-card-meta__time">
+<svg class="icon icon-time ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-time"></use>
+</svg>
+<span class="recipe-card-meta__time-text type--rabbit">
+30 mins
+</span>
+</div>
+</div><!-- end: comp recipe-card-meta -->
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_3-0-6" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7155379" data-tax-levels href="https://www.eatingwell.com/gallery/7993597/easy-diabetes-friendly-casseroles/" data-cta data-ordinal="7">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/8vQp5cI9Wl4RWZliJnLSMJDYrmA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/4552496-b0578d1f039643a6bb9755f5eb77144c.jpg"
+width="282"
+height="188"
+alt="chipotle ranch chicken casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/8vQp5cI9Wl4RWZliJnLSMJDYrmA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/4552496-b0578d1f039643a6bb9755f5eb77144c.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="chipotle ranch chicken casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">17 Easy Diabetes-Friendly Casserole Recipes</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Danielle DeAngelis"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+<a id="mntl-card-list-items_3-0-7" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7155075" data-tax-levels href="https://www.eatingwell.com/gallery/8013038/winter-casseroles-youll-want-to-make-forever/" data-cta data-ordinal="8">
+<div class="loc card__top">
+<div class="card__media mntl-universal-image card__media universal-image__container">
+<div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.eatingwell.com/thmb/MSV4LrWiu5ENg270Ag-YNocgKQk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/philly-chicken-cheesesteak-casserole-step-12-2000-9efd2759a7eb4b59a2c4d8c8ef2c8e13.jpg"
+width="282"
+height="188"
+alt="Philly Chicken Cheesesteak Casserole"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/MSV4LrWiu5ENg270Ag-YNocgKQk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/philly-chicken-cheesesteak-casserole-step-12-2000-9efd2759a7eb4b59a2c4d8c8ef2c8e13.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Philly Chicken Cheesesteak Casserole"
+/>
+</noscript>
+</div></div>
+</div>
+<div class="card__content" data-tag="Healthy Casserole Recipes">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">20 Winter Casseroles You&#39;ll Want to Make Forever</span></span>
+<div class="card__byline mntl-card__byline " data-byline="By Eleanor Chalstrom"></div>
+</div>
+</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
+</div><!-- end: comp recirc-section__card-list-2 card-list mntl-document-card-list mntl-card-list mntl-block -->
+<div id="leaderboard2-deferred-footer_1-0" class="comp js-lazy-ad has-right-label leaderboard leaderboard2-deferred-footer mntl-leaderboardfooter-flex-2-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
+<div id="leaderboardfooter-flex-2" class="wrapper"
+data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}" data-auction-floor-id="d01b5b867d294db9902b5b2884568a51" data-auction-floor-value="65"></div>
+</div><!-- end: comp js-lazy-ad has-right-label leaderboard leaderboard2-deferred-footer mntl-leaderboardfooter-flex-2-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic -->
+</div>
+</section><!-- end: comp recirc-section -->
+</main>
+<footer id="footer_1-0" class="comp footer" role="contentinfo" data-tracking-container="true">
+<div class="footer__inner">
+<div class="footer__primary">
+<div class="footer__logo">
+<a id="logo_2-0" class="comp logo mntl-block" rel="home" href="/" aria-label="Home">
+<div id="mntl-text-block_2-0" class="comp is-screenreader-only mntl-text-block">
+EatingWell</div><!-- end: comp is-screenreader-only mntl-text-block -->
+<svg class="icon icon-logo ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo"></use>
+</svg>
+</a><!-- end: comp logo mntl-block -->
+</div>
+<div class="loc newsletter-link-wrapper footer__newsletter">
+<a
+href="#"
+rel="nocaes"
+data-a11y-dialog-show="newsletter-dialog-footer"
+id="newsletter-dialog-footer-link_1-0"
+class=" newsletter-dialog-footer-link dialog-link mntl-text-link footer__newsletter-link"
+data-tracking-container="true"
+><span class="link__wrapper">Newsletter</span></a><!-- end: newsletter-dialog-footer-link dialog-link mntl-text-link footer__newsletter-link -->
+</div>
+<div class="footer__magsub-wrapper">
+<a href="https://www.magazines.com/magazines/cooking-food-beverage.html?utm_source=eatingwell.com&utm_medium=owned&utm_campaign=i202etrfw2795" target="_blank">
+<div class="loc footer__magsub">
+<div class="img-placeholder" style="padding-bottom:50.0%;">
+<img
+data-src="https://www.eatingwell.com/thmb/x7T3Q58PVkqcRK4cLhViIrIKqQM=/300x150/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/EatingwellSubscribeImage-8265a1bde4594cdd8b6e0542dd594304.png"
+width="300"
+height="150"
+alt="Magazine Sub Placeholder Image"
+class="lazyload universal-image__image"
+/>
+<noscript>
+<img
+src="https://www.eatingwell.com/thmb/x7T3Q58PVkqcRK4cLhViIrIKqQM=/300x150/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/EatingwellSubscribeImage-8265a1bde4594cdd8b6e0542dd594304.png"
+width="300"
+height="150"
+class="img--noscript universal-image__image"
+alt="Magazine Sub Placeholder Image"
+/>
+</noscript>
+</div>
+</div>
+</a>
+</div>
+<div class="loc footer__social">
+<nav id="footer__social-nav_1-0" class="comp footer__social-nav eatingwell-social-nav mntl-social-nav" role="navigation" data-tracking-container="true">
+<div class="social-nav__title">Follow Us</div>
+<ul class="social-nav__list">
+<li class="social-nav__item social-nav__item--facebook">
+<a
+href="https://www.facebook.com/EatingWell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--facebook"
+> <svg class="icon icon-facebook social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
+</svg>
+<span class="social-nav__accessible-label">Facebook</span>
+</a><!-- end: social-nav__link social-nav__link--facebook --> </li>
+<li class="social-nav__item social-nav__item--flipboard">
+<a
+href="https://flipboard.com/@EatingWell"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--flipboard"
+> <svg class="icon icon-flipboard social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard"></use>
+</svg>
+<span class="social-nav__accessible-label">Flipboard</span>
+</a><!-- end: social-nav__link social-nav__link--flipboard --> </li>
+<li class="social-nav__item social-nav__item--instagram">
+<a
+href="https://www.instagram.com/eatingwell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--instagram"
+> <svg class="icon icon-instagram social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram"></use>
+</svg>
+<span class="social-nav__accessible-label">Instagram</span>
+</a><!-- end: social-nav__link social-nav__link--instagram --> </li>
+<li class="social-nav__item social-nav__item--pinterest">
+<a
+href="https://www.pinterest.com/eatingwell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--pinterest"
+> <svg class="icon icon-pinterest social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest"></use>
+</svg>
+<span class="social-nav__accessible-label">Pinterest</span>
+</a><!-- end: social-nav__link social-nav__link--pinterest --> </li>
+<li class="social-nav__item social-nav__item--twitter">
+<a
+href="https://twitter.com/EatingWell/"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--twitter"
+> <svg class="icon icon-twitter social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use>
+</svg>
+<span class="social-nav__accessible-label">Twitter</span>
+</a><!-- end: social-nav__link social-nav__link--twitter --> </li>
+<li class="social-nav__item social-nav__item--youtube">
+<a
+href="https://www.youtube.com/@eatingwell"
+target="_blank"
+rel="noopener nocaes"
+class="social-nav__link social-nav__link--youtube"
+> <svg class="icon icon-youtube social-nav__icon">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube"></use>
+</svg>
+<span class="social-nav__accessible-label">YouTube</span>
+</a><!-- end: social-nav__link social-nav__link--youtube --> </li>
+</ul>
+</nav><!-- end: comp footer__social-nav eatingwell-social-nav mntl-social-nav -->
+</div>
+</div>
+<div class="footer__secondary">
+<nav id="footer-nav_1-0" class="comp footer-nav mntl-block">
+<ul id="mntl-block_1-0" class="comp footer-nav__list mntl-block">
+<li id="footer-nav__list-item_1-0" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/recipes/17990/mealtimes/snacks/"
+rel="nocaes"
+id="mntl-text-link_1-0"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">Healthy Recipes</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+<li id="footer-nav__list-item_1-0-1" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/category/4286/meal-plans/"
+rel="nocaes"
+id="mntl-text-link_1-0-1"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">Meal Plans</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+<li id="footer-nav__list-item_1-0-2" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/category/4306/healthy-eating-101/"
+rel="nocaes"
+id="mntl-text-link_1-0-2"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">Healthy Eating</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+<li id="footer-nav__list-item_1-0-3" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/category/4309/healthy-cooking-how-tos/"
+rel="nocaes"
+id="mntl-text-link_1-0-3"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">Healthy Cooking</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+<li id="footer-nav__list-item_1-0-4" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/category/7886691/healthy-lifestyle/"
+rel="nocaes"
+id="mntl-text-link_1-0-4"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">Healthy Lifestyle</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+<li id="footer-nav__list-item_1-0-5" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/category/4243/special-diets/"
+rel="nocaes"
+id="mntl-text-link_1-0-5"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">Special Diets</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+<li id="footer-nav__list-item_1-0-6" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/category/4248/diabetes-diet-center/"
+rel="nocaes"
+id="mntl-text-link_1-0-6"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">Diabetes</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+<li id="footer-nav__list-item_1-0-7" class="comp footer-nav__list-item mntl-block">
+<a
+href="https://www.eatingwell.com/category/4328/news/"
+rel="nocaes"
+id="mntl-text-link_1-0-7"
+class=" mntl-text-link type--squirrel-link"
+data-tracking-container="true"
+><span class="link__wrapper">News</span></a><!-- end: mntl-text-link type--squirrel-link -->
+</li><!-- end: comp footer-nav__list-item mntl-block -->
+</ul><!-- end: comp footer-nav__list mntl-block -->
+</nav><!-- end: comp footer-nav mntl-block -->
+<ul id="footer-links_1-0" class="comp footer-links">
+<li class="footer-links__item"><a
+href="/about-us-6743412"
+rel="nocaes"
+data-type="ourStory"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>About Us</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="/diversity-equity-and-inclusion-6746107"
+rel="nocaes"
+data-type="antiRacism"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Diversity & Inclusion</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="/our-food-and-nutrition-philosophy-6746110"
+rel="nocaes"
+data-type="nutritionGuidelines"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Nutrition Guidelines</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="https://www.dotdashmeredith.com/brands-privacy"
+target="_blank"
+rel="noopener nocaes"
+data-type="privacyPolicy"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Privacy Policy</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="/about-us-6743412#toc-product-reviews"
+rel="nocaes"
+data-type="productReviews"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Product Reviews</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="https://www.dotdashmeredith.com/brands/food-drink/eating-well"
+target="_blank"
+rel="noopener nocaes"
+data-type="advertise"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Advertise</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="https://www.dotdashmeredith.com/terms-of-use"
+target="_blank"
+rel="noopener nocaes"
+data-type="termsOfUse"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Terms of Use</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="https://www.dotdashmeredith.com/careers"
+target="_blank"
+rel="noopener nofollow nocaes"
+data-type="careersAtDotDash"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Careers</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item ot-pref-trigger"><a
+href="#"
+rel="nocaes"
+data-type="cmpFooterLink"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Do Not Sell My Personal Information</a><!-- end: type--rabbit-link --></li>
+<li class="footer-links__item"><a
+href="https://www.dotdashmeredith.com/contact"
+target="_blank"
+rel="noopener nocaes"
+data-type="contact"
+data-ordinal="1"
+class="type--rabbit-link"
+data-component="footerLinks"
+data-source="footerLinks"
+>Contact</a><!-- end: type--rabbit-link --></li>
+</ul><!-- end: comp footer-links -->
+</div>
+</div>
+<div class="loc footer-bottom">
+<nav id="mntl-dotdash-universal-nav_1-0" class="comp mntl-dotdash-universal-nav" role="navigation" data-tracking-container="true">
+<div class="mntl-dotdash-universal-nav__content">
+<svg class="icon mntl-dotdash-universal-nav__logo ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mntl-dotdash-universal-nav__logo"></use>
+</svg>
+<span class="mntl-dotdash-universal-nav__text">
+EatingWell is part of the <a
+href="https://www.dotdashmeredith.com"
+target="_blank"
+rel="noopener nocaes"
+class="mntl-dotdash-universal-nav__text--link"
+>Dotdash Meredith</a><!-- end: mntl-dotdash-universal-nav__text--link --> publishing&nbsp;family.
+</span>
+</div>
+</nav><!-- end: comp mntl-dotdash-universal-nav -->
+</div>
+</footer><!-- end: comp footer -->
+<div id="newsletter-dialog-header_1-0" class="comp newsletter-dialog-header mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="newsletter-dialog-header">
+<div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
+<div role="dialog" class="dialog__content" aria-labelledby="newsletter-dialog-header_1-0-title">
+<div class="dialog__heading">
+<span id="newsletter-dialog-header_1-0-title" class="dialog__title type--monkey-bold">Newsletter Sign Up</span>
+<button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
+<svg class="icon icon-close ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+</svg>
+</button>
+</div>
+<div class="loc content dialog__main">
+<div id="newsletter_1-0" class="comp newsletter mntl-newsletter" data-defer="loadDialogContent" data-defer-params></div><!-- end: comp newsletter mntl-newsletter -->
+</div>
+</div>
+</div><!-- end: comp newsletter-dialog-header mntl-dialog dialog -->
+<div id="newsletter-dialog-footer_1-0" class="comp newsletter-dialog-footer newsletter-dialog-header mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="newsletter-dialog-footer">
+<div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
+<div role="dialog" class="dialog__content" aria-labelledby="newsletter-dialog-footer_1-0-title">
+<div class="dialog__heading">
+<span id="newsletter-dialog-footer_1-0-title" class="dialog__title type--monkey-bold">Newsletter Sign Up</span>
+<button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
+<svg class="icon icon-close ">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+</svg>
+</button>
+</div>
+<div class="loc content dialog__main">
+<div id="newsletter_2-0" class="comp newsletter mntl-newsletter" data-defer="loadDialogContent" data-defer-params></div><!-- end: comp newsletter mntl-newsletter -->
+</div>
+</div>
+</div><!-- end: comp newsletter-dialog-footer newsletter-dialog-header mntl-dialog dialog -->
+<svg class="is-hidden">
+<defs>
+<symbol id="mntl-sc-block-starrating-icon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+<path d="M0,0v20h20V0H0z M14.2,12.2l1.1,6.3l-5.4-3.2l-5.1,3.2l1-6.3L1.4,8l5.9-0.8l2.6-5.8l2.7,5.8L18.5,8L14.2,12.2z"/>
+</svg>
+</symbol>
+</defs>
+</svg>
+<div id="mntl-outofpage_1-0" class="comp mntl-outofpage mntl-outofpage mntl-gpt-adunit gpt outofpage ">
+<div id="oop" class="wrapper"
+></div>
+</div><!-- end: comp mntl-outofpage mntl-outofpage mntl-gpt-adunit gpt outofpage -->		
+<script type="text/javascript" data-glb-js="bottom" src="/static/1.6.0/cache/eNqlVWtyozAMvtB62J6hf3sJ2QhQIuysLJKmp1_xSBsIgczuTAbxyfqEXlaKrKAUihaiMhYTYvK5ONjvT4dy_VXMjeygU2JSwux8R6zuQtq4p9atvbgzRGIGl4Mk5qVVSO0pRYyaC4qKEoGLEiuUnj-8CJYbpJClGh5Porgzxc_RP32hY4rHIdMH5YYDqCrLHnS0dIIXIR0jfXK04exCZY0mG6S60fcGYo0flBWjeVxTvuDrTCUmd2K4jlH5MAEn6v-L_9CJO7ZgoBNOwiwViPMCblW1HBrB8HV1UO4YRjs7_8zWCDc4U2ws2VGsLQEa1Au84SCrdEE7s3Qh2YBGLaiF2mwErd0ffZ98-nwHSV3GzfEeaBZ5TdVaGUFMYZRJfn9uXl7pZ-wk9H1wp9mvQ-zU5pJSdBUEUy-wY_CbOSxiwTPhxXmQR80L06YpsdLpJrc632mTxN0Ih6Xm38uZUyBglxuQVd0LacxcHOZ4SV-s2WzgePWke_fD2wb1CWS8Kjk4TuHofrT716ti_CRvdYDVO1xz8rZ5G4RyWD-92GnI7_G55q1K0prPfmv1lUCQ0CzgGu1W0RZztrtiYxT7ZTiHG1GVVvdUT2JYxGtfiXCmGvqhn_K0LXK-e93hVB2z_ZUhxoE3hzv9hre3qxvDezWNv2x67z8.min.js" async defer="true"></script>
+<script type="text/javascript">Mntl.utilities.scriptsOnLoad(document.querySelectorAll('script[data-glb-js="bottom"]'), function() {var Mntl = window.Mntl || {};window.Mntl.externalizeLinks.addPlugin(window.Mntl.affiliateLinkRewriter);
+window.Mntl.externalizeLinks.addPlugin(window.Mntl.amazonAffiliateTagger);
+window.Mntl.externalizeLinks.init();window.Mntl.affiliateLinkRewriter.setMappings( {
+DOC_ID: '7165416'
+,SITE: 'eatingwell'
+,REQUEST_ID: 'n0d67930b103440e6811a95e3ef3c23a218'
+}
+);
+(function() {
+var article = document.getElementById('eatingwell-article_1-0');
+if (article && !article.gtmPageView) {
+article.gtmPageView = {"country":"US","description":"This hearty ground beef and cauliflower casserole is perfect for weeknight dinners. Serve this healthy casserole with tortilla chips and sour cream.","authorId":"1017375","documentId":7165416,"muid":"4b63c4fc-c0aa-4388-acfc-3011ea0a5703","templateName":"RECIPESC","contentGroup":"Other","revenueGroup":"","title":"Cheesy Ground Beef & Cauliflower Casserole" || document.title || '',"lastEditingAuthorId":"1017375","lastEditingUserId":"153546959002053","templateId":"120","viewType":"","fullUrl":"https://www.eatingwell.com/recipe/7919044/cheesy-ground-beef-cauliflower-casserole/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"internalSessionId":"nf77991515d454c899d99b480b3173c5117","internalRequestId":"n0d67930b103440e6811a95e3ef3c23a218","hid":"","experienceTypeName":"","recircDocIdsFooter":"","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"3.14.56","commerceVersion":"","primaryTaxonomyIds":"6744898|7186545|7186551|7186481","primaryTaxonomyNames":"EatingWell|Healthy Recipes|Healthy Main Dish Recipes|Healthy Casserole Recipes"};
+}
+}());
+(function(Mntl) {
+Mntl.Tooltip.init({
+defaultPositionX: "auto",
+defaultPositionY: "auto"
+});
+})(window.Mntl || {});});</script>
+<div id="mntl-sponsor-tracking-codes_1-0" class="comp mntl-sponsor-tracking-codes" data-defer="load" data-defer-params></div><!-- end: comp mntl-sponsor-tracking-codes -->
+<div id="onetrust-consent-sdk" class="" data-tracking-container="true">
+<div id="onetrust-banner-sdk" class="otFlat bottom ot-wo-title" tabindex="0"><div role="alertdialog" aria-describedby="onetrust-policy-text" aria-label="Privacy"><div class="ot-sdk-container"><div class="ot-sdk-row"><div id="onetrust-group-container" class="ot-sdk-eight ot-sdk-columns"><div class="banner_logo"></div><div id="onetrust-policy"><p id="onetrust-policy-text">By clicking “Accept All Cookies”, you agree to the storing of cookies on your device to enhance site navigation, analyze site usage, and assist in our marketing efforts. </p></div></div><div id="onetrust-button-group-parent" class="ot-sdk-three ot-sdk-columns"><div id="onetrust-button-group"><button id="onetrust-pc-btn-handler" class=" cookie-setting-link">Cookies Settings</button> <button id="onetrust-accept-btn-handler">Accept All Cookies</button></div></div></div></div><!-- Close Button --><div id="onetrust-close-btn-container"><button class="onetrust-close-btn-handler onetrust-close-btn-ui banner-close-button ot-close-icon" aria-label="Close"></button></div><!-- Close Button END--></div></div>
+</div>		
+</body>
+</html><!-- end: comp no-js taxlevel-3 recipeScTemplate html mntl-html -->		

--- a/tests/test_eatingwell.py
+++ b/tests/test_eatingwell.py
@@ -27,7 +27,7 @@ class TestEatingWell(ScraperTest):
 
     def test_ingredients(self):
         self.assertEqual(
-                       [
+            [
                 "1 tablespoon extra-virgin olive oil",
                 "0.5 cup chopped onion",
                 "1 medium green bell pepper, chopped",

--- a/tests/test_eatingwell.py
+++ b/tests/test_eatingwell.py
@@ -21,15 +21,15 @@ class TestEatingWell(ScraperTest):
 
     def test_image(self):
         self.assertEqual(
-            "https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F44%2F2021%2F08%2F16%2Fcheesy-ground-beef-and-cauliflower-casserole.jpg",
+            "https://www.eatingwell.com/thmb/32d8L6W6cwt652tjjXAHosP3ViE=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/cheesy-ground-beef-and-cauliflower-casserole-8791b22c92404d958e2ac5aa92af8aa7.jpg",
             self.harvester_class.image(),
         )
 
     def test_ingredients(self):
         self.assertEqual(
-            [
+                       [
                 "1 tablespoon extra-virgin olive oil",
-                "½ cup chopped onion",
+                "0.5 cup chopped onion",
                 "1 medium green bell pepper, chopped",
                 "1 pound lean ground beef",
                 "3 cups bite-size cauliflower florets",
@@ -37,11 +37,11 @@ class TestEatingWell(ScraperTest):
                 "2 tablespoons chili powder",
                 "2 teaspoons ground cumin",
                 "1 teaspoon dried oregano",
-                "½ teaspoon salt",
-                "¼ teaspoon ground chipotle",
+                "0.5 teaspoon salt",
+                "0.25 teaspoon ground chipotle",
                 "1 (15 ounce) can no-salt-added petite-diced tomatoes",
                 "2 cups shredded extra-sharp Cheddar cheese",
-                "⅓ cup sliced pickled jalapeños",
+                "0.333 cup sliced pickled jalapeños",
             ],
             self.harvester_class.ingredients(),
         )


### PR DESCRIPTION
Context
the eatingwell.com recipe site was redesigned, with a slightly different HTML structure but now follows recipe schema that self.schema functions use 🥳.

Changes
* eatingwell.py member functions modified to use self.schema instead of custom parsing of the DOM
* test_eatingwell.py expected outputs changed to reflect outputs from schema
* eatingwell.testhtml updated to new website html document!

Thank you so much for the library! 😁




