### PR TITLE
goustojson scraper fix

### DIFF
--- a/recipe_scrapers/goustojson.py
+++ b/recipe_scrapers/goustojson.py
@@ -53,7 +53,8 @@ class GoustoJson(AbstractScraper):
         return [
             normalize_string(ingredient.get("label"))
             for ingredient in self.data.get("ingredients")
-            if isinstance(ingredient, dict) and "label" in ingredient.keys()
+            if isinstance(ingredient, dict)
+            and ingredient.get("label", None) is not None
         ]
 
     def instructions_list(self):

--- a/tests/test_data/gousto.testjson
+++ b/tests/test_data/gousto.testjson
@@ -2,80 +2,96 @@
   "status": "ok",
   "data": {
     "entry": {
-      "url": "/malaysian-style-coconut-meat-free-chicken-pickled-cucumber",
-      "title": "Malaysian-Style Coconut Meat-Free Chicken With Pickled Cucumber",
+      "url": "/3-cheese-veg-packed-pasta-bake",
+      "title": "3 Cheese Veg-Packed Pasta Bake",
       "categories": [
         {
           "title": "All Recipes",
           "url": "/recipes",
           "uid": "blt99b86694701028c1"
+        },
+        {
+          "title": "Vegetarian Recipes ",
+          "url": "/vegetarian-recipes",
+          "uid": "blta762d7d1d30213a2"
+        },
+        {
+          "title": "Vegetarian",
+          "url": "/vegetarian",
+          "uid": "blt5cc8b5413c283f12"
+        },
+        {
+          "title": "Everyday Favourites",
+          "url": "/everyday-favourites",
+          "uid": "blt07ef0eaa85ddfa4e"
         }
       ],
-      "gousto_id": "4138",
-      "gousto_uid": "3a1a9141-1ad1-4da8-b4ac-cf9b33f4df72",
+      "gousto_id": "2146",
+      "gousto_uid": "e03c9a77-c54b-4b7c-bc6b-d71b7f158c5b",
       "media": {
         "images": [
           {
-            "image": "https://production-media.gousto.co.uk/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600-x200.jpg",
+            "image": "https://production-media.gousto.co.uk/cms/mood-image/2023---3-Cheese-Veg-Packed-Pasta-Bake-7065-1579799730289-x200.jpg",
             "width": 200
           },
           {
-            "image": "https://production-media.gousto.co.uk/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600-x400.jpg",
+            "image": "https://production-media.gousto.co.uk/cms/mood-image/2023---3-Cheese-Veg-Packed-Pasta-Bake-7065-1579799730289-x400.jpg",
             "width": 400
           },
           {
-            "image": "https://production-media.gousto.co.uk/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600-x700.jpg",
+            "image": "https://production-media.gousto.co.uk/cms/mood-image/2023---3-Cheese-Veg-Packed-Pasta-Bake-7065-1579799730289-x700.jpg",
             "width": 700
           },
           {
-            "image": "https://production-media.gousto.co.uk/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600-x1000.jpg",
+            "image": "https://production-media.gousto.co.uk/cms/mood-image/2023---3-Cheese-Veg-Packed-Pasta-Bake-7065-1579799730289-x1000.jpg",
             "width": 1000
           },
           {
-            "image": "https://production-media.gousto.co.uk/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600-x1500.jpg",
+            "image": "https://production-media.gousto.co.uk/cms/mood-image/2023---3-Cheese-Veg-Packed-Pasta-Bake-7065-1579799730289-x1500.jpg",
             "width": 1500
           }
         ]
       },
       "rating": {
         "average": 5,
-        "count": 747
+        "count": 123989
       },
-      "description": "Inspired by the fragrant flavours of the classic Malaysian chicken dish 'Ayam Percik'. Our spice paste blends lemongrass, almonds and ginger before adding coconut cream and meat-free chicken. Served with fluffy rice and quick-pickled cucumber.",
+      "description": "This hearty pasta dish doesn't just have a rich tomato sauce, it's layered with mozzarella, cheddar cheese and Italian hard cheese for a tasty and wholesome midweek bake.",
       "prep_times": {
         "for_2": 25,
-        "for_4": 35
+        "for_4": 30
       },
       "cuisine": {
-        "slug": "asian",
-        "title": "Asian"
+        "slug": "italian",
+        "title": "Italian"
       },
       "ingredients": [
         {
-          "label": "50g solid creamed coconut",
-          "title": "50g solid coconut cream-I-06-SML-CO-12",
-          "uid": "blt8aa7a500a10b060d",
-          "name": "50g solid coconut cream",
+          "label": "10g parsley",
+          "title": "parsley-I-07-HBS-PL-25",
+          "uid": "bltea262efbf1ed9532",
+          "gousto_uuid": "2ad9f7c1-18f7-4974-b647-95059a432969",
+          "name": "parsley",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Flecked-coconut-cream-2-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5g-parsley-copy-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Flecked-coconut-cream-2-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5g-parsley-copy-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Flecked-coconut-cream-2-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5g-parsley-copy-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Flecked-coconut-cream-2-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5g-parsley-copy-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Flecked-coconut-cream-2-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5g-parsley-copy-x1500.jpg",
                 "width": 1500
               }
             ]
@@ -85,129 +101,31 @@
           }
         },
         {
-          "label": "15g fresh root ginger",
-          "title": "15g fresh root ginger-I-06-SML-OT-25",
-          "uid": "bltc22d54e029ba9745",
-          "name": "15g fresh root ginger",
+          "label": "40g cheddar cheese",
+          "title": "cheddar cheese-I-09-DAI-CH-02",
+          "uid": "bltcf8784004b8281e0",
+          "gousto_uuid": "aed1561d-bae6-487b-a645-4125a6829119",
+          "name": "cheddar cheese",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/fresh-root-ginger-1-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/40g-cheddar-cheese-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/fresh-root-ginger-1-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/40g-cheddar-cheese-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/fresh-root-ginger-1-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/40g-cheddar-cheese-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/fresh-root-ginger-1-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/40g-cheddar-cheese-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/fresh-root-ginger-1-x1500.jpg",
-                "width": 1500
-              }
-            ]
-          },
-          "allergens": {
-            "allergen": []
-          }
-        },
-        {
-          "label": "1 tsp ground turmeric",
-          "title": "1 tsp ground turmeric-IQ-06-SML-IN-04-02",
-          "uid": "blt82b75bfb157a4f5a",
-          "name": "1 tsp ground turmeric",
-          "media": {
-            "images": [
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tsp-ground-turmeric-x200.jpg",
-                "width": 200
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tsp-ground-turmeric-x400.jpg",
-                "width": 400
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tsp-ground-turmeric-x700.jpg",
-                "width": 700
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tsp-ground-turmeric-x1000.jpg",
-                "width": 1000
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tsp-ground-turmeric-x1500.jpg",
-                "width": 1500
-              }
-            ]
-          },
-          "allergens": {
-            "allergen": []
-          }
-        },
-        {
-          "label": "2 shallots",
-          "title": "1 shallot-I-02-SVG-VG-10",
-          "uid": "blt011a15790b863f51",
-          "name": "1 shallot",
-          "media": {
-            "images": [
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-shallot-x200.jpg",
-                "width": 200
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-shallot-x400.jpg",
-                "width": 400
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-shallot-x700.jpg",
-                "width": 700
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-shallot-x1000.jpg",
-                "width": 1000
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-shallot-x1500.jpg",
-                "width": 1500
-              }
-            ]
-          },
-          "allergens": {
-            "allergen": []
-          }
-        },
-        {
-          "label": "15ml soy sauce",
-          "title": "15ml soy sauce-I-06-SML-OT-14",
-          "uid": "blt3a79c2be8bfcc885",
-          "name": "15ml soy sauce",
-          "media": {
-            "images": [
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-soy-sauce-sachet-15ml-copy-x200.jpg",
-                "width": 200
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-soy-sauce-sachet-15ml-copy-x400.jpg",
-                "width": 400
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-soy-sauce-sachet-15ml-copy-x700.jpg",
-                "width": 700
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-soy-sauce-sachet-15ml-copy-x1000.jpg",
-                "width": 1000
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-soy-sauce-sachet-15ml-copy-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/40g-cheddar-cheese-x1500.jpg",
                 "width": 1500
               }
             ]
@@ -215,39 +133,105 @@
           "allergens": {
             "allergen": [
               {
-                "slug": "gluten"
-              },
-              {
-                "slug": "soya"
+                "slug": "milk"
               }
             ]
           }
         },
         {
-          "label": "165g meat-free chicken bites",
-          "title": "165g meat-free chicken bites-I-10-MPF-VE-04",
-          "uid": "bltaa06a044416f375f",
-          "name": "165g meat-free chicken bites",
+          "label": "200g finely chopped tomatoes",
+          "title": "finely chopped tomatoes-I-01-CAN-VC-50",
+          "uid": "blt269c8bc966804e9e",
+          "gousto_uuid": "f217148a-bb67-4f4e-a820-02a5122c2d3a",
+          "name": "finely chopped tomatoes",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Vegan-roast-chicken-bites-165g-2-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-can-of-chopped-tomatoes-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Vegan-roast-chicken-bites-165g-2-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-can-of-chopped-tomatoes-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Vegan-roast-chicken-bites-165g-2-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-can-of-chopped-tomatoes-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Vegan-roast-chicken-bites-165g-2-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-can-of-chopped-tomatoes-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/Vegan-roast-chicken-bites-165g-2-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-can-of-chopped-tomatoes-x1500.jpg",
+                "width": 1500
+              }
+            ]
+          },
+          "allergens": {
+            "allergen": []
+          }
+        },
+        {
+          "label": "1 tsp dried basil",
+          "title": "dried basil-I-06-SML-DL-18",
+          "uid": "bltff02573d08c29139",
+          "gousto_uuid": "8f225055-491a-4b53-9a69-ac7e4810d725",
+          "name": "dried basil",
+          "media": {
+            "images": [
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/dried-basil-2-x200.jpg",
+                "width": 200
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/dried-basil-2-x400.jpg",
+                "width": 400
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/dried-basil-2-x700.jpg",
+                "width": 700
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/dried-basil-2-x1000.jpg",
+                "width": 1000
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/dried-basil-2-x1500.jpg",
+                "width": 1500
+              }
+            ]
+          },
+          "allergens": {
+            "allergen": []
+          }
+        },
+        {
+          "label": "20g Italian hard cheese",
+          "title": "Italian hard cheese-I-09-DAI-CH-41",
+          "uid": "blteef8db6635d96ea9",
+          "gousto_uuid": "d5fc7e99-0340-4983-a486-e4f18ce5483b",
+          "name": "Italian hard cheese",
+          "media": {
+            "images": [
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/35g-Italian-hard-cheese-x200.jpg",
+                "width": 200
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/35g-Italian-hard-cheese-x400.jpg",
+                "width": 400
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/35g-Italian-hard-cheese-x700.jpg",
+                "width": 700
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/35g-Italian-hard-cheese-x1000.jpg",
+                "width": 1000
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/35g-Italian-hard-cheese-x1500.jpg",
                 "width": 1500
               }
             ]
@@ -255,39 +239,37 @@
           "allergens": {
             "allergen": [
               {
-                "slug": "gluten"
-              },
-              {
-                "slug": "soya"
+                "slug": "milk"
               }
             ]
           }
         },
         {
-          "label": "130g basmati rice",
-          "title": "130g basmati rice-IQ-03-GRN-RC-28-02",
-          "uid": "blteb8900921e2e4621",
-          "name": "130g basmati rice",
+          "label": null,
+          "title": "vegetable stock mix-I-06-SML-SC-26",
+          "uid": "blt0ca5e580e2d973c5",
+          "gousto_uuid": "166bfad3-d300-465d-b61c-fef4d2965904",
+          "name": "vegetable stock mix",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/100g-basmati-rice-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/100g-basmati-rice-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/100g-basmati-rice-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/100g-basmati-rice-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/100g-basmati-rice-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x1500.jpg",
                 "width": 1500
               }
             ]
@@ -297,30 +279,31 @@
           }
         },
         {
-          "label": "15g tamarind paste",
-          "title": "15g tamarind paste-I-08-SAU-PS-19",
-          "uid": "blta8e632d4b4071d62",
-          "name": "15g tamarind paste",
+          "label": "11g vegetable stock mix",
+          "title": "vegetable stock mix-I-06-SML-SC-27",
+          "uid": "bltebbd714d321e7e43",
+          "gousto_uuid": "0b0b68a5-7e0b-4f87-9ffd-3fd67f464b9f",
+          "name": "vegetable stock mix",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tamarind-paste-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tamarind-paste-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tamarind-paste-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tamarind-paste-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tamarind-paste-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/5.5g-vegetable-stock-powder-x1500.jpg",
                 "width": 1500
               }
             ]
@@ -330,30 +313,31 @@
           }
         },
         {
-          "label": "30ml rice vinegar",
-          "title": "30ml rice vinegar-I-08-SAU-LS-29",
-          "uid": "blt436230b41fce5828",
-          "name": "30ml rice vinegar",
+          "label": "16g tomato paste",
+          "title": "tomato paste-I-08-SAU-PS-36",
+          "uid": "blt5fa8ca0463cfd067",
+          "gousto_uuid": "0ccd25ca-a1b2-49b3-a1d8-22b5b2d72f4b",
+          "name": "tomato paste",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tbsp-rice-vinegar-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/toamto-paste-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tbsp-rice-vinegar-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/toamto-paste-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tbsp-rice-vinegar-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/toamto-paste-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tbsp-rice-vinegar-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/toamto-paste-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-tbsp-rice-vinegar-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/toamto-paste-x1500.jpg",
                 "width": 1500
               }
             ]
@@ -363,76 +347,49 @@
           }
         },
         {
-          "label": "1 red chilli",
-          "title": "1 red chilli-I-05-FVG-FV-06",
-          "uid": "blt9449c22aa5aa8996",
-          "name": "1 red chilli",
+          "label": "125g mozzarella",
+          "title": "mozzarella-I-09-DAI-CH-06",
+          "uid": "bltc60ef78862781ea1",
+          "gousto_uuid": "d93301c4-2563-4b9d-b829-991800ca87b4",
+          "name": "mozzarella",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/red-chilli-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-mozzarella-ball-125g-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/red-chilli-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-mozzarella-ball-125g-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/red-chilli-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-mozzarella-ball-125g-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/red-chilli-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-mozzarella-ball-125g-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/red-chilli-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-mozzarella-ball-125g-x1500.jpg",
                 "width": 1500
               }
             ]
           },
           "allergens": {
-            "allergen": []
-          }
-        },
-        {
-          "label": "1/2 cucumber",
-          "title": "1/2 cucumber-I-07-HBS-PL-11",
-          "uid": "blt4681c62966ac9eab",
-          "name": "1/2 cucumber",
-          "media": {
-            "images": [
+            "allergen": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cucumber-x200.jpg",
-                "width": 200
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cucumber-x400.jpg",
-                "width": 400
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cucumber-x700.jpg",
-                "width": 700
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cucumber-x1000.jpg",
-                "width": 1000
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cucumber-x1500.jpg",
-                "width": 1500
+                "slug": "milk"
               }
             ]
-          },
-          "allergens": {
-            "allergen": []
           }
         },
         {
-          "label": "3 garlic cloves",
-          "title": "1 garlic clove-I-06-SML-OT-02",
+          "label": "2 garlic cloves",
+          "title": "garlic clove-I-06-SML-OT-02",
           "uid": "bltb25c60cccec7cd15",
-          "name": "1 garlic clove",
+          "gousto_uuid": "0cdeefe0-26b8-42f2-bced-9e677f809a26",
+          "name": "garlic clove",
           "media": {
             "images": [
               {
@@ -462,73 +419,31 @@
           }
         },
         {
-          "label": "25g blanched almonds",
-          "title": "25g blanched almonds-I-04-NUT-NT-01-30",
-          "uid": "bltde57670e75c640c0",
-          "name": "25g blanched almonds",
+          "label": "1 courgette",
+          "title": "courgette-I-05-FVG-FV-03",
+          "uid": "blt49ae7a50bc5644f9",
+          "gousto_uuid": "5aba18db-c907-44f5-a499-3f53c5ab676a",
+          "name": "courgette",
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-bag-of-blanched-almonds-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/courgette-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-bag-of-blanched-almonds-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/courgette-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-bag-of-blanched-almonds-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/courgette-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-bag-of-blanched-almonds-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/courgette-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-bag-of-blanched-almonds-x1500.jpg",
-                "width": 1500
-              }
-            ]
-          },
-          "allergens": {
-            "allergen": [
-              {
-                "slug": "nut"
-              },
-              {
-                "slug": "peanut"
-              },
-              {
-                "slug": "sesame"
-              }
-            ]
-          }
-        },
-        {
-          "label": "1 fresh lemongrass",
-          "title": "1 fresh lemongrass stalk-I-07-HBS-PL-40",
-          "uid": "blt77cb1bbb2dd44b40",
-          "name": "1 fresh lemongrass stalk",
-          "media": {
-            "images": [
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-fresh-lemongrass-x200.jpg",
-                "width": 200
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-fresh-lemongrass-x400.jpg",
-                "width": 400
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-fresh-lemongrass-x700.jpg",
-                "width": 700
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-fresh-lemongrass-x1000.jpg",
-                "width": 1000
-              },
-              {
-                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/1-fresh-lemongrass-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/courgette-x1500.jpg",
                 "width": 1500
               }
             ]
@@ -536,9 +451,123 @@
           "allergens": {
             "allergen": []
           }
+        },
+        {
+          "label": "125g cherry tomatoes",
+          "title": "cherry tomatoes-I-05-FVG-FV-02-08",
+          "uid": "blt60df91997e03dd15",
+          "gousto_uuid": "b3374bc8-0097-449f-9ac6-b53299104e11",
+          "name": "cherry tomatoes",
+          "media": {
+            "images": [
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cherry-tomatoes-x200.jpg",
+                "width": 200
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cherry-tomatoes-x400.jpg",
+                "width": 400
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cherry-tomatoes-x700.jpg",
+                "width": 700
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cherry-tomatoes-x1000.jpg",
+                "width": 1000
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/cherry-tomatoes-x1500.jpg",
+                "width": 1500
+              }
+            ]
+          },
+          "allergens": {
+            "allergen": []
+          }
+        },
+        {
+          "label": "15ml balsamic vinegar",
+          "title": "balsamic vinegar-I-08-SAU-LS-15",
+          "uid": "blt36b3f7d5608537b7",
+          "gousto_uuid": "8357c090-d832-41bc-a458-b13600637e1b",
+          "name": "balsamic vinegar",
+          "media": {
+            "images": [
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/balsamic-vinegar-1-x200.jpg",
+                "width": 200
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/balsamic-vinegar-1-x400.jpg",
+                "width": 400
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/balsamic-vinegar-1-x700.jpg",
+                "width": 700
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/balsamic-vinegar-1-x1000.jpg",
+                "width": 1000
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/balsamic-vinegar-1-x1500.jpg",
+                "width": 1500
+              }
+            ]
+          },
+          "allergens": {
+            "allergen": [
+              {
+                "slug": "sulphites"
+              }
+            ]
+          }
+        },
+        {
+          "label": " 200g tortiglioni",
+          "title": "tortiglioni-IQ-03-GRN-PA-20-02",
+          "uid": "blt531310de7790801b",
+          "gousto_uuid": "248e9920-213f-426d-90d4-611a29171065",
+          "name": "tortiglioni",
+          "media": {
+            "images": [
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tortiglioni-1-x200.jpg",
+                "width": 200
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tortiglioni-1-x400.jpg",
+                "width": 400
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tortiglioni-1-x700.jpg",
+                "width": 700
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tortiglioni-1-x1000.jpg",
+                "width": 1000
+              },
+              {
+                "image": "https://production-media.gousto.co.uk/cms/ingredient-image/tortiglioni-1-x1500.jpg",
+                "width": 1500
+              }
+            ]
+          },
+          "allergens": {
+            "allergen": [
+              {
+                "slug": "gluten"
+              }
+            ]
+          }
         }
       ],
       "basics": [
+        {
+          "title": "Olive oil",
+          "slug": "olive-oil"
+        },
         {
           "title": "Pepper",
           "slug": "pepper"
@@ -550,211 +579,207 @@
         {
           "title": "Sugar",
           "slug": "sugar"
-        },
-        {
-          "title": "Vegetable oil",
-          "slug": "vegetable-oil"
         }
       ],
       "cooking_instructions": [
         {
-          "instruction": "<p>Add the <strong>basmati rice</strong> and 300ml <span class=\"text-danger\">[600ml]</span><strong> cold water </strong>to a pot with a lid and bring to the boil over a high heat</p><p>Once boiling, reduce the heat to very low and cook, covered, for 10-12 min or until all the water has absorbed and the rice is cooked</p><p>Once cooked, remove from the heat and keep covered until serving</p>",
+          "instruction": "<p>Preheat the oven to 240\u00baC/ 220\u00baC (fan)/ gas 9</p><p>Boil a kettle</p><p>Peel and finely chop (or grate) the <strong>garlic</strong></p>",
           "order": 1,
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-1-1-1636107472813-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-1-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-1-1-1636107472813-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-1-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-1-1-1636107472813-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-1-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-1-1-1636107472813-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-1-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-1-1-1636107472813-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-1-x1500.jpg",
                 "width": 1500
               }
             ]
           }
         },
         {
-          "instruction": "<p>While the rice is cooking, bash the <strong>lemongrass stalk<span class=\"text-danger\">[s]</span></strong> with a <strong>rolling pin</strong>, cut down the middle lengthways, remove the <strong>tough outer layers</strong> and chop the <strong>softer inner core<span class=\"text-danger\">[s]</span></strong> finely</p><p>Peel and roughly chop the<strong> shallots</strong>, <strong>garlic </strong>and<strong> ginger</strong></p><p>Chop <strong>half</strong> of the <strong>red</strong> <strong>chilli<span class=\"text-danger\">[es] </span></strong>roughly, and finely slice the rest (save these for garnish!)</p><p>Put everything into a <strong>food processor</strong></p>",
+          "instruction": "<p>Add the\u00a0<strong>tortiglioni</strong>\u00a0to a pot of\u00a0<strong>boiled water\u00a0</strong>with a pinch of\u00a0<strong>salt</strong>, bring to the boil over a high heat and cook for 8-10 min or until cooked with a slight bite</p><p>Once cooked,\u00a0drain the<strong> tortiglioni</strong></p><p>Reboil half a kettle</p>",
           "order": 2,
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-2-1636107479938-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-2-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-2-1636107479938-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-2-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-2-1636107479938-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-2-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-2-1636107479938-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-2-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-2-1636107479938-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-2-x1500.jpg",
                 "width": 1500
               }
             ]
           }
         },
         {
-          "instruction": "<p>Add the <strong>blanched almonds </strong>and <strong>half</strong> the<strong> ground turmeric </strong>(you’ll use the rest later!) to the<strong> food processor</strong> with 2 tbsp <span class=\"text-danger\">[4 tbsp] </span><strong>vegetable oil</strong></p><p>Add the <strong>soy sauce</strong> and a pinch of<strong> sugar</strong></p><p>Pulse until you're left with a slightly chunky paste – this is your<strong> spice paste</strong></p>",
+          "instruction": "<p>While the pasta is cooking, top, tail and chop the <strong>courgette<span class=\"text-danger\">[s]</span> </strong>into quarters lengthways, then slice finely</p><p>Heat a large, wide-based pan (preferably non-stick) with a drizzle of <strong>olive oil</strong> over a medium-high heat</p><p>Once hot, add the <strong>sliced courgette</strong> with a pinch of <strong>salt</strong> and cook for 4 min or until beginning to soften</p>",
           "order": 3,
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-3-1-1636107485348-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-3-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-3-1-1636107485348-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-3-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-3-1-1636107485348-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-3-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-3-1-1636107485348-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-3-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-3-1-1636107485348-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-3-x1500.jpg",
                 "width": 1500
               }
             ]
           }
         },
         {
-          "instruction": "<p>Boil a kettle, then heat a large wide-based pan (preferably non-stick with a matching lid), with a drizzle of <strong>vegetable oil</strong> over a medium-high heat</p><p>Cut the <strong>meat-free chicken</strong> into smaller, bite-sized pieces</p><p>Add the <strong>meat-free chicken pieces</strong> to the pan and sprinkle over the <strong>remaining</strong> <strong>ground turmeric</strong> and a pinch of<strong> salt </strong>and<strong> pepper</strong></p><p>Cook for 2-3 min or until warmed through and starting to brown</p>",
+          "instruction": "<p>Meanwhile, dissolve the <strong>vegetable stock mix</strong>, <strong>dried basil</strong>, <strong>balsamic vinegar</strong>, <strong>tomato paste</strong> and 1 tsp <span class=\"text-danger\">[2 tsp]</span> <strong>sugar</strong> in 100ml<span class=\"text-danger\"> [150ml]</span> <strong>boiled water</strong> \u2013 this is your<strong> stock</strong></p><p>Chop the <strong>cherry tomatoes </strong>roughly</p>",
           "order": 4,
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-4-1636107528114-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-4-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-4-1636107528114-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-4-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-4-1636107528114-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-4-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-4-1636107528114-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-4-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-4-1636107528114-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-4-x1500.jpg",
                 "width": 1500
               }
             ]
           }
         },
         {
-          "instruction": "<p>While the meat-free chicken is cooking, cut the <strong>cucumber<span class=\"text-danger\">[s]</span></strong> in half lengthways and then slice finely</p>",
+          "instruction": "<p>Once the courgette is beginning to soften, add the <strong>chopped garlic</strong> to the pan and cook for 30 secs</p><p>Add the <strong>stock</strong> with the <strong>chopped cherry tomatoes</strong> and<span class=\"text-danger\"> </span>the <strong>chopped tomatoes</strong> and bring to the boil over a high heat</p><p>Season with a generous grind of <strong>black pepper</strong> and cook for 3-4 min further</p>",
           "order": 5,
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-5-1636107533618-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-5-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-5-1636107533618-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-5-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-5-1636107533618-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-5-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-5-1636107533618-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-5-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-5-1636107533618-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-5-x1500.jpg",
                 "width": 1500
               }
             ]
           }
         },
         {
-          "instruction": "<p>Add the<strong> sliced cucumber</strong> to a bowl with the <strong>rice vinegar</strong>, 1 tsp <span class=\"text-danger\">[2 tsp] </span><strong>sugar</strong> and a generous pinch of<strong> salt</strong></p><p>Stir it all together and set aside until serving – this is your <strong>quick-pickled cucumber</strong></p>",
+          "instruction": "<p>Grate the <strong>cheddar cheese</strong></p><p>Grate the <strong>Italian hard cheese</strong></p><p>Drain the <strong>mozzarella</strong>, then pat and squeeze as much liquid out as you can with kitchen paper</p><p>Tear the <strong>drained mozzarella</strong> into rough, bite-sized pieces</p><p>Chop the <strong>parsley</strong> finely, including the stalks</p>",
           "order": 6,
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-6-1636107539493-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-6-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-6-1636107539493-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-6-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-6-1636107539493-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-6-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-6-1636107539493-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-6-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-6-1636107539493-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-6-x1500.jpg",
                 "width": 1500
               }
             ]
           }
         },
         {
-          "instruction": "<p>Add the <strong>spice paste</strong> to the<strong> </strong>meat-free chicken and cook for 2-3<span class=\"text-danger\"> </span>min<span class=\"text-danger\"> </span>or until fragrant</p><p>Once fragrant,<strong> </strong>add the<strong> tamarind paste</strong> with 200ml <span class=\"text-danger\">[300ml]</span> <strong>boiled water </strong>and cook for a further 2-3 min</p><p>Chop the <strong>creamed coconut </strong>roughly (if required!), then add it to the pan and cook for 1 min further – this is your <strong>Malaysian-style coconut meat-free chicken</strong></p>",
+          "instruction": "<p>Add the <strong>drained\u00a0tortiglioni</strong> to the <strong>sauce</strong> with the <strong>chopped parsley</strong> (save some for garnish!) and mix it up</p><p>Add <strong>half</strong> the <strong>pasta mixture</strong> to an <strong>oven-proof dish</strong>, then top with the <strong>grated cheddar cheese</strong></p><p>Top with the <strong>remaining pasta mixture</strong>, <strong>torn mozzarella</strong> and <strong>grated Italian hard cheese</strong> and put the dish in the oven for 5-10 min or until all the cheese has melted \u2013 this is your<strong> 3 cheese\u00a0veg-packed pasta bake</strong></p>",
           "order": 7,
           "media": {
             "images": [
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-7-1636107547970-x200.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-7-x200.jpg",
                 "width": 200
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-7-1636107547970-x400.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-7-x400.jpg",
                 "width": 400
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-7-1636107547970-x700.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-7-x700.jpg",
                 "width": 700
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-7-1636107547970-x1000.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-7-x1000.jpg",
                 "width": 1000
               },
               {
-                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/step-7-1636107547970-x1500.jpg",
+                "image": "https://production-media.gousto.co.uk/cms/recipe-step-image/2023.-step-7-x1500.jpg",
                 "width": 1500
               }
             ]
           }
         },
         {
-          "instruction": "<p>Serve the<strong> Malaysian-style coconut meat-free chicken</strong> with the <strong>cooked rice</strong> and <strong>quick-pickled cucumber</strong> to the side</p><p>Garnish with the <strong>reserved sliced chilli rounds </strong>(can't handle the heat? Go easy!)</p><p>Enjoy!</p>",
+          "instruction": "<p>Serve the <strong>3 cheese</strong> <strong>veg-packed pasta bake</strong> topped with the <strong>reserved chopped parsley</strong> and a grind of <strong>black pepper </strong>and enjoy!</p><p><strong><span class=\"text-danger\">Loved this recipe? Us too! That\u2019s why it\u2019s one of our Everyday Favourites, available every week.</span></strong></p>",
           "order": 8,
           "media": {
             "images": []
@@ -763,62 +788,548 @@
       ],
       "allergens": [
         {
-          "title": "nut",
-          "slug": "nut"
-        },
-        {
-          "title": "peanut",
-          "slug": "peanut"
-        },
-        {
-          "title": "sesame",
-          "slug": "sesame"
+          "title": "milk",
+          "slug": "milk"
         },
         {
           "title": "gluten",
           "slug": "gluten"
         },
         {
-          "title": "soya",
-          "slug": "soya"
+          "title": "sulphites",
+          "slug": "sulphites"
         }
       ],
       "seo": {
-        "title": "Malaysian-Style Coconut Meat-Free Chicken & Pickled Cucumber",
-        "description": "Inspired by the fragrant flavours of the classic Malaysian chicken dish 'Ayam Percik'. Our spice paste blends lemongrass, almonds and ginger before adding coconut cream and meat-free chicken. Served with fluffy rice and quick-pickled cucumber.",
+        "title": "3 Cheese Veg-Packed Pasta Bake",
+        "description": "This hearty courgette pasta doesn't just have a rich tomato sauce, it's layered with mozzarella, cheddar and Italian hard cheese for a tasty and wholesome midweek bake.",
         "robots": [],
         "canonical": "",
-        "open_graph_image": "https://s3-eu-west-1.amazonaws.com/s3-gousto-production-media/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600.jpg"
+        "open_graph_image": "https://production-media.gousto.co.uk/cms/mood-image/2023---3-Cheese-Veg-Packed-Pasta-Bake-7065-1579799730289.jpg"
       },
       "tags": [],
-      "uid": "bltbe42595eaba33f23",
-      "_version": 767,
+      "uid": "blta7fb47a546cfb850",
+      "_version": 84130,
       "nutritional_information": {
         "per_hundred_grams": {
-          "energy_kcal": 189,
-          "energy_kj": 794,
-          "fat_mg": 8318,
-          "fat_saturates_mg": 4873,
-          "carbs_mg": 18786,
-          "carbs_sugars_mg": 2623,
-          "fibre_mg": 3300,
-          "protein_mg": 8517,
-          "salt_mg": 732,
+          "energy_kcal": 147,
+          "energy_kj": 620,
+          "fat_mg": 4958,
+          "fat_saturates_mg": 3166,
+          "carbs_mg": 19557,
+          "carbs_sugars_mg": 2858,
+          "fibre_mg": 1485,
+          "protein_mg": 7323,
+          "salt_mg": 478,
           "net_weight_mg": 100000
         },
         "per_portion": {
-          "energy_kcal": 663,
-          "energy_kj": 2783,
-          "fat_mg": 29158,
-          "fat_saturates_mg": 17083,
-          "carbs_mg": 65846,
-          "carbs_sugars_mg": 9196,
-          "fibre_mg": 11567,
-          "protein_mg": 29855,
-          "salt_mg": 2569,
-          "net_weight_mg": 350500
+          "energy_kcal": 689,
+          "energy_kj": 2903,
+          "fat_mg": 23204,
+          "fat_saturates_mg": 14821,
+          "carbs_mg": 91529,
+          "carbs_sugars_mg": 13379,
+          "fibre_mg": 6954,
+          "protein_mg": 34276,
+          "salt_mg": 2238,
+          "net_weight_mg": 468000
         }
-      }
+      },
+      "portion_sizes": [
+        {
+          "portions": 1,
+          "is_offered": true,
+          "ingredients_skus": [
+            {
+              "id": "d5fc7e99-0340-4983-a486-e4f18ce5483b",
+              "code": "I-09-DAI-CH-41",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "8357c090-d832-41bc-a458-b13600637e1b",
+              "code": "I-08-SAU-LS-15",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "aed1561d-bae6-487b-a645-4125a6829119",
+              "code": "I-09-DAI-CH-02",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "b3374bc8-0097-449f-9ac6-b53299104e11",
+              "code": "I-05-FVG-FV-02-08",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "5aba18db-c907-44f5-a499-3f53c5ab676a",
+              "code": "I-05-FVG-FV-03",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "8f225055-491a-4b53-9a69-ac7e4810d725",
+              "code": "I-06-SML-DL-18",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "f217148a-bb67-4f4e-a820-02a5122c2d3a",
+              "code": "I-01-CAN-VC-50",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0cdeefe0-26b8-42f2-bced-9e677f809a26",
+              "code": "I-06-SML-OT-02",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "d93301c4-2563-4b9d-b829-991800ca87b4",
+              "code": "I-09-DAI-CH-06",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0ccd25ca-a1b2-49b3-a1d8-22b5b2d72f4b",
+              "code": "I-08-SAU-PS-36",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "248e9920-213f-426d-90d4-611a29171065",
+              "code": "IQ-03-GRN-PA-20-02",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "166bfad3-d300-465d-b61c-fef4d2965904",
+              "code": "I-06-SML-SC-26",
+              "quantities": {
+                "in_box": 1
+              }
+            }
+          ]
+        },
+        {
+          "portions": 2,
+          "is_offered": true,
+          "ingredients_skus": [
+            {
+              "id": "d5fc7e99-0340-4983-a486-e4f18ce5483b",
+              "code": "I-09-DAI-CH-41",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "8357c090-d832-41bc-a458-b13600637e1b",
+              "code": "I-08-SAU-LS-15",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "aed1561d-bae6-487b-a645-4125a6829119",
+              "code": "I-09-DAI-CH-02",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "b3374bc8-0097-449f-9ac6-b53299104e11",
+              "code": "I-05-FVG-FV-02-08",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "5aba18db-c907-44f5-a499-3f53c5ab676a",
+              "code": "I-05-FVG-FV-03",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "8f225055-491a-4b53-9a69-ac7e4810d725",
+              "code": "I-06-SML-DL-18",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "f217148a-bb67-4f4e-a820-02a5122c2d3a",
+              "code": "I-01-CAN-VC-50",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0cdeefe0-26b8-42f2-bced-9e677f809a26",
+              "code": "I-06-SML-OT-02",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "d93301c4-2563-4b9d-b829-991800ca87b4",
+              "code": "I-09-DAI-CH-06",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "2ad9f7c1-18f7-4974-b647-95059a432969",
+              "code": "I-07-HBS-PL-25",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0ccd25ca-a1b2-49b3-a1d8-22b5b2d72f4b",
+              "code": "I-08-SAU-PS-36",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "248e9920-213f-426d-90d4-611a29171065",
+              "code": "IQ-03-GRN-PA-20-02",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0b0b68a5-7e0b-4f87-9ffd-3fd67f464b9f",
+              "code": "I-06-SML-SC-27",
+              "quantities": {
+                "in_box": 1
+              }
+            }
+          ]
+        },
+        {
+          "portions": 3,
+          "is_offered": true,
+          "ingredients_skus": [
+            {
+              "id": "d5fc7e99-0340-4983-a486-e4f18ce5483b",
+              "code": "I-09-DAI-CH-41",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "8357c090-d832-41bc-a458-b13600637e1b",
+              "code": "I-08-SAU-LS-15",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "aed1561d-bae6-487b-a645-4125a6829119",
+              "code": "I-09-DAI-CH-02",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "b3374bc8-0097-449f-9ac6-b53299104e11",
+              "code": "I-05-FVG-FV-02-08",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "5aba18db-c907-44f5-a499-3f53c5ab676a",
+              "code": "I-05-FVG-FV-03",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "8f225055-491a-4b53-9a69-ac7e4810d725",
+              "code": "I-06-SML-DL-18",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "f217148a-bb67-4f4e-a820-02a5122c2d3a",
+              "code": "I-01-CAN-VC-50",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "0cdeefe0-26b8-42f2-bced-9e677f809a26",
+              "code": "I-06-SML-OT-02",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "d93301c4-2563-4b9d-b829-991800ca87b4",
+              "code": "I-09-DAI-CH-06",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "2ad9f7c1-18f7-4974-b647-95059a432969",
+              "code": "I-07-HBS-PL-25",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0ccd25ca-a1b2-49b3-a1d8-22b5b2d72f4b",
+              "code": "I-08-SAU-PS-36",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "248e9920-213f-426d-90d4-611a29171065",
+              "code": "IQ-03-GRN-PA-20-02",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "166bfad3-d300-465d-b61c-fef4d2965904",
+              "code": "I-06-SML-SC-26",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0b0b68a5-7e0b-4f87-9ffd-3fd67f464b9f",
+              "code": "I-06-SML-SC-27",
+              "quantities": {
+                "in_box": 1
+              }
+            }
+          ]
+        },
+        {
+          "portions": 4,
+          "is_offered": true,
+          "ingredients_skus": [
+            {
+              "id": "d5fc7e99-0340-4983-a486-e4f18ce5483b",
+              "code": "I-09-DAI-CH-41",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "8357c090-d832-41bc-a458-b13600637e1b",
+              "code": "I-08-SAU-LS-15",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "aed1561d-bae6-487b-a645-4125a6829119",
+              "code": "I-09-DAI-CH-02",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "b3374bc8-0097-449f-9ac6-b53299104e11",
+              "code": "I-05-FVG-FV-02-08",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "5aba18db-c907-44f5-a499-3f53c5ab676a",
+              "code": "I-05-FVG-FV-03",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "8f225055-491a-4b53-9a69-ac7e4810d725",
+              "code": "I-06-SML-DL-18",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "f217148a-bb67-4f4e-a820-02a5122c2d3a",
+              "code": "I-01-CAN-VC-50",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "0cdeefe0-26b8-42f2-bced-9e677f809a26",
+              "code": "I-06-SML-OT-02",
+              "quantities": {
+                "in_box": 4
+              }
+            },
+            {
+              "id": "d93301c4-2563-4b9d-b829-991800ca87b4",
+              "code": "I-09-DAI-CH-06",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "2ad9f7c1-18f7-4974-b647-95059a432969",
+              "code": "I-07-HBS-PL-25",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "0ccd25ca-a1b2-49b3-a1d8-22b5b2d72f4b",
+              "code": "I-08-SAU-PS-36",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "248e9920-213f-426d-90d4-611a29171065",
+              "code": "IQ-03-GRN-PA-20-02",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "0b0b68a5-7e0b-4f87-9ffd-3fd67f464b9f",
+              "code": "I-06-SML-SC-27",
+              "quantities": {
+                "in_box": 2
+              }
+            }
+          ]
+        },
+        {
+          "portions": 5,
+          "is_offered": true,
+          "ingredients_skus": [
+            {
+              "id": "d5fc7e99-0340-4983-a486-e4f18ce5483b",
+              "code": "I-09-DAI-CH-41",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "8357c090-d832-41bc-a458-b13600637e1b",
+              "code": "I-08-SAU-LS-15",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "aed1561d-bae6-487b-a645-4125a6829119",
+              "code": "I-09-DAI-CH-02",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "b3374bc8-0097-449f-9ac6-b53299104e11",
+              "code": "I-05-FVG-FV-02-08",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "5aba18db-c907-44f5-a499-3f53c5ab676a",
+              "code": "I-05-FVG-FV-03",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "8f225055-491a-4b53-9a69-ac7e4810d725",
+              "code": "I-06-SML-DL-18",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "f217148a-bb67-4f4e-a820-02a5122c2d3a",
+              "code": "I-01-CAN-VC-50",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "0cdeefe0-26b8-42f2-bced-9e677f809a26",
+              "code": "I-06-SML-OT-02",
+              "quantities": {
+                "in_box": 5
+              }
+            },
+            {
+              "id": "d93301c4-2563-4b9d-b829-991800ca87b4",
+              "code": "I-09-DAI-CH-06",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "2ad9f7c1-18f7-4974-b647-95059a432969",
+              "code": "I-07-HBS-PL-25",
+              "quantities": {
+                "in_box": 2
+              }
+            },
+            {
+              "id": "0ccd25ca-a1b2-49b3-a1d8-22b5b2d72f4b",
+              "code": "I-08-SAU-PS-36",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "248e9920-213f-426d-90d4-611a29171065",
+              "code": "IQ-03-GRN-PA-20-02",
+              "quantities": {
+                "in_box": 3
+              }
+            },
+            {
+              "id": "166bfad3-d300-465d-b61c-fef4d2965904",
+              "code": "I-06-SML-SC-26",
+              "quantities": {
+                "in_box": 1
+              }
+            },
+            {
+              "id": "0b0b68a5-7e0b-4f87-9ffd-3fd67f464b9f",
+              "code": "I-06-SML-SC-27",
+              "quantities": {
+                "in_box": 2
+              }
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/tests/test_goustojson.py
+++ b/tests/test_goustojson.py
@@ -9,33 +9,33 @@ class TestGoustoScraper(ScraperTest):
 
     @classmethod
     def expected_requests(cls):
-        yield GET, "https://www.gousto.co.uk/cookbook/recipes/malaysian-style-coconut-meat-free-chicken-pickled-cucumber", "tests/test_data/gousto.testjson"
-        yield GET, "https://production-api.gousto.co.uk/cmsreadbroker/v1/recipe/malaysian-style-coconut-meat-free-chicken-pickled-cucumber", "tests/test_data/gousto.testjson"
+        yield GET, "https://www.gousto.co.uk/cookbook/vegetarian-recipes/3-cheese-veg-packed-pasta-bake", "tests/test_data/gousto.testjson"
+        yield GET, "https://production-api.gousto.co.uk/cmsreadbroker/v1/recipe/3-cheese-veg-packed-pasta-bake", "tests/test_data/gousto.testjson"
 
     def test_host(self):
         self.assertEqual("gousto.co.uk", self.harvester_class.host())
 
     def test_canonical_url(self):
         self.assertEqual(
-            "https://www.gousto.co.uk/cookbook/recipes/malaysian-style-coconut-meat-free-chicken-pickled-cucumber",
+            "https://www.gousto.co.uk/cookbook/vegetarian-recipes/3-cheese-veg-packed-pasta-bake",
             self.harvester_class.canonical_url(),
         )
 
     def test_title(self):
         self.assertEqual(
             self.harvester_class.title(),
-            "Malaysian-Style Coconut Meat-Free Chicken With Pickled Cucumber",
+            "3 Cheese Veg-Packed Pasta Bake",
         )
 
     def test_description(self):
         self.assertEqual(
             self.harvester_class.description(),
-            "Inspired by the fragrant flavours of the classic Malaysian chicken dish 'Ayam Percik'. Our spice paste blends lemongrass, almonds and ginger before adding coconut cream and meat-free chicken. Served with fluffy rice and quick-pickled cucumber.",
+            "This hearty pasta dish doesn't just have a rich tomato sauce, it's layered with mozzarella, cheddar cheese and Italian hard cheese for a tasty and wholesome midweek bake.",
         )
 
     def test_image(self):
         self.assertEqual(
-            "https://s3-eu-west-1.amazonaws.com/s3-gousto-production-media/cms/mood-image/1930--Malaysian-Coconut-Chicken--Pickled-Cucumber-1636110687600.jpg",
+            "https://production-media.gousto.co.uk/cms/mood-image/2023---3-Cheese-Veg-Packed-Pasta-Bake-7065-1579799730289.jpg",
             self.harvester_class.image(),
         )
 
@@ -48,20 +48,19 @@ class TestGoustoScraper(ScraperTest):
     def test_ingredients(self):
         self.assertEqual(
             [
-                "50g solid creamed coconut",
-                "15g fresh root ginger",
-                "1 tsp ground turmeric",
-                "2 shallots",
-                "15ml soy sauce",
-                "165g meat-free chicken bites",
-                "130g basmati rice",
-                "15g tamarind paste",
-                "30ml rice vinegar",
-                "1 red chilli",
-                "1/2 cucumber",
-                "3 garlic cloves",
-                "25g blanched almonds",
-                "1 fresh lemongrass",
+                "10g parsley",
+                "40g cheddar cheese",
+                "200g finely chopped tomatoes",
+                "1 tsp dried basil",
+                "20g Italian hard cheese",
+                "11g vegetable stock mix",
+                "16g tomato paste",
+                "125g mozzarella",
+                "2 garlic cloves",
+                "1 courgette",
+                "125g cherry tomatoes",
+                "15ml balsamic vinegar",
+                "200g tortiglioni",
             ],
             self.harvester_class.ingredients(),
         )
@@ -69,21 +68,21 @@ class TestGoustoScraper(ScraperTest):
     def test_instructions_list(self):
         return self.assertEqual(
             [
-                "Add the basmati rice and 300ml [600ml] cold water to a pot with a lid and bring to the boil over a high heat\nOnce boiling, reduce the heat to very low and cook, covered, for 10-12 min or until all the water has absorbed and the rice is cooked\nOnce cooked, remove from the heat and keep covered until serving",
-                "While the rice is cooking, bash the lemongrass stalk[s] with a rolling pin, cut down the middle lengthways, remove the tough outer layers and chop the softer inner core[s] finely\nPeel and roughly chop the shallots, garlic and ginger\nChop half of the red chilli[es] roughly, and finely slice the rest (save these for garnish!)\nPut everything into a food processor",
-                "Add the blanched almonds and half the ground turmeric (you’ll use the rest later!) to the food processor with 2 tbsp [4 tbsp] vegetable oil\nAdd the soy sauce and a pinch of sugar\nPulse until you're left with a slightly chunky paste – this is your spice paste",
-                "Boil a kettle, then heat a large wide-based pan (preferably non-stick with a matching lid), with a drizzle of vegetable oil over a medium-high heat\nCut the meat-free chicken into smaller, bite-sized pieces\nAdd the meat-free chicken pieces to the pan and sprinkle over the remaining ground turmeric and a pinch of salt and pepper\nCook for 2-3 min or until warmed through and starting to brown",
-                "While the meat-free chicken is cooking, cut the cucumber[s] in half lengthways and then slice finely",
-                "Add the sliced cucumber to a bowl with the rice vinegar, 1 tsp [2 tsp] sugar and a generous pinch of salt\nStir it all together and set aside until serving – this is your quick-pickled cucumber",
-                "Add the spice paste to the meat-free chicken and cook for 2-3 min or until fragrant\nOnce fragrant, add the tamarind paste with 200ml [300ml] boiled water and cook for a further 2-3 min\nChop the creamed coconut roughly (if required!), then add it to the pan and cook for 1 min further – this is your Malaysian-style coconut meat-free chicken",
-                "Serve the Malaysian-style coconut meat-free chicken with the cooked rice and quick-pickled cucumber to the side\nGarnish with the reserved sliced chilli rounds (can't handle the heat? Go easy!)\nEnjoy!",
+                "Preheat the oven to 240ºC/ 220ºC (fan)/ gas 9\nBoil a kettle\nPeel and finely chop (or grate) the garlic",
+                "Add the tortiglioni to a pot of boiled water with a pinch of salt, bring to the boil over a high heat and cook for 8-10 min or until cooked with a slight bite\nOnce cooked, drain the tortiglioni\nReboil half a kettle",
+                "While the pasta is cooking, top, tail and chop the courgette[s] into quarters lengthways, then slice finely\nHeat a large, wide-based pan (preferably non-stick) with a drizzle of olive oil over a medium-high heat\nOnce hot, add the sliced courgette with a pinch of salt and cook for 4 min or until beginning to soften",
+                "Meanwhile, dissolve the vegetable stock mix, dried basil, balsamic vinegar, tomato paste and 1 tsp [2 tsp] sugar in 100ml [150ml] boiled water – this is your stock\nChop the cherry tomatoes roughly",
+                "Once the courgette is beginning to soften, add the chopped garlic to the pan and cook for 30 secs\nAdd the stock with the chopped cherry tomatoes and the chopped tomatoes and bring to the boil over a high heat\nSeason with a generous grind of black pepper and cook for 3-4 min further",
+                "Grate the cheddar cheese\nGrate the Italian hard cheese\nDrain the mozzarella, then pat and squeeze as much liquid out as you can with kitchen paper\nTear the drained mozzarella into rough, bite-sized pieces\nChop the parsley finely, including the stalks",
+                "Add the drained tortiglioni to the sauce with the chopped parsley (save some for garnish!) and mix it up\nAdd half the pasta mixture to an oven-proof dish, then top with the grated cheddar cheese\nTop with the remaining pasta mixture, torn mozzarella and grated Italian hard cheese and put the dish in the oven for 5-10 min or until all the cheese has melted – this is your 3 cheese veg-packed pasta bake",
+                "Serve the 3 cheese veg-packed pasta bake topped with the reserved chopped parsley and a grind of black pepper and enjoy!\nLoved this recipe? Us too! That’s why it’s one of our Everyday Favourites, available every week.",
             ],
             self.harvester_class.instructions_list(),
         )
 
     def test_instructions(self):
         return self.assertEqual(
-            "Add the basmati rice and 300ml [600ml] cold water to a pot with a lid and bring to the boil over a high heat\nOnce boiling, reduce the heat to very low and cook, covered, for 10-12 min or until all the water has absorbed and the rice is cooked\nOnce cooked, remove from the heat and keep covered until serving\nWhile the rice is cooking, bash the lemongrass stalk[s] with a rolling pin, cut down the middle lengthways, remove the tough outer layers and chop the softer inner core[s] finely\nPeel and roughly chop the shallots, garlic and ginger\nChop half of the red chilli[es] roughly, and finely slice the rest (save these for garnish!)\nPut everything into a food processor\nAdd the blanched almonds and half the ground turmeric (you’ll use the rest later!) to the food processor with 2 tbsp [4 tbsp] vegetable oil\nAdd the soy sauce and a pinch of sugar\nPulse until you're left with a slightly chunky paste – this is your spice paste\nBoil a kettle, then heat a large wide-based pan (preferably non-stick with a matching lid), with a drizzle of vegetable oil over a medium-high heat\nCut the meat-free chicken into smaller, bite-sized pieces\nAdd the meat-free chicken pieces to the pan and sprinkle over the remaining ground turmeric and a pinch of salt and pepper\nCook for 2-3 min or until warmed through and starting to brown\nWhile the meat-free chicken is cooking, cut the cucumber[s] in half lengthways and then slice finely\nAdd the sliced cucumber to a bowl with the rice vinegar, 1 tsp [2 tsp] sugar and a generous pinch of salt\nStir it all together and set aside until serving – this is your quick-pickled cucumber\nAdd the spice paste to the meat-free chicken and cook for 2-3 min or until fragrant\nOnce fragrant, add the tamarind paste with 200ml [300ml] boiled water and cook for a further 2-3 min\nChop the creamed coconut roughly (if required!), then add it to the pan and cook for 1 min further – this is your Malaysian-style coconut meat-free chicken\nServe the Malaysian-style coconut meat-free chicken with the cooked rice and quick-pickled cucumber to the side\nGarnish with the reserved sliced chilli rounds (can't handle the heat? Go easy!)\nEnjoy!",
+            "Preheat the oven to 240ºC/ 220ºC (fan)/ gas 9\nBoil a kettle\nPeel and finely chop (or grate) the garlic\nAdd the tortiglioni to a pot of boiled water with a pinch of salt, bring to the boil over a high heat and cook for 8-10 min or until cooked with a slight bite\nOnce cooked, drain the tortiglioni\nReboil half a kettle\nWhile the pasta is cooking, top, tail and chop the courgette[s] into quarters lengthways, then slice finely\nHeat a large, wide-based pan (preferably non-stick) with a drizzle of olive oil over a medium-high heat\nOnce hot, add the sliced courgette with a pinch of salt and cook for 4 min or until beginning to soften\nMeanwhile, dissolve the vegetable stock mix, dried basil, balsamic vinegar, tomato paste and 1 tsp [2 tsp] sugar in 100ml [150ml] boiled water – this is your stock\nChop the cherry tomatoes roughly\nOnce the courgette is beginning to soften, add the chopped garlic to the pan and cook for 30 secs\nAdd the stock with the chopped cherry tomatoes and the chopped tomatoes and bring to the boil over a high heat\nSeason with a generous grind of black pepper and cook for 3-4 min further\nGrate the cheddar cheese\nGrate the Italian hard cheese\nDrain the mozzarella, then pat and squeeze as much liquid out as you can with kitchen paper\nTear the drained mozzarella into rough, bite-sized pieces\nChop the parsley finely, including the stalks\nAdd the drained tortiglioni to the sauce with the chopped parsley (save some for garnish!) and mix it up\nAdd half the pasta mixture to an oven-proof dish, then top with the grated cheddar cheese\nTop with the remaining pasta mixture, torn mozzarella and grated Italian hard cheese and put the dish in the oven for 5-10 min or until all the cheese has melted – this is your 3 cheese veg-packed pasta bake\nServe the 3 cheese veg-packed pasta bake topped with the reserved chopped parsley and a grind of black pepper and enjoy!\nLoved this recipe? Us too! That’s why it’s one of our Everyday Favourites, available every week.",
             self.harvester_class.instructions(),
         )
 


### PR DESCRIPTION
Sometimes the json obtained from gousto has duplicate ingredient entries but the label value in the duplicate is None. This fix checks the value of the label key and skips any that are None.

Fixes #931 