### PR TITLE
Gousto: Add description, fix time and yields.

### DIFF
--- a/recipe_scrapers/goustojson.py
+++ b/recipe_scrapers/goustojson.py
@@ -37,11 +37,14 @@ class GoustoJson(AbstractScraper):
     def title(self):
         return self.data.get("title")
 
+    def description(self):
+        return normalize_string(self.data.get("description"))
+
     def total_time(self):
-        return get_minutes(sorted(self.data.get("prep_times").values())[-1])
+        return get_minutes(sorted(self.data.get("prep_times").values())[0])
 
     def yields(self):
-        return get_yields(sorted(self.data.get("prep_times").keys())[-1])
+        return get_yields(sorted(self.data.get("prep_times").keys())[0])
 
     def image(self):
         return self.data.get("seo").get("open_graph_image")

--- a/tests/test_goustojson.py
+++ b/tests/test_goustojson.py
@@ -22,6 +22,12 @@ class TestGoustoScraper(ScraperTest):
             "Malaysian-Style Coconut Meat-Free Chicken With Pickled Cucumber",
         )
 
+    def test_description(self):
+        self.assertEqual(
+            self.harvester_class.description(),
+            "Inspired by the fragrant flavours of the classic Malaysian chicken dish 'Ayam Percik'. Our spice paste blends lemongrass, almonds and ginger before adding coconut cream and meat-free chicken. Served with fluffy rice and quick-pickled cucumber.",
+        )
+
     def test_image(self):
         self.assertEqual(
             "https://s3-eu-west-1.amazonaws.com/s3-gousto-production-media/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600.jpg",

--- a/tests/test_goustojson.py
+++ b/tests/test_goustojson.py
@@ -35,10 +35,10 @@ class TestGoustoScraper(ScraperTest):
         )
 
     def test_total_time(self):
-        self.assertEqual(35, self.harvester_class.total_time())
+        self.assertEqual(25, self.harvester_class.total_time())
 
     def test_yields(self):
-        self.assertEqual("4 servings", self.harvester_class.yields())
+        self.assertEqual("2 servings", self.harvester_class.yields())
 
     def test_ingredients(self):
         self.assertEqual(


### PR DESCRIPTION
Another Gousto improvement.

This adds retrieving description from Gousto recipes, and fixes yield and prep time to reflect the ingredients. 

On Gousto's page they only provide time and servings for 2 servings by default, asking the user to double the ingredients for 4 servings. As we weren't doubling the ingredients (which would be quite involved), this will now instead return the total time and yield for 2 servings.