### PR TITLE
ci: coverage workflow: pin to Python versions below 3.12

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "< 3.12"  # ref: https://github.com/hhursev/recipe-scrapers/issues/909
       - name: run unittests
         run: |
           pip install tox


### PR DESCRIPTION
Pending resolution of #909.