### PR TITLE
 ci: coverage workflow: pin to Python versions below 3.12

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -16,6 +16,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "< 3.12"  # ref: https://github.com/hhursev/recipe-scrapers/issues/909
       - run: pip install tox
       - run: tox -e lint


### PR DESCRIPTION
Follows-on-from #917 -- although in this case, I'm less confident that Python 3.12 is the cause of continuous integration failures.

Relates to #909.