### PR TITLE
Removes possibility of duplicate scraper generation

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -271,13 +271,24 @@ def main():
 
     class_name = sys.argv[1]
     url = sys.argv[2]
-    host_name = get_host_name(url)
+    host_name = get_host_name(url).split(".")[0]
+
+    host_exists = False
+    with open("recipe_scrapers/__init__.py", "r") as source:
+        code = source.read()
+        if host_name.lower() in code.lower():
+            host_exists = True
+            print(
+                f"Host {host_name} already exists. Skipping scraper and __init__ generation."
+            )
     testhtml = requests.get(url, headers=HEADERS).content
 
-    generate_scraper(class_name, host_name)
+    if not host_exists:
+        generate_scraper(class_name, host_name)
+        init_scraper(class_name)
+
     generate_scraper_test(class_name, host_name, url)
     generate_test_data(class_name, testhtml)
-    init_scraper(class_name)
 
 
 if __name__ == "__main__":

--- a/generate.py
+++ b/generate.py
@@ -278,17 +278,19 @@ def main():
         code = source.read()
         if host_name.lower() in code.lower():
             host_exists = True
-            print(
-                f"Host {host_name} already exists. Skipping scraper and __init__ generation."
-            )
-    testhtml = requests.get(url, headers=HEADERS).content
+            message = f"Host {host_name} already exists."
+            if "_" in class_name:
+                message += " Skipping scraper and __init__ entry generation."
+            print(message)
 
-    if not host_exists:
-        generate_scraper(class_name, host_name)
-        init_scraper(class_name)
-
-    generate_scraper_test(class_name, host_name, url)
-    generate_test_data(class_name, testhtml)
+    if not host_exists or "_" in class_name:
+        testhtml = requests.get(url, headers=HEADERS).content
+        if not host_exists:
+            generate_scraper(class_name, host_name)
+            init_scraper(class_name)
+        if "_" in class_name:
+            generate_scraper_test(class_name, host_name, url)
+            generate_test_data(class_name, testhtml)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As discussed in #924 this PR adds functionality to the generate.py file to check if the host name already exists and respond appropriately

- For an existing host, running python .\generate.py ClassName URL will now only print "Host {host_name} already exists" and won't generate any files.
- For a class name with an underscore and an existing host, running python .\generate.py ClassName_2 URL will print "Host {host_name} already exists. Skipping scraper and init entry generation." and will only generate the testhtml and testcase files.

Example usage
```python
python .\generate.py ethanchlebowski https://www.ethanchlebowski.com/cooking-techniques-recipes/ciabatta-chimichurri-steak-sandwich  
Host ethanchlebowski already exists.

python .\generate.py ethanchlebowski_2 https://www.ethanchlebowski.com/cooking-techniques-recipes/ciabatta-chimichurri-steak-sandwich
Host ethanchlebowski already exists. Skipping scraper and __init__ entry generation.
```