### PR TITLE
tests: allow legacy tests to check for expected headers

### DIFF
--- a/tests/legacy/test_goustojson.py
+++ b/tests/legacy/test_goustojson.py
@@ -1,5 +1,6 @@
 from responses import GET
 
+from recipe_scrapers._abstract import HEADERS
 from recipe_scrapers.goustojson import GoustoJson
 from tests.legacy import ScraperTest
 
@@ -9,8 +10,9 @@ class TestGoustoScraper(ScraperTest):
 
     @classmethod
     def expected_requests(cls):
-        yield GET, "https://www.gousto.co.uk/cookbook/vegetarian-recipes/3-cheese-veg-packed-pasta-bake", "tests/legacy/test_data/gousto.testjson"
-        yield GET, "https://production-api.gousto.co.uk/cmsreadbroker/v1/recipe/3-cheese-veg-packed-pasta-bake", "tests/legacy/test_data/gousto.testjson"
+        yield GET, "https://www.gousto.co.uk/cookbook/vegetarian-recipes/3-cheese-veg-packed-pasta-bake", "tests/legacy/test_data/gousto.testhtml"
+        expected_headers = {"User-Agent": HEADERS["User-Agent"]}
+        yield GET, "https://production-api.gousto.co.uk/cmsreadbroker/v1/recipe/3-cheese-veg-packed-pasta-bake", "tests/legacy/test_data/gousto.testjson", expected_headers
 
     def test_host(self):
         self.assertEqual("gousto.co.uk", self.harvester_class.host())


### PR DESCRIPTION
@Keyruu could you please take a look at this suggestion?

What I'd like to do here is to allow the tests to optionally expect specific header values from the scraper when it makes a request.

In the case of #1014 that would include the `Accept-Language` header, which should match the original HTML page.  It may also include the `Device-Type` header (if that's required).