### PR TITLE
Run all tests for scraper even if an assertion fails

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -81,30 +81,32 @@ def test_func_factory(
         # Mandatory tests
         # If the key isn't present, check an assertion is raised
         for key in MANDATORY_TESTS:
-            scraper_func = getattr(actual, key)
-            if key in expect.keys():
-                self.assertEqual(
-                    expect[key],
-                    scraper_func(),
-                    msg=f"The actual value for .{key}() did not match the expected value.",
-                )
-            else:
-                with self.assertRaises(
-                    Exception,
-                    msg=f".{key}() was expected to raise an exception but it did not.",
-                ):
-                    scraper_func()
+            with self.subTest(key):
+                scraper_func = getattr(actual, key)
+                if key in expect.keys():
+                    self.assertEqual(
+                        expect[key],
+                        scraper_func(),
+                        msg=f"The actual value for .{key}() did not match the expected value.",
+                    )
+                else:
+                    with self.assertRaises(
+                        Exception,
+                        msg=f".{key}() was expected to raise an exception but it did not.",
+                    ):
+                        scraper_func()
 
         # Optional tests
         # If the key isn't present, skip
         for key in OPTIONAL_TESTS:
-            scraper_func = getattr(actual, key)
-            if key in expect.keys():
-                self.assertEqual(
-                    expect[key],
-                    scraper_func(),
-                    msg=f"The actual value for .{key}() did not match the expected value.",
-                )
+            with self.subTest(key):
+                scraper_func = getattr(actual, key)
+                if key in expect.keys():
+                    self.assertEqual(
+                        expect[key],
+                        scraper_func(),
+                        msg=f"The actual value for .{key}() did not match the expected value.",
+                    )
 
         # Assert that the ingredients returned by the ingredient_groups() function
         # are the same as the ingredients return by the ingredients() function.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -114,7 +114,8 @@ def test_func_factory(
         for group in actual.ingredient_groups():
             grouped.extend(group.ingredients)
 
-        self.assertEqual(sorted(actual.ingredients()), sorted(grouped))
+        with self.subTest("ingredient_groups"):
+            self.assertEqual(sorted(actual.ingredients()), sorted(grouped))
 
     return test_func
 


### PR DESCRIPTION
Prompted by @jayaddison's recent comment on #944, this changes how the test function for each scraper is built.

Currently, if an assertion fails for a scraper, the test function exists immediately and doesn't run any further tests for that scraper. With this change, each test is now run within a `unittest.subTest()` context manager, so that all the tests will run even if an assertion fails. 

As an example, I made two minor changes to the pickuplimes.json file to cause two of the tests to fail.

## Output before this change
```
$ python -m unittest -k pickuplimes
F
======================================================================
FAIL: tests/test_data/pickuplimes.com/pickuplimes.json (tests.RecipeTestCase.tests/test_data/pickuplimes.com/pickuplimes.json)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tom/Recipes/recipe-scrapers/tests/__init__.py", line 86, in test_func
    self.assertEqual(
AssertionError: 'Pick UpLimes' != 'Pick Up Limes'
- Pick UpLimes
+ Pick Up Limes
?        +
 : The actual value for .author() did not match the expected value.

----------------------------------------------------------------------
Ran 1 test in 0.091s

FAILED (failures=1)
```

## Output after this change
```
$ python -m unittest -k pickuplimes
FF
======================================================================
FAIL: tests/test_data/pickuplimes.com/pickuplimes.json (tests.RecipeTestCase.tests/test_data/pickuplimes.com/pickuplimes.json) [author]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tom/Recipes/recipe-scrapers/tests/__init__.py", line 87, in test_func
    self.assertEqual(
AssertionError: 'Pick UpLimes' != 'Pick Up Limes'
- Pick UpLimes
+ Pick Up Limes
?        +
 : The actual value for .author() did not match the expected value.

======================================================================
FAIL: tests/test_data/pickuplimes.com/pickuplimes.json (tests.RecipeTestCase.tests/test_data/pickuplimes.com/pickuplimes.json) [cook_time]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tom/Recipes/recipe-scrapers/tests/__init__.py", line 105, in test_func
    self.assertEqual(
AssertionError: 12 != 10 : The actual value for .cook_time() did not match the expected value.

----------------------------------------------------------------------
Ran 1 test in 0.182s

FAILED (failures=2)
```