### PR TITLE
Added foodnetwork.com back

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -405,6 +405,7 @@ SCRAPERS = {
     FoodAndWine.host(): FoodAndWine,
     FoodFidelity.host(): FoodFidelity,
     FoodNetwork.host(): FoodNetwork,
+    FoodNetwork.host(domain="com"): FoodNetwork,
     FoodRepublic.host(): FoodRepublic,
     ForkToSpoon.host(): ForkToSpoon,
     ForksOverKnives.host(): ForksOverKnives,

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -14,7 +14,7 @@ from ._schemaorg import SchemaOrg
 
 # some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:86.0) Gecko/20100101 Firefox/86.0"
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0"
 }
 
 

--- a/recipe_scrapers/foodnetwork.py
+++ b/recipe_scrapers/foodnetwork.py
@@ -3,8 +3,8 @@ from ._abstract import AbstractScraper
 
 class FoodNetwork(AbstractScraper):
     @classmethod
-    def host(cls):
-        return "foodnetwork.co.uk"
+    def host(cls, domain="co.uk"):
+        return f"foodnetwork.{domain}"
 
     def author(self):
         return self.schema.author()


### PR DESCRIPTION
This PR fixes #1010 

As described in the issue, this commit https://github.com/hhursev/recipe-scrapers/commit/4fef338670142c3b4563f902ded1ade1f8001d0f#diff-5d1c0cbbdbecea7561f2fa87a9ecdd8bb896262f71727989caa4cf140b54cdeb changed the URL for foodnetwork from foodnetwork.com to foodnetwork.co.uk. Additionally, foodntwork.com now is blocking requests from "old" user-agents and this PR updates the user-agent header.

I left foodnetwork.co.uk as the "default" domain and added the capability to also reference foodnetwork.com the same way as hellofresh scraper supports multiple domains. Tests are passing and I tried the following URLs locally and they both work as expected:

```python
scraper = scrape_me('https://www.foodnetwork.com/recipes/alton-brown/shepherds-pie-recipe2-1942900', wild_mode=True)
scraper = scrape_me('https://foodnetwork.co.uk/recipes/tuscan-mushrooms-5389', wild_mode=True)
``` 