### PR TITLE
Add missing properties to Sally's Baking Addiction

### DIFF
--- a/recipe_scrapers/sallysbakingaddiction.py
+++ b/recipe_scrapers/sallysbakingaddiction.py
@@ -10,6 +10,12 @@ class SallysBakingAddiction(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    def cuisine(self):
+        return self.schema.cuisine()
+
+    def description(self):
+        return self.schema.description()
+
     def prep_time(self):
         return self.schema.prep_time()
 

--- a/recipe_scrapers/sallysbakingaddiction.py
+++ b/recipe_scrapers/sallysbakingaddiction.py
@@ -10,6 +10,12 @@ class SallysBakingAddiction(AbstractScraper):
     def title(self):
         return self.schema.title()
 
+    def prep_time(self):
+        return self.schema.prep_time()
+
+    def cook_time(self):
+        return self.schema.cook_time()
+
     def total_time(self):
         return self.schema.total_time()
 

--- a/tests/test_data/sallysbakingaddiction.com/sallysbakingaddiction.json
+++ b/tests/test_data/sallysbakingaddiction.com/sallysbakingaddiction.json
@@ -2,6 +2,7 @@
   "author": "Sally",
   "canonical_url": "https://sallysbakingaddiction.com/rosemary-garlic-pull-apart-bread/",
   "category": "Bread",
+  "cook_time": 50,
   "host": "sallysbakingaddiction.com",
   "image": "https://sallysbakingaddiction.com/wp-content/uploads/2020/12/garlic-rosemary-pull-apart-bread-225x225.jpg",
   "ingredient_groups": [
@@ -67,6 +68,7 @@
   ],
   "language": "en-US",
   "nutrients": {},
+  "prep_time": 180,
   "ratings": 4.9,
   "site_name": "Sally's Baking Addiction",
   "title": "Rosemary Garlic Pull Apart Bread",

--- a/tests/test_data/sallysbakingaddiction.com/sallysbakingaddiction.json
+++ b/tests/test_data/sallysbakingaddiction.com/sallysbakingaddiction.json
@@ -2,6 +2,8 @@
   "author": "Sally",
   "canonical_url": "https://sallysbakingaddiction.com/rosemary-garlic-pull-apart-bread/",
   "category": "Bread",
+  "cuisine": "American",
+  "description": "Make a flavorful pull apart bread using this delicious rosemary-infused yeasted dough. You can use your favorite cheese in the filling. I love and usually use shredded parmesan.",
   "cook_time": 50,
   "host": "sallysbakingaddiction.com",
   "image": "https://sallysbakingaddiction.com/wp-content/uploads/2020/12/garlic-rosemary-pull-apart-bread-225x225.jpg",


### PR DESCRIPTION
Adds the `cook_time`, `prep_time`, `description` and `cuisine` properties.

I'm a bit confused whether this scraper is necessary though since it doesn't override anything and wild mode seems to work fine? Looking at #617, is it more a case of "we know this works and can prove it with the tests"? Sorry if I'm missing something obvious, just trying to understand so I can better contribute :)