### PR TITLE
pre-commit: add sphinx-lint step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,7 @@ repos:
     hooks:
     - id: pyupgrade
       args: [--py38-plus]
+-   repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v0.9.1
+    hooks:
+    - id: sphinx-lint


### PR DESCRIPTION
Listed in #617 as a suggestion, and the `sphinx-lint` readme now provides good advice on how to enable it using `pre-commit`.