### PR TITLE
Refactor the utils.get_minutes method

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -132,12 +132,12 @@ class SchemaOrg:
             return None
         if isinstance(v, str):
             return get_minutes(v)
-        # Workaround: strictly speaking schema.org does not provide for minValue (and maxValue) properties on objects of type Duration; they are however present on objects with type QuantitativeValue
+        # Workaround: strictly speaking schema.org does not provide for minValue and maxValue properties on objects of type Duration; they are however present on objects with type QuantitativeValue
         # Refs:
         #  - https://schema.org/Duration
         #  - https://schema.org/QuantitativeValue
-        if isinstance(v, dict) and v.get("minValue"):
-            return get_minutes(v["minValue"])
+        if isinstance(v, dict) and v.get("maxValue"):
+            return get_minutes(v["maxValue"])
         return None
 
     def total_time(self):

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -130,11 +130,11 @@ class SchemaOrg:
         v = self.data.get(k)
         if v is None:
             return None
-        if type(v) is int:
+        if isinstance(v, int):
             return v
-        if type(v) is str:
+        if isinstance(v, str):
             return get_minutes(v)
-        if type(v) is dict and v.get("minValue"):
+        if isinstance(v, dict) and v.get("minValue"):
             return get_minutes(v["minValue"])
         return None
 

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -130,8 +130,6 @@ class SchemaOrg:
         v = self.data.get(k)
         if v is None:
             return None
-        if isinstance(v, int):
-            return v
         if isinstance(v, str):
             return get_minutes(v)
         if isinstance(v, dict) and v.get("minValue"):

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -136,6 +136,7 @@ class SchemaOrg:
             return get_minutes(v)
         if type(v) is dict and v.get("minValue"):
             return get_minutes(v["minValue"])
+        return None
 
     def total_time(self):
         if not (self.data.keys() & {"totalTime", "prepTime", "cookTime"}):

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -132,6 +132,10 @@ class SchemaOrg:
             return None
         if isinstance(v, str):
             return get_minutes(v)
+        # Workaround: strictly speaking schema.org does not provide for minValue (and maxValue) properties on objects of type Duration; they are however present on objects with type QuantitativeValue
+        # Refs:
+        #  - https://schema.org/Duration
+        #  - https://schema.org/QuantitativeValue
         if isinstance(v, dict) and v.get("minValue"):
             return get_minutes(v["minValue"])
         return None

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -144,7 +144,7 @@ class SchemaOrg:
 
         total_time = self._read_time_field("totalTime")
         if total_time:
-            return get_minutes(total_time)
+            return total_time
 
         prep_time = self._read_time_field("prepTime") or 0
         cook_time = self._read_time_field("cookTime") or 0

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -1,7 +1,7 @@
 # mypy: disallow_untyped_defs=False
 # IF things in this file continue get messy (I'd say 300+ lines) it may be time to
 # find a package that parses https://schema.org/Recipe properly (or create one ourselves).
-
+from __future__ import annotations
 
 from itertools import chain
 

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -126,7 +126,7 @@ class SchemaOrg:
         if author:
             return author.strip()
 
-    def _read_time_field(self, k: str) -> int | None:
+    def _read_duration_field(self, k: str) -> int | None:
         v = self.data.get(k)
         if v is None:
             return None
@@ -144,24 +144,24 @@ class SchemaOrg:
         if not (self.data.keys() & {"totalTime", "prepTime", "cookTime"}):
             raise SchemaOrgException("Cooking time information not found in SchemaOrg")
 
-        total_time = self._read_time_field("totalTime")
+        total_time = self._read_duration_field("totalTime")
         if total_time:
             return total_time
 
-        prep_time = self._read_time_field("prepTime") or 0
-        cook_time = self._read_time_field("cookTime") or 0
+        prep_time = self._read_duration_field("prepTime") or 0
+        cook_time = self._read_duration_field("cookTime") or 0
         if prep_time or cook_time:
             return prep_time + cook_time
 
     def cook_time(self):
         if not (self.data.keys() & {"cookTime"}):
             raise SchemaOrgException("Cooktime information not found in SchemaOrg")
-        return self._read_time_field("cookTime")
+        return self._read_duration_field("cookTime")
 
     def prep_time(self):
         if not (self.data.keys() & {"prepTime"}):
             raise SchemaOrgException("Preptime information not found in SchemaOrg")
-        return self._read_time_field("prepTime")
+        return self._read_duration_field("prepTime")
 
     def yields(self):
         if not (self.data.keys() & {"recipeYield", "yield"}):

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -126,35 +126,39 @@ class SchemaOrg:
         if author:
             return author.strip()
 
+    def _read_time_field(self, k: str) -> int | None:
+        v = self.data.get(k)
+        if v is None:
+            return None
+        if type(v) is int:
+            return v
+        if type(v) is str:
+            return get_minutes(v)
+        if type(v) is dict and v.get("minValue"):
+            return get_minutes(v["minValue"])
+
     def total_time(self):
         if not (self.data.keys() & {"totalTime", "prepTime", "cookTime"}):
             raise SchemaOrgException("Cooking time information not found in SchemaOrg")
 
-        def get_key_and_minutes(k):
-            source = self.data.get(k)
-            # Workaround: strictly speaking schema.org does not provide for minValue (and maxValue) properties on objects of type Duration; they are however present on objects with type QuantitativeValue
-            # Refs:
-            #  - https://schema.org/Duration
-            #  - https://schema.org/QuantitativeValue
-            if type(source) is dict and "minValue" in source:
-                source = source["minValue"]
-            return get_minutes(source, return_zero_on_not_found=True)
+        total_time = self._read_time_field("totalTime")
+        if total_time:
+            return get_minutes(total_time)
 
-        total_time = get_key_and_minutes("totalTime")
-        if not total_time:
-            times = list(map(get_key_and_minutes, ["prepTime", "cookTime"]))
-            total_time = sum(times)
-        return total_time
+        prep_time = self._read_time_field("prepTime") or 0
+        cook_time = self._read_time_field("cookTime") or 0
+        if prep_time or cook_time:
+            return prep_time + cook_time
 
     def cook_time(self):
         if not (self.data.keys() & {"cookTime"}):
             raise SchemaOrgException("Cooktime information not found in SchemaOrg")
-        return get_minutes(self.data.get("cookTime"), return_zero_on_not_found=True)
+        return self._read_time_field("cookTime")
 
     def prep_time(self):
         if not (self.data.keys() & {"prepTime"}):
             raise SchemaOrgException("Preptime information not found in SchemaOrg")
-        return get_minutes(self.data.get("prepTime"), return_zero_on_not_found=True)
+        return self._read_time_field("prepTime")
 
     def yields(self):
         if not (self.data.keys() & {"recipeYield", "yield"}):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -101,7 +101,6 @@ def get_minutes(element):  # noqa: C901: TODO
     if hours_matched:
         hours_matched = hours_matched.strip()
         if any(symbol in FRACTIONS for symbol in hours_matched):
-            hours = 0
             for fraction, value in FRACTIONS.items():
                 if fraction in hours_matched:
                     hours += value
@@ -110,7 +109,6 @@ def get_minutes(element):  # noqa: C901: TODO
         elif "/" in hours_matched:
             # for example "1 1/2" is matched
             hours_matched_split = hours_matched.split(" ")
-            hours = 0
             if len(hours_matched_split) == 2:
                 hours += float(hours_matched_split[0])
             fraction = hours_matched_split[-1:][0].split("/")

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -119,10 +119,7 @@ def get_minutes(element):
     days = float(days_matched) if days_matched else 0
     hours = float(_extract_fractional(hours_matched)) if hours_matched else 0
     minutes = float(minutes_matched) if minutes_matched else 0
-
-    hours += round(days * 24)
-    minutes += round(hours * 60)
-    return minutes
+    return minutes + round(hours * 60) + round(days * 24 * 60)
 
 
 def get_yields(element):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -98,7 +98,7 @@ def get_minutes(element):  # noqa: C901: TODO
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     if days_matched:
-        minutes += 60 * 60 * float(days_matched.strip())
+        minutes += 60 * 60 * float(days_matched)
     if hours_matched:
         hours_matched = hours_matched.strip()
         if any([symbol in FRACTIONS.keys() for symbol in hours_matched]):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -66,19 +66,19 @@ def _extract_fractional(input_string: str | None):
         return
 
     input_string = input_string.strip()
-    if any(symbol in FRACTIONS for symbol in input_string):
-        for fraction, amount in FRACTIONS.items():
-            if fraction in input_string:
-                yield amount
-                input_string = input_string.replace(fraction, "")
-        yield float(input_string) if input_string else 0
-    elif "/" in input_string:
+    if "/" in input_string:
         # for example "1 1/2" is matched
         components = input_string.split(" ")
         if len(components) == 2:
             yield float(components[0])
         numerator, denominator = components[-1:][0].split("/")
         yield float(int(numerator) / int(denominator))
+    elif any(symbol in FRACTIONS for symbol in input_string):
+        for fraction, amount in FRACTIONS.items():
+            if fraction in input_string:
+                yield amount
+                input_string = input_string.replace(fraction, "")
+        yield float(input_string) if input_string else 0
     else:
         yield float(input_string)
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -65,8 +65,7 @@ def _extract_fractional(input_string: str):
     if "/" in input_string:
         # for example "1 1/2" is matched
         components = input_string.split(" ")
-        assert len(components) == 2
-        whole_part, fractional_part = components
+        whole_part, fractional_part = components[0], components[-1]
         numerator, denominator = fractional_part.split("/")
         yield float(whole_part)
         yield float(int(numerator) / int(denominator))

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -60,7 +60,7 @@ RECIPE_YIELD_TYPES = (
 )
 
 
-def _extract_fractional(input_string: str) -> tuple[float, float]:
+def _extract_fractional(input_string: str):
     input_string = input_string.strip()
     if any(symbol in FRACTIONS for symbol in input_string):
         for fraction, amount in FRACTIONS.items():

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -88,14 +88,13 @@ def get_minutes(element):  # noqa: C901: TODO
     if " to " in time_text:  # sometimes formats are like this: '12 to 15 minutes'
         time_text = time_text.split("to", 2)[1]
 
-    matched = TIME_REGEX.search(time_text)
-
-    if matched is None or not any(matched.groupdict().values()):
+    time_units = TIME_REGEX.search(time_text).groupdict()
+    if not any(time_units.values()):
         return None
 
-    minutes = int(matched.groupdict().get("minutes") or 0)
-    hours_matched = matched.groupdict().get("hours")
-    days_matched = matched.groupdict().get("days")
+    minutes = int(time_units.get("minutes") or 0)
+    hours_matched = time_units.get("hours")
+    days_matched = time_units.get("days")
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     if days_matched:

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -62,23 +62,21 @@ RECIPE_YIELD_TYPES = (
 
 def _extract_fractional(input_string: str) -> tuple[float, float]:
     input_string = input_string.strip()
-    whole_part, fractional_part = 0.0, 0.0
     if any(symbol in FRACTIONS for symbol in input_string):
         for fraction, amount in FRACTIONS.items():
             if fraction in input_string:
-                fractional_part += amount
+                yield amount
                 input_string = input_string.replace(fraction, "")
-        whole_part += float(input_string) if input_string else 0
+        yield float(input_string) if input_string else 0
     elif "/" in input_string:
         # for example "1 1/2" is matched
         components = input_string.split(" ")
         if len(components) == 2:
-            whole_part += float(components[0])
+            yield float(components[0])
         numerator, denominator = components[-1:][0].split("/")
-        fractional_part += float(int(numerator) / int(denominator))
+        yield float(int(numerator) / int(denominator))
     else:
-        whole_part = float(input_string)
-    return whole_part, fractional_part
+        yield float(input_string)
 
 
 def get_minutes(element):  # noqa: C901: TODO
@@ -120,9 +118,7 @@ def get_minutes(element):  # noqa: C901: TODO
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     hours = 0
     if hours_matched:
-        whole_hours, fractional_hours = _extract_fractional(hours_matched)
-        hours += whole_hours
-        hours += fractional_hours
+        hours += sum(_extract_fractional(hours_matched))
 
     hours += round(days * 24)
     minutes += round(hours * 60)

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -100,7 +100,7 @@ def get_minutes(element):  # noqa: C901: TODO
     hours = 0
     if hours_matched:
         hours_matched = hours_matched.strip()
-        if any([symbol in FRACTIONS.keys() for symbol in hours_matched]):
+        if any(symbol in FRACTIONS for symbol in hours_matched):
             hours = 0
             for fraction, value in FRACTIONS.items():
                 if fraction in hours_matched:

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -83,7 +83,7 @@ def _extract_fractional(input_string: str | None):
         yield float(input_string)
 
 
-def get_minutes(element):  # noqa: C901: TODO
+def get_minutes(element):
     if element is None:
         return 0
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -104,9 +104,9 @@ def get_minutes(element):
             pass
 
     if "-" in time_text:  # sometimes formats are like this: '12-15 minutes'
-        time_text = time_text.split("-", 2)[1]
+        _min, _, time_text = time_text.partition("-")
     if " to " in time_text:  # sometimes formats are like this: '12 to 15 minutes'
-        time_text = time_text.split(" to ", 2)[1]
+        _min, _to, time_text = time_text.partition(" to ")
 
     time_units = TIME_REGEX.search(time_text).groupdict()
     if not any(time_units.values()):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -1,4 +1,5 @@
 # mypy: disallow_untyped_defs=False
+from __future__ import annotations
 
 import html
 import math
@@ -60,7 +61,10 @@ RECIPE_YIELD_TYPES = (
 )
 
 
-def _extract_fractional(input_string: str):
+def _extract_fractional(input_string: str | None):
+    if not input_string:
+        return
+
     input_string = input_string.strip()
     if any(symbol in FRACTIONS for symbol in input_string):
         for fraction, amount in FRACTIONS.items():
@@ -117,9 +121,7 @@ def get_minutes(element):  # noqa: C901: TODO
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     days = float(days_matched) if days_matched else 0
-    hours = 0
-    if hours_matched:
-        hours += sum(_extract_fractional(hours_matched))
+    hours = sum(_extract_fractional(hours_matched))
 
     hours += round(days * 24)
     minutes += round(hours * 60)

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -1,5 +1,4 @@
 # mypy: disallow_untyped_defs=False
-from __future__ import annotations
 
 import html
 import math

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -98,7 +98,7 @@ def get_minutes(element):  # noqa: C901: TODO
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     if days_matched:
-        minutes += 60 * 60 * float(days_matched)
+        minutes += 24 * 60 * float(days_matched)
     if hours_matched:
         hours_matched = hours_matched.strip()
         if any([symbol in FRACTIONS.keys() for symbol in hours_matched]):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -71,12 +71,14 @@ def _extract_fractional(input_string: str):
         yield float(int(numerator) / int(denominator))
         return
 
+    whole_part = ""
     for symbol in input_string:
-        if amount := FRACTIONS.get(symbol):
-            yield amount
-            input_string = input_string.replace(symbol, "")
+        if symbol in FRACTIONS:
+            yield FRACTIONS[symbol]
+        else:
+            whole_part += symbol
 
-    yield float(input_string)
+    yield float(whole_part)
 
 
 def get_minutes(element):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -61,10 +61,7 @@ RECIPE_YIELD_TYPES = (
 )
 
 
-def _extract_fractional(input_string: str | None):
-    if not input_string:
-        return
-
+def _extract_fractional(input_string: str):
     input_string = input_string.strip()
     if "/" in input_string:
         # for example "1 1/2" is matched
@@ -121,7 +118,7 @@ def get_minutes(element):
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     days = float(days_matched) if days_matched else 0
-    hours = sum(_extract_fractional(hours_matched))
+    hours = sum(_extract_fractional(hours_matched)) if hours_matched else 0
 
     hours += round(days * 24)
     minutes += round(hours * 60)

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -92,7 +92,7 @@ def get_minutes(element):  # noqa: C901: TODO
     if not any(time_units.values()):
         return None
 
-    minutes = int(time_units.get("minutes") or 0)
+    minutes = float(time_units.get("minutes") or 0)
     hours_matched = time_units.get("hours")
     days_matched = time_units.get("days")
 
@@ -107,13 +107,13 @@ def get_minutes(element):  # noqa: C901: TODO
                 if fraction in hours_matched:
                     hours += value
                     hours_matched = hours_matched.replace(fraction, "")
-            hours += int(hours_matched) if hours_matched else 0
+            hours += float(hours_matched) if hours_matched else 0
         elif "/" in hours_matched:
             # for example "1 1/2" is matched
             hours_matched_split = hours_matched.split(" ")
             hours = 0
             if len(hours_matched_split) == 2:
-                hours += int(hours_matched_split[0])
+                hours += float(hours_matched_split[0])
             fraction = hours_matched_split[-1:][0].split("/")
             hours += float(int(fraction[0]) / int(fraction[1]))
         else:

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -67,8 +67,9 @@ def _extract_fractional(input_string: str):
         # for example "1 1/2" is matched
         components = input_string.split(" ")
         assert len(components) == 2
-        yield float(components[0])
-        numerator, denominator = components[-1].split("/")
+        whole_part, fractional_part = components
+        numerator, denominator = fractional_part.split("/")
+        yield float(whole_part)
         yield float(int(numerator) / int(denominator))
         return
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -94,11 +94,10 @@ def get_minutes(element):  # noqa: C901: TODO
 
     minutes = float(time_units.get("minutes") or 0)
     hours_matched = time_units.get("hours")
-    days_matched = time_units.get("days")
+    days = float(time_units.get("days") or 0)
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
-    if days_matched:
-        minutes += 24 * 60 * float(days_matched)
+    hours = 0
     if hours_matched:
         hours_matched = hours_matched.strip()
         if any([symbol in FRACTIONS.keys() for symbol in hours_matched]):
@@ -119,8 +118,8 @@ def get_minutes(element):  # noqa: C901: TODO
         else:
             hours = float(hours_matched)
 
-        minutes += round(60 * hours, 0)
-
+    hours += round(days * 24)
+    minutes += round(hours * 60)
     return minutes
 
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -83,14 +83,10 @@ def get_minutes(element):  # noqa: C901: TODO
         except Exception:
             pass
 
-    if "-" in time_text:
-        time_text = time_text.split("-", 2)[
-            1
-        ]  # sometimes formats are like this: '12-15 minutes'
-    if " to " in time_text:
-        time_text = time_text.split("to", 2)[
-            1
-        ]  # sometimes formats are like this: '12 to 15 minutes'
+    if "-" in time_text:  # sometimes formats are like this: '12-15 minutes'
+        time_text = time_text.split("-", 2)[1]
+    if " to " in time_text:  # sometimes formats are like this: '12 to 15 minutes'
+        time_text = time_text.split("to", 2)[1]
     if "h" in time_text:
         time_text = time_text.replace("h", "hours")
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -60,12 +60,9 @@ RECIPE_YIELD_TYPES = (
 )
 
 
-def get_minutes(element, return_zero_on_not_found=False):  # noqa: C901: TODO
+def get_minutes(element):  # noqa: C901: TODO
     if element is None:
-        # to be removed
-        if return_zero_on_not_found:
-            return 0
-        raise ElementNotFoundInHtml(element)
+        return 0
 
     # handle integer in string literal
     try:

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -112,13 +112,14 @@ def get_minutes(element):
     if not any(time_units.values()):
         return None
 
-    minutes = float(time_units.get("minutes") or 0)
+    minutes_matched = time_units.get("minutes")
     hours_matched = time_units.get("hours")
     days_matched = time_units.get("days")
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     days = float(days_matched) if days_matched else 0
     hours = sum(_extract_fractional(hours_matched)) if hours_matched else 0
+    minutes = float(minutes_matched) if minutes_matched else 0
 
     hours += round(days * 24)
     minutes += round(hours * 60)

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -76,15 +76,13 @@ def get_minutes(element):  # noqa: C901: TODO
         time_text = element.get_text()
 
     # attempt iso8601 duration parsing
-    if time_text.startswith("PT"):
+    if time_text.startswith("P") and "T" in time_text:
         try:
             duration = isodate.parse_duration(time_text)
             return math.ceil(duration.total_seconds() / 60)
         except Exception:
             pass
 
-    if time_text.startswith("P") and "T" in time_text:
-        time_text = time_text.split("T", 2)[1]
     if "-" in time_text:
         time_text = time_text.split("-", 2)[
             1

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -87,8 +87,6 @@ def get_minutes(element):  # noqa: C901: TODO
         time_text = time_text.split("-", 2)[1]
     if " to " in time_text:  # sometimes formats are like this: '12 to 15 minutes'
         time_text = time_text.split("to", 2)[1]
-    if "h" in time_text:
-        time_text = time_text.replace("h", "hours")
 
     matched = TIME_REGEX.search(time_text)
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -60,25 +60,23 @@ RECIPE_YIELD_TYPES = (
 )
 
 
-def _extract_fractional(input_string: str):
+def _extract_fractional(input_string: str) -> float:
     input_string = input_string.strip()
     if "/" in input_string:
         # for example "1 1/2" is matched
         components = input_string.split(" ")
         whole_part, fractional_part = components[0], components[-1]
         numerator, denominator = fractional_part.split("/")
-        yield float(whole_part)
-        yield float(int(numerator) / int(denominator))
-        return
+        return float(whole_part) + float(int(numerator) / int(denominator))
 
-    whole_part = ""
+    whole_part, fractional_amount = "", 0
     for symbol in input_string:
         if symbol in FRACTIONS:
-            yield FRACTIONS[symbol]
+            fractional_amount += FRACTIONS[symbol]
         else:
             whole_part += symbol
 
-    yield float(whole_part)
+    return float(whole_part) + float(fractional_amount)
 
 
 def get_minutes(element):
@@ -119,7 +117,7 @@ def get_minutes(element):
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
     days = float(days_matched) if days_matched else 0
-    hours = sum(_extract_fractional(hours_matched)) if hours_matched else 0
+    hours = float(_extract_fractional(hours_matched)) if hours_matched else 0
     minutes = float(minutes_matched) if minutes_matched else 0
 
     hours += round(days * 24)

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -66,9 +66,9 @@ def _extract_fractional(input_string: str):
     if "/" in input_string:
         # for example "1 1/2" is matched
         components = input_string.split(" ")
-        if len(components) == 2:
-            yield float(components[0])
-        numerator, denominator = components[-1:][0].split("/")
+        assert len(components) == 2
+        yield float(components[0])
+        numerator, denominator = components[-1].split("/")
         yield float(int(numerator) / int(denominator))
         return
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -106,7 +106,7 @@ def get_minutes(element):
     if "-" in time_text:  # sometimes formats are like this: '12-15 minutes'
         time_text = time_text.split("-", 2)[1]
     if " to " in time_text:  # sometimes formats are like this: '12 to 15 minutes'
-        time_text = time_text.split("to", 2)[1]
+        time_text = time_text.split(" to ", 2)[1]
 
     time_units = TIME_REGEX.search(time_text).groupdict()
     if not any(time_units.values()):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -73,14 +73,14 @@ def _extract_fractional(input_string: str | None):
             yield float(components[0])
         numerator, denominator = components[-1:][0].split("/")
         yield float(int(numerator) / int(denominator))
-    elif any(symbol in FRACTIONS for symbol in input_string):
-        for fraction, amount in FRACTIONS.items():
-            if fraction in input_string:
-                yield amount
-                input_string = input_string.replace(fraction, "")
-        yield float(input_string) if input_string else 0
-    else:
-        yield float(input_string)
+        return
+
+    for symbol in input_string:
+        if amount := FRACTIONS.get(symbol):
+            yield amount
+            input_string = input_string.replace(symbol, "")
+
+    yield float(input_string)
 
 
 def get_minutes(element):

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -113,9 +113,10 @@ def get_minutes(element):  # noqa: C901: TODO
 
     minutes = float(time_units.get("minutes") or 0)
     hours_matched = time_units.get("hours")
-    days = float(time_units.get("days") or 0)
+    days_matched = time_units.get("days")
 
     # workaround for formats like: 0D4H45M, that are not a valid iso8601 it seems
+    days = float(days_matched) if days_matched else 0
     hours = 0
     if hours_matched:
         hours += sum(_extract_fractional(hours_matched))

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -82,7 +82,7 @@ def _extract_fractional(input_string: str):
 
 def get_minutes(element):
     if element is None:
-        return 0
+        raise ElementNotFoundInHtml(element)
 
     # handle integer in string literal
     try:

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -69,7 +69,7 @@ def _extract_fractional(input_string: str) -> float:
         numerator, denominator = fractional_part.split("/")
         return float(whole_part) + float(int(numerator) / int(denominator))
 
-    whole_part, fractional_amount = "", 0
+    whole_part, fractional_amount = "", 0.0
     for symbol in input_string:
         if symbol in FRACTIONS:
             fractional_amount += FRACTIONS[symbol]

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -101,12 +101,15 @@ class AllRecipesUser(AbstractScraper):
 
     def total_time(self):
         if "total" in self.meta:
-            total_time = get_minutes(self.meta["total"], return_zero_on_not_found=True)
+            return get_minutes(self.meta.get("total"))
         else:
-            total_time = get_minutes(self.meta.get("cook", 0)) + get_minutes(
-                self.meta.get("prep", 0)
-            )
-        return total_time
+            return self.prep_time() + self.cook_time()
+
+    def prep_time(self):
+        return get_minutes(self.meta.get("prep"))
+
+    def cook_time(self):
+        return get_minutes(self.meta.get("cook"))
 
     def yields(self):
         yield_data = self.meta.get("yield")

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -101,15 +101,15 @@ class AllRecipesUser(AbstractScraper):
 
     def total_time(self):
         if "total" in self.meta:
-            return get_minutes(self.meta.get("total"))
+            return get_minutes(self.meta.get("total") or 0)
         else:
             return self.prep_time() + self.cook_time()
 
     def prep_time(self):
-        return get_minutes(self.meta.get("prep"))
+        return get_minutes(self.meta.get("prep") or 0)
 
     def cook_time(self):
-        return get_minutes(self.meta.get("cook"))
+        return get_minutes(self.meta.get("cook") or 0)
 
     def yields(self):
         yield_data = self.meta.get("yield")

--- a/recipe_scrapers/receitasnestlebr.py
+++ b/recipe_scrapers/receitasnestlebr.py
@@ -21,7 +21,7 @@ class ReceitasNestleBR(AbstractScraper):
 
     def total_time(self):
         total_time = self.schema.total_time()
-        if total_time == 0:
+        if total_time is None:
             time_div = self.soup.find("div", {"class": "recipeDetail__infoItem--time"})
             if time_div:
                 time_str = "".join(time_div.stripped_strings)

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -32,6 +32,10 @@ class TestUtils(unittest.TestCase):
         text = "1.5 hours"
         self.assertEqual(90, get_minutes(text))
 
+    def test_get_minutes_integer_days(self):
+        text = "2 days"
+        self.assertEqual(2880, get_minutes(text))
+
     def test_get_minutes_fraction_with_fraction_unicode_character_halves(self):
         text = "1½ hours"
         self.assertEqual(90, get_minutes(text))

--- a/tests/test_data/arla.se/arla_2.json
+++ b/tests/test_data/arla.se/arla_2.json
@@ -72,6 +72,6 @@
   "ratings": 3.5,
   "site_name": "Arla",
   "title": "Trifle på äpple med smulkrisp och vaniljglass",
-  "total_time": 0,
+  "total_time": null,
   "yields": "4 servings"
 }


### PR DESCRIPTION
The `_utils.get_minutes` method has a high McCabe cyclomatic complexity, meaning that [`flake8` would complain](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-max-complexity) about it if we didn't [suppress the relevant `C901` warning](https://github.com/hhursev/recipe-scrapers/blob/663b7500b57c6c51314c3c308c31be508749c6b2/recipe_scrapers/_utils.py#L63).

Although not perfect, a high complexity score is usually a good indicator that some code could be refactored into something cleaner.

I've wanted to try this for a while, and I'll see how far I get with this branch.  There are a few inter-dependencies (exception handling, plugins, zero-value handling, ...), not to mention that we only have a few tests per scraper, so a few experiments may be required along the way.