### PR TITLE
cleanup: remove redundant additional dependencies from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,3 @@ repos:
     rev: v1.6.1
     hooks:
     - id: mypy
-      additional_dependencies: [types-beautifulsoup4, types-requests]


### PR DESCRIPTION
These are included as [development requirements](https://github.com/hhursev/recipe-scrapers/blob/43584c9f3188f5999b83722692265cd48cef7210/requirements-dev.txt#L6-L7), as [installed by `tox`](https://github.com/hhursev/recipe-scrapers/blob/43584c9f3188f5999b83722692265cd48cef7210/tox.ini#L5) (for example, during `tox -e lint`).