### PR TITLE
pre-commit: update flake8 to v6.1.0 - providing support for Python 3.12

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -16,6 +16,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "< 3.12"  # ref: https://github.com/hhursev/recipe-scrapers/issues/909
+          python-version: "3.x"
       - run: pip install tox
       - run: tox -e lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
     - id: flake8
       additional_dependencies: [flake8-use-fstring, pep8-naming]


### PR DESCRIPTION
Follows-on-from #918, removing a version pin.

Relates to #909.