### PR TITLE
continuous integration: unittests: Drop support for Python3.7

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           # set toxenv to workaround-darwin on macos (check tox.ini)
           - toxenv: py


### PR DESCRIPTION
Save a few GitHub Actions continuous integration pennies by no longer running the unit test suite on Python 3.7 (that [reached end-of-life phase in June this year](https://peps.python.org/pep-0537/)).