### PR TITLE
Refactor: use unittest.expectedFailure as a declarative indicator for single-instruction test recipes

### DIFF
--- a/docs/how-to-develop-scraper.md
+++ b/docs/how-to-develop-scraper.md
@@ -59,7 +59,6 @@ To develop the scraper for the website, first identify a recipe. This will be us
 > [!NOTE]
 > Try to pick a recipe that involves more than one instruction, if you can.  The test suite considers single-instruction recipes to indicate possible human error.  If you need to, though, you can indicate that that's expected.
 
-
 Next, find out if the website supports [Recipe Schema](https://schema.org/Recipe). If the website does support Recipe Schema, this will make creating the scraper straightforward. If not, supporting the site will be more complex but still possible.
 
 ```python

--- a/docs/how-to-develop-scraper.md
+++ b/docs/how-to-develop-scraper.md
@@ -56,6 +56,10 @@ This will run all the tests for all the scrapers. You should not see any errors 
 
 To develop the scraper for the website, first identify a recipe. This will be used to create the test case that will validate that the scraper is working correctly.
 
+> [!NOTE]
+> Try to pick a recipe that involves more than one instruction, if you can.  The test suite considers single-instruction recipes to indicate possible human error.  If you need to, though, you can indicate that that's expected.
+
+
 Next, find out if the website supports [Recipe Schema](https://schema.org/Recipe). If the website does support Recipe Schema, this will make creating the scraper straightforward. If not, supporting the site will be more complex but still possible.
 
 ```python

--- a/tests/test_allrecipes.py
+++ b/tests/test_allrecipes.py
@@ -146,4 +146,5 @@ class TestAllRecipesUserScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()

--- a/tests/test_allrecipes.py
+++ b/tests/test_allrecipes.py
@@ -1,3 +1,5 @@
+import unittest
+
 from recipe_scrapers.allrecipes import AllRecipesCurated, AllRecipesUser
 from tests import ScraperTest
 
@@ -142,6 +144,6 @@ class TestAllRecipesUserScraper(ScraperTest):
     def test_category(self):
         self.assertEqual(None, self.harvester_class.category())
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()

--- a/tests/test_farmhousedelivery_1.py
+++ b/tests/test_farmhousedelivery_1.py
@@ -56,4 +56,5 @@ class TestFarmhouseDeliveryScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()

--- a/tests/test_farmhousedelivery_1.py
+++ b/tests/test_farmhousedelivery_1.py
@@ -1,3 +1,5 @@
+import unittest
+
 from recipe_scrapers.farmhousedelivery import FarmhouseDelivery
 from tests import ScraperTest
 
@@ -52,6 +54,6 @@ class TestFarmhouseDeliveryScraper(ScraperTest):
             self.harvester_class.image(),
         )
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()

--- a/tests/test_foodandwine_1.py
+++ b/tests/test_foodandwine_1.py
@@ -1,6 +1,7 @@
+import unittest
+
 from recipe_scrapers.foodandwine import FoodAndWine
 from tests import ScraperTest
-import unittest
 
 
 class TestFoodAndWineScraper(ScraperTest):

--- a/tests/test_foodandwine_1.py
+++ b/tests/test_foodandwine_1.py
@@ -57,6 +57,7 @@ class TestFoodAndWineScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()
 
     def test_yields(self):

--- a/tests/test_foodandwine_1.py
+++ b/tests/test_foodandwine_1.py
@@ -1,5 +1,6 @@
 from recipe_scrapers.foodandwine import FoodAndWine
 from tests import ScraperTest
+import unittest
 
 
 class TestFoodAndWineScraper(ScraperTest):
@@ -53,9 +54,9 @@ class TestFoodAndWineScraper(ScraperTest):
             self.harvester_class.instructions(),
         )
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()
 
     def test_yields(self):
         return self.assertEqual("4 servings", self.harvester_class.yields())

--- a/tests/test_halfbakedharvest.py
+++ b/tests/test_halfbakedharvest.py
@@ -1,3 +1,5 @@
+import unittest
+
 from recipe_scrapers.halfbakedharvest import HalfBakedHarvest
 from tests import ScraperTest
 
@@ -62,6 +64,6 @@ class TestHalfBakedHarvestScraper(ScraperTest):
             self.harvester_class.instructions(),
         )
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()

--- a/tests/test_halfbakedharvest.py
+++ b/tests/test_halfbakedharvest.py
@@ -66,4 +66,5 @@ class TestHalfBakedHarvestScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()

--- a/tests/test_halfbakedharvest_groups.py
+++ b/tests/test_halfbakedharvest_groups.py
@@ -1,3 +1,5 @@
+import unittest
+
 from recipe_scrapers._grouping_utils import IngredientGroup
 from recipe_scrapers.halfbakedharvest import HalfBakedHarvest
 from tests import ScraperTest
@@ -104,6 +106,6 @@ class TestHalfBakedHarvestScraper(ScraperTest):
             self.harvester_class.instructions(),
         )
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()

--- a/tests/test_halfbakedharvest_groups.py
+++ b/tests/test_halfbakedharvest_groups.py
@@ -108,4 +108,5 @@ class TestHalfBakedHarvestScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()

--- a/tests/test_heinzbrasil.py
+++ b/tests/test_heinzbrasil.py
@@ -1,3 +1,5 @@
+import unittest
+
 from recipe_scrapers.heinzbrasil import HeinzBrasil
 from tests import ScraperTest
 
@@ -56,6 +58,6 @@ class TestHeinzBrasilScraper(ScraperTest):
     def test_language(self):
         self.assertEqual("pt-BR", self.harvester_class.language())
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()

--- a/tests/test_heinzbrasil.py
+++ b/tests/test_heinzbrasil.py
@@ -60,4 +60,5 @@ class TestHeinzBrasilScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()

--- a/tests/test_ig.py
+++ b/tests/test_ig.py
@@ -66,4 +66,5 @@ class TestIGScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()

--- a/tests/test_ig.py
+++ b/tests/test_ig.py
@@ -1,3 +1,5 @@
+import unittest
+
 from recipe_scrapers.ig import IG
 from tests import ScraperTest
 
@@ -62,6 +64,6 @@ class TestIGScraper(ScraperTest):
     def test_language(self):
         self.assertEqual("pt-BR", self.harvester_class.language())
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()

--- a/tests/test_inspiralized.py
+++ b/tests/test_inspiralized.py
@@ -1,3 +1,5 @@
+import unittest
+
 from recipe_scrapers.inspiralized import Inspiralized
 from tests import ScraperTest
 
@@ -51,6 +53,6 @@ class TestInspiralizedScraper(ScraperTest):
             self.harvester_class.instructions(),
         )
 
+    @unittest.expectedFailure
     def test_multiple_instructions(self):
-        # override: this test case legitimately does only contain a single instruction in the source HTML
-        pass
+        super().test_multiple_instructions()

--- a/tests/test_inspiralized.py
+++ b/tests/test_inspiralized.py
@@ -55,4 +55,5 @@ class TestInspiralizedScraper(ScraperTest):
 
     @unittest.expectedFailure
     def test_multiple_instructions(self):
+        # override: this test case legitimately does only contain a single instruction in the source HTML
         super().test_multiple_instructions()


### PR DESCRIPTION
cc @jknndy - what do you reckon?