### PR TITLE
Add UTF-8 two-byte hex 'C2 A0' encoding of non-breaking-space to 'normalize_string' replacements

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -142,7 +142,8 @@ def normalize_string(string):
     return re.sub(
         r"\s+",
         " ",
-        unescaped_string.replace("\xa0", " ")
+        unescaped_string.replace("\xc2\xa0", " ")
+        .replace("\xa0", " ")
         .replace("\u200b", "")
         .replace("\n", " ")  # &nbsp;
         .replace("\t", " ")


### PR DESCRIPTION
This should address this small oddity: https://github.com/hhursev/recipe-scrapers/commit/663baceec7659b9506d48bc0d919c6ed07ee8b53#diff-d13e1c74ee546f9fba5254f732e9e7de78fa9a0ffe6eb5788504d46c0c40ed18R75

(a `description` output containing the text `TomatoesÂ`)

cc @jknndy 