### PR TITLE
Updates get_yields util functionality to handle additional metrics

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -44,6 +44,18 @@ RECIPE_YIELD_TYPES = (
     ("cupcake", "cupcakes"),
     ("loaf", "loaves"),
     ("pie", "pies"),
+    ("cup", "cups"),
+    ("pint", "pints"),
+    ("gallon", "gallons"),
+    ("ounce", "ounces"),
+    ("pound", "pounds"),
+    ("gram", "grams"),
+    ("liter", "liters"),
+    ("piece", "pieces"),
+    ("layer", "layers"),
+    ("scoop", "scoops"),
+    ("bar", "bars"),
+    ("patty", "patties"),
     # ... add more types as needed, in (singular, plural) format ...
 )
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -139,6 +139,8 @@ def get_yields(element):
         return f"{matched} batch{'' if int(matched) == 1 else 'es'}"
 
     if SERVE_REGEX_ITEMS.search(serve_text) is not None:
+        # This assumes if object(s), like sandwiches, it is 1 person.
+        # Issue: "Makes one 9-inch pie, (realsimple-testcase, gives "9 items")
         return "{} item{}".format(matched, "" if int(matched) == 1 else "s")
 
     return "{} serving{}".format(matched, "" if int(matched) == 1 else "s")

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -33,6 +33,20 @@ SERVE_REGEX_ITEMS = re.compile(
 
 SERVE_REGEX_TO = re.compile(r"\d+(\s+to\s+|-)\d+", flags=re.I | re.X)
 
+RECIPE_YIELD_TYPES = (
+    ("dozen", "dozens"),
+    ("batch", "batches"),
+    ("cake", "cakes"),
+    ("sandwich", "sandwiches"),
+    ("bun", "buns"),
+    ("cookie", "cookies"),
+    ("muffin", "muffins"),
+    ("cupcake", "cupcakes"),
+    ("loaf", "loaves"),
+    ("pie", "pies"),
+    # ... add more types as needed, in (singular, plural) format ...
+)
+
 
 def get_minutes(element, return_zero_on_not_found=False):  # noqa: C901: TODO
     if element is None:
@@ -112,16 +126,18 @@ def get_minutes(element, return_zero_on_not_found=False):  # noqa: C901: TODO
 
 def get_yields(element):
     """
+    Will return a string of servings or items, if the recipe is for number of items and not servings
+    the method will return the string "x item(s)" where x is the quantity.
     Returns a string of servings or items. If the recipe is for a number of items (not servings),
     it returns "x item(s)" where x is the quantity. This function handles cases where the yield is in dozens,
     such as "4 dozen cookies", returning "4 dozen" instead of "4 servings". Additionally
     accommodates yields specified in batches (e.g., "2 batches of brownies"), returning the yield as stated.
     :param element: Should be BeautifulSoup.TAG, in some cases not feasible and will then be text.
-    :return: The number of servings, items, dozen or batches.
+    :return: The number of servings or items.
+    :return: The number of servings, items, dozen, batches, etc...
     """
     if element is None:
         raise ElementNotFoundInHtml(element)
-
     if isinstance(element, str):
         serve_text = element
     else:
@@ -131,16 +147,13 @@ def get_yields(element):
         serve_text = serve_text.split(SERVE_REGEX_TO.split(serve_text, 2)[1], 2)[1]
 
     matched = SERVE_REGEX_NUMBER.search(serve_text).groupdict().get("items") or 0
+    serve_text_lower = serve_text.lower()
 
-    if "dozen" in serve_text.lower():
-        return f"{matched} dozen"
-
-    if "batch" in serve_text.lower():
-        return f"{matched} batch{'' if int(matched) == 1 else 'es'}"
+    for singular, plural in RECIPE_YIELD_TYPES:
+        if singular in serve_text_lower:
+            return "{} {}".format(matched, singular if int(matched) == 1 else plural)
 
     if SERVE_REGEX_ITEMS.search(serve_text) is not None:
-        # This assumes if object(s), like sandwiches, it is 1 person.
-        # Issue: "Makes one 9-inch pie, (realsimple-testcase, gives "9 items")
         return "{} item{}".format(matched, "" if int(matched) == 1 else "s")
 
     return "{} serving{}".format(matched, "" if int(matched) == 1 else "s")

--- a/tests/test_data/hersheyland.com/herseyland.json
+++ b/tests/test_data/hersheyland.com/herseyland.json
@@ -62,5 +62,5 @@
   "site_name": null,
   "title": "HERSHEY'S \"Perfectly Chocolate\" Chocolate Cake Recipe | Hersheyland",
   "total_time": 45,
-  "yields": "1 serving"
+  "yields": "1 cake"
 }

--- a/tests/test_data/kingarthurbaking.com/kingarthur.json
+++ b/tests/test_data/kingarthurbaking.com/kingarthur.json
@@ -70,5 +70,5 @@
   "site_name": "King Arthur Baking",
   "title": "Spiced Rye Ginger Cookies",
   "total_time": 35,
-  "yields": "22 items"
+  "yields": "22 cookies"
 }

--- a/tests/test_data/myplate.gov/usdamyplate.json
+++ b/tests/test_data/myplate.gov/usdamyplate.json
@@ -70,5 +70,5 @@
   "site_name": null,
   "title": "Fabulous Fig Bars",
   "total_time": 75,
-  "yields": "24 servings"
+  "yields": "24 bars"
 }

--- a/tests/test_data/myrecipes.com/myrecipes.json
+++ b/tests/test_data/myrecipes.com/myrecipes.json
@@ -35,5 +35,5 @@
   "site_name": "MyRecipes",
   "title": "Cacio e Pepe",
   "total_time": 20.0,
-  "yields": "2 items"
+  "yields": "2 cups"
 }

--- a/tests/test_data/ohsheglows.com/ohsheglows.json
+++ b/tests/test_data/ohsheglows.com/ohsheglows.json
@@ -52,5 +52,5 @@
   "site_name": "Oh She Glows",
   "title": "Obsession-Worthy Peanut Butter Cookie Ice Cream",
   "total_time": 22,
-  "yields": "8 servings"
+  "yields": "8 cups"
 }

--- a/tests/test_data/paninihappy.com/paninihappy.json
+++ b/tests/test_data/paninihappy.com/paninihappy.json
@@ -40,5 +40,5 @@
   "site_name": null,
   "title": "Grilled Mac & Cheese with BBQ Pulled Pork",
   "total_time": 30,
-  "yields": "4 items"
+  "yields": "4 sandwiches"
 }


### PR DESCRIPTION
Adds functionality to the get_yields function to handle cases where the "serving" metric is dozen (#960) or batches. 

This may be an unwanted functionality in which case we can just close this without merge but wanted to take a shot at addressing the bug report but if this is something that could be beneficial going forward it could be expanded to handle piece(s), jar(s), cup(s), slice(s), etc...

Resolves #960 