### PR TITLE
Run unittests against macos-13. See how it goes without the lxml work…

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
           #  lxml built-from-source fails or produces unreliable results on these platforms


### PR DESCRIPTION
…arund