### PR TITLE
Expanding functionality of get_yields function

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -148,10 +148,10 @@ def get_yields(element):
     """
     Returns a string indicating the number of servings or items for a recipe. It handles various formats,
     including servings, items, and special cases including dozens and fractions (e.g., "1 ½ dozen cookies").
-    If the recipe specifies yields in terms of items (not servings), it returns a string in the format 
-    "x item(s)" where x is the quantity. This function also handles yields specified in dozens, returning 
-    them appropriately (e.g., "1.5 dozen cookies" instead of "18 items"), and incorporates fractional 
-    quantities with proper conversion. Additionally, it accommodates yields specified in other units 
+    If the recipe specifies yields in terms of items (not servings), it returns a string in the format
+    "x item(s)" where x is the quantity. This function also handles yields specified in dozens, returning
+    them appropriately (e.g., "1.5 dozen cookies" instead of "18 items"), and incorporates fractional
+    quantities with proper conversion. Additionally, it accommodates yields specified in other units
     like batches (e.g., "2 batches of brownies"), returning the yield as specified.
 
     :param element: Should ideally be BeautifulSoup.TAG. In some cases, where this is not feasible,

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -1,130 +1,93 @@
 import unittest
 
-from recipe_scrapers._utils import get_minutes
+from recipe_scrapers._utils import _extract_fractional, get_minutes, get_yields
 
 
 class TestUtils(unittest.TestCase):
-    def test_get_minutes_english_description(self):
-        text = "1 hour 15 mins"
-        self.assertEqual(75, get_minutes(text))
+    @classmethod
+    def setUpClass(cls):
+        cls.iso8601_fixtures = {
+            "PT1H": 60,
+            "PT20M": 20,
+            "PT2H10M": 130,
+            "PT0H9M30S": 10,
+        }
+        cls.minutes_fixtures = [
+            ("1 hour 15 mins", 75),
+            ("1h and 15mins", 75),
+            ("3h10m", 190),
+            ("PT2H30M", 150),
+            ("P0DT1H10M", 70),
+            ("90", 90),
+            ("1.5 hours", 90),
+            ("2 days", 2880),
+            ("1½ hours", 90),
+            ("1¾ hours", 105),
+            ("1¼ hours", 75),
+            ("1⅔ hours", 100),
+            ("1 1/2 hours", 90),
+            ("1 3/4 hours", 105),
+            ("1 1/4 hours", 75),
+            ("1 2/3 hours", 100),
+            ("15 - 20 minutes", 20),
+            ("15 to 20 minutes", 20),
+            ("Pá-Pum", None),
+        ]
 
-    def test_get_minutes_english_description_with_and(self):
-        text = "1h and 15mins"
-        self.assertEqual(75, get_minutes(text))
-
-    def test_get_minutes_english_abbreviation(self):
-        text = "3h10m"
-        self.assertEqual(190, get_minutes(text))
-
-    def test_get_minutes_short_iso_format(self):
-        text = "PT2H30M"
-        self.assertEqual(150, get_minutes(text))
-
-    def test_get_minutes_long_iso_format(self):
-        text = "P0DT1H10M"
-        self.assertEqual(70, get_minutes(text))
-
-    def test_get_minutes_int_in_string_literal(self):
-        text = "90"
-        self.assertEqual(90, get_minutes(text))
-
-    def test_get_minutes_fraction_in_hours_with_dot_notation(self):
-        text = "1.5 hours"
-        self.assertEqual(90, get_minutes(text))
-
-    def test_get_minutes_integer_days(self):
-        text = "2 days"
-        self.assertEqual(2880, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_unicode_character_halves(self):
-        text = "1½ hours"
-        self.assertEqual(90, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_unicode_character_three_fours(self):
-        text = "1¾ hours"
-        self.assertEqual(105, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_unicode_character_one_fours(self):
-        text = "1¼ hours"
-        self.assertEqual(75, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_unicode_character_two_thirds(self):
-        text = "1⅔ hours"
-        self.assertEqual(100, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_digits_with_slash(self):
-        text = "1 1/2 hours"
-        self.assertEqual(90, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_digits_with_slash_three_fours(self):
-        text = "1 3/4 hours"
-        self.assertEqual(105, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_digits_with_slash_one_fours(self):
-        text = "1 1/4 hours"
-        self.assertEqual(75, get_minutes(text))
-
-    def test_get_minutes_fraction_with_fraction_digits_with_slash_two_thirds(self):
-        text = "1 2/3 hours"
-        self.assertEqual(100, get_minutes(text))
-
-    def test_get_minutes_handles_dashes(self):
-        text = "15 - 20 minutes"
-        self.assertEqual(20, get_minutes(text))
-
-    def test_get_minutes_handles_to(self):
-        text = "15 to 20 minutes"
-        self.assertEqual(20, get_minutes(text))
-
-    def test_get_minutes_imprecise_description(self):
-        text = "Pá-Pum"
-        self.assertEqual(None, get_minutes(text))
-
-    iso8601_fixtures = {
-        "PT1H": 60,
-        "PT20M": 20,
-        "PT2H10M": 130,
-        "PT0H9M30S": 10,
-    }
-
-    def test_get_minutes_handles_iso8601(self):
-        for text, expected_minutes in self.iso8601_fixtures.items():
+    def test_minutes_fixtures(self):
+        # Tests for minute related output formats.
+        for text, expected in self.minutes_fixtures:
             with self.subTest(text=text):
-                self.assertEqual(expected_minutes, get_minutes(text))
+                self.assertEqual(expected, get_minutes(text))
+
+    def test_iso8601_fixtures(self):
+        # Tests for ISO 8601 formatted outputs formats.
+        for text, expected in self.iso8601_fixtures.items():
+            with self.subTest(text=text):
+                self.assertEqual(expected, get_minutes(text))
+
+    def test_split_fractions(self):
+        input_string = "3 1 / 2"
+        expected_result = 3.5
+        self.assertEqual(expected_result, _extract_fractional(input_string))
+
+    def test_get_yields_with_fraction(self):
+        input_string = "1 ½ dozen cookies"
+        expected_result = "1.5 dozen cookies"
+        self.assertEqual(expected_result, get_yields(input_string))
 
     def test_list_public_methods(self):
         from recipe_scrapers import AbstractScraper
 
-        public_method_names = [
+        expected_methods = [
+            "author",
+            "canonical_url",
+            "category",
+            "cook_time",
+            "cuisine",
+            "description",
+            "equipment",
+            "host",
+            "image",
+            "ingredient_groups",
+            "ingredients",
+            "instructions",
+            "instructions_list",
+            "language",
+            "nutrients",
+            "prep_time",
+            "ratings",
+            "reviews",
+            "site_name",
+            "title",
+            "total_time",
+            "yields",
+        ]
+        public_methods = [
             method
             for method in dir(AbstractScraper)
             if callable(getattr(AbstractScraper, method))
-            if not method.startswith("_") and method not in ["soup", "links", "to_json"]
+            and not method.startswith("_")
+            and method not in ["soup", "links", "to_json"]
         ]
-        self.assertEqual(
-            [
-                "author",
-                "canonical_url",
-                "category",
-                "cook_time",
-                "cuisine",
-                "description",
-                "equipment",
-                "host",
-                "image",
-                "ingredient_groups",
-                "ingredients",
-                "instructions",
-                "instructions_list",
-                "language",
-                "nutrients",
-                "prep_time",
-                "ratings",
-                "reviews",
-                "site_name",
-                "title",
-                "total_time",
-                "yields",
-            ],
-            public_method_names,
-        )
+        self.assertEqual((expected_methods), (public_methods))

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -56,6 +56,16 @@ class TestUtils(unittest.TestCase):
         expected_result = "1.5 dozen cookies"
         self.assertEqual(expected_result, get_yields(input_string))
 
+    def test_get_yields_with_fraction(self):
+        input_string = "3 ½ dozen cookies"
+        expected_result = "3.5 dozen cookies"
+        self.assertEqual(expected_result, get_yields(input_string))
+
+    def test_get_yields_with_fraction(self):
+        input_string = "7 ⅕ chocolate cream pies"
+        expected_result = "7.2 pies"
+        self.assertEqual(expected_result, get_yields(input_string))
+
     def test_list_public_methods(self):
         from recipe_scrapers import AbstractScraper
 

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -56,12 +56,7 @@ class TestUtils(unittest.TestCase):
         expected_result = "1.5 dozen cookies"
         self.assertEqual(expected_result, get_yields(input_string))
 
-    def test_get_yields_with_fraction(self):
-        input_string = "3 ½ dozen cookies"
-        expected_result = "3.5 dozen cookies"
-        self.assertEqual(expected_result, get_yields(input_string))
-
-    def test_get_yields_with_fraction(self):
+    def test_get_yields_with_fraction2(self):
         input_string = "7 ⅕ chocolate cream pies"
         expected_result = "7.2 pies"
         self.assertEqual(expected_result, get_yields(input_string))


### PR DESCRIPTION
Only changes that are not included in #1031 are to `get_yields` function

`_utils - get_yields`

- Rewrote portions of the function to simplify some logic for readability
- Implemented the fractional functionality that is implemented as part of #1031
- Added specific handling for yield returns containing `dozen/s`

