### PR TITLE
Maintenance / investigation: reapply lxml workaround for MacOS unit test workflows

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -13,11 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
-          - os: macos-13
+          #  lxml built-from-source fails or produces unreliable results on these platforms
+          # ... so skip these platforms
+          - os: windows-latest
             python-version: "3.11"
+          - os: macos-latest
+            python-version: "3.11"
+        include:
+          # set toxenv to workaround-darwin on macos (check tox.ini)
+          - toxenv: py
+          - os: macos-latest
+            toxenv: workaround-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -28,4 +37,4 @@ jobs:
       - name: Run Tests
         run: |
           pip install tox
-          tox
+          tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -13,19 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          #  lxml built-from-source fails or produces unreliable results on these platforms
-          # ... so skip these platforms
-          - os: windows-latest
-            python-version: "3.11"
-          - os: macos-latest
-            python-version: "3.11"
         include:
           # set toxenv to workaround-darwin on macos (check tox.ini)
           - toxenv: py
-          - os: macos-latest
+          - os: macos-13
             toxenv: workaround-darwin
     runs-on: ${{ matrix.os }}
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,15 @@ isolated_build = true
 deps = -r{toxinidir}/requirements-dev.txt
 commands = coverage run -m unittest {posargs}
 
+# The system-provided libxml2 on MacOS is typically outdated and this can lead to lxml parsing issues
+# Using PyPi-provided binary wheels instead resolves this
+# We are affected by https://bugs.launchpad.net/lxml/+bug/1949271 in test_wild_mode when using system-provided libxml2 on MacOS
+platform =
+    workaround-darwin: darwin
+install_command =
+    py: python -I -m pip install {opts} {packages}
+    workaround-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
+
 [testenv:lint]
 # note: skip_install affects whether the package-under-test is installed; not whether deps are installed
 skip_install = true


### PR DESCRIPTION
Attempting to investigate and resolve some unit test failures for MacOS on Python versions 3.7 and 3.8 observed during #778.