### PR TITLE
utils: get_minutes: return 'None' (empty) when no timing information is found in text

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -75,6 +75,9 @@ def get_minutes(element, return_zero_on_not_found=False):  # noqa: C901: TODO
 
     matched = TIME_REGEX.search(time_text)
 
+    if matched is None or not any(matched.groupdict().values()):
+        return None
+
     minutes = int(matched.groupdict().get("minutes") or 0)
     hours_matched = matched.groupdict().get("hours")
     days_matched = matched.groupdict().get("days")

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -23,7 +23,9 @@ class NIHHealthyEating(AbstractScraper):
         if time_table is None:
             raise ElementNotFoundInHtml("Table with times was not found.")
 
-        return sum([get_minutes(td) for td in time_table.find_all("td")])
+        return sum(
+            [get_minutes(td) for td in time_table.find_all("td") if get_minutes(td)]
+        )
 
     def yields(self):
         # This content must be present for all recipes on this website.

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -12,12 +12,9 @@ class TastyKitchen(AbstractScraper):
         return self.soup.find("h1", {"itemprop": "name"}).get_text()
 
     def total_time(self):
-        return sum(
-            [
-                get_minutes(self.soup.find("time", {"itemprop": "prepTime"})),
-                get_minutes(self.soup.find("time", {"itemprop": "cookTime"})),
-            ]
-        )
+        prep_time = get_minutes(self.soup.find("time", {"itemprop": "prepTime"})) or 0
+        cook_time = get_minutes(self.soup.find("time", {"itemprop": "cookTime"})) or 0
+        return prep_time + cook_time
 
     def yields(self):
         return get_yields(self.soup.find("span", {"itemprop": "yield"}))

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -72,7 +72,7 @@ class TestUtils(unittest.TestCase):
         text = "15 to 20 minutes"
         self.assertEqual(20, get_minutes(text))
 
-    def test_tbd(self):
+    def test_get_minutes_imprecise_description(self):
         text = "Pá-Pum"
         self.assertEqual(None, get_minutes(text))
 

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -72,6 +72,10 @@ class TestUtils(unittest.TestCase):
         text = "15 to 20 minutes"
         self.assertEqual(20, get_minutes(text))
 
+    def test_tbd(self):
+        text = "Pá-Pum"
+        self.assertEqual(None, get_minutes(text))
+
     iso8601_fixtures = {
         "PT1H": 60,
         "PT20M": 20,

--- a/tests/test_kitchenstories.py
+++ b/tests/test_kitchenstories.py
@@ -27,7 +27,7 @@ class TestKitchenStoriesScraper(ScraperTest):
         self.assertEqual(80, self.harvester_class.total_time())
 
     def test_cook_time(self):
-        self.assertEqual(0, self.harvester_class.cook_time())
+        self.assertEqual(None, self.harvester_class.cook_time())
 
     def test_prep_time(self):
         self.assertEqual(20, self.harvester_class.prep_time())

--- a/tests/test_panelinha_2.py
+++ b/tests/test_panelinha_2.py
@@ -16,7 +16,7 @@ class TestPanelinhaScraper(ScraperTest):
         self.assertEqual(self.harvester_class.author(), "Panelinha")
 
     def test_total_time(self):
-        self.assertEqual(0, self.harvester_class.total_time())
+        self.assertEqual(None, self.harvester_class.total_time())
 
     def test_yields(self):
         self.assertEqual("2 servings", self.harvester_class.yields())

--- a/tests/test_weightwatchers.py
+++ b/tests/test_weightwatchers.py
@@ -27,7 +27,7 @@ class TestWeightwatchersScraper(ScraperTest):
         self.assertEqual(25, self.harvester_class.total_time())
 
     def test_cook_time(self):
-        self.assertEqual(0, self.harvester_class.cook_time())
+        self.assertEqual(None, self.harvester_class.cook_time())
 
     def test_prep_time(self):
         self.assertEqual(25, self.harvester_class.prep_time())


### PR DESCRIPTION
Resolves #914.