### PR TITLE
Development dependencies: limit to extruct-0.16-compatible lxml.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -e .
 coverage>=4.5.1
+lxml<5.1.1  # https://github.com/scrapinghub/extruct/issues/215
 responses>=0.21.0
 # language-tags>=1.0.0
 # tld>=0.12.3


### PR DESCRIPTION
The version-range applied here excludes v5.1.1 of `lxml`, where removal of a non-unicode string type in https://github.com/lxml/lxml/commit/eba79343d0e7ad1ce40169f60460cdd4caa29eb3 causes problems for [v0.16 of `extruct`](https://github.com/scrapinghub/extruct/blob/85b5f0d19e2d4a6e1bb2e15068380e014df9bc98/extruct/xmldom.py#L12).  The version-range is applied for development dependencies (continuous integration, local development).

Ref: https://github.com/scrapinghub/extruct/issues/215

Relates to #1045 (but does not resolve it).