### PR TITLE
Add KitchenAid Australia

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,6 +226,7 @@ Scrapers available for:
 - `https://www.justonecookbook.com/ <https://www.justonecookbook.com>`_
 - `https://kennymcgovern.com/ <https://kennymcgovern.com>`_
 - `https://www.kingarthurbaking.com <https://www.kingarthurbaking.com>`_
+- `https://kitchenaid.com.au/ <https://kitchenaid.com.au/blogs/kitchenthusiast/tagged/blog-category-recipes>`_
 - `https://www.kitchenstories.com/ <https://www.kitchenstories.com>`_
 - `https://kochbar.de/ <https://kochbar.de>`_
 - `https://kochbucher.com/ <https://kochbucher.com/>`_

--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -142,6 +142,7 @@ from .justonecookbook import JustOneCookbook
 from .kennymcgovern import KennyMcGovern
 from .keukenliefdenl import KeukenLiefdeNL
 from .kingarthur import KingArthur
+from .kitchenaidaustralia import KitchenAidAustralia
 from .kitchenstories import KitchenStories
 from .kochbar import Kochbar
 from .kochbucher import Kochbucher
@@ -381,6 +382,7 @@ SCRAPERS = {
     GrandFrais.host(): GrandFrais,
     HeatherChristo.host(): HeatherChristo,
     JoshuaWeissman.host(): JoshuaWeissman,
+    KitchenAidAustralia.host(): KitchenAidAustralia,
     KuchynaLidla.host(): KuchynaLidla,
     MundoDeReceitasBimby.host(): MundoDeReceitasBimby,
     MyJewishLearning.host(): MyJewishLearning,

--- a/recipe_scrapers/kitchenaidaustralia.py
+++ b/recipe_scrapers/kitchenaidaustralia.py
@@ -25,7 +25,7 @@ class KitchenAidAustralia(AbstractScraper):
     def total_time(self):
         time_pattern = re.compile("time", re.IGNORECASE)
 
-        summary = self.get_summary()
+        summary = self._get_summary()
         time_items = summary.find_all("strong", string=time_pattern)
 
         if not time_items:
@@ -33,25 +33,25 @@ class KitchenAidAustralia(AbstractScraper):
 
         # The last item is always the total time
         time_item = time_items[-1]
-        total_time = self.parse_summary_item(time_item)
+        total_time = self._parse_summary_item(time_item)
 
         return get_minutes(total_time)
 
     def yields(self):
-        return self.get_summary_value("Makes")
+        return self._get_summary_value("Makes")
 
     def image(self):
         return self.schema.image()
 
     def ingredients(self):
-        recipe = self.get_recipe()
+        recipe = self._get_recipe()
         ingredients = recipe.find("div", {"class": "leftPanel"})
 
-        elements = self.parse_list(ingredients)
+        elements = self._parse_list(ingredients)
         return elements
 
     def ingredient_groups(self) -> List[IngredientGroup]:
-        recipe = self.get_recipe()
+        recipe = self._get_recipe()
         ingredients = recipe.find("div", {"class": "leftPanel"})
 
         groups = []
@@ -59,7 +59,7 @@ class KitchenAidAustralia(AbstractScraper):
         headings = ingredients.find_all("h2")
         for heading in headings:
             ul = heading.find_next_sibling("ul")
-            elements = self.parse_list(ul)
+            elements = self._parse_list(ul)
             ingredient_group = IngredientGroup(elements, heading.text)
             groups.append(ingredient_group)
 
@@ -69,10 +69,10 @@ class KitchenAidAustralia(AbstractScraper):
         return "\n".join(self.instructions_list())
 
     def instructions_list(self) -> List[str]:
-        recipe = self.get_recipe()
+        recipe = self._get_recipe()
         method = recipe.find("div", {"class": "rightPanel"})
 
-        return self.parse_list(method)
+        return self._parse_list(method)
 
     def ratings(self):
         return self.schema.ratings()
@@ -83,39 +83,39 @@ class KitchenAidAustralia(AbstractScraper):
     def description(self):
         return self.schema.description()
 
-    def get_recipe(self):
+    def _get_recipe(self):
         """
         Get the recipe container element.
         """
         return self.soup.find("article")
 
-    def get_summary(self):
+    def _get_summary(self):
         """
         Get the summary container element.
         """
         return self.soup.find("div", {"class": "blogRecipe-summary"})
 
-    def get_summary_value(self, field) -> str:
+    def _get_summary_value(self, field) -> str:
         """
         Get the value from the given summary field search string.
         """
-        summary = self.get_summary()
+        summary = self._get_summary()
 
         item = summary.find("strong", string=field)
-        return self.parse_summary_item(item)
+        return self._parse_summary_item(item)
 
-    def parse_summary_item(self, item):
+    def _parse_summary_item(self, item):
         """
         Get the value associated with a summary field.
         """
-        return item.find_next_sibling("p").get_text()
+        return item.find_next_sibling("p").text
 
-    def parse_list(self, container) -> List[str]:
+    def _parse_list(self, container) -> List[str]:
         """
         Get the text from each of the li elements contained by the given container.
         """
         li_list = container.find_all("li")
 
-        elements = [li.get_text() for li in li_list]
+        elements = [li.text for li in li_list]
 
         return elements

--- a/recipe_scrapers/kitchenaidaustralia.py
+++ b/recipe_scrapers/kitchenaidaustralia.py
@@ -1,0 +1,121 @@
+# mypy: allow-untyped-defs
+
+import re
+from typing import List
+
+from ._abstract import AbstractScraper
+from ._grouping_utils import IngredientGroup
+from ._utils import get_minutes
+
+
+class KitchenAidAustralia(AbstractScraper):
+    @classmethod
+    def host(cls):
+        return "kitchenaid.com.au"
+
+    def author(self):
+        return self.schema.author()
+
+    def title(self):
+        return self.schema.title()
+
+    def category(self):
+        return self.schema.category()
+
+    def total_time(self):
+        time_pattern = re.compile("time", re.IGNORECASE)
+
+        summary = self.get_summary()
+        time_items = summary.find_all("strong", string=time_pattern)
+
+        if not time_items:
+            return None
+
+        # The last item is always the total time
+        time_item = time_items[-1]
+        total_time = self.parse_summary_item(time_item)
+
+        return get_minutes(total_time)
+
+    def yields(self):
+        return self.get_summary_value("Makes")
+
+    def image(self):
+        return self.schema.image()
+
+    def ingredients(self):
+        recipe = self.get_recipe()
+        ingredients = recipe.find("div", {"class": "leftPanel"})
+
+        elements = self.parse_list(ingredients)
+        return elements
+
+    def ingredient_groups(self) -> List[IngredientGroup]:
+        recipe = self.get_recipe()
+        ingredients = recipe.find("div", {"class": "leftPanel"})
+
+        groups = []
+
+        headings = ingredients.find_all("h2")
+        for heading in headings:
+            ul = heading.find_next_sibling("ul")
+            elements = self.parse_list(ul)
+            ingredient_group = IngredientGroup(elements, heading.text)
+            groups.append(ingredient_group)
+
+        return groups
+
+    def instructions(self):
+        return "\n".join(self.instructions_list())
+
+    def instructions_list(self) -> List[str]:
+        recipe = self.get_recipe()
+        method = recipe.find("div", {"class": "rightPanel"})
+
+        return self.parse_list(method)
+
+    def ratings(self):
+        return self.schema.ratings()
+
+    def cuisine(self):
+        return self.schema.cuisine()
+
+    def description(self):
+        return self.schema.description()
+
+    def get_recipe(self):
+        """
+        Get the recipe container element.
+        """
+        return self.soup.find("article")
+
+    def get_summary(self):
+        """
+        Get the summary container element.
+        """
+        return self.soup.find("div", {"class": "blogRecipe-summary"})
+
+    def get_summary_value(self, field) -> str:
+        """
+        Get the value from the given summary field search string.
+        """
+        summary = self.get_summary()
+
+        item = summary.find("strong", string=field)
+        return self.parse_summary_item(item)
+
+    def parse_summary_item(self, item):
+        """
+        Get the value associated with a summary field.
+        """
+        return item.find_next_sibling("p").get_text()
+
+    def parse_list(self, container) -> List[str]:
+        """
+        Get the text from each of the li elements contained by the given container.
+        """
+        li_list = container.find_all("li")
+
+        elements = [li.get_text() for li in li_list]
+
+        return elements

--- a/tests/test_data/kitchenaid.com.au/kitchenaidaustralia_1.json
+++ b/tests/test_data/kitchenaid.com.au/kitchenaidaustralia_1.json
@@ -1,0 +1,78 @@
+{
+  "author": "KitchenAid",
+  "canonical_url": "https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns",
+  "host": "kitchenaid.com.au",
+  "description": "An everyday classic Easter treat! Ben Milbourne shares his recipe for hot cross buns, filled with fruit and spices. Serve fresh with a dollop of butter! Explore our Easter dessert and lunch recipe ideas too!",
+  "image": "https://kitchenaid.com.au/cdn/shop/articles/1U9A1839_BM_1_1356x.jpg?v=1649313257",
+  "ingredients": [
+    "4 cups plain flour",
+    "¼ cup caster sugar",
+    "1 tsp cinnamon",
+    "pinch of salt",
+    "¾ cup sultanas",
+    "2 x 7g sachets dried yeast",
+    "3½ teaspoon ground allspice",
+    "3¼ teaspoon grated nutmeg",
+    "¾ cup currants",
+    "300ml milk",
+    "50g butter",
+    "2 eggs",
+    "4 Tbs plain flour",
+    "4 Tbs water",
+    "1/3 cup sugar",
+    "½ cup hot water",
+    "¼ tsp cinnamon"
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "4 cups plain flour",
+        "¼ cup caster sugar",
+        "1 tsp cinnamon",
+        "pinch of salt",
+        "¾ cup sultanas",
+        "2 x 7g sachets dried yeast",
+        "3½ teaspoon ground allspice",
+        "3¼ teaspoon grated nutmeg",
+        "¾ cup currants",
+        "300ml milk",
+        "50g butter",
+        "2 eggs"
+      ],
+      "purpose": "Ingredients"
+    },
+    {
+      "ingredients": [
+        "4 Tbs plain flour",
+        "4 Tbs water"
+      ],
+      "purpose": "Crosses"
+    },
+    {
+      "ingredients": [
+        "1/3 cup sugar",
+        "½ cup hot water",
+        "¼ tsp cinnamon"
+      ],
+      "purpose": "Glaze"
+    }
+  ],
+  "instructions": "Pre-heated oven to 220 degrees\nUsing the KitchenAid Sifter + Scale Attachment, sift flour, sugar, salt and spices into KitchenAid stand mixer bowl with dough hook attachment.\nAdd yeast\nIn a saucepan heat the milk over a low temperature, add butter, stir until melted\nAdd milk and butter mixture to dry mix and turn stand mixer to level 2 until mixed thoroughly. Add the eggs and then the dried fruit continue mixing for 3-4 minutes until the dough is smooth and no longer sticky.\nRemove bowl from mixer, shape dough into a ball and cover with plastic wrap and place in a warm spot to prove for 1 hour or until doubled in size.\nPortion dough into 12 equal sized buns, placed closely together on a greased baking tray. Leave to rise for 1 hour\nTo make the crosses, mix the flour and water thoroughly to form a thick paste. Spoon into a piping bag and pipe the paste in crosses on the buns\nBake in oven for 20 minutes or until golden\nMix glaze ingredients together until sugar has dissolved. Brush glaze over buns while still hot.",
+  "instructions_list": [
+    "Pre-heated oven to 220 degrees",
+    "Using the KitchenAid Sifter + Scale Attachment, sift flour, sugar, salt and spices into KitchenAid stand mixer bowl with dough hook attachment.",
+    "Add yeast",
+    "In a saucepan heat the milk over a low temperature, add butter, stir until melted",
+    "Add milk and butter mixture to dry mix and turn stand mixer to level 2 until mixed thoroughly. Add the eggs and then the dried fruit continue mixing for 3-4 minutes until the dough is smooth and no longer sticky.",
+    "Remove bowl from mixer, shape dough into a ball and cover with plastic wrap and place in a warm spot to prove for 1 hour or until doubled in size.",
+    "Portion dough into 12 equal sized buns, placed closely together on a greased baking tray. Leave to rise for 1 hour",
+    "To make the crosses, mix the flour and water thoroughly to form a thick paste. Spoon into a piping bag and pipe the paste in crosses on the buns",
+    "Bake in oven for 20 minutes or until golden",
+    "Mix glaze ingredients together until sugar has dissolved. Brush glaze over buns while still hot."
+  ],
+  "language": "en",
+  "site_name": "KitchenAid Australia",
+  "title": "Hot Cross Buns",
+  "total_time": 80,
+  "yields": "12 servings"
+}

--- a/tests/test_data/kitchenaid.com.au/kitchenaidaustralia_1.testhtml
+++ b/tests/test_data/kitchenaid.com.au/kitchenaidaustralia_1.testhtml
@@ -1,0 +1,6111 @@
+<!doctype html>
+<html class="no-js" lang="en">
+<head>
+  
+  
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if (document.querySelectorAll('.panel-home-hero-banner').length > 0) {
+      var headerContainer = document.querySelector('#shopify-section-kitchenaid-new-header .header-container');
+      if (headerContainer) {
+        headerContainer.classList.add('w-bg');
+      }
+
+      var banner = document.querySelector('.panel-home-hero-banner');
+      banner.classList.add('is-header-bg');
+    }
+  });
+</script>
+  <!--
+Elevar Data Layer V2
+
+This file is automatically updated and should not be edited directly.
+
+https://knowledge.getelevar.com/how-to-customize-data-layer-version-2
+
+Updated: 2022-12-14 00:36:04+00:00
+Version: 2.43.0
+-->
+<!-- Google Tag Manager -->
+<script>
+  window.dataLayer = window.dataLayer || [];
+</script>
+<script>
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":
+  new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src=
+  "https://www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,"script","dataLayer","GTM-MJJKCRS");
+</script>
+<!-- End Google Tag Manager -->
+<script id="elevar-gtm-suite-config" type="application/json">{"gtm_id": "GTM-MJJKCRS", "event_config": {"cart_reconcile": true, "cart_view": true, "checkout_complete": true, "checkout_step": true, "collection_view": true, "product_add_to_cart": false, "product_add_to_cart_ajax": true, "product_remove_from_cart": true, "product_select": true, "product_view": true, "search_results_view": true, "user": true, "save_order_notes": false}, "gtm_suite_script": "https://shopify-gtm-suite.getelevar.com/shops/da9a05d6027077beb79d30e1d6e8d2792a917d2a/2.43.0/gtm-suite.js", "consent_enabled": false}</script>
+
+  <!-- Start VWO Async SmartCode -->
+<link rel="preconnect" href="https://dev.visualwebsiteoptimizer.com" />
+<script type='text/javascript' id='vwoCode'>
+
+function getCookie(cname) { var name = cname + '='; var decodedCookie = decodeURIComponent(document.cookie); var ca = decodedCookie.split(';'); for (var i = 0; i < ca.length; i++) { var c = ca[i]; while (c.charAt(0) == ' ') { c = c.substring(1); } if (c.indexOf(name) == 0) { return c.substring(name.length, c.length); } } return ''; } function setCookie(cname, cvalue, exdays) { var d = new Date(); d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000); var expires = 'expires=' + d.toUTCString(); document.cookie = cname + '=' + cvalue + ';' + expires + ';path=/'; } function bucketing() { var optVal = getCookie('optVal'); if (optVal == '') { optVal = Math.floor(Math.random() * 10) + 1; setCookie('optVal', optVal, 360); } } bucketing();
+
+window._vwo_code || (function() {
+var account_id=759593,
+version=2.0,
+settings_tolerance=2000,
+hide_element='body',
+hide_element_style = 'opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important',
+/* DO NOT EDIT BELOW THIS LINE */
+f=false,w=window,d=document,v=d.querySelector('#vwoCode'),cK='_vwo_'+account_id+'_settings',cc={};try{var c=JSON.parse(localStorage.getItem('_vwo_'+account_id+'_config'));cc=c&&typeof c==='object'?c:{}}catch(e){}var stT=cc.stT==='session'?w.sessionStorage:w.localStorage;code={use_existing_jquery:function(){return typeof use_existing_jquery!=='undefined'?use_existing_jquery:undefined},library_tolerance:function(){return typeof library_tolerance!=='undefined'?library_tolerance:undefined},settings_tolerance:function(){return cc.sT||settings_tolerance},hide_element_style:function(){return'{'+(cc.hES||hide_element_style)+'}'},hide_element:function(){return typeof cc.hE==='string'?cc.hE:hide_element},getVersion:function(){return version},finish:function(){if(!f){f=true;var e=d.getElementById('_vis_opt_path_hides');if(e)e.parentNode.removeChild(e)}},finished:function(){return f},load:function(e){var t=this.getSettings(),n=d.createElement('script'),i=this;if(t){n.textContent=t;d.getElementsByTagName('head')[0].appendChild(n);if(!w.VWO||VWO.caE){stT.removeItem(cK);i.load(e)}}else{n.fetchPriority='high';n.src=e;n.type='text/javascript';n.onerror=function(){_vwo_code.finish()};d.getElementsByTagName('head')[0].appendChild(n)}},getSettings:function(){try{var e=stT.getItem(cK);if(!e){return}e=JSON.parse(e);if(Date.now()>e.e){stT.removeItem(cK);return}return e.s}catch(e){return}},init:function(){if(d.URL.indexOf('__vwo_disable__')>-1)return;var e=this.settings_tolerance();w._vwo_settings_timer=setTimeout(function(){_vwo_code.finish();stT.removeItem(cK)},e);var t=d.currentScript,n=d.createElement('style'),i=this.hide_element(),r=t&&!t.async&&i?i+this.hide_element_style():'',c=d.getElementsByTagName('head')[0];n.setAttribute('id','_vis_opt_path_hides');v&&n.setAttribute('nonce',v.nonce);n.setAttribute('type','text/css');if(n.styleSheet)n.styleSheet.cssText=r;else n.appendChild(d.createTextNode(r));c.appendChild(n);this.load('https://dev.visualwebsiteoptimizer.com/j.php?a='+account_id+'&u='+encodeURIComponent(d.URL)+'&vn='+version)}};w._vwo_code=code;code.init();})();
+</script>
+<!-- End VWO Async SmartCode -->
+  
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta content="width=device-width, initial-scale=1.0, viewport-fit=cover" name="viewport">
+  <meta name="theme-color" content="#557b97">
+  <!-- Google search console verification marketing@intersquad.co -->
+  <meta name="google-site-verification" content="5OefCcr73IOq6aVUfW0Lau75CbuMBtegyuYkWaZCLCw" />
+  
+  
+  <link rel="canonical" href="https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns" />
+  
+
+
+  
+
+  
+
+  <link rel="shortcut icon" href="//kitchenaid.com.au/cdn/shop/files/favicon-96x96_32x32.png?v=1614739746" type="image/png">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-57x57_57x57.png?v=99634425958952796871712289949">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-60x60_60x60.png?v=157389876851543072731712289949">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-72x72_72x72.png?v=37185153831071001401712289950">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-76x76_76x76.png?v=182934322136550519001712289950">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-114x114_114x114.png?v=61356284488503937361712289946">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-120x120_120x120.png?v=125989641801020106511712289947">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-144x144_144x144.png?v=122843232898547645271712289947">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-152x152_152x152.png?v=74485544081645629971712289948">
+  <link rel="apple-touch-icon" href="//kitchenaid.com.au/cdn/shop/t/235/assets/apple-icon-180x180_180x180.png?v=183344010570285098031712289948">
+  <link rel="icon" type="image/png" href="//kitchenaid.com.au/cdn/shop/t/235/assets/android-icon-192x192_192x192.png?v=137311713532573483871712289944">
+  <link rel="icon" type="image/png" href="//kitchenaid.com.au/cdn/shop/t/235/assets/favicon-32x32_32x32.png?v=68104714593422804001712289982">
+  <link rel="icon" type="image/png" href="//kitchenaid.com.au/cdn/shop/t/235/assets/favicon-96x96_96x96.png?v=84245604281601594641712289983">
+  <link rel="icon" type="image/png" href="//kitchenaid.com.au/cdn/shop/t/235/assets/favicon-16x16_16x16.png?v=88704828135450830581712289982">
+  <link rel="manifest" href="//kitchenaid.com.au/cdn/shop/t/235/assets/manifest.json?v=170153710576350459501712290055">
+  <meta name="msapplication-TileColor" content="#ffffff">
+  <meta name="msapplication-TileImage" content="//kitchenaid.com.au/cdn/shop/t/235/assets/ms-icon-144x144_144x144.png?v=122843232898547645271712290059">
+  <meta name="theme-color" content="#ffffff">
+    
+  <meta name="format-detection" content="telephone=no"><link rel="shortcut icon" href="//kitchenaid.com.au/cdn/shop/files/favicon-96x96_32x32.png?v=1614739746" type="image/png"><title>Easy Hot Cross Buns Recipe </title><meta name="description" content="Treat the whole family with our fruity, sweet and easy Hot Cross Buns recipe. Visit is at KitchenAid and dazzle the family with more baked treats.">
+
+  <!-- /snippets/social-meta-tags.liquid -->
+
+
+
+
+<meta property="og:site_name" content="KitchenAid Australia">
+<meta property="og:url" content="https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns">
+<meta property="og:title" content="Hot Cross Buns">
+<meta property="og:type" content="article">
+<meta property="og:description" content="An everyday classic Easter treat! Ben Milbourne shares his recipe for hot cross buns, filled with fruit and spices. Serve fresh with a dollop of butter!
+Explore our Easter dessert and lunch recipe ideas too!">
+
+<meta property="og:image" content="http://kitchenaid.com.au/cdn/shop/articles/1U9A1839_BM_1_1200x1200.jpg?v=1649313257">
+<meta property="og:image:secure_url" content="https://kitchenaid.com.au/cdn/shop/articles/1U9A1839_BM_1_1200x1200.jpg?v=1649313257">
+
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Hot Cross Buns">
+<meta name="twitter:description" content="An everyday classic Easter treat! Ben Milbourne shares his recipe for hot cross buns, filled with fruit and spices. Serve fresh with a dollop of butter!
+Explore our Easter dessert and lunch recipe ideas too!">
+
+  
+  
+      <link rel="alternate" hreflang="x-default" href="https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns" />
+  
+  <link rel="alternate" hreflang="en-au" href="https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns" />
+
+
+  
+  
+  <style type="text/css">
+	/* Hide pixel tracking image to avoid 1 white px appear on the top of the */
+	body > img[src^="https://secure.adnxs.com"]{
+    display: none;
+}
+</style>
+
+	<link href="//kitchenaid.com.au/cdn/shop/t/235/assets/kitchenaid-all.css?v=102417861398847363641712538349" rel="stylesheet" type="text/css" media="all" /> 
+
+
+  <script>
+    var theme = {
+      strings: {
+        addToCart: "Add to cart",
+        soldOut: "Sold out",
+        unavailable: "Unavailable",
+        regularPrice: "Regular price",
+        sale: "Sale",
+        showMore: "Show More",
+        showLess: "Show Less",
+        addressError: "Error looking up that address",
+        addressNoResults: "No results for that address",
+        addressQueryLimit: "You have exceeded the Google API usage limit. Consider upgrading to a \u003ca href=\"https:\/\/developers.google.com\/maps\/premium\/usage-limits\"\u003ePremium Plan\u003c\/a\u003e.",
+        authError: "There was a problem authenticating your Google Maps account.",
+        newWindow: "Opens in a new window.",
+        external: "Opens external website.",
+        newWindowExternal: "Opens external website in a new window.",
+        quantityMinimumMessage: "Quantity must be 1 or more"
+      },
+      moneyFormat: "${{amount}}"
+    }
+
+    document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
+  </script>
+
+  <script>window.performance && window.performance.mark && window.performance.mark('shopify.content_for_header.start');</script><meta name="google-site-verification" content="jscL-CBcjqCdHonjUxVm3Riey6UE92Wj44xy_XMPs3c">
+<meta name="google-site-verification" content="R8kMqek-_o4v7EAmeUJaIodmY9wTEMK6vK12kwUr8YM">
+<meta name="google-site-verification" content="OVY3NIv8b-QWlzTivrixN8Mt6Wmts9TGB8UhqQMeVKg">
+<meta name="google-site-verification" content="2_QX6J96DiLGkv9OTMMkjg50hPnXo24qLKfwF6bzrQ4">
+<meta name="facebook-domain-verification" content="xwbz7fu1lm7mzf1d3ktj4obbn6l5c9">
+<meta name="facebook-domain-verification" content="qkktcof9w970w0j032umcbj5b8fw8z">
+<meta id="shopify-digital-wallet" name="shopify-digital-wallet" content="/17286922294/digital_wallets/dialog">
+<meta name="shopify-checkout-api-token" content="9e63768a1a54dfa3e558eb3da0269f7d">
+<meta id="in-context-paypal-metadata" data-shop-id="17286922294" data-venmo-supported="false" data-environment="production" data-locale="en_US" data-paypal-v4="true" data-currency="AUD">
+<link rel="alternate" type="application/atom+xml" title="Feed" href="/blogs/kitchenthusiast.atom" />
+<script async="async" src="/checkouts/internal/preloads.js?locale=en-AU"></script>
+<script async="async" src="https://shop.app/checkouts/internal/preloads.js?locale=en-AU&shop_id=17286922294" crossorigin="anonymous"></script>
+<script id="apple-pay-shop-capabilities" type="application/json">{"shopId":17286922294,"countryCode":"AU","currencyCode":"AUD","merchantCapabilities":["supports3DS"],"merchantId":"gid:\/\/shopify\/Shop\/17286922294","merchantName":"KitchenAid Australia","requiredBillingContactFields":["postalAddress","email","phone"],"requiredShippingContactFields":["postalAddress","email","phone"],"shippingType":"shipping","supportedNetworks":["visa","masterCard","amex","jcb"],"total":{"type":"pending","label":"KitchenAid Australia","amount":"1.00"},"shopifyPaymentsEnabled":true,"supportsSubscriptions":true}</script>
+<script id="shopify-features" type="application/json">{"accessToken":"9e63768a1a54dfa3e558eb3da0269f7d","betas":["rich-media-storefront-analytics"],"domain":"kitchenaid.com.au","predictiveSearch":true,"shopId":17286922294,"smart_payment_buttons_url":"https:\/\/kitchenaid.com.au\/cdn\/shopifycloud\/payment-sheet\/assets\/latest\/spb.en.js","dynamic_checkout_cart_url":"https:\/\/kitchenaid.com.au\/cdn\/shopifycloud\/payment-sheet\/assets\/latest\/dynamic-checkout-cart.en.js","locale":"en","flg4ff40b22":false}</script>
+<script>var Shopify = Shopify || {};
+Shopify.shop = "kitchenaid-australia.myshopify.com";
+Shopify.locale = "en";
+Shopify.currency = {"active":"AUD","rate":"1.0"};
+Shopify.country = "AU";
+Shopify.theme = {"name":"2024.04.05 Mother's Day launch","id":123443544136,"theme_store_id":796,"role":"main"};
+Shopify.theme.handle = "null";
+Shopify.theme.style = {"id":null,"handle":null};
+Shopify.cdnHost = "kitchenaid.com.au/cdn";
+Shopify.routes = Shopify.routes || {};
+Shopify.routes.root = "/";</script>
+<script type="module">!function(o){(o.Shopify=o.Shopify||{}).modules=!0}(window);</script>
+<script>!function(o){function n(){var o=[];function n(){o.push(Array.prototype.slice.apply(arguments))}return n.q=o,n}var t=o.Shopify=o.Shopify||{};t.loadFeatures=n(),t.autoloadFeatures=n()}(window);</script>
+<script>window.ShopifyPay = window.ShopifyPay || {};
+window.ShopifyPay.apiHost = "shop.app\/pay";</script>
+<script id="shop-js-features" type="application/json">{"compact":""}</script>
+<script>
+  window.Shopify = window.Shopify || {};
+  if (!window.Shopify.featureAssets) window.Shopify.featureAssets = {};
+  window.Shopify.featureAssets['shop-js'] = {"pay-button":["modules/client.pay-button_2b981547.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"avatar":["modules/client.avatar_cdad0c7d.en.esm.js"],"init-shop-email-lookup-coordinator":["modules/client.init-shop-email-lookup-coordinator_d39a6ea2.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"init-customer-accounts-sign-up":["modules/client.init-customer-accounts-sign-up_4f23fe3e.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"init-shop-for-new-customer-accounts":["modules/client.init-shop-for-new-customer-accounts_9fc21b0e.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"shop-pay-checkout-sheet":["modules/client.shop-pay-checkout-sheet_285e4320.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"init-customer-accounts":["modules/client.init-customer-accounts_70391801.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"shop-pay-payment-request":["modules/client.shop-pay-payment-request_193b5c5b.en.esm.js","modules/chunk.common_b1ce2487.esm.js","modules/chunk.shop-pay_20b687cc.esm.js"],"login-button":["modules/client.login-button_ba0d050e.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"discount-app":["modules/client.discount-app_4340936c.en.esm.js","modules/chunk.common_b1ce2487.esm.js"],"payment-terms":["modules/client.payment-terms_77da710a.en.esm.js","modules/chunk.common_b1ce2487.esm.js"]};
+</script>
+<script>(function() {
+  function asyncLoad() {
+    var urls = ["\/\/cdn.shopify.com\/proxy\/f16ec0fdfa963b336d2a17fdffd2d4f6c89cd4b8501f398771cff8b8fd800ce1\/bundle.thimatic-apps.com\/theme_files\/only_style.php?shop=kitchenaid-australia.myshopify.com\u0026sp-cache-control=cHVibGljLCBtYXgtYWdlPTkwMA","https:\/\/cdn.jsdelivr.net\/gh\/baberuth22\/saltye@main\/token.js?shop=kitchenaid-australia.myshopify.com","https:\/\/cdn.jsdelivr.net\/gh\/baberuth22\/saltye@main\/scrollIntoView.js?shop=kitchenaid-australia.myshopify.com","https:\/\/app.latitudepayapps.com\/inject.jsx?shop=kitchenaid-australia.myshopify.com","https:\/\/checkout.latitudefinancial.com\/assets\/shopify.js?containerId=latitude-interest-free-product-widget\u0026layout=standard\u0026merchantId=000418060\u0026promotionCode=2006\u0026promotionMonths=6\u0026shop=kitchenaid-australia.myshopify.com","\/\/social-login.oxiapps.com\/api\/init?vt=928356\u0026shop=kitchenaid-australia.myshopify.com","https:\/\/cdn.shopify.com\/s\/files\/1\/0172\/8692\/2294\/t\/113\/assets\/subscribe-it.js?v=1672663821\u0026shop=kitchenaid-australia.myshopify.com"];
+    for (var i = 0; i < urls.length; i++) {
+      var s = document.createElement('script');
+      s.type = 'text/javascript';
+      s.async = true;
+      s.src = urls[i];
+      var x = document.getElementsByTagName('script')[0];
+      x.parentNode.insertBefore(s, x);
+    }
+  };
+  if(window.attachEvent) {
+    window.attachEvent('onload', asyncLoad);
+  } else {
+    window.addEventListener('load', asyncLoad, false);
+  }
+})();</script>
+<script id="__st">var __st={"a":17286922294,"offset":36000,"reqid":"bd107c32-bbc9-4f15-96d5-d3a55ac7ff64-1712585411","pageurl":"kitchenaid.com.au\/blogs\/kitchenthusiast\/hot-cross-buns","s":"articles-31178489910","u":"493d960f7d27","p":"article","rtyp":"article","rid":31178489910};</script>
+<script>window.ShopifyPaypalV4VisibilityTracking = true;</script>
+<script integrity="sha256-n5Uet9jVOXPHGd4hH4B9Y6+BxkTluaaucmYaxAjUcvY=" data-source-attribution="shopify.loadfeatures" defer="defer" src="//kitchenaid.com.au/cdn/shopifycloud/shopify/assets/storefront/load_feature-9f951eb7d8d53973c719de211f807d63af81c644e5b9a6ae72661ac408d472f6.js" crossorigin="anonymous"></script>
+<script crossorigin="anonymous" defer="defer" src="//kitchenaid.com.au/cdn/shopifycloud/shopify/assets/shopify_pay/storefront-80e528be853eac23af2454534897ca9536b1d3d04aa043b042f34879a3c111c8.js?v=20220906"></script>
+<script integrity="sha256-HAs5a9TQVLlKuuHrahvWuke+s1UlxXohfHeoYv8G2D8=" data-source-attribution="shopify.dynamic-checkout" defer="defer" src="//kitchenaid.com.au/cdn/shopifycloud/shopify/assets/storefront/features-1c0b396bd4d054b94abae1eb6a1bd6ba47beb35525c57a217c77a862ff06d83f.js" crossorigin="anonymous"></script>
+
+
+<style id="shopify-dynamic-checkout-cart">@media screen and (min-width: 750px) {
+  #dynamic-checkout-cart {
+    min-height: 50px;
+  }
+}
+
+@media screen and (max-width: 750px) {
+  #dynamic-checkout-cart {
+    min-height: 180px;
+  }
+}
+</style><script>window.performance && window.performance.mark && window.performance.mark('shopify.content_for_header.end');</script>
+  
+  <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "OnlineStore",
+        "name": "KitchenAid Australia",
+        "url": "https://kitchenaid.com.au",
+        "description": "Welcome to KitchenAid Australia! Here you will find our range of kitchen appliances, from Stand Mixers or Blenders to Food Processors, Kettles & much more.",
+        "logo": "https://cdn.shopify.com/s/files/1/0172/8692/2294/files/logo_442x60.png?v=1565233306",
+        "image": "https://cdn.shopify.com/s/files/1/0172/8692/2294/files/logo_442x60.png?v=1565233306",
+        "sameAs": ["https://twitter.com/KitchenAidAusNZ","https://facebook.com/KitchenAidAusNZ","http://instagram.com/kitchenaidausnz/","http://youtube.com/user/KitchenaidAustralia","http://pinterest.com/kitchenaidausnz/"],
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": "6-8 Billbrooke Close",
+            "addressLocality": "Cameron Park",
+            "addressRegion": "NSW",
+            "postalCode": "2286",
+            "addressCountry": "Australia"
+        }
+    }
+  </script>
+  <!--BEGIN QUALTRICS WEBSITE FEEDBACK SNIPPET-->
+  <script type='text/javascript'>
+  (function(){var g=function(e,h,f,g){
+  this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
+  this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};
+  this.check=function(){var a=this.get(f);if(a)a=a.split(":");else if(100!=e)"v"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(":"));else return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case "v":return!1;case "r":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(":")),!c}return!0};
+  this.go=function(){if(this.check()){var a=document.createElement("script");a.type="text/javascript";a.src=g;document.body&&document.body.appendChild(a)}};
+  this.start=function(){var t=this;"complete"!==document.readyState?window.addEventListener?window.addEventListener("load",function(){t.go()},!1):window.attachEvent&&window.attachEvent("onload",function(){t.go()}):t.go()};};
+  try{(new g(100,"r","QSI_S_ZN_cvxxAL8sGDm15xI","https://zncvxxal8sgdm15xi-kasa.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_cvxxAL8sGDm15xI")).start()}catch(i){}})();
+  </script><div id='ZN_cvxxAL8sGDm15xI'><!--DO NOT REMOVE-CONTENTS PLACED HERE--></div>
+  <!--END WEBSITE FEEDBACK SNIPPET-->
+  <style>
+    .tolstoy-text-bubble-container {
+      height: 270px!important;
+    }
+  </style>
+
+  
+    
+
+
+
+<script src="https://snapui.searchspring.io/p5v2hc/bundle.js" id="searchspring-context" defer>
+	
+		template = "article.kitchenaid-v2";
+	
+	format = "${{amount}}";
+
+</script>
+
+  
+  
+<!-- BEGIN app block: shopify://apps/tolstoy-shoppable-video-quiz/blocks/widget-block/06fa8282-42ff-403e-b67c-1936776aed11 -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  <link
+    rel="preload"
+    fetchpriority="high"
+    type="image/webp"
+    as="image"
+    href="https://cdn.shopify.com/s/files/1/0172/8692/2294/files/tolstoy_65f69c4f-2a55-4014-8a4d-9eb3bbbcdba7_hero_desktop_25bzvrbo6pio0.webp?v=1712538284"
+    media="only screen and (min-width: 575px)"
+  >
+  <link
+    rel="preload"
+    fetchpriority="high"
+    type="image/webp"
+    as="image"
+    href="https://cdn.shopify.com/s/files/1/0172/8692/2294/files/tolstoy_2f40892a-b4e3-48a0-8b59-49ea1deaf029_hero_mobile_25bzvrbo6pio0.webp?v=1712538257"
+    media="only screen and (max-width: 575px)"
+  >
+
+
+
+
+<script
+  type="module"
+  async
+  src="https://widget.gotolstoy.com/we/widget.js"
+  data-shop=kitchenaid-australia.myshopify.com
+  data-app-key=074f53d6-9b5d-4d03-89eb-8dea5e9d731b
+  data-product-id=
+>
+</script>
+<script
+  type="text/javascript"
+  nomodule
+  async
+  src="https://widget.gotolstoy.com/widget/widget.js"
+  data-shop=kitchenaid-australia.myshopify.com
+  data-app-key=074f53d6-9b5d-4d03-89eb-8dea5e9d731b
+  data-product-id=
+></script>
+
+
+<!-- END app app block --><!-- BEGIN app block: shopify://apps/crazy-egg/blocks/app-embed/7ea73823-6ad9-4252-a63e-088397d54aed -->
+  <script async src="https://script.crazyegg.com/pages/scripts/0105/2217.js"></script>
+
+
+
+<!-- END app app block --><link href="https://monorail-edge.shopifysvc.com" rel="dns-prefetch">
+<script>(function(){if ("sendBeacon" in navigator && "performance" in window) {var session_token = document.cookie.match(/_shopify_s=([^;]*)/);function handle_abandonment_event(e) {var entries = performance.getEntries().filter(function(entry) {return /monorail-edge.shopifysvc.com/.test(entry.name);});if (!window.abandonment_tracked && entries.length === 0) {window.abandonment_tracked = true;var currentMs = Date.now();var navigation_start = performance.timing.navigationStart;var payload = {shop_id: 17286922294,url: window.location.href,navigation_start,duration: currentMs - navigation_start,session_token: session_token && session_token.length === 2 ? session_token[1] : "",page_type: "article"};window.navigator.sendBeacon("https://monorail-edge.shopifysvc.com/v1/produce", JSON.stringify({schema_id: "online_store_buyer_site_abandonment/1.1",payload: payload,metadata: {event_created_at_ms: currentMs,event_sent_at_ms: currentMs}}));}}window.addEventListener('pagehide', handle_abandonment_event);}}());</script>
+<script id="web-pixels-manager-setup">(function e(e,n,a,t,r){var o="function"==typeof BigInt&&-1!==BigInt.toString().indexOf("[native code]")?"modern":"legacy";window.Shopify=window.Shopify||{};var i=window.Shopify;i.analytics=i.analytics||{};var s=i.analytics;s.replayQueue=[],s.publish=function(e,n,a){return s.replayQueue.push([e,n,a]),!0};try{self.performance.mark("wpm:start")}catch(e){}var l=[a,"/wpm","/b",r,o.substring(0,1),".js"].join("");!function(e){var n=e.src,a=e.async,t=void 0===a||a,r=e.onload,o=e.onerror,i=document.createElement("script"),s=document.head,l=document.body;i.async=t,i.src=n,r&&i.addEventListener("load",r),o&&i.addEventListener("error",o),s?s.appendChild(i):l?l.appendChild(i):console.error("Did not find a head or body element to append the script")}({src:l,async:!0,onload:function(){var a=window.webPixelsManager.init(e);n(a);var t=window.Shopify.analytics;t.replayQueue.forEach((function(e){var n=e[0],t=e[1],r=e[2];a.publishCustomEvent(n,t,r)})),t.replayQueue=[],t.publish=a.publishCustomEvent,t.visitor=a.visitor},onerror:function(){var n=e.storefrontBaseUrl.replace(/\/$/,""),a="".concat(n,"/.well-known/shopify/monorail/unstable/produce_batch"),r=JSON.stringify({metadata:{event_sent_at_ms:(new Date).getTime()},events:[{schema_id:"web_pixels_manager_load/2.0",payload:{version:t||"latest",page_url:self.location.href,status:"failed",error_msg:"".concat(l," has failed to load")},metadata:{event_created_at_ms:(new Date).getTime()}}]});try{if(self.navigator.sendBeacon.bind(self.navigator)(a,r))return!0}catch(e){}var o=new XMLHttpRequest;try{return o.open("POST",a,!0),o.setRequestHeader("Content-Type","text/plain"),o.send(r),!0}catch(e){console&&console.warn&&console.warn("[Web Pixels Manager] Got an unhandled error while logging a load error.")}return!1}})})({shopId: 17286922294,storefrontBaseUrl: "https://kitchenaid.com.au",cdnBaseUrl: "https://kitchenaid.com.au/cdn",surface: "storefront-renderer",enabledBetaFlags: [],webPixelsConfigList: [{"id":"393288","configuration":"{\"global__consentEnabled\": \"false\", \"global__serverSideUrl\": \"__EMPTY__\", \"audiohook__live\": \"false\", \"audiohook__pixelId\": \"__EMPTY__\", \"audiohook__enabledWebEvents__pageView\": \"false\", \"audiohook__enabledWebEvents__purchase\": \"false\", \"audiohook__consent__enabled\": \"false\", \"audiohook__consent__ad_storage\": \"false\", \"audiohook__consent__analytics_storage\": \"false\", \"audiohook__consent__functionality_storage\": \"false\", \"audiohook__consent__personalization_storage\": \"false\", \"audiohook__consent__security_storage\": \"false\"}","eventPayloadVersion":"v1","runtimeContext":"STRICT","scriptVersion":"0.3.0","type":"APP","apiClientId":2509311,"privacyPurposes":null},{"id":"shopify-app-pixel","configuration":"{}","eventPayloadVersion":"v1","runtimeContext":"STRICT","scriptVersion":"0575","apiClientId":"shopify-pixel","type":"APP","purposes":["ANALYTICS"]},{"id":"shopify-custom-pixel","eventPayloadVersion":"v1","runtimeContext":"LAX","scriptVersion":"0575","apiClientId":"shopify-pixel","type":"CUSTOM","purposes":["ANALYTICS"]}],initData: {"cart":null,"checkout":null,"customer":null,"productVariants":[]},},function pageEvents(webPixelsManagerAPI) {webPixelsManagerAPI.publish("page_viewed");},"https://kitchenaid.com.au/cdn","0.0.469","7265dc79wdf6f2cd2p26523560m583183dc",);</script>  <script>window.ShopifyAnalytics = window.ShopifyAnalytics || {};
+window.ShopifyAnalytics.meta = window.ShopifyAnalytics.meta || {};
+window.ShopifyAnalytics.meta.currency = 'AUD';
+var meta = {"page":{"pageType":"article","resourceType":"article","resourceId":31178489910}};
+for (var attr in meta) {
+  window.ShopifyAnalytics.meta[attr] = meta[attr];
+}</script>
+<script>window.ShopifyAnalytics.merchantGoogleAnalytics = function() {
+  
+};
+</script>
+<script class="analytics">(window.gaDevIds=window.gaDevIds||[]).push('BwiEti');
+
+
+(function () {
+    var customDocumentWrite = function(content) {
+      var jquery = null;
+
+      if (window.jQuery) {
+        jquery = window.jQuery;
+      } else if (window.Checkout && window.Checkout.$) {
+        jquery = window.Checkout.$;
+      }
+
+      if (jquery) {
+        jquery('body').append(content);
+      }
+    };
+
+    var hasLoggedConversion = function(token) {
+      if (token) {
+        return document.cookie.indexOf('loggedConversion=' + token) !== -1;
+      }
+      return false;
+    }
+
+    var setCookieIfConversion = function(token) {
+      if (token) {
+        var twoMonthsFromNow = new Date(Date.now());
+        twoMonthsFromNow.setMonth(twoMonthsFromNow.getMonth() + 2);
+
+        document.cookie = 'loggedConversion=' + token + '; expires=' + twoMonthsFromNow;
+      }
+    }
+
+    var trekkie = window.ShopifyAnalytics.lib = window.trekkie = window.trekkie || [];
+    if (trekkie.integrations) {
+      return;
+    }
+    trekkie.methods = [
+      'identify',
+      'page',
+      'ready',
+      'track',
+      'trackForm',
+      'trackLink'
+    ];
+    trekkie.factory = function(method) {
+      return function() {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift(method);
+        trekkie.push(args);
+        return trekkie;
+      };
+    };
+    for (var i = 0; i < trekkie.methods.length; i++) {
+      var key = trekkie.methods[i];
+      trekkie[key] = trekkie.factory(key);
+    }
+    trekkie.load = function(config) {
+      trekkie.config = config || {};
+      trekkie.config.initialDocumentCookie = document.cookie;
+      var first = document.getElementsByTagName('script')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.onerror = function(e) {
+        var scriptFallback = document.createElement('script');
+        scriptFallback.type = 'text/javascript';
+        scriptFallback.onerror = function(error) {
+                var Monorail = {
+      produce: function produce(monorailDomain, schemaId, payload) {
+        var currentMs = new Date().getTime();
+        var event = {
+          schema_id: schemaId,
+          payload: payload,
+          metadata: {
+            event_created_at_ms: currentMs,
+            event_sent_at_ms: currentMs
+          }
+        };
+        return Monorail.sendRequest("https://" + monorailDomain + "/v1/produce", JSON.stringify(event));
+      },
+      sendRequest: function sendRequest(endpointUrl, payload) {
+        // Try the sendBeacon API
+        if (window && window.navigator && typeof window.navigator.sendBeacon === 'function' && typeof window.Blob === 'function' && !Monorail.isIos12()) {
+          var blobData = new window.Blob([payload], {
+            type: 'text/plain'
+          });
+
+          if (window.navigator.sendBeacon(endpointUrl, blobData)) {
+            return true;
+          } // sendBeacon was not successful
+
+        } // XHR beacon
+
+        var xhr = new XMLHttpRequest();
+
+        try {
+          xhr.open('POST', endpointUrl);
+          xhr.setRequestHeader('Content-Type', 'text/plain');
+          xhr.send(payload);
+        } catch (e) {
+          console.log(e);
+        }
+
+        return false;
+      },
+      isIos12: function isIos12() {
+        return window.navigator.userAgent.lastIndexOf('iPhone; CPU iPhone OS 12_') !== -1 || window.navigator.userAgent.lastIndexOf('iPad; CPU OS 12_') !== -1;
+      }
+    };
+    Monorail.produce('monorail-edge.shopifysvc.com',
+      'trekkie_storefront_load_errors/1.1',
+      {shop_id: 17286922294,
+      theme_id: 123443544136,
+      app_name: "storefront",
+      context_url: window.location.href,
+      source_url: "//kitchenaid.com.au/cdn/s/trekkie.storefront.2eced10260225d6798d99c4a95501a3f587f6b15.min.js"});
+
+        };
+        scriptFallback.async = true;
+        scriptFallback.src = '//kitchenaid.com.au/cdn/s/trekkie.storefront.2eced10260225d6798d99c4a95501a3f587f6b15.min.js';
+        first.parentNode.insertBefore(scriptFallback, first);
+      };
+      script.async = true;
+      script.src = '//kitchenaid.com.au/cdn/s/trekkie.storefront.2eced10260225d6798d99c4a95501a3f587f6b15.min.js';
+      first.parentNode.insertBefore(script, first);
+    };
+    trekkie.load(
+      {"Trekkie":{"appName":"storefront","development":false,"defaultAttributes":{"shopId":17286922294,"isMerchantRequest":null,"themeId":123443544136,"themeCityHash":"15513900758859395574","contentLanguage":"en","currency":"AUD"},"isServerSideCookieWritingEnabled":true,"monorailRegion":"shop_domain","enabledBetaFlags":["bbcf04e6"]},"Google Analytics":{"trackingId":"UA-20088246-1","domain":"auto","siteSpeedSampleRate":"10","enhancedEcommerce":true,"doubleClick":true,"includeSearch":true},"Facebook Pixel":{"pixelIds":["2293596274291013","485567175401321"],"agent":"plshopify1.2"},"Google Gtag Pixel":{"conversionId":"GT-5TPL8MH","eventLabels":[{"type":"purchase","action_label":"MC-8D86LW5SS3"},{"type":"page_view","action_label":"MC-8D86LW5SS3"},{"type":"view_item","action_label":"MC-8D86LW5SS3"}],"targetCountry":"AU"},"Session Attribution":{},"S2S":{"facebookCapiEnabled":true,"facebookAppPixelId":"485567175401321","source":"trekkie-storefront-renderer"}}
+    );
+
+    var loaded = false;
+    trekkie.ready(function() {
+      if (loaded) return;
+      loaded = true;
+
+      window.ShopifyAnalytics.lib = window.trekkie;
+
+        ga('require', 'linker');
+      function addListener(element, type, callback) {
+        if (element.addEventListener) {
+          element.addEventListener(type, callback);
+        }
+        else if (element.attachEvent) {
+          element.attachEvent('on' + type, callback);
+        }
+      }
+      function decorate(event) {
+        event = event || window.event;
+        var target = event.target || event.srcElement;
+        if (target && (target.getAttribute('action') || target.getAttribute('href'))) {
+          ga(function (tracker) {
+            var linkerParam = tracker.get('linkerParam');
+            document.cookie = '_shopify_ga=' + linkerParam + '; ' + 'path=/';
+          });
+        }
+      }
+      addListener(window, 'load', function(){
+        for (var i=0; i < document.forms.length; i++) {
+          var action = document.forms[i].getAttribute('action');
+          if(action && action.indexOf('/cart') >= 0) {
+            addListener(document.forms[i], 'submit', decorate);
+          }
+        }
+        for (var i=0; i < document.links.length; i++) {
+          var href = document.links[i].getAttribute('href');
+          if(href && href.indexOf('/checkout') >= 0) {
+            addListener(document.links[i], 'click', decorate);
+          }
+        }
+      });
+    
+
+      var originalDocumentWrite = document.write;
+      document.write = customDocumentWrite;
+      try { window.ShopifyAnalytics.merchantGoogleAnalytics.call(this); } catch(error) {};
+      document.write = originalDocumentWrite;
+
+      window.ShopifyAnalytics.lib.page(null,{"pageType":"article","resourceType":"article","resourceId":31178489910});
+
+      var match = window.location.pathname.match(/checkouts\/(.+)\/(thank_you|post_purchase)/)
+      var token = match? match[1]: undefined;
+      if (!hasLoggedConversion(token)) {
+        setCookieIfConversion(token);
+        
+      }
+    });
+
+
+        var eventsListenerScript = document.createElement('script');
+        eventsListenerScript.async = true;
+        eventsListenerScript.src = "//kitchenaid.com.au/cdn/shopifycloud/shopify/assets/shop_events_listener-61fa9e0a912c675e178777d2b27f6cbd482f8912a6b0aa31fa3515985a8cd626.js";
+        document.getElementsByTagName('head')[0].appendChild(eventsListenerScript);
+
+})();</script>
+<script class="boomerang">
+(function () {
+  if (window.BOOMR && (window.BOOMR.version || window.BOOMR.snippetExecuted)) {
+    return;
+  }
+  window.BOOMR = window.BOOMR || {};
+  window.BOOMR.snippetStart = new Date().getTime();
+  window.BOOMR.snippetExecuted = true;
+  window.BOOMR.snippetVersion = 12;
+  window.BOOMR.application = "storefront-renderer";
+  window.BOOMR.themeName = "Debut";
+  window.BOOMR.themeVersion = "11.5.0";
+  window.BOOMR.shopId = 17286922294;
+  window.BOOMR.themeId = 123443544136;
+  window.BOOMR.renderRegion = "gcp-australia-southeast1";
+  window.BOOMR.url =
+    "https://kitchenaid.com.au/cdn/shopifycloud/boomerang/shopify-boomerang-1.0.0.min.js";
+  var where = document.currentScript || document.getElementsByTagName("script")[0];
+  var parentNode = where.parentNode;
+  var promoted = false;
+  var LOADER_TIMEOUT = 3000;
+  function promote() {
+    if (promoted) {
+      return;
+    }
+    var script = document.createElement("script");
+    script.id = "boomr-scr-as";
+    script.src = window.BOOMR.url;
+    script.async = true;
+    parentNode.appendChild(script);
+    promoted = true;
+  }
+  function iframeLoader(wasFallback) {
+    promoted = true;
+    var dom, bootstrap, iframe, iframeStyle;
+    var doc = document;
+    var win = window;
+    window.BOOMR.snippetMethod = wasFallback ? "if" : "i";
+    bootstrap = function(parent, scriptId) {
+      var script = doc.createElement("script");
+      script.id = scriptId || "boomr-if-as";
+      script.src = window.BOOMR.url;
+      BOOMR_lstart = new Date().getTime();
+      parent = parent || doc.body;
+      parent.appendChild(script);
+    };
+    if (!window.addEventListener && window.attachEvent && navigator.userAgent.match(/MSIE [67]./)) {
+      window.BOOMR.snippetMethod = "s";
+      bootstrap(parentNode, "boomr-async");
+      return;
+    }
+    iframe = document.createElement("IFRAME");
+    iframe.src = "about:blank";
+    iframe.title = "";
+    iframe.role = "presentation";
+    iframe.loading = "eager";
+    iframeStyle = (iframe.frameElement || iframe).style;
+    iframeStyle.width = 0;
+    iframeStyle.height = 0;
+    iframeStyle.border = 0;
+    iframeStyle.display = "none";
+    parentNode.appendChild(iframe);
+    try {
+      win = iframe.contentWindow;
+      doc = win.document.open();
+    } catch (e) {
+      dom = document.domain;
+      iframe.src = "javascript:var d=document.open();d.domain='" + dom + "';void(0);";
+      win = iframe.contentWindow;
+      doc = win.document.open();
+    }
+    if (dom) {
+      doc._boomrl = function() {
+        this.domain = dom;
+        bootstrap();
+      };
+      doc.write("<body onload='document._boomrl();'>");
+    } else {
+      win._boomrl = function() {
+        bootstrap();
+      };
+      if (win.addEventListener) {
+        win.addEventListener("load", win._boomrl, false);
+      } else if (win.attachEvent) {
+        win.attachEvent("onload", win._boomrl);
+      }
+    }
+    doc.close();
+  }
+  var link = document.createElement("link");
+  if (link.relList &&
+    typeof link.relList.supports === "function" &&
+    link.relList.supports("preload") &&
+    ("as" in link)) {
+    window.BOOMR.snippetMethod = "p";
+    link.href = window.BOOMR.url;
+    link.rel = "preload";
+    link.as = "script";
+    link.addEventListener("load", promote);
+    link.addEventListener("error", function() {
+      iframeLoader(true);
+    });
+    setTimeout(function() {
+      if (!promoted) {
+        iframeLoader(true);
+      }
+    }, LOADER_TIMEOUT);
+    BOOMR_lstart = new Date().getTime();
+    parentNode.appendChild(link);
+  } else {
+    iframeLoader(false);
+  }
+  function boomerangSaveLoadTime(e) {
+    window.BOOMR_onload = (e && e.timeStamp) || new Date().getTime();
+  }
+  if (window.addEventListener) {
+    window.addEventListener("load", boomerangSaveLoadTime, false);
+  } else if (window.attachEvent) {
+    window.attachEvent("onload", boomerangSaveLoadTime);
+  }
+  if (document.addEventListener) {
+    document.addEventListener("onBoomerangLoaded", function(e) {
+      e.detail.BOOMR.init({
+        ResourceTiming: {
+          enabled: true,
+          trackedResourceTypes: ["script", "img", "css"]
+        },
+      });
+      e.detail.BOOMR.t_end = new Date().getTime();
+    });
+  } else if (document.attachEvent) {
+    document.attachEvent("onpropertychange", function(e) {
+      if (!e) e=event;
+      if (e.propertyName === "onBoomerangLoaded") {
+        e.detail.BOOMR.init({
+          ResourceTiming: {
+            enabled: true,
+            trackedResourceTypes: ["script", "img", "css"]
+          },
+        });
+        e.detail.BOOMR.t_end = new Date().getTime();
+      }
+    });
+  }
+})();</script>
+</head>
+
+<body class="template-article " data-template="article" data-suffix="kitchenaid-v2" t="">
+  <script>
+  (() => {
+    const configElement = document.getElementById("elevar-gtm-suite-config");
+
+    if (!configElement) {
+      console.error("Elevar Data Layer: Config element not found");
+      return;
+    }
+
+    const config = JSON.parse(configElement.textContent);
+
+    const script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src = config.gtm_suite_script;
+
+    script.onerror = () => {
+      console.error("Elevar Data Layer: JS script failed to load");
+    };
+    script.onload = async () => {
+      if (!window.ElevarGtmSuite) {
+        console.error("Elevar Data Layer: `ElevarGtmSuite` is not defined");
+        return;
+      }
+
+      const cartData = {
+  attributes:{},
+  cartTotal: "0.0",
+  currencyCode:"AUD",
+  items: []
+}
+;
+
+      await window.ElevarGtmSuite.handlers.cartAttributesReconcile(
+        cartData,
+        config.event_config.save_order_notes,
+        config.consent_enabled
+      );
+
+      if (config.event_config.user) {
+        const data = {cartTotal: "0.0",
+    currencyCode:"AUD",};
+        window.ElevarGtmSuite.handlers.user(data);
+      }
+
+      if (config.event_config.product_add_to_cart_ajax) {
+        window.ElevarGtmSuite.handlers.productAddToCartAjax(
+          config.event_config.save_order_notes,
+          config.consent_enabled
+        );
+      }
+
+      if (config.event_config.cart_reconcile) {
+        window.ElevarGtmSuite.handlers.cartItemsReconcile(cartData);
+      }};
+
+    document.body.appendChild(script);
+  })();
+</script>
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MJJKCRS" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->
+<div id="shopify-section-kitchenaid-new-header" class="shopify-section">
+
+
+
+
+<div class="header-container">
+    <span data-screen-overlay data-support-overlay></span>
+    <span data-screen-overlay data-nav-overlay></span>
+    <span data-screen-overlay data-account-overlay></span>
+    <header class="new-header is-sale-item"><div class="sale-notification-bar relative z-20 overflow-hidden py-8px bg-grey-100">
+                    <div class="swiper-container" data-slider>
+                        <div class="swiper-wrapper"><div class="swiper-slide">
+                                    <span class="block text-12px leading-16px text-white font-normal tracking-1px uppercase text-center px-5px md:px-0">FREE DELIVERY ON ALL ORDERS OVER $99 | FREE RETURNS</span>
+                                </div></div>
+                    </div>
+                </div>
+
+                <script>
+                    document.body.classList.add('w-sale');
+                </script><div class="new-header-wrap">
+                <div class="inner w-1920px">
+                    <div class="top lg:flex lg:items-center lg:justify-between lg:items-end">
+                        <div class="hidden lg:flex lg:flex-1 flex items-center">
+                            <a href="/" class="logo ml-15px lg:ml-0">
+                                <svg width="159" height="16" viewBox="0 0 159 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M39.3614 13.286C38.8539 13.286 38.3672 13.0839 38.008 12.7239C37.6489 12.3639 37.4468 11.8755 37.446 11.366V8.55246H40.5612V5.92H37.446V2.29736H31.2667V5.92H29.4023V8.55246H31.2667V12.3291V12.4589C31.2667 14.3396 33.3445 15.8672 35.9124 15.8672C37.517 15.8909 39.1058 15.5471 40.5582 14.8619V12.8543C40.2207 13.1324 39.7979 13.2849 39.3614 13.286Z" fill="#C41230" />
+                                    <path d="M27.4117 5.92004H21.3076V15.3087H27.4117V5.92004Z" fill="#C41230" />
+                                    <path d="M24.3565 4.54925C26.0404 4.54925 27.4026 3.54095 27.4026 2.29416C27.4026 1.04736 26.0404 0.0390625 24.3565 0.0390625C22.6726 0.0390625 21.3135 1.05038 21.3135 2.29416C21.3135 3.53793 22.6756 4.54925 24.3565 4.54925Z" fill="#C41230" />
+                                    <path d="M80.5384 11.3992H89.1323C89.1323 11.3992 89.3668 9.13812 88.2542 7.70416C87.0514 6.16755 84.6459 5.28906 81.9817 5.28906C79.3175 5.28906 74.3621 5.94718 74.3621 10.6506C74.3621 15.354 78.9988 15.8762 81.9697 15.8762C87.6619 15.8762 88.9609 14.5479 88.9609 14.5479V12.6309C87.156 13.228 85.2682 13.5337 83.3679 13.5366C80.2226 13.5366 80.5384 11.7494 80.5384 11.3992ZM80.5384 9.1985V8.88152C80.5384 8.48119 80.6968 8.09726 80.9787 7.81418C81.2607 7.53111 81.6431 7.37208 82.0418 7.37208C82.4406 7.37208 82.823 7.53111 83.105 7.81418C83.3869 8.09726 83.5453 8.48119 83.5453 8.88152C83.5453 8.88152 83.5453 9.20453 83.5453 9.20755V9.23774H80.5384V9.1985Z" fill="#C41230" />
+                                    <path d="M67.2146 5.62712C65.9435 5.67424 64.7162 6.10565 63.6935 6.86485V0.902588H57.5894V15.3056H63.6845V10.7441C63.6845 10.3438 63.8429 9.95984 64.1248 9.67677C64.4068 9.39369 64.7892 9.23466 65.1879 9.23466C65.5867 9.23466 65.9691 9.39369 66.2511 9.67677C66.533 9.95984 66.6914 10.3438 66.6914 10.7441V15.3056H72.2874V9.85353C72.2814 8.86032 71.1177 5.62712 67.2146 5.62712Z" fill="#C41230" />
+                                    <path d="M101.064 5.62714C99.7937 5.67374 98.5672 6.10523 97.5459 6.86487V5.91997H91.4387V15.3056H97.5338V10.7441C97.5338 10.3438 97.6922 9.95986 97.9742 9.67679C98.2561 9.39371 98.6386 9.23468 99.0373 9.23468C99.4361 9.23468 99.8185 9.39371 100.1 9.67679C100.382 9.95986 100.541 10.3438 100.541 10.7441V15.3056H106.137V9.85355C106.131 8.86034 104.967 5.62714 101.064 5.62714Z" fill="#C41230" />
+                                    <path d="M134.571 5.92004H128.467V15.3087H134.571V5.92004Z" fill="#C41230" />
+                                    <path d="M131.518 4.54925C133.202 4.54925 134.565 3.54095 134.565 2.29416C134.565 1.04736 133.202 0.0390625 131.518 0.0390625C129.835 0.0390625 128.472 1.05038 128.472 2.29416C128.472 3.53793 129.838 4.54925 131.518 4.54925Z" fill="#C41230" />
+                                    <path d="M119.437 15.3057H126.743L120.176 0H112.869L113.642 1.81132L107.866 15.3057H111.504L112.677 12.6068H118.294L119.437 15.3057ZM114.108 9.23773L115.47 6.06189L116.832 9.23773H114.108Z" fill="#C41230" />
+                                    <path d="M16.4121 7.93962C16.2032 7.43305 15.8754 6.98476 15.4565 6.63307C15.0376 6.28137 14.5401 6.03671 14.0065 5.92L18.126 0H12.6564L8.95481 5.31924C8.81477 5.50671 8.63317 5.65887 8.4244 5.76366C8.21564 5.86846 7.98544 5.92302 7.75203 5.92302C7.59266 5.92302 7.47238 5.92302 7.42126 5.92302V0H0.300781V15.3057H7.43329V9.96528C7.73406 9.81846 8.06409 9.74207 8.39852 9.74189C8.84323 9.74454 9.27739 9.87809 9.64724 10.126C10.0171 10.3739 10.3064 10.7253 10.4793 11.1366L12.2835 15.3057H19.5904L16.4121 7.93962Z" fill="#C41230" />
+                                    <path d="M51.8611 12.5435C49.8404 12.5435 48.2016 11.9096 48.2016 10.5752C48.2016 9.2409 49.8404 8.60996 51.8611 8.60996C53.0639 8.60996 54.1283 8.83637 54.7959 9.29826V6.59335C53.4398 5.70279 51.5875 5.27411 49.5307 5.27411C45.4292 5.27411 42.1035 6.97977 42.1035 10.5752C42.1035 14.1707 45.4292 15.8764 49.5307 15.8764C51.5875 15.8764 53.4398 15.4477 54.7959 14.5662V11.8492C54.1283 12.3292 53.0639 12.5435 51.8611 12.5435Z" fill="#C41230" />
+                                    <path d="M146.087 0.881287V6.16732C145.045 5.57529 143.869 5.26333 142.671 5.26166C139.144 5.26166 136.573 6.8828 136.573 10.3002C136.573 13.7175 139.138 15.3266 142.671 15.3266C143.868 15.3234 145.045 15.0116 146.087 14.4209V15.2903H152.191V0.881287H146.087ZM144.421 12.0934C143.976 12.0485 143.564 11.8393 143.264 11.5063C142.964 11.1732 142.797 10.7402 142.797 10.2911C142.797 9.84203 142.964 9.40896 143.264 9.07594C143.564 8.74292 143.976 8.53368 144.421 8.48883C145.047 8.49315 145.646 8.74603 146.087 9.19223V11.3869C145.647 11.834 145.048 12.0879 144.421 12.0934Z" fill="#C41230" />
+                                    <path d="M156.879 1.60302C156.879 1.12302 156.536 0.857361 155.977 0.857361H155.138V3.31774H155.676V2.36679H155.857L156.506 3.33585L157.069 3.23925L156.41 2.27321C156.55 2.22753 156.671 2.13751 156.756 2.01665C156.841 1.8958 156.884 1.75065 156.879 1.60302ZM155.926 1.99547H155.676V1.29812H155.932C156.191 1.29812 156.335 1.42189 156.335 1.64227C156.335 1.86264 156.179 1.99547 155.92 1.99547H155.926Z" fill="#C41230" />
+                                    <path d="M155.956 0.0390138C155.679 0.0302938 155.404 0.0793198 155.147 0.182995C154.89 0.286669 154.657 0.442738 154.463 0.641338C154.269 0.839938 154.118 1.07675 154.02 1.33681C153.922 1.59687 153.879 1.87452 153.893 2.15222C153.893 3.42015 154.738 4.26543 155.956 4.26543C156.233 4.27507 156.509 4.22667 156.767 4.12332C157.024 4.01997 157.257 3.86392 157.451 3.66513C157.645 3.46634 157.796 3.22915 157.894 2.96867C157.991 2.7082 158.034 2.43014 158.019 2.15222C158.019 0.896372 157.18 0.0390138 155.956 0.0390138ZM155.956 3.92128C155.036 3.92128 154.299 3.28732 154.299 2.1643C154.299 1.04128 155.036 0.398259 155.956 0.398259C156.876 0.398259 157.622 1.03524 157.622 2.1643C157.622 3.29335 156.879 3.92128 155.956 3.92128Z" fill="#C41230" />
+                                </svg>
+                                <span class="sr-only">Logo Kitchenaid</span>
+                            </a>
+                        </div>
+                        <div class="hidden lg:block lg:w-36.946564885 xxxl:w-43.181818181 lg:pb-3px">
+                            <div class="search">
+
+                                
+                                <form method="get" action="/collections/shop">
+                                    <div class="form-group flex lg:mx-auto lg:rounded-bl-20px lg:rounded-br-20px">
+                                        <div class="input w-search">
+                                            <label class="sr-only" for="search-accordion-term-dk">Search</label>
+                                            <input type="text" name="s" class="ss__autocomplete__input form-control relative z-20 text-black-100 tracking-0.2px text-15px font-light px-15px py-10px xl:py-15px border-0 xl:pl-32px" id="search-accordion-term-dk" value="">
+                                            <div class="placeholder flex items-center justify-center">
+                                                <span class="icon-search-ver2 w-16px h-16px text-16px "></span>
+                                                <span class="text-14px leading-19px tracking-0_01em font-light pl-8px">Search</span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </form>
+                                
+                                
+                            </div>
+                        </div>
+                        <div class="lg:flex-1 flex items-center justify-end lg:items-end">
+                            <div class="hidden lg:block">
+                                <a href="#" class="hidden lg:flex items-center justify-center lg:w-38px lg:h-38px rounded-full" role="button" arial-label="Open support menu" data-btn-control data-support-element data-kb-element data-name="support-dk">
+                                    <span class="new-home-icon-headphones-mic lg:text-20px"></span>
+                                    <span class="sr-only">Support</span>
+                                </a>
+
+                                <!-- support dk -->
+                                
+                                <div data-support-content data-kb-content data-name="support-dk" class="absolute left-0 top-full w-full">
+                                    
+                                    <div data-support-box class="relative bg-gray-200 z-10 py-48px">
+                                        <a href="#" class="block absolute z-20 top-24px right-25px" data-support-close data-name="support-dk">
+                                            <span class="sr-only">Close support popup</span>
+                                            <span class="new-home-icon-close text-15px text-black-100"></span>
+                                        </a>
+
+                                        <div class="inner w-1920px">
+                                            <div class="flex -mx-16px xxxl:-mx-24px">
+                                                
+                                                    
+
+                                                    <div class="w-1/4 relative px-16px xxxl:px-24px">
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+                                                                    
+
+                                                                    <div w-group>
+                                                                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-38 mb-16px">Support</span>
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/faqs" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Frequently asked questions</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="https://kitchenaid.com.au/blogs/kitchenthusiast/tagged/blog-category-hints-tips" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Product Hints & Tips</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/delivery" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Delivery</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/returns-policy" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Returns</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/register-my-product" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Register My Product</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/stockists" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Stockist & Service Centre Finder</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/user-guides" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">User Guides</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="https://cdn.shopify.com/s/files/1/0172/8692/2294/files/KA_2021_Warranty_Flyer_updated_30.07.21.pdf?v=1627614148" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Warranty Information</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/product-safety-recall" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Product Safety Recall</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="/pages/price-match-policy" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Price Match Policy</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                        <div class="flex" w-orther-link>
+                                                                            <a href="https://giftcards.kitchenaid.com.au/" class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100">Gift Cards</a>
+                                                                        </div>
+                                                                    
+                                                            
+                                                        
+
+                                                        <!-- close new group when last -->
+                                                        
+
+                                                        
+
+                                                        
+
+                                                        
+
+                                                        
+                                                            
+                                                            </div>
+                                                        
+
+                                                        <!-- <span class="block my-16px h-1px bg-black-8"></span> -->
+                                                        
+                                                            <span class="absolute right-0 top-0 w-1px bg-black-8 z-10 h-full"></span>
+                                                        
+
+                                                    </div>
+                                                
+                                                    
+
+                                                    <div class="w-1/4 relative px-16px xxxl:px-24px">
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+                                                                    
+
+                                                                    <div w-group>
+                                                                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-38 mb-16px">Track my order</span>
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                    
+                                                                    <div class="flex" w-orther-link>
+                                                                        <a href="/pages/track-my-order"  class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100 flex"><span class="new-home-icon-track-order text-18px text-red-100 mr-17px"></span>Check my order status</a>
+                                                                    </div>
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+                                                                        
+                                                                            
+                                                                            </div>
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                    
+
+                                                                    
+                                                                    
+
+                                                                    <div w-group>
+                                                                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-38 mb-16px"> <span class="normal-case">CUSTOMER SERVICE FOR SMALL APPLIANCES (STAND MIXER, FOOD PROCESSOR, BLENDERS, BREAKFAST)</span></span>
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                    
+                                                                    <div class="flex" w-orther-link>
+                                                                        <a href="/pages/contact-us"  class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100 flex"><span class="new-home-icon-form-fill text-18px text-red-100 mr-17px"></span>Online Enquiry Form</a>
+                                                                    </div>
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                    
+                                                                    <div class="flex" w-orther-link>
+                                                                        <a href="tel:1800990990"  class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100 flex"><span class="new-home-icon-headphones-mic text-18px text-red-100 mr-17px"></span>1800 990 990</a>
+                                                                    </div>
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+
+                                                        
+                                                            
+
+                                                            
+                                                                    
+                                                                        
+                                                                            
+                                                                            </div>
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                    
+
+                                                                    
+                                                                    
+
+                                                                    <div w-group>
+                                                                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-38 mb-16px"> <span class="normal-case">CUSTOMER SERVICE FOR KITCHENWARE & OVENWARE (COOKWARE & BAKEWARE))</span></span>
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                        
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                    
+                                                                    <div class="flex" w-orther-link>
+                                                                        <a href="tel:1800918480"  class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100 flex"><span class="new-home-icon-headphones-mic text-18px text-red-100 mr-17px"></span>1800 918 480 (Hours of Operation: Mon-Fri; 9am – 6pm)</a>
+                                                                    </div>
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+
+                                                                    
+
+                                                                    
+                                                                    
+                                                                    <div class="flex" w-orther-link>
+                                                                        <a href="https://support.kitchenaidtools.com/hc/en-au"  class="capitalize font-light text-15px leading-20px text-black-100 transition-colors duration-250 lg:hover:text-red-100 flex"><span class="new-home-icon-web text-18px text-red-100 mr-17px"></span>Kitchenware Information</a>
+                                                                    </div>
+
+                                                                
+                                                        
+
+                                                        <!-- close new group when last -->
+                                                        
+
+                                                        
+
+                                                        
+
+                                                        
+
+                                                        
+                                                            
+                                                            </div>
+                                                        
+
+                                                        <!-- <span class="block my-16px h-1px bg-black-8"></span> -->
+                                                        
+                                                            <span class="absolute right-0 top-0 w-1px bg-black-8 z-10 h-full"></span>
+                                                        
+
+                                                    </div>
+                                                
+                                                    
+
+                                                    <div class="w-1/2 relative px-16px xxxl:px-24px">
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+                                                        
+
+                                                        
+                                                            
+
+                                                            
+                                                                    
+                                                                        
+                                                                        <div class="flex -mx-8px xxxl:-mx-16px">
+                                                                    
+
+                                                                    
+                                                                    
+                                                                        
+                                                                    
+                                                                        
+                                                                    
+                                                                        
+                                                                    
+
+                                                                
+                                                        
+                                                            
+
+                                                            
+                                                                    
+
+                                                                    
+                                                                    
+                                                                        
+                                                                    
+                                                                        
+                                                                    
+                                                                        
+                                                                    
+
+                                                                
+                                                        
+
+                                                        <!-- close new group when last -->
+                                                        
+
+                                                        
+
+                                                        
+
+                                                        
+                                                            
+                                                            </div>
+                                                        
+
+                                                        
+
+                                                        <!-- <span class="block my-16px h-1px bg-black-8"></span> -->
+                                                        
+
+                                                    </div>
+                                                
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                
+                                <!-- end support dk -->
+                            </div>
+                            <div class="lg:ml-15px">
+                                <a href="" class="hidden lg:flex items-center justify-center lg:w-38px lg:h-38px rounded-full" data-btn-control data-account-element data-kb-element data-name="account" role="button" arial-label="Open account menu" >
+                                    <span class="new-home-icon-user text-16px lg:text-18px"></span>
+                                    <span class="sr-only">Account</span>
+                                </a>
+
+                                <!-- account -->
+                                
+                                    <div data-account-content data-kb-content data-name="account">
+                                        <span class="overlay bg-black-40 lg:hidden" data-account-close></span>
+                                        <div class="wrap relative z-2 bg-white pt-40px pb-100px px-35px lg:pt-20px lg:pb-25px lg:px-26px">
+                                            <a href="#" class="close lg:hidden" data-account-close>
+                                                <span class="sr-only">Close account popup</span>
+                                                <span class="icon-close text-19px text-dark-gray-500"></span>
+                                            </a>
+                                            <div class="relative overflow-hidden max-w-520px mx-auto lg:max-w-none">
+                                                <div data-account-form data-name="login-popup" class="p-4px">
+                                                    
+                                                    <form method="post" action="/account/login" id="LoginPopupForm" accept-charset="UTF-8" data-login-with-shop-sign-in="true" class="form"><input type="hidden" name="form_type" value="customer_login" /><input type="hidden" name="utf8" value="✓" />
+                                                        <p class="text-20px leading-26px text-dark-gray-500 capitalize font-medium text-center mb-27px md:text-18px lg:mb-12px">sign in</p>
+                                                        <div class="form-list">
+                                                            <div class="form-item mb-15px lg:mb-12px">
+                                                                <label class="sr-only" for="CustomerEmailPopup">Email address</label>
+                                                                <div class="input">
+                                                                    <input type="email" name="customer[email]" id="CustomerEmailPopup" autocomplete="email" autocorrect="off" autocapitalize="off" class="form-control text-center" placeholder="Email address" required>
+                                                                </div>
+                                                            </div>
+                                                            <div class="form-item">
+                                                                <label class="sr-only" for="CustomerPasswordPopup">Password</label>
+                                                                <div class="input">
+                                                                    <input type="password" value="" placeholder="Password" name="customer[password]" id="CustomerPasswordPopup" class="form-control text-center" required>
+                                                                </div>
+                                                            </div>
+                                                            <div class="text-right mt-9px lg:mt-8px">
+                                                                <a href="#" data-account-btn data-kb-element data-name="recover-password-popup" class="text-dark-red text-12px leading-26px font-medium" id="recover-password">Forgot your password?</a>
+                                                            </div>
+                                                            <div class="mt-27px lg:mt-12px">
+                                                                <button type="submit" class="btn btn-link inline-block w-bg medium dark-red w-full">
+                                                                    <span class="txt uppercase text-center">sign in</span>
+                                                                </button>
+                                                            </div>
+                                                            <div class="message error"></div>
+                                                        </div>
+                                                    </form>
+                                                    <div class="mt-50px lg:mt-20px">
+                                                        <div class="flex items-center">
+                                                            <span class="flex-1 h-1px bg-grey-200"></span>
+                                                            <p class="text-12px italic px-9px">or sign in with</p>
+                                                            <style>
+                                                                @media screen and (max-width: 441px), screen and (min-width: 1024px) {
+                                                                    #social_login_frame {
+                                                                        height: 40px !important;
+                                                                        margin: 0 !important;
+                                                                    }
+                                                                }
+                                                            </style>
+                                                            <span class="flex-1 h-1px bg-grey-200"></span>
+                                                        </div>
+                                                        <div class='mt-20px lg:mt-12px oxi-social-login w-op2 loading'></div>
+                                                        <div class="mt-40px lg:mt-30px">
+                                                            <a href="/account/register" class="btn btn-link inline-block w-bg medium dark-red-outline w-full bg-white">
+                                                                <span class="txt uppercase text-center">CREATE an account</span>
+                                                            </a>
+                                                        </div>
+                                                    </div>
+                                                </div>
+
+                                                <div class="absolute z-10 top-0 left-0 w-full h-full bg-white p-4px" data-account-form data-kb-content data-name="recover-password-popup">
+                                                    <form method="post" action="/account/recover" accept-charset="UTF-8" class="form"><input type="hidden" name="form_type" value="recover_customer_password" /><input type="hidden" name="utf8" value="✓" />
+                                                    <p class="text-20px leading-26px text-dark-gray-500 capitalize font-medium text-center mb-27px md:text-18px lg:mb-12px">reset your password</p>
+                                                    <div class="form-list">
+                                                        <div class="form-item">
+                                                            <label class="sr-only" for="RecoverEmailPopup">Email address</label>
+                                                            <div class="input">
+                                                                <input type="email" value="" name="email" placeholder="Email address" id="RecoverEmailPopup" class="form-control text-center" autocorrect="off" autocapitalize="off" required>
+                                                            </div>
+                                                        </div>
+                                                        <div class="mt-15px">
+                                                            <button type="submit" class="btn btn-link inline-block w-bg medium dark-red w-full">
+                                                                <span class="txt uppercase text-center">submit</span>
+                                                            </button>
+                                                            <div class="text-center mt-12px">
+                                                                <a href="#" data-account-btn data-name="login-popup" class="text-dark-red text-12px font-medium">Cancel</a>
+                                                            </div>
+                                                        </div>
+                                                        <div class="message error"></div>
+                                                    </div>
+                                                    <div class="hidden" data-account-form-success>
+                                                        <p class="text-dark-gray-500">We've sent you an email with a link to update your password.</p>
+                                                        <div class="mt-12px">
+                                                            <a href="#" data-account-btn data-name="login-popup" class="text-dark-red text-12px font-medium">Sign in</a>
+                                                        </div>
+                                                    </div>
+                                                    </form>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                
+                                <!-- end account -->
+                            </div>
+                            <div class="hidden lg:block">
+                                
+	
+    <a href="/apps/iwish" class="flex items-center justify-center w-40px h-40px lg:w-38px lg:h-38px rounded-full lg:ml-15px" data-btn-control arial-label="View wishlist">
+        <span class="new-home-icon-favourire text-16px lg:text-18px"></span>
+        <span class="sr-only">Wishlist</span>
+    </a>
+
+
+                            </div>
+                            <a href="/cart" class="hidden lg:flex items-center justify-center w-40px h-40px lg:w-38px lg:h-38px rounded-full -mr-12px lg:-mr-14px lg:ml-15px " data-btn-control arial-label="View cart" data-shopping-cart-element role="button" arial-label="Open popup cart" >
+                                <span class="new-home-icon-cart text-16px lg:text-20px"></span>
+                                <span class="sr-only">Cart</span>
+                                <div id="CartCount" class="site-header__cart-count text-12px hidden">
+                                    (0)
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="bottom flex items-center justify-between lg:block">
+                        <div class="flex items-center lg:block">
+                            <button class="hamburger flex items-center justify-center w-48px h-56px lg:hidden -ml-13px" data-hamburger="" aria-haspopup="true" aria-expanded="false" aria-controls="nav-masthead">
+                                <span class="sr-only">Menu</span>
+                                <svg width="22" height="15" viewBox="0 0 22 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <line x1="1.72656" y1="1.12744" x2="21.1523" y2="1.12744" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                    <line x1="1.72656" y1="7.68555" x2="21.1523" y2="7.68555" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                    <line x1="1.72656" y1="14.2437" x2="21.1523" y2="14.2437" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                </svg>
+                            </button>
+                            
+                            <div class="nav" data-nav="" id="nav-masthead" data-kb-content="" data-name="nav" data-kb-mobile="true">
+                                <span class="overlay" data-close="">&nbsp;</span>
+                                
+                                <a href="#" class="invisible" data-nav-close role="button" aria-label="Close mega menu" aria-controls="nav-masthead">
+                                    <svg width="34" height="35" viewBox="0 0 34 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <line x1="25.001" y1="9.81579" x2="9.09107" y2="25.7257" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                                        <line x1="25.151" y1="25.4824" x2="9.24111" y2="9.57252" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+                                    </svg>
+
+                                </a>
+                                <div class="wrap invisible">
+                                    <!-- <a href="#" class="open"></a> -->
+                                    <nav aria-label="Main Navigation">
+                                        <span class="block text-center text-14px leading-19px font-light tracking-0_01em pt-14px pb-23px lg:hidden">Shop</span>
+                                        <ul class="nav-menu ul-main">
+                                            
+                                                
+                                                <li class="nav-item is-dropdown">
+                                                    <a href="#" class="no-link" data-expand="" data-sub-name="stand-mixers" aria-expanded="false" aria-haspopup="true" role="button">
+                                                        
+                                                        <span class="icon-svg">
+                                                            
+		<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.6287 8.89317C14.9742 8.89317 14.4353 9.39365 14.4353 10.0866C14.4353 10.7411 14.9357 11.28 15.6287 11.28C16.2062 11.28 16.7066 10.8566 16.7836 10.2791H21.8269V9.93262H16.7836C16.7066 9.31665 16.2062 8.89317 15.6287 8.89317ZM16.4371 10.0866C16.4371 10.5486 16.0522 10.8951 15.6287 10.8951C15.1667 10.8951 14.8202 10.5101 14.8202 10.0866C14.8202 9.62463 15.2053 9.27815 15.6287 9.27815C16.0522 9.27815 16.4371 9.62463 16.4371 10.0866ZM39.5748 23.0991V16.0539H29.4112V15.5534H31.0667C31.8751 15.5534 32.5296 14.9374 32.568 14.129H32.8761C33.6845 14.129 34.3005 13.4745 34.3005 12.7045V8.66217H35.4555C36.264 8.66217 36.88 8.0077 36.88 7.23773V5.4283C36.88 4.61983 36.2254 4.00385 35.4555 4.00385H34.0695C33.0301 1.57844 30.6432 0 28.0253 0H7.62101C3.96365 0 0.999256 2.96439 0.999256 6.62175C0.999256 8.04619 1.46124 9.39365 2.2697 10.5101V10.9335C2.2697 11.4341 2.4622 12.2425 3.77115 12.512L6.11956 13.1665C6.81254 13.3975 7.23602 14.0905 7.08203 14.8219L1.96172 35.4957C0.883757 35.8806 0.267782 36.9586 0.460275 38.0751C0.652768 39.1531 1.65373 40 2.84719 40H35.6094C36.8414 40 37.8423 39.1145 37.9964 37.9595C38.0734 37.3051 37.8809 36.6121 37.4188 36.1501C36.9954 35.6496 36.341 35.3417 35.6864 35.3417H33.1456V33.4937C37.0339 31.5688 39.5748 27.4495 39.5748 23.0991ZM35.648 36.2656C36.0329 36.2656 36.4564 36.4581 36.6874 36.7277C36.9569 37.0356 37.0724 37.4206 37.0339 37.8055C36.9569 38.4985 36.3409 39.0375 35.571 39.0375H2.80869C2.11571 39.0375 1.46123 38.5371 1.38424 37.8825C1.26875 37.1511 1.73072 36.4581 2.4622 36.2656L2.73169 36.1886L7.9675 14.976C8.85296 14.1675 9.93092 13.744 11.0474 13.744C12.2793 13.744 13.4728 14.283 14.4353 15.2839C13.8963 17.0549 13.8963 19.0568 13.8963 21.0202V21.5976C13.8963 27.796 17.6307 33.9558 22.751 36.2271L22.828 36.2656H23.6749V32.8393L23.4054 32.7238C19.671 30.9528 17.2072 27.18 17.2072 23.0221V16.9009H38.6124V23.0221C38.6124 27.18 36.1869 30.9913 32.4141 32.7238L32.1446 32.8393V36.2271H35.648V36.2656ZM3.11667 10.0866C2.30821 9.08565 1.92322 7.8922 1.92322 6.62175C1.92322 3.77286 4.00214 1.42445 6.65855 1.00097V12.435C6.54305 12.358 6.42755 12.358 6.31206 12.3195L3.96365 11.6651H3.92514C3.15517 11.5111 3.15517 11.1261 3.15517 11.0106V10.3176L3.11667 10.0866ZM31.6056 13.1665V14.0519C31.6056 14.36 31.3746 14.5909 31.0667 14.5909H28.4872V16.0154H27.4093V14.5909H24.8299C24.5219 14.5909 24.2909 14.36 24.2909 14.0519V13.1665H23.3284C23.0589 13.1665 22.828 12.974 22.828 12.7045V12.0501H18.1696C16.9377 12.0501 15.7443 12.7045 15.1283 13.7825C14.8972 14.1675 14.7048 14.5909 14.5507 15.0144C13.5882 14.0519 12.3564 13.513 11.0474 13.513C9.96941 13.513 8.92995 13.8595 8.04449 14.5909C8.04449 13.821 7.69801 13.0894 7.08203 12.666V0.962464C7.27452 0.923965 7.42851 0.923964 7.62101 0.923964H27.9097C30.2582 0.923964 32.4141 2.42541 33.2226 4.65832L33.338 4.96631H35.3785C35.648 4.96631 35.8789 5.15881 35.8789 5.4283V7.23773C35.8789 7.50722 35.6864 7.73821 35.4169 7.73821H33.2996V12.666C33.2996 12.9355 33.107 13.1665 32.8375 13.1665H31.6056ZM22.751 33.4937V35.2262C18.2081 33.0317 14.7818 27.2184 14.7818 21.6362V21.0588C14.7818 18.6333 14.7818 16.1308 15.8982 14.2444C16.3987 13.4359 17.2456 12.974 18.1696 12.974H21.9039C22.0195 13.6285 22.6354 14.129 23.2899 14.129C23.3284 14.9374 23.9828 15.5534 24.7914 15.5534H26.4468V16.0539H16.2831V23.0991C16.2831 27.4495 18.8241 31.5688 22.751 33.4937Z" fill="#C41230"/>
+</svg>
+
+	
+                                                        </span>
+                                                        <span class="txt">Stand Mixers</span>
+
+                                                        
+                                                            <span class="expand">
+                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                </svg>
+                                                            </span>
+                                                        
+                                                    </a>
+
+                                                     
+                                                        <div data-nav-dropdown-content="" class="sub-nav invisible" id="stand-mixers">
+                                                            <div class="__box" data-subnav="">
+                                                                 <a href="#" class="back" data-back="" data-level-02 aria-controls="stand-mixers">
+                                                                    <span class="icon">
+                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                        </svg>
+                                                                    </span>
+                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Stand Mixers</span>
+                                                                </a>
+
+                                                                
+                                                                
+
+                                                                <div class="__box-wrap">
+                                                                    <div class="inner w-1920px">
+                                                                        <ul class="sub-nav-group ul-sub">
+                                                                            
+
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/kitchenaid-mixers" >
+                                                                                        <span class="icon-svg stand-mixers">
+                                                                                            
+		<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.6287 8.89317C14.9742 8.89317 14.4353 9.39365 14.4353 10.0866C14.4353 10.7411 14.9357 11.28 15.6287 11.28C16.2062 11.28 16.7066 10.8566 16.7836 10.2791H21.8269V9.93262H16.7836C16.7066 9.31665 16.2062 8.89317 15.6287 8.89317ZM16.4371 10.0866C16.4371 10.5486 16.0522 10.8951 15.6287 10.8951C15.1667 10.8951 14.8202 10.5101 14.8202 10.0866C14.8202 9.62463 15.2053 9.27815 15.6287 9.27815C16.0522 9.27815 16.4371 9.62463 16.4371 10.0866ZM39.5748 23.0991V16.0539H29.4112V15.5534H31.0667C31.8751 15.5534 32.5296 14.9374 32.568 14.129H32.8761C33.6845 14.129 34.3005 13.4745 34.3005 12.7045V8.66217H35.4555C36.264 8.66217 36.88 8.0077 36.88 7.23773V5.4283C36.88 4.61983 36.2254 4.00385 35.4555 4.00385H34.0695C33.0301 1.57844 30.6432 0 28.0253 0H7.62101C3.96365 0 0.999256 2.96439 0.999256 6.62175C0.999256 8.04619 1.46124 9.39365 2.2697 10.5101V10.9335C2.2697 11.4341 2.4622 12.2425 3.77115 12.512L6.11956 13.1665C6.81254 13.3975 7.23602 14.0905 7.08203 14.8219L1.96172 35.4957C0.883757 35.8806 0.267782 36.9586 0.460275 38.0751C0.652768 39.1531 1.65373 40 2.84719 40H35.6094C36.8414 40 37.8423 39.1145 37.9964 37.9595C38.0734 37.3051 37.8809 36.6121 37.4188 36.1501C36.9954 35.6496 36.341 35.3417 35.6864 35.3417H33.1456V33.4937C37.0339 31.5688 39.5748 27.4495 39.5748 23.0991ZM35.648 36.2656C36.0329 36.2656 36.4564 36.4581 36.6874 36.7277C36.9569 37.0356 37.0724 37.4206 37.0339 37.8055C36.9569 38.4985 36.3409 39.0375 35.571 39.0375H2.80869C2.11571 39.0375 1.46123 38.5371 1.38424 37.8825C1.26875 37.1511 1.73072 36.4581 2.4622 36.2656L2.73169 36.1886L7.9675 14.976C8.85296 14.1675 9.93092 13.744 11.0474 13.744C12.2793 13.744 13.4728 14.283 14.4353 15.2839C13.8963 17.0549 13.8963 19.0568 13.8963 21.0202V21.5976C13.8963 27.796 17.6307 33.9558 22.751 36.2271L22.828 36.2656H23.6749V32.8393L23.4054 32.7238C19.671 30.9528 17.2072 27.18 17.2072 23.0221V16.9009H38.6124V23.0221C38.6124 27.18 36.1869 30.9913 32.4141 32.7238L32.1446 32.8393V36.2271H35.648V36.2656ZM3.11667 10.0866C2.30821 9.08565 1.92322 7.8922 1.92322 6.62175C1.92322 3.77286 4.00214 1.42445 6.65855 1.00097V12.435C6.54305 12.358 6.42755 12.358 6.31206 12.3195L3.96365 11.6651H3.92514C3.15517 11.5111 3.15517 11.1261 3.15517 11.0106V10.3176L3.11667 10.0866ZM31.6056 13.1665V14.0519C31.6056 14.36 31.3746 14.5909 31.0667 14.5909H28.4872V16.0154H27.4093V14.5909H24.8299C24.5219 14.5909 24.2909 14.36 24.2909 14.0519V13.1665H23.3284C23.0589 13.1665 22.828 12.974 22.828 12.7045V12.0501H18.1696C16.9377 12.0501 15.7443 12.7045 15.1283 13.7825C14.8972 14.1675 14.7048 14.5909 14.5507 15.0144C13.5882 14.0519 12.3564 13.513 11.0474 13.513C9.96941 13.513 8.92995 13.8595 8.04449 14.5909C8.04449 13.821 7.69801 13.0894 7.08203 12.666V0.962464C7.27452 0.923965 7.42851 0.923964 7.62101 0.923964H27.9097C30.2582 0.923964 32.4141 2.42541 33.2226 4.65832L33.338 4.96631H35.3785C35.648 4.96631 35.8789 5.15881 35.8789 5.4283V7.23773C35.8789 7.50722 35.6864 7.73821 35.4169 7.73821H33.2996V12.666C33.2996 12.9355 33.107 13.1665 32.8375 13.1665H31.6056ZM22.751 33.4937V35.2262C18.2081 33.0317 14.7818 27.2184 14.7818 21.6362V21.0588C14.7818 18.6333 14.7818 16.1308 15.8982 14.2444C16.3987 13.4359 17.2456 12.974 18.1696 12.974H21.9039C22.0195 13.6285 22.6354 14.129 23.2899 14.129C23.3284 14.9374 23.9828 15.5534 24.7914 15.5534H26.4468V16.0539H16.2831V23.0991C16.2831 27.4495 18.8241 31.5688 22.751 33.4937Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Shop</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/pages/stand-mixers" >
+                                                                                        <span class="icon-svg learn">
+                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Learn</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/pages/stand-mixers-comparison" >
+                                                                                        <span class="icon-svg compare">
+                                                                                            
+		<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.1732 3.64907C23.1732 4.84963 22.2 5.82287 20.9994 5.82287C19.7989 5.82287 18.8256 4.84963 18.8256 3.64907C18.8256 2.44851 19.7989 1.47526 20.9994 1.47526C22.2 1.47526 23.1732 2.44851 23.1732 3.64907ZM23.6623 4.04977C23.4999 5.13821 22.6861 6.01384 21.6302 6.2673C21.6337 6.29156 21.6355 6.31636 21.6355 6.34158L21.6355 40.0062H38.4412C38.7277 40.0062 38.9599 40.2384 38.9599 40.5249C38.9599 40.8114 38.7277 41.0436 38.4412 41.0436H21.1168H3.78959C3.50311 41.0436 3.27088 40.8114 3.27088 40.5249C3.27088 40.2384 3.50311 40.0062 3.78959 40.0062H20.598L20.598 6.34158C20.598 6.33165 20.5983 6.32179 20.5989 6.312C19.4326 6.13806 18.5106 5.2162 18.3365 4.05C18.3275 4.05047 18.3183 4.05071 18.3091 4.05071H11.7185C11.5993 4.13687 11.4576 4.22324 11.2989 4.29793L19.0258 25.351C19.0373 25.3803 19.046 25.4104 19.052 25.4409C19.0667 25.5158 19.0643 25.5912 19.047 25.6624C19.0285 25.7396 18.992 25.8131 18.9382 25.8763C18.9196 25.8983 18.8991 25.9188 18.8768 25.9375C17.8177 26.865 15.0018 28.8688 9.99698 28.8688C7.44049 28.8688 5.34165 28.3884 3.78934 27.7794C3.0137 27.475 2.37027 27.1369 1.87231 26.807C1.38773 26.486 1.00944 26.1521 0.7938 25.8405C0.78631 25.8299 0.779229 25.8191 0.772569 25.808C0.690714 25.6723 0.678119 25.5122 0.726653 25.3712C0.731138 25.3582 0.736145 25.3453 0.741667 25.3327L9.56676 4.33118C9.42694 4.2607 9.28988 4.16832 9.15842 4.05071H7.07073C6.78426 4.05071 6.55202 3.81848 6.55202 3.532C6.55202 3.24552 6.78426 3.01328 7.07073 3.01328H9.37257H9.6046L9.75926 3.18626C9.82931 3.26461 9.90007 3.3244 9.97108 3.36901L9.98703 3.33104C10.0696 3.1345 10.2641 3.0085 10.4772 3.01341C10.6777 3.01803 10.8563 3.13761 10.9379 3.31839C11.0417 3.26222 11.1317 3.19882 11.1985 3.14064L11.345 3.01328H11.539H18.3091C18.3336 3.01328 18.3576 3.01498 18.3812 3.01825C18.6651 1.83554 19.7296 0.956543 20.9994 0.956543C22.2694 0.956543 23.334 1.83581 23.6178 3.0188C23.6425 3.01517 23.6679 3.01328 23.6936 3.01328H30.4637H30.6219L30.7532 3.10155C30.8505 3.16699 31.0048 3.24588 31.1862 3.30212C31.2712 3.12988 31.4464 3.01664 31.6425 3.01335C31.8321 3.01017 32.0055 3.11032 32.0989 3.2699C32.1651 3.2359 32.2293 3.19285 32.2909 3.1396L32.437 3.01328H32.6302H34.932C35.2185 3.01328 35.4507 3.24552 35.4507 3.532C35.4507 3.81848 35.2185 4.05071 34.932 4.05071H32.808C32.6958 4.12979 32.5807 4.19374 32.4646 4.24459L41.2699 28.2887C41.3341 28.4639 41.2978 28.6513 41.1905 28.788C40.9726 29.0936 40.6004 29.4198 40.1266 29.7337C39.6286 30.0636 38.9852 30.4017 38.2095 30.706C36.6572 31.3151 34.5584 31.7955 32.0019 31.7955C26.984 31.7955 24.1665 29.7812 23.1139 28.857C22.9442 28.708 22.895 28.4729 22.9743 28.2746L30.8573 4.28623C30.6506 4.22034 30.4667 4.13587 30.3172 4.05071H23.6936C23.6831 4.05071 23.6727 4.05039 23.6623 4.04977ZM24.1879 27.9045L24.0596 28.295C24.4883 28.4085 25.0994 28.5135 25.8582 28.6034C27.4553 28.7925 29.6689 28.9102 32.1189 28.9102C34.5688 28.9102 36.7824 28.7925 38.3795 28.6034C39.1326 28.5142 39.7401 28.4101 40.1683 28.2976L40.0219 27.8978C39.6059 27.7993 39.0505 27.708 38.3795 27.6285C36.7824 27.4394 34.5688 27.3217 32.1189 27.3217C29.6689 27.3217 27.4553 27.4394 25.8582 27.6285C25.1721 27.7098 24.6068 27.8034 24.1879 27.9045ZM24.2825 27.6166L31.6777 5.11281L39.9158 27.6081C38.4015 27.2828 35.4775 27.0624 32.1189 27.0624C28.7308 27.0624 25.7851 27.2866 24.2825 27.6166ZM32.0019 30.758C28.2471 30.758 25.8438 29.5622 24.5623 28.6724C26.1331 28.9709 28.93 29.1696 32.1189 29.1696C35.4563 29.1696 38.3646 28.9519 39.887 28.63C39.7905 28.7053 39.6797 28.7853 39.5536 28.8688C39.1239 29.1535 38.5468 29.4593 37.8306 29.7403C36.3993 30.3019 34.429 30.758 32.0019 30.758ZM10.4326 4.9486L17.6748 24.6809C16.1598 24.3559 13.2371 24.1357 9.88002 24.1357C6.5675 24.1357 3.67779 24.3501 2.14625 24.6681L10.4326 4.9486ZM2.02344 24.9603L1.84889 25.3757C2.27603 25.4864 2.87699 25.5888 3.61937 25.6767C5.21647 25.8659 7.43006 25.9835 9.88002 25.9835C12.33 25.9835 14.5436 25.8659 16.1407 25.6767C16.893 25.5876 17.5 25.4836 17.9282 25.3713L17.7812 24.9707C17.3654 24.8723 16.8106 24.7812 16.1407 24.7018C14.5436 24.5127 12.33 24.395 9.88002 24.395C7.43006 24.395 5.21647 24.5127 3.61937 24.7018C2.97309 24.7784 2.43399 24.8659 2.02344 24.9603ZM17.4366 25.7457C16.1551 26.6356 13.7518 27.8314 9.99698 27.8314C7.56993 27.8314 5.59963 27.3752 4.16826 26.8136C3.45207 26.5326 2.87503 26.2269 2.44526 25.9422C2.31922 25.8587 2.20837 25.7786 2.11188 25.7033C3.63428 26.0253 6.54255 26.2429 9.88002 26.2429C13.0688 26.2429 15.8658 26.0442 17.4366 25.7457Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Compare</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/pages/personalise" >
+                                                                                        <span class="icon-svg personalise">
+                                                                                            
+		<svg width="50" height="51" viewBox="0 0 50 51" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2301_15738)">
+<path d="M40.1818 39.8636H17.6363C15.3636 39.8636 15 38.9545 15 36.2272V28.1363C15 27.9545 15 27.7727 15 27.6818C15 27.4999 15 27.2272 15 27.2272C15 27.2272 14.8182 27.0454 13.7272 27.0454C13.2727 27.0454 12.7272 27.0454 12.2727 27.0454C9.99997 27.0454 8.90906 27.1363 8.72725 26.3181C8.63634 26.0454 8.09088 24.4999 8.09088 21.3181C8.09088 17.8636 8.90906 16.9545 9.2727 16.7727L9.45452 16.6818H12.0909C14.0909 16.6818 14.8182 16.4999 16.3636 14.1363C17.9091 11.7727 22.9091 7.31812 30.6363 7.31812H50.3636C50.7272 7.31812 51 7.59084 51 7.95448C51 8.31812 50.7272 8.59084 50.3636 8.59084H30.7272C24.0909 8.59084 19.1818 12.3181 17.5454 14.8636C15.8182 17.4999 14.6363 17.9545 12.1818 17.9545H9.99997C9.81815 18.2272 9.45452 19.1363 9.45452 21.3181C9.45452 23.9545 9.81815 25.3181 9.90906 25.7727C10.3636 25.8636 11.4545 25.8636 12.3636 25.8636C12.8182 25.8636 13.2727 25.8636 13.8182 25.8636C15 25.8636 15.6363 26.0454 16 26.4999C16.4545 26.9545 16.3636 27.4999 16.3636 27.9545C16.3636 28.0454 16.3636 28.2272 16.3636 28.3181V34.8636C17.3636 34.7727 21.3636 34.5908 27.1818 34.5908C33.9091 34.5908 36.8182 34.6817 36.9091 34.6817H37.0909L37.2727 34.7727C38 35.2272 38.0909 35.2272 39.7273 35.4999C41.7273 35.7727 42.0909 36.5908 42.0909 36.8636V37.0454C42 38.3181 42 39.8636 40.1818 39.8636ZM16.2727 35.8636V36.1363C16.2727 38.4999 16.3636 38.4999 17.6363 38.4999H40.1818C40.6363 38.4999 40.7272 38.4999 40.7272 36.7727C40.6363 36.6818 40.2727 36.4999 39.4545 36.3181C37.8182 36.0454 37.4545 35.9545 36.6363 35.4999C35.9091 35.4999 32.9091 35.4999 27.0909 35.4999C21.0909 35.5908 17.0909 35.8636 16.2727 35.8636Z" fill="#C41230"/>
+<path d="M50.8182 44.6818H4.9091C3.54546 44.6818 2.18182 44.3182 2.18182 43.5C2.18182 43.2273 2.36364 42.8636 3.09091 42.6818C3.54546 42.5909 4.18182 42.5 5.00001 42.5H51C51.2727 42.5 51.4545 42.6818 51.4545 42.9545C51.4545 43.2273 51.2727 43.4091 51 43.4091H4.9091C4.09091 43.4091 3.54546 43.5 3.27273 43.5909C3.54546 43.6818 4.09091 43.8636 4.9091 43.8636H50.9091C51.1818 43.8636 51.3636 44.0455 51.3636 44.3182C51.3636 44.5909 51.0909 44.6818 50.8182 44.6818Z" fill="#C41230"/>
+<path d="M4.18185 44.0454H2.90912V51.409H4.18185V44.0454Z" fill="#C41230"/>
+<path d="M31.9091 42.9546H30.6364C30.6364 42.8637 30.6364 42.8637 30.6364 42.7728C30.6364 42.4091 30.5455 41.9546 30.9091 41.5909C31.2727 41.2273 31.7273 41.0455 32.5455 41.0455H36.1818C36.5455 41.0455 36.7273 40.9546 36.9091 40.7728C37.2727 40.3182 37.3637 39.5909 37.2727 39.3182L38.5455 39.2273C38.5455 39.4091 38.6364 40.7728 37.8182 41.6818C37.3637 42.1364 36.8182 42.4091 36.1818 42.4091H32.5455C32 42.4091 31.8182 42.5 31.8182 42.5C31.9091 42.5 31.8182 42.5909 31.8182 42.6818C31.9091 42.6818 31.9091 42.7728 31.9091 42.9546Z" fill="#C41230"/>
+<path d="M26.2728 42.9547H25C25 42.8637 25 42.7728 25 42.6819C25 42.591 25 42.5001 25 42.4092C25 42.4092 24.8182 42.3183 24.3637 42.3183H20.7273C20.0909 42.3183 19.4546 42.0456 19.0909 41.591C18.2728 40.6819 18.3637 39.3183 18.3637 39.1365L19.6364 39.2274C19.6364 39.5001 19.6364 40.3183 20 40.6819C20.1818 40.8637 20.3637 40.9547 20.7273 40.9547H24.3637C25.1818 40.9547 25.7273 41.1365 26 41.5001C26.3637 41.8637 26.3637 42.4092 26.2728 42.6819C26.3637 42.7728 26.2728 42.8637 26.2728 42.9547Z" fill="#C41230"/>
+<path d="M15.9091 27.3183C15.6364 27.3183 15.3637 27.0456 15.2727 26.7728C15.1818 26.4092 15.4546 26.1365 15.8182 26.0456C15.9091 26.0456 21.7273 25.1365 32.1818 25.1365H50.8182C51.1818 25.1365 51.4546 25.4092 51.4546 25.7728C51.4546 26.1365 51.1818 26.4092 50.8182 26.4092H32.1818C21.8182 26.4092 16.0909 27.2274 16 27.3183C16 27.3183 15.9091 27.3183 15.9091 27.3183Z" fill="#C41230"/>
+<path d="M15.9091 31.9545C15.6364 31.9545 15.3637 31.6818 15.2727 31.4091C15.1818 31.0454 15.4546 30.7727 15.8182 30.6818C15.9091 30.6818 21.7273 29.7727 32.1818 29.7727H50.8182C51.1818 29.7727 51.4546 30.0454 51.4546 30.4091C51.4546 30.7727 51.1818 31.0454 50.8182 31.0454H32.1818C21.8182 31.0454 16.0909 31.8636 16 31.9545C16 31.9545 15.9091 31.9545 15.9091 31.9545Z" fill="#C41230"/>
+<path d="M23.5455 27.6819H23.8182L24.0909 28.6819L24.2727 27.6819H24.5455L24.8182 28.6819L25 27.6819H25.2727L25 28.9546H24.7273L24.4546 27.9546L24.2727 28.9546H24L23.5455 27.6819Z" fill="#C41230"/>
+<path d="M25.3636 27.5908H25.5455V27.7726H25.3636V27.5908ZM25.3636 27.9545H25.5455V28.8635H25.3636V27.9545Z" fill="#C41230"/>
+<path d="M25.7273 27.9546H25.9091V27.6819H26.0909V27.9546H26.2727V28.1364H26.0909V28.6819C26.0909 28.6819 26.0909 28.6819 26.0909 28.7728C26.0909 28.7728 26.0909 28.7728 26.1818 28.7728V28.9546C26.1818 28.9546 26.1818 28.9546 26.0909 28.9546C26.0909 28.9546 26.0909 28.9546 26 28.9546C25.9091 28.9546 25.9091 28.9546 25.9091 28.9546H25.8182C25.8182 28.9546 25.8182 28.9546 25.8182 28.8637V28.7728V28.2273H25.6364L25.7273 27.9546Z" fill="#C41230"/>
+<path d="M26.3636 27.5H26.5455V27.9545L26.6364 27.8636C26.7273 27.8636 26.7273 27.7727 26.8182 27.7727C26.9091 27.7727 27 27.7727 27.0909 27.8636C27.1818 27.9545 27.1818 27.9545 27.1818 28.1364V28.7727H27V28.1364C27 28.0455 27 28.0455 26.9091 27.9545C26.9091 27.9545 26.8182 27.8636 26.7273 27.8636H26.6364C26.6364 27.8636 26.5455 27.8636 26.5455 27.9545V28.0455V28.1364V28.6818H26.3636V27.5Z" fill="#C41230"/>
+<path d="M28 27.5H28.1818V28.5909H28.8182V28.7727H27.9091L28 27.5Z" fill="#C41230"/>
+<path d="M29.3637 28.7726C29.2728 28.7726 29.1818 28.7726 29.1818 28.7726C29.0909 28.7726 29.0909 28.6817 29 28.6817C29 28.6817 28.9091 28.5908 28.9091 28.4999C28.9091 28.409 28.9091 28.409 28.9091 28.3181C28.9091 28.2272 28.9091 28.1363 28.9091 28.1363C28.9091 28.0453 29 28.0453 29 27.9544C29 27.8635 29.0909 27.8635 29.1818 27.8635C29.2728 27.8635 29.2728 27.8635 29.3637 27.8635C29.4546 27.8635 29.5455 27.8635 29.5455 27.8635C29.6364 27.8635 29.6364 27.9544 29.7273 27.9544C29.7273 27.9544 29.8182 28.0453 29.8182 28.1363C29.8182 28.2272 29.8182 28.2272 29.8182 28.3181C29.8182 28.409 29.8182 28.4999 29.8182 28.4999C29.8182 28.4999 29.7273 28.5908 29.7273 28.6817C29.7273 28.6817 29.6364 28.7726 29.5455 28.7726C29.4546 28.7726 29.4546 28.7726 29.3637 28.7726ZM29.3637 28.5908C29.4546 28.5908 29.4546 28.5908 29.4546 28.5908C29.4546 28.5908 29.5455 28.5908 29.5455 28.4999C29.5455 28.409 29.5455 28.409 29.6364 28.409V28.3181V28.2272C29.6364 28.2272 29.6364 28.1363 29.5455 28.1363L29.4546 28.0453H29.3637C29.2728 28.0453 29.2728 28.0453 29.2728 28.0453L29.1818 28.1363C29.1818 28.1363 29.1818 28.2272 29.0909 28.2272V28.3181V28.409C29.0909 28.409 29.0909 28.4999 29.1818 28.4999C29.2728 28.4999 29.2728 28.5908 29.2728 28.5908C29.2728 28.5908 29.3637 28.5908 29.3637 28.5908Z" fill="#C41230"/>
+<path d="M29.9091 27.8635H30.0909L30.3637 28.5908L30.5455 27.8635H30.7273L30.3637 28.7726H30.0909L29.9091 27.8635Z" fill="#C41230"/>
+<path d="M31.0909 28.3181V28.409C31.0909 28.409 31.0909 28.4999 31.1818 28.4999C31.1818 28.4999 31.2727 28.4999 31.2727 28.5908C31.2727 28.6817 31.3636 28.5908 31.3636 28.5908C31.4545 28.5908 31.4545 28.5908 31.5454 28.5908L31.6364 28.4999H31.8182C31.8182 28.5908 31.8182 28.5908 31.7273 28.6817C31.6364 28.7726 31.6364 28.6817 31.5454 28.6817C31.4545 28.6817 31.4545 28.7726 31.4545 28.7726C31.3636 28.7726 31.3636 28.7726 31.2727 28.7726C31.1818 28.7726 31.0909 28.7726 31.0909 28.7726C31 28.7726 31 28.6817 30.9091 28.6817C30.9091 28.6817 30.8182 28.5908 30.8182 28.4999C30.8182 28.409 30.8182 28.409 30.8182 28.3181C30.8182 28.2272 30.8182 28.2272 30.8182 28.1363C30.8182 28.0453 30.9091 28.0453 30.9091 27.9544C30.9091 27.9544 31 27.8635 31.0909 27.8635C31.1818 27.8635 31.1818 27.8635 31.2727 27.8635C31.3636 27.8635 31.4545 27.8635 31.4545 27.8635C31.5454 27.8635 31.5454 27.9544 31.6364 27.9544C31.7273 27.9544 31.7273 28.0453 31.7273 28.1363C31.7273 28.2272 31.7273 28.2272 31.7273 28.3181H31.0909ZM31.5454 28.2272V28.1363C31.5454 28.1363 31.5454 28.0453 31.4545 28.0453C31.4545 28.0453 31.4545 28.0453 31.3636 27.9544H31.2727H31.1818C31.1818 27.9544 31.0909 27.9544 31.0909 28.0453C31.0909 28.0453 31.0909 28.1363 31 28.1363C30.9091 28.1363 31 28.2272 31 28.2272H31.5454Z" fill="#C41230"/>
+<path d="M44.7273 31.6818H42.0909C41.6364 31.6818 41.1818 31.3181 41.1818 30.7727V29.9545C41.1818 29.5 41.5455 29.0454 42.0909 29.0454H44.7273C45.1818 29.0454 45.6364 29.409 45.6364 29.9545V30.7727C45.6364 31.2272 45.2727 31.6818 44.7273 31.6818Z" fill="#C41230"/>
+<path d="M50.8182 37.3181H41.3637C41 37.3181 40.7273 37.0454 40.7273 36.6818C40.7273 36.3181 41 36.0454 41.3637 36.0454H50.9091C51.2727 36.0454 51.5455 36.3181 51.5455 36.6818C51.5455 37.0454 51.1818 37.3181 50.8182 37.3181Z" fill="#C41230"/>
+<path d="M14 20.1364C13.7273 19.7728 13.4546 19.9546 12.8182 19.6819C12.1818 19.4091 12.2727 19.0455 11.9091 18.7728C11.7273 18.6819 11.3637 18.6819 10.9091 18.7728C10.4546 18.9546 10.1818 19.1364 10.0909 19.3182C9.90911 19.6819 10.2727 19.9546 9.8182 20.591C9.36366 21.2273 9.18184 21.1364 9.09093 21.591C9.00002 22.0455 9.45457 22.9546 9.63638 23.1364C9.8182 23.3182 10.0909 23.1364 10.7273 23.3182C11.3637 23.5 11.4546 23.9546 11.8182 24.0455C12 24.1364 12.2727 24.0455 12.5455 23.9546C12.8182 23.8637 13 23.7728 13.1818 23.591C13.3637 23.3182 13.2727 22.9546 13.6364 22.4091C14.0909 21.8637 14.3637 21.8637 14.4546 21.6819C14.4546 21.5 14.2727 20.5 14 20.1364Z" fill="#C41230"/>
+<path d="M17.7273 28.409L18.2727 28.3181V29.5908L17.7273 29.6817V28.409Z" fill="#C41230"/>
+<path d="M18 28.2272C18.1818 28.2272 18.2727 28.0454 18.2727 27.8635C18.2727 27.6817 18.1818 27.5908 18 27.5908C17.8182 27.5908 17.7273 27.7726 17.7273 27.9545C17.7273 28.1363 17.9091 28.2272 18 28.2272Z" fill="#C41230"/>
+<path d="M16.9091 29.7728L17.5455 29.6819L17 27.6819L16.3637 27.7728L16.4546 28.0455L15.9091 29.9546H16.2728L16.3637 29.591L16.9091 29.5001V29.7728ZM16.4546 28.9546L16.5455 28.5001L16.6364 28.9546H16.4546Z" fill="#C41230"/>
+<path d="M19.3637 27.5909V28.3182C19.2727 28.2273 19.1818 28.2273 19.0909 28.2273C18.8182 28.2273 18.5455 28.5 18.5455 28.9545C18.5455 29.4091 18.8182 29.5909 19.0909 29.5909C19.1818 29.5909 19.2727 29.5 19.3637 29.4091V29.5L19.9091 29.4091V27.5L19.3637 27.5909ZM19.1818 29.1364C19.0909 29.1364 19 29.0455 19 28.8636C19 28.7727 19.0909 28.5909 19.1818 28.5909C19.2727 28.5909 19.2727 28.5909 19.3637 28.6818V28.9545C19.2727 29.0455 19.2727 29.1364 19.1818 29.1364Z" fill="#C41230"/>
+<path d="M33.3636 27.7728C33.3636 27.7728 33.5454 27.4091 33.9091 27.5909C34.2727 27.7728 34.3636 28.2273 33.3636 28.9546C32.3636 28.3182 32.4545 27.7728 32.8182 27.5909C33.1818 27.4091 33.3636 27.7728 33.3636 27.7728Z" fill="#C41230"/>
+</g>
+<defs>
+<clipPath id="clip0_2301_15738">
+<rect width="50" height="50" fill="white" transform="translate(0 0.5)"/>
+</clipPath>
+</defs>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Personalise</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/stand-mixer-attachments-accessories" >
+                                                                                        <span class="icon-svg attachments-accessories">
+                                                                                            
+		<svg width="49" height="36" viewBox="0 0 49 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M48.7418 6.57796C48.6037 4.90685 46.8092 4.01796 43.5308 3.0224C40.5284 2.09796 29.0021 0.853516 24.792 0.853516C20.5472 0.853516 11.7127 1.63574 8.81393 2.34685C6.01863 3.09351 6.22569 4.80018 6.39824 6.29352C6.43276 6.43574 6.43276 6.57796 6.46726 6.72018C5.8806 6.72018 4.87981 6.75574 3.46491 6.72018C2.63668 6.72018 1.6704 6.75574 1.01472 7.46685C0.290009 8.21352 0.0829494 9.45796 0.15197 12.0535C0.497067 25.4935 8.53785 26.738 12.2995 27.1646C13.1277 28.4802 15.854 30.7913 17.5449 31.8935C17.4069 32.3913 17.2689 33.1024 17.6485 33.5646L17.7175 33.6357C19.4775 34.8802 22.3073 35.4846 25.1026 35.4846C27.9323 35.4846 30.7622 34.9157 32.4186 33.8846L32.4876 33.8135C32.9018 33.4224 32.8327 32.818 32.7637 32.3913C32.7637 32.3557 32.7637 32.2846 32.7292 32.2491C33.7645 31.7513 35.7316 30.3646 38.6649 26.6313C41.6328 22.8269 43.8069 11.9113 44.0485 8.99574C44.1175 8.17796 44.3935 7.64463 44.9457 7.28907C45.7739 6.72018 47.0853 6.79129 47.948 7.07574L48.7073 7.32463C48.7418 7.36018 48.7418 6.57796 48.7418 6.57796ZM9.09001 3.37796C11.9198 2.63129 20.6508 1.92018 24.8265 1.92018C29.0021 1.92018 40.3214 3.16463 43.2892 4.05352C44.5661 4.40907 45.6359 4.83574 46.3606 5.22685C44.9112 4.90685 43.3583 5.15574 42.2884 5.33352H42.254C37.6986 6.11574 32.4186 6.47129 27.0351 6.47129C20.7544 6.47129 14.7842 5.93796 9.78021 4.94241C8.50334 4.69352 7.81315 4.33796 7.64059 4.12463C7.81315 3.80463 8.26177 3.59129 9.09001 3.37796ZM31.901 33.0669C28.8987 34.8446 21.548 35.058 18.4421 32.8891C18.4077 32.7113 18.5457 32.3202 18.5802 32.1424C18.6147 32.0002 18.6492 31.8935 18.6492 31.858C20.5818 32.6757 22.9975 33.0669 25.5512 33.0669C27.8633 33.0669 30.0375 32.7469 31.8665 32.0713C31.8665 32.2846 31.901 32.4269 31.901 32.6402V33.0669ZM44.5661 6.47129C43.7723 7.00463 43.3237 7.89352 43.1857 8.96018C42.9096 11.8402 40.8045 22.4002 37.9747 26.0624C34.6273 30.3646 32.6602 31.3602 32.1426 31.5024L31.8665 31.6091V31.6802C30.0375 32.3557 27.8288 32.7113 25.5166 32.7113C22.9629 32.7113 20.5472 32.2846 18.6147 31.4669V31.3957L18.3731 31.2535C16.6477 30.2224 13.5763 27.5557 13.0931 26.4891L12.9551 26.2046L12.6791 26.1691C9.09001 25.778 1.49785 24.8891 1.18726 12.018C1.11824 9.84907 1.29079 8.67574 1.77393 8.21352C2.05001 7.92907 2.60216 7.82241 3.46491 7.82241C5.74256 7.89352 7.01942 7.82241 7.05393 7.82241L7.57158 7.78685L7.53707 7.25352L7.43354 6.18685C7.33001 5.47574 7.26099 4.9424 7.43354 4.48018C7.74413 4.76463 8.53786 5.08463 9.7112 5.33352C14.7496 6.32907 20.7198 6.86241 27.0351 6.86241C32.4531 6.86241 37.7676 6.47129 42.323 5.72463H42.392C43.7723 5.51129 45.7049 5.15574 47.2234 5.97352C46.4296 5.86685 45.3943 5.93796 44.5661 6.47129ZM7.95118 9.42241L7.88216 8.99574H7.46804L6.05315 9.03129L4.36216 9.06685C3.53393 9.06685 2.98177 9.24463 2.60216 9.63574C2.05001 10.2046 2.08452 11.058 2.11903 12.0891V12.8002C2.11903 15.3602 3.11981 20.0891 5.8806 22.7557C7.12295 23.9646 8.57236 24.5691 10.1944 24.5691C10.3668 24.5691 10.4704 24.5691 10.6774 24.5335L11.5057 24.4624L11.1261 23.7157C9.64219 21.0846 8.39981 13.2624 7.95118 9.42241ZM6.60531 21.9024C4.08609 19.4846 3.11981 14.9691 3.11981 12.7291V11.9824C3.11981 11.2002 3.11981 10.5602 3.32687 10.3468C3.49942 10.1691 3.84452 10.098 4.32766 10.098C4.91432 10.098 5.50099 10.098 6.05315 10.0624C6.36374 10.0624 6.70883 10.0268 6.98491 10.0268C7.26099 12.018 8.29629 19.8757 9.84922 23.4313C8.67589 23.3602 7.57158 22.8269 6.60531 21.9024Z" fill="#C41230"/>
+</svg>
+
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Attachments & Accessories</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+                                                                                    
+                                                                                    
+
+                                                                            
+                                                                        </ul>
+
+                                                                        
+                                                                            <div class="shop-by-colour">
+                                                                                <span class="block text-14px leading-19px font-light mb-24px max-w-224px mx-auto lg:max-w-none lg:text-center">Shop By Colour</span>
+                                                                                <ul class="ul-colour">
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-black+colour-cast-iron-black+colour-matte-black+colour-onyx-black+colour-black-shell+colour-radiant-black">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Black_80x_crop_center.png?v=17779125815039517021712290170"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Black">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Black</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-contour-silver+colour-matte-grey+colour-medallion-silver+colour-stainless-steel">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Silver_Grey_80x_crop_center.png?v=148523081079502679671712290191"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Silver & Grey">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Silver & Grey</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-almond-cream+colour-fresh-linen+colour-frosted-pearl+colour-light&shadow+colour-milkshake+colour-white+colour-classic-columms+colour-grey-speckle+colour-white-shell+colour-bread-bowl+colour-speckled-stone+colour-white-chocolate">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_White_Cream_80x_crop_center.png?v=158046024231842864691712290193"
+                                                                                                                class="lazy w-full h-full object-cover" alt="White & Cream">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">White & Cream</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-candy-apple-red+colour-empire-red+colour-passion-red">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Red_80x_crop_center.png?v=138189077129343621011712290189"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Red">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Red</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-honey+colour-majestic-yellow+colour-scorched-orange+colour-radiant-copper+colour-fired-clay+colour-poppy+colour-radiant-gold">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Yellows_Orange_80x_crop_center.png?v=36565329337539341881712290194"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Yellows & Orange">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Yellows & Orange</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-agave+colour-blossom+colour-pebbled-palm+colour-pistachio+colour-shaded-palm+colour-sage-leaf+colour-dew-drop">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Green_80x_crop_center.png?v=89325764147066379891712290175"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Green">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Green</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-blue-velvet+colour-ink-blue+colour-mineral-water+colour-blue-salt">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Blues_80x_crop_center.png?v=178668111473528231751712290170"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Blues">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Blues</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-beetroot+colour-lavender-cream">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Purples_80x_crop_center.png?v=134324095146316180331712290189"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Purples">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Purples</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenaid-mixers/colour-birds-of-paradise+colour-dried-rose+colour-feathered-pink+colour-pink+colour-hibiscus">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Pink_80x_crop_center.png?v=71142539006687793671712290187"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Pink">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Pink</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                </ul>
+                                                                            </div> 
+                                                                        
+
+                                                                        <!-- desktop_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end desktop_banner -->
+
+                                                                        <!-- desktop_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="hidden lg:block max-w-1048px mx-auto mt-64px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="box-promotion block relative ">
+                                                                                        <div class="absolute z-20 md:top-1/2 md:-translate-y-50 top-0 left-0 w-full pt-20px md:pt-0 px-64px" >
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px lg:text-32px lg:leading-44px">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img h-274px md:h-180px loaded">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end desktop_sale_banner -->
+
+                                                                        <!-- mobile_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end mobile_banner -->
+
+                                                                        <!-- mobile_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                            
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img pb-89.250814332">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end mobile_sale_banner -->
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                     
+                                                </li>
+                                            
+                                                
+                                                <li class="nav-item is-dropdown">
+                                                    <a href="#" class="no-link" data-expand="" data-sub-name="small-appliances" aria-expanded="false" aria-haspopup="true" role="button">
+                                                        
+                                                        <span class="icon-svg">
+                                                            
+		<svg width="23" height="36" viewBox="0 0 23 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21.0691 9.42498H17.688L17.7121 8.99026C17.7121 8.38648 17.6639 7.80688 17.3016 7.58952C16.2631 6.93744 14.7899 6.43028 13.1476 6.11632V1.91405C13.148 1.70781 13.1075 1.50354 13.0288 1.31293C12.95 1.12233 12.8344 0.94915 12.6885 0.803316C12.5427 0.657484 12.3695 0.541865 12.1789 0.463087C11.9884 0.38431 11.784 0.343922 11.5778 0.34424H7.47212C7.2659 0.343922 7.06165 0.38431 6.87105 0.463087C6.68043 0.541865 6.50725 0.657484 6.36142 0.803316C6.21558 0.94915 6.09996 1.12233 6.02118 1.31293C5.9424 1.50354 5.90202 1.70781 5.90234 1.91405V6.11632C4.26008 6.43028 2.78687 6.93744 1.74838 7.58952C1.38611 7.83106 1.33781 8.41066 1.33781 8.89367L1.82083 22.3458C1.82083 22.5631 1.86913 22.7563 1.94158 22.9495C1.41026 23.0703 1.02385 23.6258 1.02385 24.302L0.613281 34.3246C0.613281 35.0975 1.1446 35.7012 1.79668 35.7012H17.205C17.857 35.7012 18.3884 35.0733 18.3884 34.3005L18.002 24.2778C18.002 23.6016 17.5914 23.0462 17.0843 22.9254C17.1567 22.7563 17.205 22.5631 17.205 22.3458V22.1525H18.3642C20.4412 22.1525 22.1801 19.9065 22.1801 17.2741V10.7291C22.1801 10.0046 21.6729 9.42498 21.0691 9.42498ZM16.5046 22.1767V22.3458C16.5046 22.6597 16.3355 22.9254 16.1182 22.9254H11.9159V22.1042C11.9159 21.742 11.7227 21.428 11.4329 21.2348V19.8824H14.6933C14.7094 19.8835 14.7256 19.881 14.7407 19.8754C14.7559 19.8697 14.7696 19.8608 14.7811 19.8494C14.7925 19.8379 14.8013 19.8242 14.807 19.8091C14.8127 19.7939 14.8151 19.7778 14.814 19.7616V19.2786C14.814 19.2303 14.7657 19.182 14.7174 19.1578L11.4329 18.4574V9.25591H16.9635L16.5046 22.1767ZM7.76195 21.428C7.81025 21.4039 7.83443 21.3556 7.83443 21.3314V9.25591H11.2156V21.3073C11.2156 21.3556 11.2397 21.4039 11.288 21.4039C11.5536 21.5488 11.6986 21.7903 11.6986 22.0801V22.9012H7.35142V22.0801C7.32724 21.8386 7.4963 21.5729 7.76195 21.428ZM7.56877 20.8484H4.42913V20.5827L7.56877 19.9065V20.8484ZM11.4329 19.6408V18.699L14.5725 19.3752V19.6408H11.4329ZM6.60271 1.91405C6.60271 1.45518 6.98911 1.06877 7.44801 1.06877H11.5536C12.0125 1.06877 12.399 1.45518 12.399 1.91405V5.99556C11.457 5.85066 10.4668 5.7782 9.50082 5.7782C8.5348 5.7782 7.54459 5.85066 6.60271 5.99556V1.91405ZM2.13479 8.1933C3.7529 7.17898 6.72347 6.50273 9.50082 6.50273C12.2782 6.50273 15.2487 7.17898 16.8669 8.1933C16.891 8.21741 16.9152 8.31407 16.9393 8.55554H2.06234C2.08649 8.31407 2.11064 8.21741 2.13479 8.1933ZM7.56877 9.25591V19.665L4.28422 20.3654C4.23592 20.3654 4.18762 20.4379 4.18762 20.4861V20.9692C4.18656 20.9853 4.18895 21.0015 4.19464 21.0166C4.20033 21.0317 4.20919 21.0454 4.22062 21.0569C4.23205 21.0683 4.2458 21.0772 4.26093 21.0829C4.27607 21.0886 4.29224 21.0909 4.30838 21.0899H7.56877V21.2348C7.27894 21.428 7.08576 21.742 7.08576 22.1042V22.9254H2.90762C2.69026 22.9254 2.5212 22.6597 2.5212 22.3458L2.06234 9.28009H7.56877V9.25591ZM17.688 34.3246C17.688 34.6869 17.4706 34.9767 17.2291 34.9767H1.79668C1.55517 34.9767 1.33781 34.6869 1.33781 34.3246L1.41026 32.7065H17.6156L17.688 34.3246ZM17.2774 24.302L17.5914 32.465H1.41026L1.72422 24.302C1.72422 23.9156 1.94158 23.6499 2.15894 23.6499H16.891C17.0601 23.6499 17.2774 23.9156 17.2774 24.302ZM21.4555 17.2982C21.4555 19.5201 20.0065 21.4522 18.3642 21.4522H17.2532L17.4223 16.9842L17.688 10.1495H21.0691C21.2865 10.1495 21.4555 10.4152 21.4555 10.7291V17.2982ZM19.9823 10.8741H18.6782C18.5574 10.8741 18.4367 10.9707 18.4367 11.0914L17.9537 20.3896C17.9537 20.462 17.9537 20.5103 18.002 20.5586C18.0503 20.6069 18.1227 20.6552 18.1952 20.6552C19.5959 20.6552 20.562 18.9888 20.562 16.622V11.5503C20.562 11.1638 20.2963 10.8741 19.9823 10.8741ZM20.0789 16.6461C20.0789 18.5299 19.4027 19.9548 18.4367 20.1722C18.485 19.5201 18.5816 17.5155 18.8955 11.3571H19.9582C20.0065 11.3571 20.0548 11.4295 20.0548 11.5503V16.6461H20.0789ZM14.1619 28.0937H4.8397C4.54988 28.0937 4.33252 28.3111 4.33252 28.6008V30.7261C4.33252 31.0159 4.54988 31.2333 4.8397 31.2333H14.1619C14.4518 31.2333 14.6691 31.0159 14.6691 30.7261V28.6008C14.6691 28.3352 14.4518 28.0937 14.1619 28.0937ZM7.66536 30.9918H4.8397C4.76944 30.9912 4.70223 30.963 4.65254 30.9133C4.60286 30.8636 4.57467 30.7964 4.57404 30.7261V28.6008C4.57467 28.5306 4.60286 28.4634 4.65254 28.4137C4.70223 28.364 4.76944 28.3358 4.8397 28.3352H7.66536V30.9918ZM11.0465 30.9918H7.90684V28.3352H11.0465V30.9918ZM14.4276 30.7261C14.427 30.7964 14.3988 30.8636 14.3491 30.9133C14.2994 30.963 14.2322 30.9912 14.1619 30.9918H11.288V28.3352H14.1619C14.2322 28.3358 14.2994 28.364 14.3491 28.4137C14.3988 28.4634 14.427 28.5306 14.4276 28.6008V30.7261Z" fill="#C41230"/>
+</svg>
+	
+                                                        </span>
+                                                        <span class="txt">Small Appliances</span>
+
+                                                        
+                                                            <span class="expand">
+                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                </svg>
+                                                            </span>
+                                                        
+                                                    </a>
+
+                                                     
+                                                        <div data-nav-dropdown-content="" class="sub-nav invisible" id="small-appliances">
+                                                            <div class="__box" data-subnav="">
+                                                                 <a href="#" class="back" data-back="" data-level-02 aria-controls="small-appliances">
+                                                                    <span class="icon">
+                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                        </svg>
+                                                                    </span>
+                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Small Appliances</span>
+                                                                </a>
+
+                                                                
+                                                                
+
+                                                                <div class="__box-wrap">
+                                                                    <div class="inner w-1920px">
+                                                                        <ul class="sub-nav-group ul-sub">
+                                                                            
+
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li class="is-dropdown w-hover-state">
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/kitchenaid-food-processors"  class="no-link" data-expand="" data-sub-name="food-processors" aria-expanded="false" aria-haspopup="true" role="button" data-level-03 data-level-03-role >
+                                                                                        <span class="icon-svg food-processors">
+                                                                                            
+		<svg width="30" height="49" viewBox="0 0 30 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M28.1311 12.8278H23.5409L23.5737 12.2377C23.5737 11.418 23.5081 10.6311 23.0164 10.3361C21.6065 9.45081 19.6065 8.76229 17.377 8.33607V2.63115C17.3774 2.35116 17.3226 2.07384 17.2156 1.81508C17.1087 1.55632 16.9517 1.32122 16.7537 1.12323C16.5557 0.925257 16.3207 0.768295 16.0619 0.661347C15.8032 0.5544 15.5258 0.49957 15.2458 0.500003H9.67203C9.39207 0.49957 9.11478 0.5544 8.85603 0.661347C8.59725 0.768295 8.36214 0.925257 8.16416 1.12323C7.96618 1.32122 7.80921 1.55632 7.70226 1.81508C7.59531 2.07384 7.54049 2.35116 7.54092 2.63115V8.33607C5.31142 8.76229 3.31142 9.45081 1.90158 10.3361C1.40977 10.664 1.3442 11.4508 1.3442 12.1065L1.99994 30.3689C1.99994 30.664 2.06552 30.9262 2.16387 31.1885C1.44256 31.3524 0.917972 32.1065 0.917972 33.0246L0.360596 46.6311C0.360596 47.6803 1.08191 48.5 1.96715 48.5H22.8851C23.7704 48.5 24.4918 47.6475 24.4918 46.5984L23.9672 32.9918C23.9672 32.0737 23.4097 31.3197 22.7213 31.1557C22.8196 30.9262 22.8851 30.664 22.8851 30.3689V30.1065H24.4589C27.2786 30.1065 29.6393 27.0573 29.6393 23.4836V14.5983C29.6393 13.6148 28.9507 12.8278 28.1311 12.8278ZM21.9343 30.1394V30.3689C21.9343 30.7951 21.7048 31.1557 21.4097 31.1557H15.7049V30.041C15.7049 29.5492 15.4425 29.1229 15.0492 28.8606V27.0246H19.4754C19.4972 27.0261 19.5192 27.0227 19.5397 27.0151C19.5603 27.0073 19.5789 26.9953 19.5945 26.9798C19.61 26.9643 19.622 26.9456 19.6297 26.9251C19.6375 26.9045 19.6407 26.8826 19.6392 26.8606V26.2049C19.6392 26.1393 19.5737 26.0738 19.5081 26.041L15.0492 25.0901V12.5983H22.5573L21.9343 30.1394ZM10.0655 29.1229C10.1311 29.0902 10.1639 29.0246 10.1639 28.9918V12.5983H14.7541V28.959C14.7541 29.0246 14.7868 29.0902 14.8524 29.0902C15.213 29.2869 15.4098 29.6148 15.4098 30.0081V31.1229H9.50816V30.0081C9.47534 29.6803 9.70485 29.3197 10.0655 29.1229ZM9.80324 28.336H5.54092V27.9754L9.80324 27.0573V28.336ZM15.0492 26.6967V25.4181L19.3114 26.336V26.6967H15.0492ZM8.49174 2.63115C8.49174 2.00819 9.0163 1.48361 9.63929 1.48361H15.213C15.836 1.48361 16.3606 2.00819 16.3606 2.63115V8.17213C15.0819 7.97541 13.7376 7.87705 12.4262 7.87705C11.1147 7.87705 9.77042 7.97541 8.49174 8.17213V2.63115ZM2.42617 11.1557C4.62289 9.77872 8.65567 8.86066 12.4262 8.86066C16.1967 8.86066 20.2294 9.77872 22.4262 11.1557C22.4589 11.1885 22.4918 11.3197 22.5245 11.6475H2.32781C2.3606 11.3197 2.39338 11.1885 2.42617 11.1557ZM9.80324 12.5983V26.7295L5.3442 27.6803C5.27863 27.6803 5.21305 27.7787 5.21305 27.8443V28.5C5.21161 28.5219 5.21485 28.5439 5.22258 28.5644C5.23031 28.5849 5.24233 28.6036 5.25785 28.6191C5.27337 28.6346 5.29203 28.6467 5.31258 28.6544C5.33312 28.6621 5.35508 28.6653 5.37699 28.664H9.80324V28.8606C9.40977 29.1229 9.14752 29.5492 9.14752 30.041V31.1557H3.47534C3.18026 31.1557 2.95075 30.7951 2.95075 30.3689L2.32781 12.6311H9.80324V12.5983ZM23.5409 46.6311C23.5409 47.1229 23.2458 47.5164 22.918 47.5164H1.96715C1.63928 47.5164 1.3442 47.1229 1.3442 46.6311L1.44256 44.4344H23.4426L23.5409 46.6311ZM22.9835 33.0246L23.4097 44.1065H1.44256L1.86879 33.0246C1.86879 32.5 2.16387 32.1394 2.45895 32.1394H22.4589C22.6885 32.1394 22.9835 32.5 22.9835 33.0246ZM28.6557 23.5163C28.6557 26.5328 26.6885 29.1557 24.4589 29.1557H22.9507L23.1802 23.0901L23.5409 13.8115H28.1311C28.4261 13.8115 28.6557 14.1721 28.6557 14.5983V23.5163ZM26.6556 14.7951H24.8852C24.7212 14.7951 24.5573 14.9262 24.5573 15.0902L23.9016 27.7131C23.9016 27.8114 23.9016 27.877 23.9672 27.9426C24.0327 28.0082 24.131 28.0738 24.2294 28.0738C26.131 28.0738 27.4426 25.8114 27.4426 22.5984V15.7131C27.4426 15.1885 27.0819 14.7951 26.6556 14.7951ZM26.7868 22.6311C26.7868 25.1885 25.8688 27.123 24.5573 27.4181C24.6229 26.5328 24.754 23.8114 25.1802 15.4508H26.6229C26.6885 15.4508 26.754 15.5491 26.754 15.7131V22.6311H26.7868ZM18.754 38.1721H6.0983C5.70485 38.1721 5.40977 38.4672 5.40977 38.8606V41.7459C5.40977 42.1393 5.70485 42.4344 6.0983 42.4344H18.754C19.1475 42.4344 19.4426 42.1393 19.4426 41.7459V38.8606C19.4426 38.5 19.1475 38.1721 18.754 38.1721ZM9.93437 42.1065H6.0983C6.00291 42.1057 5.91168 42.0674 5.84422 42C5.77677 41.9325 5.7385 41.8413 5.73764 41.7459V38.8606C5.7385 38.7653 5.77677 38.674 5.84422 38.6066C5.91168 38.5391 6.00291 38.5009 6.0983 38.5H9.93437V42.1065ZM14.5246 42.1065H10.2622V38.5H14.5246V42.1065ZM19.1146 41.7459C19.1138 41.8413 19.0755 41.9325 19.0081 42C18.9406 42.0674 18.8494 42.1057 18.754 42.1065H14.8524V38.5H18.754C18.8494 38.5009 18.9406 38.5391 19.0081 38.6066C19.0755 38.674 19.1138 38.7653 19.1146 38.8606V41.7459Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Food Processors</span>
+                                                                                            <i class="not-italic" data-txt>Shop Food Processors</i>
+                                                                                        </span>
+
+                                                                                        
+                                                                                            <span class="expand">
+                                                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                                                </svg>
+                                                                                            </span>
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+                                                                                        <span class="hidden absolute lg:flex lg:flex-wrap lg:pt-2px" data-sub>
+                                                                                            
+                                                                                                
+                                                                                                    
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/food-processors">Learn</a>
+                                                                                                </span>
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/food-processors-comparison">Compare</a>
+                                                                                                </span>
+                                                                                        </span>
+                                                                                    
+
+                                                                                    
+                                                                                        <div data-nav-dropdown-content="" data-level-03 class="invisible" id="food-processors">
+                                                                                            <div class="__box" data-subnav="">
+                                                                                                 <a href="#" class="back" data-back="" data-level-03 aria-controls="food-processors">
+                                                                                                    <span class="icon">
+                                                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                                                        </svg>
+                                                                                                    </span>
+                                                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Food Processors</span>
+                                                                                                </a>
+
+                                                                                                <div class="__box-wrap">
+                                                                                                    <div class="inner w-1920px">
+                                                                                                        <ul class="ul-sub" xxx>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/collections/kitchenaid-food-processors">
+                                                                                                                        <span class="icon-svg food-processors">
+                                                                                                                            
+		<svg width="30" height="49" viewBox="0 0 30 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M28.1311 12.8278H23.5409L23.5737 12.2377C23.5737 11.418 23.5081 10.6311 23.0164 10.3361C21.6065 9.45081 19.6065 8.76229 17.377 8.33607V2.63115C17.3774 2.35116 17.3226 2.07384 17.2156 1.81508C17.1087 1.55632 16.9517 1.32122 16.7537 1.12323C16.5557 0.925257 16.3207 0.768295 16.0619 0.661347C15.8032 0.5544 15.5258 0.49957 15.2458 0.500003H9.67203C9.39207 0.49957 9.11478 0.5544 8.85603 0.661347C8.59725 0.768295 8.36214 0.925257 8.16416 1.12323C7.96618 1.32122 7.80921 1.55632 7.70226 1.81508C7.59531 2.07384 7.54049 2.35116 7.54092 2.63115V8.33607C5.31142 8.76229 3.31142 9.45081 1.90158 10.3361C1.40977 10.664 1.3442 11.4508 1.3442 12.1065L1.99994 30.3689C1.99994 30.664 2.06552 30.9262 2.16387 31.1885C1.44256 31.3524 0.917972 32.1065 0.917972 33.0246L0.360596 46.6311C0.360596 47.6803 1.08191 48.5 1.96715 48.5H22.8851C23.7704 48.5 24.4918 47.6475 24.4918 46.5984L23.9672 32.9918C23.9672 32.0737 23.4097 31.3197 22.7213 31.1557C22.8196 30.9262 22.8851 30.664 22.8851 30.3689V30.1065H24.4589C27.2786 30.1065 29.6393 27.0573 29.6393 23.4836V14.5983C29.6393 13.6148 28.9507 12.8278 28.1311 12.8278ZM21.9343 30.1394V30.3689C21.9343 30.7951 21.7048 31.1557 21.4097 31.1557H15.7049V30.041C15.7049 29.5492 15.4425 29.1229 15.0492 28.8606V27.0246H19.4754C19.4972 27.0261 19.5192 27.0227 19.5397 27.0151C19.5603 27.0073 19.5789 26.9953 19.5945 26.9798C19.61 26.9643 19.622 26.9456 19.6297 26.9251C19.6375 26.9045 19.6407 26.8826 19.6392 26.8606V26.2049C19.6392 26.1393 19.5737 26.0738 19.5081 26.041L15.0492 25.0901V12.5983H22.5573L21.9343 30.1394ZM10.0655 29.1229C10.1311 29.0902 10.1639 29.0246 10.1639 28.9918V12.5983H14.7541V28.959C14.7541 29.0246 14.7868 29.0902 14.8524 29.0902C15.213 29.2869 15.4098 29.6148 15.4098 30.0081V31.1229H9.50816V30.0081C9.47534 29.6803 9.70485 29.3197 10.0655 29.1229ZM9.80324 28.336H5.54092V27.9754L9.80324 27.0573V28.336ZM15.0492 26.6967V25.4181L19.3114 26.336V26.6967H15.0492ZM8.49174 2.63115C8.49174 2.00819 9.0163 1.48361 9.63929 1.48361H15.213C15.836 1.48361 16.3606 2.00819 16.3606 2.63115V8.17213C15.0819 7.97541 13.7376 7.87705 12.4262 7.87705C11.1147 7.87705 9.77042 7.97541 8.49174 8.17213V2.63115ZM2.42617 11.1557C4.62289 9.77872 8.65567 8.86066 12.4262 8.86066C16.1967 8.86066 20.2294 9.77872 22.4262 11.1557C22.4589 11.1885 22.4918 11.3197 22.5245 11.6475H2.32781C2.3606 11.3197 2.39338 11.1885 2.42617 11.1557ZM9.80324 12.5983V26.7295L5.3442 27.6803C5.27863 27.6803 5.21305 27.7787 5.21305 27.8443V28.5C5.21161 28.5219 5.21485 28.5439 5.22258 28.5644C5.23031 28.5849 5.24233 28.6036 5.25785 28.6191C5.27337 28.6346 5.29203 28.6467 5.31258 28.6544C5.33312 28.6621 5.35508 28.6653 5.37699 28.664H9.80324V28.8606C9.40977 29.1229 9.14752 29.5492 9.14752 30.041V31.1557H3.47534C3.18026 31.1557 2.95075 30.7951 2.95075 30.3689L2.32781 12.6311H9.80324V12.5983ZM23.5409 46.6311C23.5409 47.1229 23.2458 47.5164 22.918 47.5164H1.96715C1.63928 47.5164 1.3442 47.1229 1.3442 46.6311L1.44256 44.4344H23.4426L23.5409 46.6311ZM22.9835 33.0246L23.4097 44.1065H1.44256L1.86879 33.0246C1.86879 32.5 2.16387 32.1394 2.45895 32.1394H22.4589C22.6885 32.1394 22.9835 32.5 22.9835 33.0246ZM28.6557 23.5163C28.6557 26.5328 26.6885 29.1557 24.4589 29.1557H22.9507L23.1802 23.0901L23.5409 13.8115H28.1311C28.4261 13.8115 28.6557 14.1721 28.6557 14.5983V23.5163ZM26.6556 14.7951H24.8852C24.7212 14.7951 24.5573 14.9262 24.5573 15.0902L23.9016 27.7131C23.9016 27.8114 23.9016 27.877 23.9672 27.9426C24.0327 28.0082 24.131 28.0738 24.2294 28.0738C26.131 28.0738 27.4426 25.8114 27.4426 22.5984V15.7131C27.4426 15.1885 27.0819 14.7951 26.6556 14.7951ZM26.7868 22.6311C26.7868 25.1885 25.8688 27.123 24.5573 27.4181C24.6229 26.5328 24.754 23.8114 25.1802 15.4508H26.6229C26.6885 15.4508 26.754 15.5491 26.754 15.7131V22.6311H26.7868ZM18.754 38.1721H6.0983C5.70485 38.1721 5.40977 38.4672 5.40977 38.8606V41.7459C5.40977 42.1393 5.70485 42.4344 6.0983 42.4344H18.754C19.1475 42.4344 19.4426 42.1393 19.4426 41.7459V38.8606C19.4426 38.5 19.1475 38.1721 18.754 38.1721ZM9.93437 42.1065H6.0983C6.00291 42.1057 5.91168 42.0674 5.84422 42C5.77677 41.9325 5.7385 41.8413 5.73764 41.7459V38.8606C5.7385 38.7653 5.77677 38.674 5.84422 38.6066C5.91168 38.5391 6.00291 38.5009 6.0983 38.5H9.93437V42.1065ZM14.5246 42.1065H10.2622V38.5H14.5246V42.1065ZM19.1146 41.7459C19.1138 41.8413 19.0755 41.9325 19.0081 42C18.9406 42.0674 18.8494 42.1057 18.754 42.1065H14.8524V38.5H18.754C18.8494 38.5009 18.9406 38.5391 19.0081 38.6066C19.0755 38.674 19.1138 38.7653 19.1146 38.8606V41.7459Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Shop</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/food-processors">
+                                                                                                                        <span class="icon-svg learn">
+                                                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Learn</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/food-processors-comparison">
+                                                                                                                        <span class="icon-svg compare">
+                                                                                                                            
+		<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.1732 3.64907C23.1732 4.84963 22.2 5.82287 20.9994 5.82287C19.7989 5.82287 18.8256 4.84963 18.8256 3.64907C18.8256 2.44851 19.7989 1.47526 20.9994 1.47526C22.2 1.47526 23.1732 2.44851 23.1732 3.64907ZM23.6623 4.04977C23.4999 5.13821 22.6861 6.01384 21.6302 6.2673C21.6337 6.29156 21.6355 6.31636 21.6355 6.34158L21.6355 40.0062H38.4412C38.7277 40.0062 38.9599 40.2384 38.9599 40.5249C38.9599 40.8114 38.7277 41.0436 38.4412 41.0436H21.1168H3.78959C3.50311 41.0436 3.27088 40.8114 3.27088 40.5249C3.27088 40.2384 3.50311 40.0062 3.78959 40.0062H20.598L20.598 6.34158C20.598 6.33165 20.5983 6.32179 20.5989 6.312C19.4326 6.13806 18.5106 5.2162 18.3365 4.05C18.3275 4.05047 18.3183 4.05071 18.3091 4.05071H11.7185C11.5993 4.13687 11.4576 4.22324 11.2989 4.29793L19.0258 25.351C19.0373 25.3803 19.046 25.4104 19.052 25.4409C19.0667 25.5158 19.0643 25.5912 19.047 25.6624C19.0285 25.7396 18.992 25.8131 18.9382 25.8763C18.9196 25.8983 18.8991 25.9188 18.8768 25.9375C17.8177 26.865 15.0018 28.8688 9.99698 28.8688C7.44049 28.8688 5.34165 28.3884 3.78934 27.7794C3.0137 27.475 2.37027 27.1369 1.87231 26.807C1.38773 26.486 1.00944 26.1521 0.7938 25.8405C0.78631 25.8299 0.779229 25.8191 0.772569 25.808C0.690714 25.6723 0.678119 25.5122 0.726653 25.3712C0.731138 25.3582 0.736145 25.3453 0.741667 25.3327L9.56676 4.33118C9.42694 4.2607 9.28988 4.16832 9.15842 4.05071H7.07073C6.78426 4.05071 6.55202 3.81848 6.55202 3.532C6.55202 3.24552 6.78426 3.01328 7.07073 3.01328H9.37257H9.6046L9.75926 3.18626C9.82931 3.26461 9.90007 3.3244 9.97108 3.36901L9.98703 3.33104C10.0696 3.1345 10.2641 3.0085 10.4772 3.01341C10.6777 3.01803 10.8563 3.13761 10.9379 3.31839C11.0417 3.26222 11.1317 3.19882 11.1985 3.14064L11.345 3.01328H11.539H18.3091C18.3336 3.01328 18.3576 3.01498 18.3812 3.01825C18.6651 1.83554 19.7296 0.956543 20.9994 0.956543C22.2694 0.956543 23.334 1.83581 23.6178 3.0188C23.6425 3.01517 23.6679 3.01328 23.6936 3.01328H30.4637H30.6219L30.7532 3.10155C30.8505 3.16699 31.0048 3.24588 31.1862 3.30212C31.2712 3.12988 31.4464 3.01664 31.6425 3.01335C31.8321 3.01017 32.0055 3.11032 32.0989 3.2699C32.1651 3.2359 32.2293 3.19285 32.2909 3.1396L32.437 3.01328H32.6302H34.932C35.2185 3.01328 35.4507 3.24552 35.4507 3.532C35.4507 3.81848 35.2185 4.05071 34.932 4.05071H32.808C32.6958 4.12979 32.5807 4.19374 32.4646 4.24459L41.2699 28.2887C41.3341 28.4639 41.2978 28.6513 41.1905 28.788C40.9726 29.0936 40.6004 29.4198 40.1266 29.7337C39.6286 30.0636 38.9852 30.4017 38.2095 30.706C36.6572 31.3151 34.5584 31.7955 32.0019 31.7955C26.984 31.7955 24.1665 29.7812 23.1139 28.857C22.9442 28.708 22.895 28.4729 22.9743 28.2746L30.8573 4.28623C30.6506 4.22034 30.4667 4.13587 30.3172 4.05071H23.6936C23.6831 4.05071 23.6727 4.05039 23.6623 4.04977ZM24.1879 27.9045L24.0596 28.295C24.4883 28.4085 25.0994 28.5135 25.8582 28.6034C27.4553 28.7925 29.6689 28.9102 32.1189 28.9102C34.5688 28.9102 36.7824 28.7925 38.3795 28.6034C39.1326 28.5142 39.7401 28.4101 40.1683 28.2976L40.0219 27.8978C39.6059 27.7993 39.0505 27.708 38.3795 27.6285C36.7824 27.4394 34.5688 27.3217 32.1189 27.3217C29.6689 27.3217 27.4553 27.4394 25.8582 27.6285C25.1721 27.7098 24.6068 27.8034 24.1879 27.9045ZM24.2825 27.6166L31.6777 5.11281L39.9158 27.6081C38.4015 27.2828 35.4775 27.0624 32.1189 27.0624C28.7308 27.0624 25.7851 27.2866 24.2825 27.6166ZM32.0019 30.758C28.2471 30.758 25.8438 29.5622 24.5623 28.6724C26.1331 28.9709 28.93 29.1696 32.1189 29.1696C35.4563 29.1696 38.3646 28.9519 39.887 28.63C39.7905 28.7053 39.6797 28.7853 39.5536 28.8688C39.1239 29.1535 38.5468 29.4593 37.8306 29.7403C36.3993 30.3019 34.429 30.758 32.0019 30.758ZM10.4326 4.9486L17.6748 24.6809C16.1598 24.3559 13.2371 24.1357 9.88002 24.1357C6.5675 24.1357 3.67779 24.3501 2.14625 24.6681L10.4326 4.9486ZM2.02344 24.9603L1.84889 25.3757C2.27603 25.4864 2.87699 25.5888 3.61937 25.6767C5.21647 25.8659 7.43006 25.9835 9.88002 25.9835C12.33 25.9835 14.5436 25.8659 16.1407 25.6767C16.893 25.5876 17.5 25.4836 17.9282 25.3713L17.7812 24.9707C17.3654 24.8723 16.8106 24.7812 16.1407 24.7018C14.5436 24.5127 12.33 24.395 9.88002 24.395C7.43006 24.395 5.21647 24.5127 3.61937 24.7018C2.97309 24.7784 2.43399 24.8659 2.02344 24.9603ZM17.4366 25.7457C16.1551 26.6356 13.7518 27.8314 9.99698 27.8314C7.56993 27.8314 5.59963 27.3752 4.16826 26.8136C3.45207 26.5326 2.87503 26.2269 2.44526 25.9422C2.31922 25.8587 2.20837 25.7786 2.11188 25.7033C3.63428 26.0253 6.54255 26.2429 9.88002 26.2429C13.0688 26.2429 15.8658 26.0442 17.4366 25.7457Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Compare</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+                                                                                                        </ul>
+
+                                                                                                        <!-- mobile_banner -->
+                                                                                                        
+                                                                                                        
+
+                                                                                                        
+                                                                                                        <!-- end mobile_banner -->
+
+                                                                                                        <!-- mobile_sale_banner -->
+                                                                                                        
+                                                                                                            
+
+                                                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                                                            
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                        <div class="img pb-89.250814332">
+                                                                                                                            
+                                                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                </div>
+                                                                                                            
+                                                                                                        
+                                                                                                        <!-- end mobile_sale_banner -->
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                     
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li class="is-dropdown w-hover-state">
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/kitchenaid-blender"  class="no-link" data-expand="" data-sub-name="blenders" aria-expanded="false" aria-haspopup="true" role="button" data-level-03 data-level-03-role >
+                                                                                        <span class="icon-svg blenders">
+                                                                                            
+		<svg width="25" height="49" viewBox="0 0 25 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.5154 8.82943H13.3977C13.3741 8.82793 13.3505 8.83138 13.3284 8.8397C13.3062 8.84803 13.2861 8.861 13.2694 8.87765C13.2528 8.89438 13.2398 8.91448 13.2315 8.9366C13.2231 8.95873 13.2197 8.98235 13.2212 9.0059C13.2197 9.02953 13.2231 9.05315 13.2315 9.07528C13.2398 9.0974 13.2528 9.1175 13.2694 9.13415C13.2861 9.15088 13.3062 9.16385 13.3284 9.17218C13.3505 9.18043 13.3741 9.18395 13.3977 9.18238H15.5154C15.5389 9.18395 15.5625 9.18043 15.5847 9.17218C15.6068 9.16385 15.6269 9.15088 15.6436 9.13415C15.6603 9.1175 15.6732 9.0974 15.6816 9.07528C15.6899 9.05315 15.6933 9.02953 15.6918 9.0059C15.6933 8.98235 15.6899 8.95873 15.6816 8.9366C15.6732 8.91448 15.6603 8.89438 15.6436 8.87765C15.6269 8.861 15.6068 8.84803 15.5847 8.8397C15.5625 8.83138 15.5389 8.82793 15.5154 8.82943ZM15.5154 12.3589H13.3977C13.3741 12.3573 13.3505 12.3608 13.3284 12.3691C13.3062 12.3775 13.2861 12.3904 13.2694 12.4071C13.2528 12.4238 13.2398 12.4439 13.2315 12.466C13.2231 12.4882 13.2197 12.5118 13.2212 12.5353C13.2197 12.559 13.2231 12.5826 13.2315 12.6047C13.2398 12.6268 13.2528 12.6469 13.2694 12.6636C13.2861 12.6803 13.3062 12.6933 13.3284 12.7015C13.3505 12.7099 13.3741 12.7134 13.3977 12.7118H15.5154C15.5389 12.7134 15.5625 12.7099 15.5847 12.7015C15.6068 12.6933 15.6269 12.6803 15.6436 12.6636C15.6603 12.6469 15.6732 12.6268 15.6816 12.6047C15.6899 12.5826 15.6933 12.559 15.6918 12.5353C15.6933 12.5118 15.6899 12.4882 15.6816 12.466C15.6732 12.4439 15.6603 12.4238 15.6436 12.4071C15.6269 12.3904 15.6068 12.3775 15.5847 12.3691C15.5625 12.3608 15.5389 12.3573 15.5154 12.3589ZM15.5154 15.8883H13.3977C13.3509 15.8883 13.306 15.9069 13.2729 15.94C13.2398 15.973 13.2212 16.018 13.2212 16.0648C13.2212 16.1116 13.2398 16.1564 13.2729 16.1896C13.306 16.2226 13.3509 16.2412 13.3977 16.2412H15.5154C15.5622 16.2412 15.607 16.2226 15.6402 16.1896C15.6732 16.1564 15.6918 16.1116 15.6918 16.0648C15.6918 16.018 15.6732 15.973 15.6402 15.94C15.607 15.9069 15.5622 15.8883 15.5154 15.8883ZM15.5154 19.4177H13.3977C13.3509 19.4177 13.306 19.4363 13.2729 19.4694C13.2398 19.5025 13.2212 19.5474 13.2212 19.5942C13.2212 19.641 13.2398 19.6858 13.2729 19.719C13.306 19.7521 13.3509 19.7707 13.3977 19.7707H15.5154C15.5622 19.7707 15.607 19.7521 15.6402 19.719C15.6732 19.6858 15.6918 19.641 15.6918 19.5942C15.6918 19.5474 15.6732 19.5025 15.6402 19.4694C15.607 19.4363 15.5622 19.4177 15.5154 19.4177ZM11.9506 35.1942C9.97415 35.1942 8.35062 36.8177 8.35062 38.7942C8.35062 40.7707 9.97415 42.3942 11.9506 42.3942C13.9271 42.3942 15.5506 40.7707 15.5506 38.7942C15.5506 36.8177 13.9271 35.1942 11.9506 35.1942ZM11.9506 42.0059C10.1506 42.0059 8.70357 40.5589 8.70357 38.7589C8.70357 36.9589 10.1506 35.5118 11.9506 35.5118C13.7506 35.5118 15.1977 36.9589 15.1977 38.7589C15.1977 40.5589 13.7154 42.0059 11.9506 42.0059ZM17.3859 34.3471C16.9271 34.3471 16.5389 34.7353 16.5389 35.1942C16.5389 35.653 16.9271 36.0412 17.3859 36.0412C17.8448 36.0412 18.233 35.653 18.233 35.1942C18.233 34.7353 17.8448 34.3471 17.3859 34.3471ZM17.3859 35.653C17.1036 35.653 16.8918 35.4412 16.8918 35.1589C16.8918 34.8766 17.1036 34.6648 17.3859 34.6648C17.6683 34.6648 17.88 34.8766 17.88 35.1589C17.88 35.4412 17.633 35.653 17.3859 35.653ZM18.833 19.1353L19.9977 19.1001C22.3624 19.1001 24.3741 16.5589 24.3741 13.5589V6.21769C24.3741 5.33534 23.7741 4.62946 22.9977 4.62946H19.5036L19.6448 1.24122C19.6448 1.10004 19.6095 0.958866 19.5036 0.852984C19.3977 0.747101 19.2565 0.676514 19.1154 0.676514H4.64476C4.50359 0.676514 4.36241 0.747101 4.25653 0.852984C4.15064 0.958866 4.11535 1.10004 4.11535 1.24122L5.17417 24.6412L5.10359 25.1707C4.9977 26.0883 4.29182 26.7942 3.40946 26.9707C1.50359 27.2883 0.0918191 28.9118 0.0918191 30.8883V45.7824C0.0904181 46.1165 0.155191 46.4476 0.282401 46.7566C0.409613 47.0655 0.596738 47.3461 0.832988 47.5824C1.06924 47.8186 1.34993 48.0058 1.65887 48.133C1.96782 48.2602 2.29889 48.325 2.633 48.3236H21.0918C21.4259 48.325 21.757 48.2602 22.0659 48.133C22.3749 48.0058 22.6556 47.8186 22.8918 47.5824C23.1281 47.3461 23.3152 47.0655 23.4424 46.7566C23.5696 46.4476 23.6344 46.1165 23.633 45.7824V30.8883C23.633 28.9471 22.2212 27.2883 20.3154 26.9707C19.433 26.8294 18.7271 26.0883 18.6212 25.1707L18.5506 24.7118L18.833 19.1353ZM17.5624 24.1471H6.233L5.38594 5.68828H18.4095L17.5624 24.1471ZM22.9977 5.68828C23.1389 5.68828 23.3154 5.90005 23.3154 6.21769V13.5236C23.3154 15.9236 21.7624 18.0059 19.9977 18.0059L18.9036 18.0412L19.4683 5.65299L22.9977 5.68828ZM18.5859 1.73534L18.4448 4.62946H5.31535L5.17417 1.73534H18.5859ZM22.6095 30.853V33.0059C22.5741 32.9707 22.5389 32.9707 22.5036 32.9707H1.15064V30.5353H22.4683C22.5036 30.5353 22.5389 30.5353 22.5389 30.5001C22.6095 30.6412 22.6095 30.7471 22.6095 30.853ZM21.1271 47.2648H2.66829C2.276 47.262 1.90057 47.1049 1.62317 46.8275C1.34578 46.5502 1.18871 46.1747 1.18594 45.7824V33.3236H22.5389C22.5741 33.3236 22.6095 33.3236 22.6448 33.2883V45.7824C22.6095 46.5942 21.9389 47.2648 21.1271 47.2648ZM20.1741 27.9942C21.3741 28.2059 22.2565 29.0883 22.5389 30.2177H1.25653C1.50359 29.0883 2.42123 28.2059 3.62123 28.0294C4.9977 27.8177 6.05653 26.6883 6.1977 25.3118V25.2059H17.5977V25.3118C17.7389 26.653 18.7977 27.7824 20.1741 27.9942ZM19.6448 17.1589C19.68 17.1942 19.7154 17.2294 19.7859 17.2294C21.2683 17.2294 22.3271 15.4294 22.3271 12.853V7.13534C22.3271 6.7824 22.08 6.50005 21.7624 6.50005H20.3154C20.2917 6.49849 20.2681 6.50198 20.246 6.5103C20.2239 6.51862 20.2038 6.53156 20.1871 6.54827C20.1704 6.56497 20.1574 6.58506 20.1491 6.60718C20.1408 6.6293 20.1373 6.65293 20.1389 6.67651L19.6095 17.0177C19.6095 17.053 19.6095 17.0883 19.6448 17.1589ZM20.4918 6.85299H21.7624C21.8683 6.85299 21.9741 6.99416 21.9741 7.13534V12.8177C21.9741 15.0766 21.1624 16.7001 19.9624 16.8412C20.033 16.2766 20.1389 14.2294 20.4918 6.85299Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Blenders</span>
+                                                                                            <i class="not-italic" data-txt>Shop Blenders</i>
+                                                                                        </span>
+
+                                                                                        
+                                                                                            <span class="expand">
+                                                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                                                </svg>
+                                                                                            </span>
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+                                                                                        <span class="hidden absolute lg:flex lg:flex-wrap lg:pt-2px" data-sub>
+                                                                                            
+                                                                                                
+                                                                                                    
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/blenders">Learn</a>
+                                                                                                </span>
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/blenders-comparison">Compare</a>
+                                                                                                </span>
+                                                                                                
+<span class="w-full px-1px pt-2px">
+                                                                                                    <a class="sub-link" href="/pages/blender-personalise-tool">Personalise</a>
+                                                                                                </span>
+                                                                                        </span>
+                                                                                    
+
+                                                                                    
+                                                                                        <div data-nav-dropdown-content="" data-level-03 class="invisible" id="blenders">
+                                                                                            <div class="__box" data-subnav="">
+                                                                                                 <a href="#" class="back" data-back="" data-level-03 aria-controls="blenders">
+                                                                                                    <span class="icon">
+                                                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                                                        </svg>
+                                                                                                    </span>
+                                                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Blenders</span>
+                                                                                                </a>
+
+                                                                                                <div class="__box-wrap">
+                                                                                                    <div class="inner w-1920px">
+                                                                                                        <ul class="ul-sub" xxx>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/collections/kitchenaid-blender">
+                                                                                                                        <span class="icon-svg blenders">
+                                                                                                                            
+		<svg width="25" height="49" viewBox="0 0 25 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.5154 8.82943H13.3977C13.3741 8.82793 13.3505 8.83138 13.3284 8.8397C13.3062 8.84803 13.2861 8.861 13.2694 8.87765C13.2528 8.89438 13.2398 8.91448 13.2315 8.9366C13.2231 8.95873 13.2197 8.98235 13.2212 9.0059C13.2197 9.02953 13.2231 9.05315 13.2315 9.07528C13.2398 9.0974 13.2528 9.1175 13.2694 9.13415C13.2861 9.15088 13.3062 9.16385 13.3284 9.17218C13.3505 9.18043 13.3741 9.18395 13.3977 9.18238H15.5154C15.5389 9.18395 15.5625 9.18043 15.5847 9.17218C15.6068 9.16385 15.6269 9.15088 15.6436 9.13415C15.6603 9.1175 15.6732 9.0974 15.6816 9.07528C15.6899 9.05315 15.6933 9.02953 15.6918 9.0059C15.6933 8.98235 15.6899 8.95873 15.6816 8.9366C15.6732 8.91448 15.6603 8.89438 15.6436 8.87765C15.6269 8.861 15.6068 8.84803 15.5847 8.8397C15.5625 8.83138 15.5389 8.82793 15.5154 8.82943ZM15.5154 12.3589H13.3977C13.3741 12.3573 13.3505 12.3608 13.3284 12.3691C13.3062 12.3775 13.2861 12.3904 13.2694 12.4071C13.2528 12.4238 13.2398 12.4439 13.2315 12.466C13.2231 12.4882 13.2197 12.5118 13.2212 12.5353C13.2197 12.559 13.2231 12.5826 13.2315 12.6047C13.2398 12.6268 13.2528 12.6469 13.2694 12.6636C13.2861 12.6803 13.3062 12.6933 13.3284 12.7015C13.3505 12.7099 13.3741 12.7134 13.3977 12.7118H15.5154C15.5389 12.7134 15.5625 12.7099 15.5847 12.7015C15.6068 12.6933 15.6269 12.6803 15.6436 12.6636C15.6603 12.6469 15.6732 12.6268 15.6816 12.6047C15.6899 12.5826 15.6933 12.559 15.6918 12.5353C15.6933 12.5118 15.6899 12.4882 15.6816 12.466C15.6732 12.4439 15.6603 12.4238 15.6436 12.4071C15.6269 12.3904 15.6068 12.3775 15.5847 12.3691C15.5625 12.3608 15.5389 12.3573 15.5154 12.3589ZM15.5154 15.8883H13.3977C13.3509 15.8883 13.306 15.9069 13.2729 15.94C13.2398 15.973 13.2212 16.018 13.2212 16.0648C13.2212 16.1116 13.2398 16.1564 13.2729 16.1896C13.306 16.2226 13.3509 16.2412 13.3977 16.2412H15.5154C15.5622 16.2412 15.607 16.2226 15.6402 16.1896C15.6732 16.1564 15.6918 16.1116 15.6918 16.0648C15.6918 16.018 15.6732 15.973 15.6402 15.94C15.607 15.9069 15.5622 15.8883 15.5154 15.8883ZM15.5154 19.4177H13.3977C13.3509 19.4177 13.306 19.4363 13.2729 19.4694C13.2398 19.5025 13.2212 19.5474 13.2212 19.5942C13.2212 19.641 13.2398 19.6858 13.2729 19.719C13.306 19.7521 13.3509 19.7707 13.3977 19.7707H15.5154C15.5622 19.7707 15.607 19.7521 15.6402 19.719C15.6732 19.6858 15.6918 19.641 15.6918 19.5942C15.6918 19.5474 15.6732 19.5025 15.6402 19.4694C15.607 19.4363 15.5622 19.4177 15.5154 19.4177ZM11.9506 35.1942C9.97415 35.1942 8.35062 36.8177 8.35062 38.7942C8.35062 40.7707 9.97415 42.3942 11.9506 42.3942C13.9271 42.3942 15.5506 40.7707 15.5506 38.7942C15.5506 36.8177 13.9271 35.1942 11.9506 35.1942ZM11.9506 42.0059C10.1506 42.0059 8.70357 40.5589 8.70357 38.7589C8.70357 36.9589 10.1506 35.5118 11.9506 35.5118C13.7506 35.5118 15.1977 36.9589 15.1977 38.7589C15.1977 40.5589 13.7154 42.0059 11.9506 42.0059ZM17.3859 34.3471C16.9271 34.3471 16.5389 34.7353 16.5389 35.1942C16.5389 35.653 16.9271 36.0412 17.3859 36.0412C17.8448 36.0412 18.233 35.653 18.233 35.1942C18.233 34.7353 17.8448 34.3471 17.3859 34.3471ZM17.3859 35.653C17.1036 35.653 16.8918 35.4412 16.8918 35.1589C16.8918 34.8766 17.1036 34.6648 17.3859 34.6648C17.6683 34.6648 17.88 34.8766 17.88 35.1589C17.88 35.4412 17.633 35.653 17.3859 35.653ZM18.833 19.1353L19.9977 19.1001C22.3624 19.1001 24.3741 16.5589 24.3741 13.5589V6.21769C24.3741 5.33534 23.7741 4.62946 22.9977 4.62946H19.5036L19.6448 1.24122C19.6448 1.10004 19.6095 0.958866 19.5036 0.852984C19.3977 0.747101 19.2565 0.676514 19.1154 0.676514H4.64476C4.50359 0.676514 4.36241 0.747101 4.25653 0.852984C4.15064 0.958866 4.11535 1.10004 4.11535 1.24122L5.17417 24.6412L5.10359 25.1707C4.9977 26.0883 4.29182 26.7942 3.40946 26.9707C1.50359 27.2883 0.0918191 28.9118 0.0918191 30.8883V45.7824C0.0904181 46.1165 0.155191 46.4476 0.282401 46.7566C0.409613 47.0655 0.596738 47.3461 0.832988 47.5824C1.06924 47.8186 1.34993 48.0058 1.65887 48.133C1.96782 48.2602 2.29889 48.325 2.633 48.3236H21.0918C21.4259 48.325 21.757 48.2602 22.0659 48.133C22.3749 48.0058 22.6556 47.8186 22.8918 47.5824C23.1281 47.3461 23.3152 47.0655 23.4424 46.7566C23.5696 46.4476 23.6344 46.1165 23.633 45.7824V30.8883C23.633 28.9471 22.2212 27.2883 20.3154 26.9707C19.433 26.8294 18.7271 26.0883 18.6212 25.1707L18.5506 24.7118L18.833 19.1353ZM17.5624 24.1471H6.233L5.38594 5.68828H18.4095L17.5624 24.1471ZM22.9977 5.68828C23.1389 5.68828 23.3154 5.90005 23.3154 6.21769V13.5236C23.3154 15.9236 21.7624 18.0059 19.9977 18.0059L18.9036 18.0412L19.4683 5.65299L22.9977 5.68828ZM18.5859 1.73534L18.4448 4.62946H5.31535L5.17417 1.73534H18.5859ZM22.6095 30.853V33.0059C22.5741 32.9707 22.5389 32.9707 22.5036 32.9707H1.15064V30.5353H22.4683C22.5036 30.5353 22.5389 30.5353 22.5389 30.5001C22.6095 30.6412 22.6095 30.7471 22.6095 30.853ZM21.1271 47.2648H2.66829C2.276 47.262 1.90057 47.1049 1.62317 46.8275C1.34578 46.5502 1.18871 46.1747 1.18594 45.7824V33.3236H22.5389C22.5741 33.3236 22.6095 33.3236 22.6448 33.2883V45.7824C22.6095 46.5942 21.9389 47.2648 21.1271 47.2648ZM20.1741 27.9942C21.3741 28.2059 22.2565 29.0883 22.5389 30.2177H1.25653C1.50359 29.0883 2.42123 28.2059 3.62123 28.0294C4.9977 27.8177 6.05653 26.6883 6.1977 25.3118V25.2059H17.5977V25.3118C17.7389 26.653 18.7977 27.7824 20.1741 27.9942ZM19.6448 17.1589C19.68 17.1942 19.7154 17.2294 19.7859 17.2294C21.2683 17.2294 22.3271 15.4294 22.3271 12.853V7.13534C22.3271 6.7824 22.08 6.50005 21.7624 6.50005H20.3154C20.2917 6.49849 20.2681 6.50198 20.246 6.5103C20.2239 6.51862 20.2038 6.53156 20.1871 6.54827C20.1704 6.56497 20.1574 6.58506 20.1491 6.60718C20.1408 6.6293 20.1373 6.65293 20.1389 6.67651L19.6095 17.0177C19.6095 17.053 19.6095 17.0883 19.6448 17.1589ZM20.4918 6.85299H21.7624C21.8683 6.85299 21.9741 6.99416 21.9741 7.13534V12.8177C21.9741 15.0766 21.1624 16.7001 19.9624 16.8412C20.033 16.2766 20.1389 14.2294 20.4918 6.85299Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Shop</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/blenders">
+                                                                                                                        <span class="icon-svg learn">
+                                                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Learn</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/blenders-comparison">
+                                                                                                                        <span class="icon-svg compare">
+                                                                                                                            
+		<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.1732 3.64907C23.1732 4.84963 22.2 5.82287 20.9994 5.82287C19.7989 5.82287 18.8256 4.84963 18.8256 3.64907C18.8256 2.44851 19.7989 1.47526 20.9994 1.47526C22.2 1.47526 23.1732 2.44851 23.1732 3.64907ZM23.6623 4.04977C23.4999 5.13821 22.6861 6.01384 21.6302 6.2673C21.6337 6.29156 21.6355 6.31636 21.6355 6.34158L21.6355 40.0062H38.4412C38.7277 40.0062 38.9599 40.2384 38.9599 40.5249C38.9599 40.8114 38.7277 41.0436 38.4412 41.0436H21.1168H3.78959C3.50311 41.0436 3.27088 40.8114 3.27088 40.5249C3.27088 40.2384 3.50311 40.0062 3.78959 40.0062H20.598L20.598 6.34158C20.598 6.33165 20.5983 6.32179 20.5989 6.312C19.4326 6.13806 18.5106 5.2162 18.3365 4.05C18.3275 4.05047 18.3183 4.05071 18.3091 4.05071H11.7185C11.5993 4.13687 11.4576 4.22324 11.2989 4.29793L19.0258 25.351C19.0373 25.3803 19.046 25.4104 19.052 25.4409C19.0667 25.5158 19.0643 25.5912 19.047 25.6624C19.0285 25.7396 18.992 25.8131 18.9382 25.8763C18.9196 25.8983 18.8991 25.9188 18.8768 25.9375C17.8177 26.865 15.0018 28.8688 9.99698 28.8688C7.44049 28.8688 5.34165 28.3884 3.78934 27.7794C3.0137 27.475 2.37027 27.1369 1.87231 26.807C1.38773 26.486 1.00944 26.1521 0.7938 25.8405C0.78631 25.8299 0.779229 25.8191 0.772569 25.808C0.690714 25.6723 0.678119 25.5122 0.726653 25.3712C0.731138 25.3582 0.736145 25.3453 0.741667 25.3327L9.56676 4.33118C9.42694 4.2607 9.28988 4.16832 9.15842 4.05071H7.07073C6.78426 4.05071 6.55202 3.81848 6.55202 3.532C6.55202 3.24552 6.78426 3.01328 7.07073 3.01328H9.37257H9.6046L9.75926 3.18626C9.82931 3.26461 9.90007 3.3244 9.97108 3.36901L9.98703 3.33104C10.0696 3.1345 10.2641 3.0085 10.4772 3.01341C10.6777 3.01803 10.8563 3.13761 10.9379 3.31839C11.0417 3.26222 11.1317 3.19882 11.1985 3.14064L11.345 3.01328H11.539H18.3091C18.3336 3.01328 18.3576 3.01498 18.3812 3.01825C18.6651 1.83554 19.7296 0.956543 20.9994 0.956543C22.2694 0.956543 23.334 1.83581 23.6178 3.0188C23.6425 3.01517 23.6679 3.01328 23.6936 3.01328H30.4637H30.6219L30.7532 3.10155C30.8505 3.16699 31.0048 3.24588 31.1862 3.30212C31.2712 3.12988 31.4464 3.01664 31.6425 3.01335C31.8321 3.01017 32.0055 3.11032 32.0989 3.2699C32.1651 3.2359 32.2293 3.19285 32.2909 3.1396L32.437 3.01328H32.6302H34.932C35.2185 3.01328 35.4507 3.24552 35.4507 3.532C35.4507 3.81848 35.2185 4.05071 34.932 4.05071H32.808C32.6958 4.12979 32.5807 4.19374 32.4646 4.24459L41.2699 28.2887C41.3341 28.4639 41.2978 28.6513 41.1905 28.788C40.9726 29.0936 40.6004 29.4198 40.1266 29.7337C39.6286 30.0636 38.9852 30.4017 38.2095 30.706C36.6572 31.3151 34.5584 31.7955 32.0019 31.7955C26.984 31.7955 24.1665 29.7812 23.1139 28.857C22.9442 28.708 22.895 28.4729 22.9743 28.2746L30.8573 4.28623C30.6506 4.22034 30.4667 4.13587 30.3172 4.05071H23.6936C23.6831 4.05071 23.6727 4.05039 23.6623 4.04977ZM24.1879 27.9045L24.0596 28.295C24.4883 28.4085 25.0994 28.5135 25.8582 28.6034C27.4553 28.7925 29.6689 28.9102 32.1189 28.9102C34.5688 28.9102 36.7824 28.7925 38.3795 28.6034C39.1326 28.5142 39.7401 28.4101 40.1683 28.2976L40.0219 27.8978C39.6059 27.7993 39.0505 27.708 38.3795 27.6285C36.7824 27.4394 34.5688 27.3217 32.1189 27.3217C29.6689 27.3217 27.4553 27.4394 25.8582 27.6285C25.1721 27.7098 24.6068 27.8034 24.1879 27.9045ZM24.2825 27.6166L31.6777 5.11281L39.9158 27.6081C38.4015 27.2828 35.4775 27.0624 32.1189 27.0624C28.7308 27.0624 25.7851 27.2866 24.2825 27.6166ZM32.0019 30.758C28.2471 30.758 25.8438 29.5622 24.5623 28.6724C26.1331 28.9709 28.93 29.1696 32.1189 29.1696C35.4563 29.1696 38.3646 28.9519 39.887 28.63C39.7905 28.7053 39.6797 28.7853 39.5536 28.8688C39.1239 29.1535 38.5468 29.4593 37.8306 29.7403C36.3993 30.3019 34.429 30.758 32.0019 30.758ZM10.4326 4.9486L17.6748 24.6809C16.1598 24.3559 13.2371 24.1357 9.88002 24.1357C6.5675 24.1357 3.67779 24.3501 2.14625 24.6681L10.4326 4.9486ZM2.02344 24.9603L1.84889 25.3757C2.27603 25.4864 2.87699 25.5888 3.61937 25.6767C5.21647 25.8659 7.43006 25.9835 9.88002 25.9835C12.33 25.9835 14.5436 25.8659 16.1407 25.6767C16.893 25.5876 17.5 25.4836 17.9282 25.3713L17.7812 24.9707C17.3654 24.8723 16.8106 24.7812 16.1407 24.7018C14.5436 24.5127 12.33 24.395 9.88002 24.395C7.43006 24.395 5.21647 24.5127 3.61937 24.7018C2.97309 24.7784 2.43399 24.8659 2.02344 24.9603ZM17.4366 25.7457C16.1551 26.6356 13.7518 27.8314 9.99698 27.8314C7.56993 27.8314 5.59963 27.3752 4.16826 26.8136C3.45207 26.5326 2.87503 26.2269 2.44526 25.9422C2.31922 25.8587 2.20837 25.7786 2.11188 25.7033C3.63428 26.0253 6.54255 26.2429 9.88002 26.2429C13.0688 26.2429 15.8658 26.0442 17.4366 25.7457Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Compare</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/blender-personalise-tool">
+                                                                                                                        <span class="icon-svg personalise-blenders">
+                                                                                                                            
+		<svg width="48" height="51" viewBox="0 0 48 51" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path fill-rule="evenodd" clip-rule="evenodd" d="M14.626 0L15.5814 20.734L15.4623 21.6119C15.2835 23.1333 14.0916 24.3037 12.6018 24.5964C9.38377 25.123 7.00004 27.8148 7.00004 31.0918V35C5.97101 35 5.12346 36.7486 5.01235 38H5C4.06808 38 3.28503 38.6374 3.06301 39.5H2.65921C2.05917 39.5 1.51686 39.8576 1.28049 40.4091L0.544546 42.0636C0.340589 42.5222 0 42.9878 0 43.5V45.5C0 46.0523 0.447715 46.5 1 46.5H2C3 46.5 3 47.5 3 47.5V49C3 50.1046 3.89543 51 5 51H5.01235H6.02784C6.00964 50.9145 6 50.8252 6 50.7333V38.2667C6 37.6407 6.44772 37.1333 7 37.1333V51H8.84743V35.1296H44.9013C44.9608 35.1296 45.0205 35.1296 45.0801 35.0711V51H46.7487V31.0918C46.7487 27.8733 44.3649 25.123 41.147 24.5964C39.6571 24.3621 38.4652 23.1333 38.2864 21.6119L38.1672 20.8511L38.644 11.6051L40.6106 11.5467C44.6033 11.5467 48 7.33336 48 2.35929V0H46.2124V2.30076C46.2124 6.28002 43.5902 9.73252 40.6106 9.73252L38.7632 9.79105L39.2177 0H37.4293L36.4986 19.9148H17.3693L16.4386 0H14.626ZM1.44481 42.5H2C3 42.5 3 41.5 3 41.5V40.5H2.65921C2.45919 40.5 2.27842 40.6192 2.19963 40.803L1.44481 42.5ZM40.3771 0L39.9551 8.09406C39.9551 8.15259 39.9551 8.21112 40.0147 8.32817C40.0741 8.3867 40.1339 8.44506 40.253 8.44506C42.7559 8.44506 44.5437 5.46062 44.5437 1.18889V0H43.9477V1.13037C43.9477 4.87567 42.5771 7.56747 40.551 7.80142C40.6346 7.14471 40.7476 5.27821 41.0133 0H40.3771ZM33.0423 0.369663H29.4667C29.4268 0.36701 29.387 0.372814 29.3496 0.386576C29.3122 0.400503 29.2782 0.42189 29.25 0.449579C29.222 0.477268 29.2 0.510595 29.186 0.547237C29.1718 0.584045 29.1661 0.623177 29.1686 0.66214C29.1661 0.701435 29.1718 0.740564 29.186 0.777206C29.2 0.813848 29.222 0.847174 29.25 0.874863C29.2782 0.902552 29.3122 0.924107 29.3496 0.937702C29.387 0.95163 29.4268 0.957432 29.4667 0.954779H33.0423C33.082 0.957432 33.1219 0.95163 33.1593 0.937702C33.1967 0.924107 33.2306 0.902552 33.2588 0.874863C33.287 0.847174 33.3088 0.813848 33.323 0.777206C33.337 0.740564 33.3427 0.701435 33.3402 0.66214C33.3427 0.623177 33.337 0.584045 33.323 0.547237C33.3088 0.510595 33.287 0.477268 33.2588 0.449579C33.2306 0.42189 33.1967 0.400503 33.1593 0.386576C33.1219 0.372814 33.082 0.36701 33.0423 0.369663ZM33.0423 6.22149H29.4667C29.3876 6.22149 29.3118 6.25233 29.2559 6.30721C29.2 6.36192 29.1686 6.43654 29.1686 6.51413C29.1686 6.59173 29.2 6.66601 29.2559 6.72105C29.3118 6.77577 29.3876 6.8066 29.4667 6.8066H33.0423C33.1213 6.8066 33.197 6.77577 33.2531 6.72105C33.3088 6.66601 33.3402 6.59173 33.3402 6.51413C33.3402 6.43654 33.3088 6.36192 33.2531 6.30721C33.197 6.25233 33.1213 6.22149 33.0423 6.22149ZM33.0423 12.0733H29.4667C29.3876 12.0733 29.3118 12.1042 29.2559 12.159C29.2 12.2139 29.1686 12.2884 29.1686 12.366C29.1686 12.4436 29.2 12.5178 29.2559 12.5729C29.3118 12.6278 29.3876 12.6586 29.4667 12.6586H33.0423C33.1213 12.6586 33.197 12.6278 33.2531 12.5729C33.3088 12.5178 33.3402 12.4436 33.3402 12.366C33.3402 12.2884 33.3088 12.2139 33.2531 12.159C33.197 12.1042 33.1213 12.0733 33.0423 12.0733ZM5 50V39C4.44772 39 4 39.4477 4 40V49C4 49.5523 4.44772 50 5 50ZM45.0205 31.0333V34.6029C44.9608 34.5445 44.9013 34.5445 44.8417 34.5445H8.78783V30.5065H44.7821C44.8417 30.5065 44.9013 30.5065 44.9013 30.4482C45.0205 30.6821 45.0205 30.8577 45.0205 31.0333ZM40.9084 26.2934C42.9346 26.6444 44.4245 28.1074 44.9013 29.98H8.96662C9.38377 28.1074 10.9332 26.6444 12.9594 26.3517C15.2835 26.0007 17.0713 24.1281 17.3097 21.8459V21.6703H36.5582V21.8459C36.7966 24.0696 38.5844 25.9422 40.9084 26.2934ZM33.7988 32.2328C33.7988 32.2328 33.9806 31.8691 34.3443 32.0509C34.7079 32.2328 34.7988 32.6873 33.7988 33.4146C32.7988 32.7782 32.8897 32.2328 33.2534 32.0509C33.617 31.8691 33.7988 32.2328 33.7988 32.2328ZM22.6092 32.0373V33.4701H22.8269V32.0373H22.6092ZM22.6101 31.7547C22.6409 31.7839 22.6775 31.7985 22.7199 31.7985C22.7623 31.7985 22.7986 31.7839 22.8287 31.7547C22.8595 31.7254 22.8749 31.6903 22.8749 31.6493C22.8749 31.6082 22.8595 31.5731 22.8287 31.5438C22.7986 31.5146 22.7623 31.5 22.7199 31.5C22.6775 31.5 22.6409 31.5146 22.6101 31.5438C22.58 31.5731 22.565 31.6082 22.565 31.6493C22.565 31.6903 22.58 31.7254 22.6101 31.7547ZM20 31.5597L20.5165 33.4701H20.7526L21.1695 31.9478H21.1843L21.6011 33.4701H21.8372L22.3537 31.5597H22.1213L21.7266 33.1157H21.7081L21.306 31.5597H21.0477L20.6456 33.1157H20.6272L20.2324 31.5597H20ZM23.8417 32.0373V32.2239H23.5392V33.0597C23.5392 33.1219 23.5481 33.1685 23.5659 33.1996C23.5843 33.2301 23.6077 33.2506 23.636 33.2612C23.6649 33.2711 23.6953 33.2761 23.7273 33.2761C23.7513 33.2761 23.771 33.2749 23.7863 33.2724L23.8232 33.2649L23.8675 33.4627C23.8527 33.4683 23.8321 33.4739 23.8057 33.4795C23.7793 33.4857 23.7457 33.4888 23.7052 33.4888C23.6437 33.4888 23.5834 33.4754 23.5244 33.4487C23.466 33.422 23.4174 33.3812 23.3787 33.3265C23.3405 33.2718 23.3215 33.2027 23.3215 33.1194V32.2239H23.1075V32.0373H23.3215V31.694H23.5392V32.0373H23.8417ZM24.4172 33.4701V32.6082C24.4172 32.5249 24.4332 32.454 24.4652 32.3955C24.4977 32.3371 24.542 32.2926 24.598 32.2621C24.6545 32.2317 24.7185 32.2164 24.7898 32.2164C24.8925 32.2164 24.9727 32.2478 25.0305 32.3106C25.0889 32.3728 25.1182 32.4608 25.1182 32.5746V33.4701H25.3358V32.5597C25.3358 32.4366 25.3155 32.3352 25.2749 32.2556C25.235 32.1754 25.1787 32.116 25.1062 32.0774C25.0336 32.0382 24.9491 32.0187 24.8525 32.0187C24.7412 32.0187 24.6521 32.0407 24.5851 32.0849C24.5186 32.1284 24.4688 32.1872 24.4356 32.2612H24.4172V31.5597H24.1995V33.4701H24.4172ZM26.494 33.4701V31.5597H26.7227V33.2649H27.6008V33.4701H26.494ZM28.1643 33.4076C28.2609 33.4692 28.3731 33.5 28.501 33.5C28.6289 33.5 28.7408 33.4692 28.8367 33.4076C28.9332 33.3461 29.0082 33.2599 29.0617 33.1493C29.1158 33.0386 29.1429 32.9092 29.1429 32.7612C29.1429 32.6119 29.1158 32.4817 29.0617 32.3703C29.0082 32.259 28.9332 32.1726 28.8367 32.111C28.7408 32.0494 28.6289 32.0187 28.501 32.0187C28.3731 32.0187 28.2609 32.0494 28.1643 32.111C28.0684 32.1726 27.9934 32.259 27.9393 32.3703C27.8858 32.4817 27.859 32.6119 27.859 32.7612C27.859 32.9092 27.8858 33.0386 27.9393 33.1493C27.9934 33.2599 28.0684 33.3461 28.1643 33.4076ZM28.7408 33.2267C28.6781 33.2771 28.5981 33.3022 28.501 33.3022C28.4038 33.3022 28.3239 33.2771 28.2612 33.2267C28.1985 33.1763 28.152 33.1101 28.1219 33.028C28.0918 32.9459 28.0767 32.857 28.0767 32.7612C28.0767 32.6654 28.0918 32.5762 28.1219 32.4935C28.152 32.4108 28.1985 32.3439 28.2612 32.2929C28.3239 32.2419 28.4038 32.2164 28.501 32.2164C28.5981 32.2164 28.6781 32.2419 28.7408 32.2929C28.8035 32.3439 28.8499 32.4108 28.88 32.4935C28.9102 32.5762 28.9252 32.6654 28.9252 32.7612C28.9252 32.857 28.9102 32.9459 28.88 33.028C28.8499 33.1101 28.8035 33.1763 28.7408 33.2267ZM30.5829 32.0373L30.059 33.4701H29.8376L29.3138 32.0373H29.5499L29.9409 33.1791H29.9557L30.3468 32.0373H30.5829ZM31.0602 33.4086C31.1592 33.4695 31.2769 33.5 31.4134 33.5C31.5093 33.5 31.5957 33.4851 31.6726 33.4552C31.7494 33.4248 31.814 33.3825 31.8663 33.3284C31.9185 33.2736 31.9557 33.2102 31.9779 33.1381L31.7676 33.0784C31.7491 33.1281 31.723 33.1698 31.6892 33.2034C31.6554 33.2363 31.6151 33.2612 31.5684 33.278C31.5222 33.2942 31.4706 33.3022 31.4134 33.3022C31.3255 33.3022 31.2483 33.283 31.1819 33.2444C31.1155 33.2052 31.0635 33.1483 31.026 33.0737C30.9926 33.0055 30.9743 32.9237 30.9712 32.8284H32V32.7351C32 32.6014 31.9825 32.4888 31.9474 32.3974C31.9124 32.306 31.8653 32.2326 31.8063 32.1772C31.7473 32.1213 31.6818 32.0808 31.6099 32.056C31.5379 32.0311 31.4651 32.0187 31.3913 32.0187C31.2634 32.0187 31.1515 32.0504 31.0555 32.1138C30.9602 32.1766 30.8858 32.2643 30.8323 32.3769C30.7795 32.4888 30.753 32.6182 30.753 32.7649C30.753 32.9117 30.7795 33.0404 30.8323 33.1511C30.8858 33.2612 30.9618 33.347 31.0602 33.4086ZM30.9717 32.6381C30.9759 32.5716 30.9924 32.5088 31.0214 32.4496C31.0552 32.3806 31.1035 32.3246 31.1662 32.2817C31.2296 32.2382 31.3046 32.2164 31.3913 32.2164C31.47 32.2164 31.5382 32.2348 31.596 32.2715C31.6544 32.3081 31.6993 32.3582 31.7307 32.4216C31.7627 32.4851 31.7786 32.5572 31.7786 32.6381H30.9717Z" fill="#C41230"/>
+		</svg>
+
+
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Personalise</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+                                                                                                        </ul>
+
+                                                                                                        <!-- mobile_banner -->
+                                                                                                        
+                                                                                                        
+
+                                                                                                        
+                                                                                                        <!-- end mobile_banner -->
+
+                                                                                                        <!-- mobile_sale_banner -->
+                                                                                                        
+                                                                                                            
+
+                                                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                                                            
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                        <div class="img pb-89.250814332">
+                                                                                                                            
+                                                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                </div>
+                                                                                                            
+                                                                                                        
+                                                                                                        <!-- end mobile_sale_banner -->
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                     
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li class="is-dropdown w-hover-state">
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/kitchenaid-toasters"  class="no-link" data-expand="" data-sub-name="toasters" aria-expanded="false" aria-haspopup="true" role="button" data-level-03 data-level-03-role >
+                                                                                        <span class="icon-svg toasters">
+                                                                                            
+		<svg width="30" height="39" viewBox="0 0 30 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M28.6163 31.1941V13.5576L28.587 12.6772C28.2348 7.33633 24.8014 2.87584 20.1062 0.939048L19.8127 0.821668C19.6953 0.792327 19.6073 0.73363 19.4899 0.704289C19.4606 0.704289 19.4312 0.67494 19.4019 0.67494C19.2258 0.61625 19.0791 0.55756 18.903 0.528219C18.8443 0.528219 18.815 0.49887 18.7563 0.49887C18.6096 0.440181 18.4334 0.410832 18.2868 0.381491C18.2281 0.381491 18.1693 0.352142 18.14 0.352142L17.6999 0.264111C17.6411 0.264111 17.5824 0.234762 17.5238 0.234762L17.0836 0.146724C17.0249 0.146724 16.9662 0.117381 16.8782 0.117381C16.7314 0.0880355 16.5847 0.0880363 16.438 0.0586906C16.3793 0.0586906 16.2913 0.0293449 16.2326 0.0293449C16.0859 0.0293449 15.9391 0 15.7631 0H14.149C14.0023 0 13.8262 0.0293449 13.6795 0.0293449C13.6208 0.0293449 13.5621 0.0586906 13.4742 0.0586906C13.3274 0.0880363 13.1807 0.0880355 13.0339 0.117381C12.9752 0.117381 12.9166 0.146724 12.8579 0.146724L12.4177 0.234762C12.359 0.234762 12.3003 0.264111 12.2416 0.264111L11.7721 0.352142C11.7134 0.352142 11.6841 0.381491 11.6253 0.381491C11.4787 0.410832 11.3025 0.469521 11.1559 0.49887C11.1265 0.49887 11.0678 0.528219 11.0384 0.528219C10.8624 0.586909 10.7156 0.645599 10.5396 0.704289C10.5102 0.704289 10.4809 0.73363 10.4809 0.73363C10.3635 0.762979 10.2755 0.821668 10.1581 0.851017L9.86462 0.968397C5.16937 2.87584 1.73597 7.36568 1.38383 12.7066L1.35448 13.6162V31.2528C0.79692 31.869 0.474121 32.6613 0.474121 33.483V35.7133C0.474121 37.5327 1.94139 39 3.7608 39H26.2393C28.0588 39 29.526 37.5327 29.526 35.7133V33.483C29.4967 32.6026 29.1739 31.8103 28.6163 31.1941ZM15.4109 0.821668H15.7044C15.8511 0.821668 15.9685 0.851017 16.1152 0.851017H16.2619C16.438 0.880358 16.6141 0.880358 16.7901 0.909707H16.8195L17.4064 0.997738H17.4651C17.6411 1.02709 17.8172 1.05644 17.9933 1.11513C18.0227 1.11513 18.052 1.14447 18.0814 1.14447C18.2574 1.17382 18.4041 1.2325 18.5802 1.29119C18.6096 1.29119 18.6096 1.29119 18.6389 1.32054C18.8443 1.37923 19.0497 1.43792 19.2551 1.52595V4.75395C19.2551 5.39954 18.7269 5.92776 18.0814 5.92776H16.6141C15.9685 5.92776 15.4403 5.39954 15.4403 4.75395L15.4109 0.821668ZM10.7156 1.52595C10.9211 1.46726 11.1265 1.37923 11.3319 1.32054C11.3612 1.32054 11.3613 1.32054 11.3906 1.29119C11.5666 1.2325 11.7134 1.20316 11.8894 1.14447C11.9188 1.14447 11.9482 1.11513 11.9775 1.11513C12.1536 1.08578 12.3297 1.02709 12.5057 0.997738H12.5644L13.1513 0.909707H13.1807C13.3567 0.880358 13.5328 0.851017 13.7089 0.851017H13.8556C14.0023 0.851017 14.1197 0.821668 14.2664 0.821668H14.5599V4.78329C14.5599 5.42888 14.0317 5.9571 13.3861 5.9571H11.9188C11.2732 5.9571 10.745 5.42888 10.745 4.78329L10.7156 1.52595ZM28.6163 35.6546C28.6132 36.2918 28.3587 36.9021 27.9081 37.3527C27.4575 37.8033 26.8473 38.0578 26.21 38.0609H3.73145C3.09421 38.0578 2.48395 37.8033 2.03334 37.3527C1.58274 36.9021 1.32822 36.2918 1.32514 35.6546V33.4243C1.32514 32.7494 1.58925 32.1331 2.05877 31.693L2.20549 31.5756V13.5869L2.23484 12.7066C2.55764 7.83517 5.60956 3.75621 9.83532 1.8781V4.75395C9.83532 5.89841 10.745 6.80812 11.8894 6.80812H13.3567C14.0024 6.80812 14.5893 6.48532 14.9707 6.0158C15.3522 6.48532 15.9391 6.80812 16.5847 6.80812H18.052C19.1965 6.80812 20.1062 5.89841 20.1062 4.75395V1.8781C24.3319 3.75621 27.3838 7.83517 27.7066 12.7066L27.736 13.5576V31.5462L27.8827 31.6637C28.3522 32.1331 28.6163 32.7494 28.6163 33.395V35.6546ZM13.3567 26.763C11.9775 26.763 10.8624 27.8781 10.8624 29.2573C10.8624 30.6365 11.9775 31.7516 13.3567 31.7516C14.7359 31.7516 15.8511 30.6365 15.8511 29.2573C15.8511 27.8781 14.7359 26.763 13.3567 26.763ZM13.3567 31.4582C12.1535 31.4582 11.1559 30.4605 11.1559 29.2573C11.1559 28.0541 12.1535 27.0564 13.3567 27.0564C14.5599 27.0564 15.5576 28.0541 15.5576 29.2573C15.5576 30.4605 14.5599 31.4582 13.3567 31.4582ZM23.4515 20.6004H6.48991C6.13778 20.6004 5.87367 20.8645 5.87367 21.2167V22.3318C5.87367 22.684 6.13778 22.9481 6.48991 22.9481H23.4515C23.8037 22.9481 24.0678 22.684 24.0678 22.3318V21.2167C24.0678 20.8939 23.8037 20.6004 23.4515 20.6004ZM23.7744 22.3318C23.7735 22.4172 23.7393 22.4989 23.679 22.5592C23.6185 22.6196 23.5369 22.6539 23.4515 22.6546H6.48991C6.40454 22.6539 6.32288 22.6196 6.26251 22.5592C6.20214 22.4989 6.16788 22.4172 6.16712 22.3318V21.2167C6.16788 21.1313 6.20214 21.0496 6.26251 20.9892C6.32288 20.9289 6.40454 20.8946 6.48991 20.8939H23.4515C23.5369 20.8946 23.6185 20.9289 23.679 20.9892C23.7393 21.0496 23.7735 21.1313 23.7744 21.2167V22.3318Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Toasters</span>
+                                                                                            <i class="not-italic" data-txt>Shop Toasters</i>
+                                                                                        </span>
+
+                                                                                        
+                                                                                            <span class="expand">
+                                                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                                                </svg>
+                                                                                            </span>
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+                                                                                        <span class="hidden absolute lg:flex lg:flex-wrap lg:pt-2px" data-sub>
+                                                                                            
+                                                                                                
+                                                                                                    
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/toasters">Learn</a>
+                                                                                                </span>
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/toasters-comparison">Compare</a>
+                                                                                                </span>
+                                                                                        </span>
+                                                                                    
+
+                                                                                    
+                                                                                        <div data-nav-dropdown-content="" data-level-03 class="invisible" id="toasters">
+                                                                                            <div class="__box" data-subnav="">
+                                                                                                 <a href="#" class="back" data-back="" data-level-03 aria-controls="toasters">
+                                                                                                    <span class="icon">
+                                                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                                                        </svg>
+                                                                                                    </span>
+                                                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Toasters</span>
+                                                                                                </a>
+
+                                                                                                <div class="__box-wrap">
+                                                                                                    <div class="inner w-1920px">
+                                                                                                        <ul class="ul-sub" xxx>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/collections/kitchenaid-toasters">
+                                                                                                                        <span class="icon-svg toasters">
+                                                                                                                            
+		<svg width="30" height="39" viewBox="0 0 30 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M28.6163 31.1941V13.5576L28.587 12.6772C28.2348 7.33633 24.8014 2.87584 20.1062 0.939048L19.8127 0.821668C19.6953 0.792327 19.6073 0.73363 19.4899 0.704289C19.4606 0.704289 19.4312 0.67494 19.4019 0.67494C19.2258 0.61625 19.0791 0.55756 18.903 0.528219C18.8443 0.528219 18.815 0.49887 18.7563 0.49887C18.6096 0.440181 18.4334 0.410832 18.2868 0.381491C18.2281 0.381491 18.1693 0.352142 18.14 0.352142L17.6999 0.264111C17.6411 0.264111 17.5824 0.234762 17.5238 0.234762L17.0836 0.146724C17.0249 0.146724 16.9662 0.117381 16.8782 0.117381C16.7314 0.0880355 16.5847 0.0880363 16.438 0.0586906C16.3793 0.0586906 16.2913 0.0293449 16.2326 0.0293449C16.0859 0.0293449 15.9391 0 15.7631 0H14.149C14.0023 0 13.8262 0.0293449 13.6795 0.0293449C13.6208 0.0293449 13.5621 0.0586906 13.4742 0.0586906C13.3274 0.0880363 13.1807 0.0880355 13.0339 0.117381C12.9752 0.117381 12.9166 0.146724 12.8579 0.146724L12.4177 0.234762C12.359 0.234762 12.3003 0.264111 12.2416 0.264111L11.7721 0.352142C11.7134 0.352142 11.6841 0.381491 11.6253 0.381491C11.4787 0.410832 11.3025 0.469521 11.1559 0.49887C11.1265 0.49887 11.0678 0.528219 11.0384 0.528219C10.8624 0.586909 10.7156 0.645599 10.5396 0.704289C10.5102 0.704289 10.4809 0.73363 10.4809 0.73363C10.3635 0.762979 10.2755 0.821668 10.1581 0.851017L9.86462 0.968397C5.16937 2.87584 1.73597 7.36568 1.38383 12.7066L1.35448 13.6162V31.2528C0.79692 31.869 0.474121 32.6613 0.474121 33.483V35.7133C0.474121 37.5327 1.94139 39 3.7608 39H26.2393C28.0588 39 29.526 37.5327 29.526 35.7133V33.483C29.4967 32.6026 29.1739 31.8103 28.6163 31.1941ZM15.4109 0.821668H15.7044C15.8511 0.821668 15.9685 0.851017 16.1152 0.851017H16.2619C16.438 0.880358 16.6141 0.880358 16.7901 0.909707H16.8195L17.4064 0.997738H17.4651C17.6411 1.02709 17.8172 1.05644 17.9933 1.11513C18.0227 1.11513 18.052 1.14447 18.0814 1.14447C18.2574 1.17382 18.4041 1.2325 18.5802 1.29119C18.6096 1.29119 18.6096 1.29119 18.6389 1.32054C18.8443 1.37923 19.0497 1.43792 19.2551 1.52595V4.75395C19.2551 5.39954 18.7269 5.92776 18.0814 5.92776H16.6141C15.9685 5.92776 15.4403 5.39954 15.4403 4.75395L15.4109 0.821668ZM10.7156 1.52595C10.9211 1.46726 11.1265 1.37923 11.3319 1.32054C11.3612 1.32054 11.3613 1.32054 11.3906 1.29119C11.5666 1.2325 11.7134 1.20316 11.8894 1.14447C11.9188 1.14447 11.9482 1.11513 11.9775 1.11513C12.1536 1.08578 12.3297 1.02709 12.5057 0.997738H12.5644L13.1513 0.909707H13.1807C13.3567 0.880358 13.5328 0.851017 13.7089 0.851017H13.8556C14.0023 0.851017 14.1197 0.821668 14.2664 0.821668H14.5599V4.78329C14.5599 5.42888 14.0317 5.9571 13.3861 5.9571H11.9188C11.2732 5.9571 10.745 5.42888 10.745 4.78329L10.7156 1.52595ZM28.6163 35.6546C28.6132 36.2918 28.3587 36.9021 27.9081 37.3527C27.4575 37.8033 26.8473 38.0578 26.21 38.0609H3.73145C3.09421 38.0578 2.48395 37.8033 2.03334 37.3527C1.58274 36.9021 1.32822 36.2918 1.32514 35.6546V33.4243C1.32514 32.7494 1.58925 32.1331 2.05877 31.693L2.20549 31.5756V13.5869L2.23484 12.7066C2.55764 7.83517 5.60956 3.75621 9.83532 1.8781V4.75395C9.83532 5.89841 10.745 6.80812 11.8894 6.80812H13.3567C14.0024 6.80812 14.5893 6.48532 14.9707 6.0158C15.3522 6.48532 15.9391 6.80812 16.5847 6.80812H18.052C19.1965 6.80812 20.1062 5.89841 20.1062 4.75395V1.8781C24.3319 3.75621 27.3838 7.83517 27.7066 12.7066L27.736 13.5576V31.5462L27.8827 31.6637C28.3522 32.1331 28.6163 32.7494 28.6163 33.395V35.6546ZM13.3567 26.763C11.9775 26.763 10.8624 27.8781 10.8624 29.2573C10.8624 30.6365 11.9775 31.7516 13.3567 31.7516C14.7359 31.7516 15.8511 30.6365 15.8511 29.2573C15.8511 27.8781 14.7359 26.763 13.3567 26.763ZM13.3567 31.4582C12.1535 31.4582 11.1559 30.4605 11.1559 29.2573C11.1559 28.0541 12.1535 27.0564 13.3567 27.0564C14.5599 27.0564 15.5576 28.0541 15.5576 29.2573C15.5576 30.4605 14.5599 31.4582 13.3567 31.4582ZM23.4515 20.6004H6.48991C6.13778 20.6004 5.87367 20.8645 5.87367 21.2167V22.3318C5.87367 22.684 6.13778 22.9481 6.48991 22.9481H23.4515C23.8037 22.9481 24.0678 22.684 24.0678 22.3318V21.2167C24.0678 20.8939 23.8037 20.6004 23.4515 20.6004ZM23.7744 22.3318C23.7735 22.4172 23.7393 22.4989 23.679 22.5592C23.6185 22.6196 23.5369 22.6539 23.4515 22.6546H6.48991C6.40454 22.6539 6.32288 22.6196 6.26251 22.5592C6.20214 22.4989 6.16788 22.4172 6.16712 22.3318V21.2167C6.16788 21.1313 6.20214 21.0496 6.26251 20.9892C6.32288 20.9289 6.40454 20.8946 6.48991 20.8939H23.4515C23.5369 20.8946 23.6185 20.9289 23.679 20.9892C23.7393 21.0496 23.7735 21.1313 23.7744 21.2167V22.3318Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Shop</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/toasters">
+                                                                                                                        <span class="icon-svg learn">
+                                                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Learn</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/toasters-comparison">
+                                                                                                                        <span class="icon-svg compare">
+                                                                                                                            
+		<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.1732 3.64907C23.1732 4.84963 22.2 5.82287 20.9994 5.82287C19.7989 5.82287 18.8256 4.84963 18.8256 3.64907C18.8256 2.44851 19.7989 1.47526 20.9994 1.47526C22.2 1.47526 23.1732 2.44851 23.1732 3.64907ZM23.6623 4.04977C23.4999 5.13821 22.6861 6.01384 21.6302 6.2673C21.6337 6.29156 21.6355 6.31636 21.6355 6.34158L21.6355 40.0062H38.4412C38.7277 40.0062 38.9599 40.2384 38.9599 40.5249C38.9599 40.8114 38.7277 41.0436 38.4412 41.0436H21.1168H3.78959C3.50311 41.0436 3.27088 40.8114 3.27088 40.5249C3.27088 40.2384 3.50311 40.0062 3.78959 40.0062H20.598L20.598 6.34158C20.598 6.33165 20.5983 6.32179 20.5989 6.312C19.4326 6.13806 18.5106 5.2162 18.3365 4.05C18.3275 4.05047 18.3183 4.05071 18.3091 4.05071H11.7185C11.5993 4.13687 11.4576 4.22324 11.2989 4.29793L19.0258 25.351C19.0373 25.3803 19.046 25.4104 19.052 25.4409C19.0667 25.5158 19.0643 25.5912 19.047 25.6624C19.0285 25.7396 18.992 25.8131 18.9382 25.8763C18.9196 25.8983 18.8991 25.9188 18.8768 25.9375C17.8177 26.865 15.0018 28.8688 9.99698 28.8688C7.44049 28.8688 5.34165 28.3884 3.78934 27.7794C3.0137 27.475 2.37027 27.1369 1.87231 26.807C1.38773 26.486 1.00944 26.1521 0.7938 25.8405C0.78631 25.8299 0.779229 25.8191 0.772569 25.808C0.690714 25.6723 0.678119 25.5122 0.726653 25.3712C0.731138 25.3582 0.736145 25.3453 0.741667 25.3327L9.56676 4.33118C9.42694 4.2607 9.28988 4.16832 9.15842 4.05071H7.07073C6.78426 4.05071 6.55202 3.81848 6.55202 3.532C6.55202 3.24552 6.78426 3.01328 7.07073 3.01328H9.37257H9.6046L9.75926 3.18626C9.82931 3.26461 9.90007 3.3244 9.97108 3.36901L9.98703 3.33104C10.0696 3.1345 10.2641 3.0085 10.4772 3.01341C10.6777 3.01803 10.8563 3.13761 10.9379 3.31839C11.0417 3.26222 11.1317 3.19882 11.1985 3.14064L11.345 3.01328H11.539H18.3091C18.3336 3.01328 18.3576 3.01498 18.3812 3.01825C18.6651 1.83554 19.7296 0.956543 20.9994 0.956543C22.2694 0.956543 23.334 1.83581 23.6178 3.0188C23.6425 3.01517 23.6679 3.01328 23.6936 3.01328H30.4637H30.6219L30.7532 3.10155C30.8505 3.16699 31.0048 3.24588 31.1862 3.30212C31.2712 3.12988 31.4464 3.01664 31.6425 3.01335C31.8321 3.01017 32.0055 3.11032 32.0989 3.2699C32.1651 3.2359 32.2293 3.19285 32.2909 3.1396L32.437 3.01328H32.6302H34.932C35.2185 3.01328 35.4507 3.24552 35.4507 3.532C35.4507 3.81848 35.2185 4.05071 34.932 4.05071H32.808C32.6958 4.12979 32.5807 4.19374 32.4646 4.24459L41.2699 28.2887C41.3341 28.4639 41.2978 28.6513 41.1905 28.788C40.9726 29.0936 40.6004 29.4198 40.1266 29.7337C39.6286 30.0636 38.9852 30.4017 38.2095 30.706C36.6572 31.3151 34.5584 31.7955 32.0019 31.7955C26.984 31.7955 24.1665 29.7812 23.1139 28.857C22.9442 28.708 22.895 28.4729 22.9743 28.2746L30.8573 4.28623C30.6506 4.22034 30.4667 4.13587 30.3172 4.05071H23.6936C23.6831 4.05071 23.6727 4.05039 23.6623 4.04977ZM24.1879 27.9045L24.0596 28.295C24.4883 28.4085 25.0994 28.5135 25.8582 28.6034C27.4553 28.7925 29.6689 28.9102 32.1189 28.9102C34.5688 28.9102 36.7824 28.7925 38.3795 28.6034C39.1326 28.5142 39.7401 28.4101 40.1683 28.2976L40.0219 27.8978C39.6059 27.7993 39.0505 27.708 38.3795 27.6285C36.7824 27.4394 34.5688 27.3217 32.1189 27.3217C29.6689 27.3217 27.4553 27.4394 25.8582 27.6285C25.1721 27.7098 24.6068 27.8034 24.1879 27.9045ZM24.2825 27.6166L31.6777 5.11281L39.9158 27.6081C38.4015 27.2828 35.4775 27.0624 32.1189 27.0624C28.7308 27.0624 25.7851 27.2866 24.2825 27.6166ZM32.0019 30.758C28.2471 30.758 25.8438 29.5622 24.5623 28.6724C26.1331 28.9709 28.93 29.1696 32.1189 29.1696C35.4563 29.1696 38.3646 28.9519 39.887 28.63C39.7905 28.7053 39.6797 28.7853 39.5536 28.8688C39.1239 29.1535 38.5468 29.4593 37.8306 29.7403C36.3993 30.3019 34.429 30.758 32.0019 30.758ZM10.4326 4.9486L17.6748 24.6809C16.1598 24.3559 13.2371 24.1357 9.88002 24.1357C6.5675 24.1357 3.67779 24.3501 2.14625 24.6681L10.4326 4.9486ZM2.02344 24.9603L1.84889 25.3757C2.27603 25.4864 2.87699 25.5888 3.61937 25.6767C5.21647 25.8659 7.43006 25.9835 9.88002 25.9835C12.33 25.9835 14.5436 25.8659 16.1407 25.6767C16.893 25.5876 17.5 25.4836 17.9282 25.3713L17.7812 24.9707C17.3654 24.8723 16.8106 24.7812 16.1407 24.7018C14.5436 24.5127 12.33 24.395 9.88002 24.395C7.43006 24.395 5.21647 24.5127 3.61937 24.7018C2.97309 24.7784 2.43399 24.8659 2.02344 24.9603ZM17.4366 25.7457C16.1551 26.6356 13.7518 27.8314 9.99698 27.8314C7.56993 27.8314 5.59963 27.3752 4.16826 26.8136C3.45207 26.5326 2.87503 26.2269 2.44526 25.9422C2.31922 25.8587 2.20837 25.7786 2.11188 25.7033C3.63428 26.0253 6.54255 26.2429 9.88002 26.2429C13.0688 26.2429 15.8658 26.0442 17.4366 25.7457Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Compare</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+                                                                                                        </ul>
+
+                                                                                                        <!-- mobile_banner -->
+                                                                                                        
+                                                                                                        
+
+                                                                                                        
+                                                                                                        <!-- end mobile_banner -->
+
+                                                                                                        <!-- mobile_sale_banner -->
+                                                                                                        
+                                                                                                            
+
+                                                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                                                            
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                        <div class="img pb-89.250814332">
+                                                                                                                            
+                                                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                </div>
+                                                                                                            
+                                                                                                        
+                                                                                                        <!-- end mobile_sale_banner -->
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                     
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li class="is-dropdown w-hover-state">
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/kitchenaid-kettles"  class="no-link" data-expand="" data-sub-name="kettles" aria-expanded="false" aria-haspopup="true" role="button" data-level-03 data-level-03-role >
+                                                                                        <span class="icon-svg kettles">
+                                                                                            
+		<svg width="40" height="35" viewBox="0 0 40 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.6032 27.8459C9.8878 27.8459 9.30994 28.3963 9.22745 29.0842H7.71405V29.3593H9.22745C9.30994 30.0472 9.8878 30.5975 10.6032 30.5975C11.3186 30.5975 11.8964 30.0472 11.979 29.3593H23.9483V29.0842H11.979C11.8964 28.3963 11.3186 27.8459 10.6032 27.8459ZM10.6032 30.3498C9.99785 30.3498 9.47509 29.8546 9.47509 29.2492C9.47509 28.6439 9.97037 28.1486 10.6032 28.1486C11.2086 28.1486 11.7039 28.6439 11.7039 29.2492C11.7039 29.8546 11.2086 30.3498 10.6032 30.3498ZM16.0238 14.033C18.4452 14.033 20.4263 12.0519 20.4263 9.63051C20.4263 7.20912 18.4452 5.22799 16.0238 5.22799C13.6024 5.22799 11.6213 7.20912 11.6213 9.63051C11.6213 12.0519 13.6024 14.033 16.0238 14.033ZM16.0238 6.05346C18.005 6.05346 19.6008 7.64938 19.6008 9.63051C19.6008 11.6116 18.005 13.2075 16.0238 13.2075C14.0427 13.2075 12.4468 11.6116 12.4468 9.63051C12.4468 7.64938 14.0427 6.05346 16.0238 6.05346ZM38.6967 12.9324C36.8807 7.67685 34.762 3.16431 34.3493 2.31132C34.2393 2.06368 33.9916 1.9261 33.7164 1.9261H24.2785C24.251 1.70598 24.0859 1.51336 23.8933 1.43081C21.9122 0.522799 19.023 0 15.9963 0C12.9695 0 10.1079 0.522799 8.09926 1.43081C7.87914 1.54088 7.74156 1.73349 7.71405 1.95362C7.41137 2.00865 7.16373 2.25629 7.13621 2.58648C7.13621 2.64151 7.13622 2.69654 7.1087 2.77909H2.67867C2.43102 2.77909 2.23841 2.88915 2.10083 3.08176C1.96325 3.27437 1.96325 3.52202 2.0458 3.74214L3.77929 7.64938C3.83432 7.75943 3.88935 7.842 3.9719 7.89702C2.67867 10.4285 2.18338 13.2075 2.12835 13.5652V13.6478L1.57804 26.195L0.917658 27.5157C0.807595 27.7359 0.752563 28.011 0.752563 28.2587V31.1203C0.752563 31.5606 0.917658 31.9457 1.22033 32.2759C3.80681 35 11.8139 35 16.1063 35C20.3988 35 28.4059 35 30.9924 32.2759C31.295 31.9733 31.4601 31.5606 31.4601 31.1478V28.1761C31.4601 27.956 31.4051 27.7083 31.3226 27.5157L30.6071 25.8923C34.7345 24.1038 41.1731 20.0865 38.6967 12.9324ZM16.0238 0.825471C18.6378 0.825471 21.1142 1.21069 22.9578 1.9261H9.08985C10.9334 1.21069 13.4098 0.825471 16.0238 0.825471ZM2.89879 3.57705H6.91609C6.72348 3.96227 6.44832 4.31997 6.0631 4.78774C5.73292 5.20048 5.34769 5.69576 4.90744 6.35614C4.90744 6.35614 4.90744 6.38365 4.87992 6.38365C4.82489 6.49372 4.74235 6.57626 4.6598 6.68633C4.63228 6.71384 4.63228 6.74136 4.60477 6.79639C4.54974 6.87893 4.49471 6.96148 4.43968 7.07154L2.89879 3.57705ZM30.1394 25.1769C29.973 25.2607 29.838 25.3958 29.7542 25.5621C29.6991 25.7272 29.6991 25.9198 29.7542 26.1125L30.5246 27.8734C30.5797 27.9835 30.6071 28.0936 30.6071 28.2036V31.0928C30.6071 31.3129 30.5246 31.5055 30.387 31.6706C28.0482 34.147 19.9861 34.147 16.1063 34.147C12.2266 34.147 4.16452 34.147 1.82568 31.6706C1.6881 31.5055 1.60555 31.3129 1.60555 31.0928V28.2311C1.60555 28.0936 1.63307 27.9835 1.6881 27.8459L2.37599 26.5252C2.42826 26.4427 2.45683 26.3476 2.45854 26.2501L3.00886 13.6754C3.03637 13.5378 3.6142 10.0982 5.1826 7.51179C5.78795 6.52123 6.31074 5.86085 6.75099 5.31054C7.19125 4.73271 7.57647 4.29245 7.79659 3.71463V3.6596C7.90666 3.38444 7.9892 3.08176 8.01672 2.72406H33.6614C34.1291 3.74214 36.1653 8.11711 37.9263 13.1801C40.1001 19.4536 34.8721 23.1682 30.1394 25.1769ZM32.3682 6.3011C32.3406 6.24607 31.6803 4.67767 29.7817 4.67767H26.9751C26.7274 4.67767 26.5073 4.81526 26.3697 5.03538C26.2321 5.25551 26.2596 5.50315 26.3697 5.72327C27.4153 7.48428 30.7997 13.7854 30.4695 20.3891C30.4695 20.6093 30.5521 20.8294 30.7172 20.967C30.8548 21.077 30.9924 21.1321 31.1574 21.1321C31.2125 21.1321 31.2676 21.1321 31.35 21.1046C34.2117 20.3341 35.9452 17.6651 35.3949 14.941C34.8721 12.162 32.4782 6.54875 32.3682 6.3011ZM31.3226 20.2516C31.5702 13.7304 28.3783 7.56682 27.1952 5.53066H29.7817C31.13 5.53066 31.5702 6.60378 31.5977 6.65881C31.6252 6.71384 34.0741 12.4371 34.5969 15.1061C35.0647 17.3349 33.6614 19.5086 31.3226 20.2516Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Kettles</span>
+                                                                                            <i class="not-italic" data-txt>Shop Kettles</i>
+                                                                                        </span>
+
+                                                                                        
+                                                                                            <span class="expand">
+                                                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                                                </svg>
+                                                                                            </span>
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+                                                                                        <span class="hidden absolute lg:flex lg:flex-wrap lg:pt-2px" data-sub>
+                                                                                            
+                                                                                                
+                                                                                                    
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/kettles">Learn</a>
+                                                                                                </span>
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/kettles-comparison">Compare</a>
+                                                                                                </span>
+                                                                                        </span>
+                                                                                    
+
+                                                                                    
+                                                                                        <div data-nav-dropdown-content="" data-level-03 class="invisible" id="kettles">
+                                                                                            <div class="__box" data-subnav="">
+                                                                                                 <a href="#" class="back" data-back="" data-level-03 aria-controls="kettles">
+                                                                                                    <span class="icon">
+                                                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                                                        </svg>
+                                                                                                    </span>
+                                                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Kettles</span>
+                                                                                                </a>
+
+                                                                                                <div class="__box-wrap">
+                                                                                                    <div class="inner w-1920px">
+                                                                                                        <ul class="ul-sub" xxx>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/collections/kitchenaid-kettles">
+                                                                                                                        <span class="icon-svg kettles">
+                                                                                                                            
+		<svg width="40" height="35" viewBox="0 0 40 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.6032 27.8459C9.8878 27.8459 9.30994 28.3963 9.22745 29.0842H7.71405V29.3593H9.22745C9.30994 30.0472 9.8878 30.5975 10.6032 30.5975C11.3186 30.5975 11.8964 30.0472 11.979 29.3593H23.9483V29.0842H11.979C11.8964 28.3963 11.3186 27.8459 10.6032 27.8459ZM10.6032 30.3498C9.99785 30.3498 9.47509 29.8546 9.47509 29.2492C9.47509 28.6439 9.97037 28.1486 10.6032 28.1486C11.2086 28.1486 11.7039 28.6439 11.7039 29.2492C11.7039 29.8546 11.2086 30.3498 10.6032 30.3498ZM16.0238 14.033C18.4452 14.033 20.4263 12.0519 20.4263 9.63051C20.4263 7.20912 18.4452 5.22799 16.0238 5.22799C13.6024 5.22799 11.6213 7.20912 11.6213 9.63051C11.6213 12.0519 13.6024 14.033 16.0238 14.033ZM16.0238 6.05346C18.005 6.05346 19.6008 7.64938 19.6008 9.63051C19.6008 11.6116 18.005 13.2075 16.0238 13.2075C14.0427 13.2075 12.4468 11.6116 12.4468 9.63051C12.4468 7.64938 14.0427 6.05346 16.0238 6.05346ZM38.6967 12.9324C36.8807 7.67685 34.762 3.16431 34.3493 2.31132C34.2393 2.06368 33.9916 1.9261 33.7164 1.9261H24.2785C24.251 1.70598 24.0859 1.51336 23.8933 1.43081C21.9122 0.522799 19.023 0 15.9963 0C12.9695 0 10.1079 0.522799 8.09926 1.43081C7.87914 1.54088 7.74156 1.73349 7.71405 1.95362C7.41137 2.00865 7.16373 2.25629 7.13621 2.58648C7.13621 2.64151 7.13622 2.69654 7.1087 2.77909H2.67867C2.43102 2.77909 2.23841 2.88915 2.10083 3.08176C1.96325 3.27437 1.96325 3.52202 2.0458 3.74214L3.77929 7.64938C3.83432 7.75943 3.88935 7.842 3.9719 7.89702C2.67867 10.4285 2.18338 13.2075 2.12835 13.5652V13.6478L1.57804 26.195L0.917658 27.5157C0.807595 27.7359 0.752563 28.011 0.752563 28.2587V31.1203C0.752563 31.5606 0.917658 31.9457 1.22033 32.2759C3.80681 35 11.8139 35 16.1063 35C20.3988 35 28.4059 35 30.9924 32.2759C31.295 31.9733 31.4601 31.5606 31.4601 31.1478V28.1761C31.4601 27.956 31.4051 27.7083 31.3226 27.5157L30.6071 25.8923C34.7345 24.1038 41.1731 20.0865 38.6967 12.9324ZM16.0238 0.825471C18.6378 0.825471 21.1142 1.21069 22.9578 1.9261H9.08985C10.9334 1.21069 13.4098 0.825471 16.0238 0.825471ZM2.89879 3.57705H6.91609C6.72348 3.96227 6.44832 4.31997 6.0631 4.78774C5.73292 5.20048 5.34769 5.69576 4.90744 6.35614C4.90744 6.35614 4.90744 6.38365 4.87992 6.38365C4.82489 6.49372 4.74235 6.57626 4.6598 6.68633C4.63228 6.71384 4.63228 6.74136 4.60477 6.79639C4.54974 6.87893 4.49471 6.96148 4.43968 7.07154L2.89879 3.57705ZM30.1394 25.1769C29.973 25.2607 29.838 25.3958 29.7542 25.5621C29.6991 25.7272 29.6991 25.9198 29.7542 26.1125L30.5246 27.8734C30.5797 27.9835 30.6071 28.0936 30.6071 28.2036V31.0928C30.6071 31.3129 30.5246 31.5055 30.387 31.6706C28.0482 34.147 19.9861 34.147 16.1063 34.147C12.2266 34.147 4.16452 34.147 1.82568 31.6706C1.6881 31.5055 1.60555 31.3129 1.60555 31.0928V28.2311C1.60555 28.0936 1.63307 27.9835 1.6881 27.8459L2.37599 26.5252C2.42826 26.4427 2.45683 26.3476 2.45854 26.2501L3.00886 13.6754C3.03637 13.5378 3.6142 10.0982 5.1826 7.51179C5.78795 6.52123 6.31074 5.86085 6.75099 5.31054C7.19125 4.73271 7.57647 4.29245 7.79659 3.71463V3.6596C7.90666 3.38444 7.9892 3.08176 8.01672 2.72406H33.6614C34.1291 3.74214 36.1653 8.11711 37.9263 13.1801C40.1001 19.4536 34.8721 23.1682 30.1394 25.1769ZM32.3682 6.3011C32.3406 6.24607 31.6803 4.67767 29.7817 4.67767H26.9751C26.7274 4.67767 26.5073 4.81526 26.3697 5.03538C26.2321 5.25551 26.2596 5.50315 26.3697 5.72327C27.4153 7.48428 30.7997 13.7854 30.4695 20.3891C30.4695 20.6093 30.5521 20.8294 30.7172 20.967C30.8548 21.077 30.9924 21.1321 31.1574 21.1321C31.2125 21.1321 31.2676 21.1321 31.35 21.1046C34.2117 20.3341 35.9452 17.6651 35.3949 14.941C34.8721 12.162 32.4782 6.54875 32.3682 6.3011ZM31.3226 20.2516C31.5702 13.7304 28.3783 7.56682 27.1952 5.53066H29.7817C31.13 5.53066 31.5702 6.60378 31.5977 6.65881C31.6252 6.71384 34.0741 12.4371 34.5969 15.1061C35.0647 17.3349 33.6614 19.5086 31.3226 20.2516Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Shop</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/kettles">
+                                                                                                                        <span class="icon-svg learn">
+                                                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Learn</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/kettles-comparison">
+                                                                                                                        <span class="icon-svg compare">
+                                                                                                                            
+		<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.1732 3.64907C23.1732 4.84963 22.2 5.82287 20.9994 5.82287C19.7989 5.82287 18.8256 4.84963 18.8256 3.64907C18.8256 2.44851 19.7989 1.47526 20.9994 1.47526C22.2 1.47526 23.1732 2.44851 23.1732 3.64907ZM23.6623 4.04977C23.4999 5.13821 22.6861 6.01384 21.6302 6.2673C21.6337 6.29156 21.6355 6.31636 21.6355 6.34158L21.6355 40.0062H38.4412C38.7277 40.0062 38.9599 40.2384 38.9599 40.5249C38.9599 40.8114 38.7277 41.0436 38.4412 41.0436H21.1168H3.78959C3.50311 41.0436 3.27088 40.8114 3.27088 40.5249C3.27088 40.2384 3.50311 40.0062 3.78959 40.0062H20.598L20.598 6.34158C20.598 6.33165 20.5983 6.32179 20.5989 6.312C19.4326 6.13806 18.5106 5.2162 18.3365 4.05C18.3275 4.05047 18.3183 4.05071 18.3091 4.05071H11.7185C11.5993 4.13687 11.4576 4.22324 11.2989 4.29793L19.0258 25.351C19.0373 25.3803 19.046 25.4104 19.052 25.4409C19.0667 25.5158 19.0643 25.5912 19.047 25.6624C19.0285 25.7396 18.992 25.8131 18.9382 25.8763C18.9196 25.8983 18.8991 25.9188 18.8768 25.9375C17.8177 26.865 15.0018 28.8688 9.99698 28.8688C7.44049 28.8688 5.34165 28.3884 3.78934 27.7794C3.0137 27.475 2.37027 27.1369 1.87231 26.807C1.38773 26.486 1.00944 26.1521 0.7938 25.8405C0.78631 25.8299 0.779229 25.8191 0.772569 25.808C0.690714 25.6723 0.678119 25.5122 0.726653 25.3712C0.731138 25.3582 0.736145 25.3453 0.741667 25.3327L9.56676 4.33118C9.42694 4.2607 9.28988 4.16832 9.15842 4.05071H7.07073C6.78426 4.05071 6.55202 3.81848 6.55202 3.532C6.55202 3.24552 6.78426 3.01328 7.07073 3.01328H9.37257H9.6046L9.75926 3.18626C9.82931 3.26461 9.90007 3.3244 9.97108 3.36901L9.98703 3.33104C10.0696 3.1345 10.2641 3.0085 10.4772 3.01341C10.6777 3.01803 10.8563 3.13761 10.9379 3.31839C11.0417 3.26222 11.1317 3.19882 11.1985 3.14064L11.345 3.01328H11.539H18.3091C18.3336 3.01328 18.3576 3.01498 18.3812 3.01825C18.6651 1.83554 19.7296 0.956543 20.9994 0.956543C22.2694 0.956543 23.334 1.83581 23.6178 3.0188C23.6425 3.01517 23.6679 3.01328 23.6936 3.01328H30.4637H30.6219L30.7532 3.10155C30.8505 3.16699 31.0048 3.24588 31.1862 3.30212C31.2712 3.12988 31.4464 3.01664 31.6425 3.01335C31.8321 3.01017 32.0055 3.11032 32.0989 3.2699C32.1651 3.2359 32.2293 3.19285 32.2909 3.1396L32.437 3.01328H32.6302H34.932C35.2185 3.01328 35.4507 3.24552 35.4507 3.532C35.4507 3.81848 35.2185 4.05071 34.932 4.05071H32.808C32.6958 4.12979 32.5807 4.19374 32.4646 4.24459L41.2699 28.2887C41.3341 28.4639 41.2978 28.6513 41.1905 28.788C40.9726 29.0936 40.6004 29.4198 40.1266 29.7337C39.6286 30.0636 38.9852 30.4017 38.2095 30.706C36.6572 31.3151 34.5584 31.7955 32.0019 31.7955C26.984 31.7955 24.1665 29.7812 23.1139 28.857C22.9442 28.708 22.895 28.4729 22.9743 28.2746L30.8573 4.28623C30.6506 4.22034 30.4667 4.13587 30.3172 4.05071H23.6936C23.6831 4.05071 23.6727 4.05039 23.6623 4.04977ZM24.1879 27.9045L24.0596 28.295C24.4883 28.4085 25.0994 28.5135 25.8582 28.6034C27.4553 28.7925 29.6689 28.9102 32.1189 28.9102C34.5688 28.9102 36.7824 28.7925 38.3795 28.6034C39.1326 28.5142 39.7401 28.4101 40.1683 28.2976L40.0219 27.8978C39.6059 27.7993 39.0505 27.708 38.3795 27.6285C36.7824 27.4394 34.5688 27.3217 32.1189 27.3217C29.6689 27.3217 27.4553 27.4394 25.8582 27.6285C25.1721 27.7098 24.6068 27.8034 24.1879 27.9045ZM24.2825 27.6166L31.6777 5.11281L39.9158 27.6081C38.4015 27.2828 35.4775 27.0624 32.1189 27.0624C28.7308 27.0624 25.7851 27.2866 24.2825 27.6166ZM32.0019 30.758C28.2471 30.758 25.8438 29.5622 24.5623 28.6724C26.1331 28.9709 28.93 29.1696 32.1189 29.1696C35.4563 29.1696 38.3646 28.9519 39.887 28.63C39.7905 28.7053 39.6797 28.7853 39.5536 28.8688C39.1239 29.1535 38.5468 29.4593 37.8306 29.7403C36.3993 30.3019 34.429 30.758 32.0019 30.758ZM10.4326 4.9486L17.6748 24.6809C16.1598 24.3559 13.2371 24.1357 9.88002 24.1357C6.5675 24.1357 3.67779 24.3501 2.14625 24.6681L10.4326 4.9486ZM2.02344 24.9603L1.84889 25.3757C2.27603 25.4864 2.87699 25.5888 3.61937 25.6767C5.21647 25.8659 7.43006 25.9835 9.88002 25.9835C12.33 25.9835 14.5436 25.8659 16.1407 25.6767C16.893 25.5876 17.5 25.4836 17.9282 25.3713L17.7812 24.9707C17.3654 24.8723 16.8106 24.7812 16.1407 24.7018C14.5436 24.5127 12.33 24.395 9.88002 24.395C7.43006 24.395 5.21647 24.5127 3.61937 24.7018C2.97309 24.7784 2.43399 24.8659 2.02344 24.9603ZM17.4366 25.7457C16.1551 26.6356 13.7518 27.8314 9.99698 27.8314C7.56993 27.8314 5.59963 27.3752 4.16826 26.8136C3.45207 26.5326 2.87503 26.2269 2.44526 25.9422C2.31922 25.8587 2.20837 25.7786 2.11188 25.7033C3.63428 26.0253 6.54255 26.2429 9.88002 26.2429C13.0688 26.2429 15.8658 26.0442 17.4366 25.7457Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Compare</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+                                                                                                        </ul>
+
+                                                                                                        <!-- mobile_banner -->
+                                                                                                        
+                                                                                                        
+
+                                                                                                        
+                                                                                                        <!-- end mobile_banner -->
+
+                                                                                                        <!-- mobile_sale_banner -->
+                                                                                                        
+                                                                                                            
+
+                                                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                                                            
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                        <div class="img pb-89.250814332">
+                                                                                                                            
+                                                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                </div>
+                                                                                                            
+                                                                                                        
+                                                                                                        <!-- end mobile_sale_banner -->
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                     
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li class="is-dropdown w-hover-state">
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/kitchenaid-hand-mixer"  class="no-link" data-expand="" data-sub-name="hand-mixers" aria-expanded="false" aria-haspopup="true" role="button" data-level-03 data-level-03-role >
+                                                                                        <span class="icon-svg hand-mixers">
+                                                                                            
+		<svg width="30" height="43" viewBox="0 0 30 43" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.7355 4.90999C15.6688 3.89665 6.54883 5.46999 6.46882 5.49666C5.29549 5.70999 4.62883 6.61666 4.62883 8.0033C4.62883 10.0033 6.28216 10.5367 7.13549 10.5367C7.16216 10.5367 9.29548 10.6433 11.9089 10.6433C13.2155 10.6433 14.6555 10.6167 15.9889 10.5367C19.7755 10.2433 19.8289 7.49665 19.8289 7.46999V6.42999C19.8555 5.73666 19.4022 5.12332 18.7355 4.90999ZM19.0555 7.46999C19.0555 7.54999 18.9755 9.49663 15.9622 9.73663C12.0421 10.0033 7.26883 9.73663 7.18882 9.73663C7.00216 9.73663 5.45549 9.6833 5.45549 8.0033C5.45549 6.48332 6.3355 6.32332 6.62883 6.26999C7.96213 6.00332 12.4422 5.38999 15.6955 5.38999C16.8688 5.38999 17.8555 5.46999 18.4955 5.68333C18.8155 5.78999 19.0288 6.08332 19.0288 6.42999L19.0555 7.46999ZM26.6288 11.07H24.4422C24.4243 11.0688 24.4065 11.0715 24.3898 11.0777C24.373 11.084 24.3579 11.0938 24.3453 11.1064C24.3326 11.119 24.3228 11.1343 24.3165 11.1509C24.3102 11.1676 24.3076 11.1855 24.3088 11.2033C24.3076 11.2211 24.3102 11.239 24.3165 11.2557C24.3228 11.2724 24.3326 11.2876 24.3453 11.3002C24.3579 11.3128 24.373 11.3227 24.3898 11.3289C24.4065 11.3352 24.4243 11.3378 24.4422 11.3367H26.6288C26.6467 11.3378 26.6645 11.3352 26.6812 11.3289C26.698 11.3227 26.7131 11.3128 26.7257 11.3002C26.7384 11.2876 26.7481 11.2724 26.7544 11.2557C26.7607 11.239 26.7634 11.2211 26.7622 11.2033C26.7634 11.1855 26.7607 11.1676 26.7544 11.1509C26.7481 11.1343 26.7384 11.119 26.7257 11.1064C26.7131 11.0938 26.698 11.084 26.6812 11.0777C26.6645 11.0715 26.6467 11.0688 26.6288 11.07ZM26.6288 12.11H24.4422C24.4068 12.11 24.3729 12.124 24.3479 12.1491C24.3229 12.1741 24.3088 12.208 24.3088 12.2434C24.3088 12.2787 24.3229 12.3126 24.3479 12.3376C24.3729 12.3626 24.4068 12.3766 24.4422 12.3766H26.6288C26.6642 12.3766 26.6981 12.3626 26.7231 12.3376C26.7481 12.3126 26.7622 12.2787 26.7622 12.2434C26.7622 12.208 26.7481 12.1741 26.7231 12.1491C26.6981 12.124 26.6642 12.11 26.6288 12.11ZM26.6288 13.1233H24.4422C24.4068 13.1233 24.3729 13.1374 24.3479 13.1624C24.3229 13.1874 24.3088 13.2213 24.3088 13.2567C24.3088 13.292 24.3229 13.3259 24.3479 13.351C24.3729 13.3759 24.4068 13.39 24.4422 13.39H26.6288C26.6642 13.39 26.6981 13.3759 26.7231 13.351C26.7481 13.3259 26.7622 13.292 26.7622 13.2567C26.7622 13.2213 26.7481 13.1874 26.7231 13.1624C26.6981 13.1374 26.6642 13.1233 26.6288 13.1233ZM26.6288 14.1367H24.4422C24.4068 14.1367 24.3729 14.1507 24.3479 14.1757C24.3229 14.2007 24.3088 14.2346 24.3088 14.27C24.3088 14.3053 24.3229 14.3393 24.3479 14.3643C24.3729 14.3893 24.4068 14.4034 24.4422 14.4034H26.6288C26.6642 14.4034 26.6981 14.3893 26.7231 14.3643C26.7481 14.3393 26.7622 14.3053 26.7622 14.27C26.7622 14.2346 26.7481 14.2007 26.7231 14.1757C26.6981 14.1507 26.6642 14.1367 26.6288 14.1367ZM28.8954 14.43L28.6021 13.95C28.5488 13.8967 28.5222 13.8166 28.5222 13.71C28.6821 8.05663 26.8155 5.14999 25.8022 3.60332L25.6955 3.44332V1.81666C25.6934 1.52026 25.5747 1.2366 25.3651 1.02701C25.1556 0.817423 24.8719 0.69875 24.5755 0.696655H21.7755C21.2155 0.696655 20.7622 1.09666 20.6555 1.62999C16.3621 1.12332 9.40213 1.46999 3.77549 3.38999C3.42883 3.52333 3.18883 3.78999 3.08216 4.13665C1.98883 7.84333 1.48216 11.7634 1.26883 14.35C1.24216 14.43 1.10883 14.6434 1.02883 14.7766C0.842161 15.0433 0.682162 15.2833 0.682162 15.5233C0.602161 16.67 0.548828 17.6033 0.548828 18.27C0.548828 18.51 0.628828 18.75 0.762161 18.9634L1.72216 20.2966C1.93549 20.59 2.28216 20.7766 2.65549 20.7766H18.1489C18.1755 20.7766 18.2288 20.7766 18.2555 20.8033C19.7755 21.2833 21.4555 21.47 22.5222 21.55V26.9367C22.2822 26.99 22.1221 27.1767 22.1221 27.4433V28.8034H21.7755C21.0022 28.8034 20.3355 29.3633 20.2021 30.1366L18.8689 38.0033C18.6822 39.0433 18.9755 40.0834 19.6422 40.8833C20.3089 41.6833 21.2955 42.1366 22.3621 42.1366H23.4555C24.4955 42.1366 25.4821 41.6833 26.1755 40.8833C26.8688 40.0834 27.1355 39.0433 26.9488 38.0033L25.6155 30.1366C25.4821 29.3633 24.8155 28.8034 24.0421 28.8034H23.7222V27.4433C23.7222 27.2033 23.5621 26.99 23.3221 26.9367V21.6034H23.6155C25.7755 21.6034 27.2689 21.3367 28.0422 20.83C28.3621 20.6167 28.5488 20.27 28.5488 19.87V19.31C28.5488 19.23 28.5755 19.1767 28.6021 19.0966L28.8688 18.67C29.0022 18.4834 29.0555 18.2434 29.0555 18.03V14.99C29.0555 14.8033 29.0022 14.6167 28.8954 14.43ZM21.6955 38.8834V38.91C21.6955 38.9633 21.6421 39.8967 22.0422 41.31C21.3488 41.23 20.7088 40.8833 20.2555 40.35C19.7221 39.7366 19.5088 38.91 19.6422 38.11L20.9755 30.2434C21.0289 29.87 21.3755 29.5767 21.7755 29.5767L22.4955 33.9766L21.6955 38.8834ZM24.0155 29.6033C24.4155 29.6033 24.7355 29.87 24.8155 30.27L26.1488 38.1367C26.2821 38.9367 26.0688 39.7366 25.5355 40.3767C25.0821 40.91 24.4422 41.2567 23.7488 41.3367C24.1488 39.9233 24.0955 38.9633 24.0955 38.9367L23.2955 34.03L24.0155 29.6033ZM22.9222 41.3367H22.8688C22.4689 40.03 22.4955 39.0967 22.4955 38.99L22.8955 36.5367L23.2955 38.99C23.2955 39.1234 23.2955 40.03 22.9222 41.3367ZM22.5755 29.6033H23.1889L22.8688 31.5233L22.5755 29.6033ZM27.7221 19.87C27.7221 20.0033 27.6688 20.11 27.5622 20.1634C27.1888 20.4034 26.2021 20.8033 23.5888 20.8033C23.5621 20.8033 22.0955 20.8033 20.4155 20.51C20.9221 20.3767 21.2422 20.19 21.5622 20.03C22.0155 19.79 22.3888 19.6033 23.1889 19.6033H27.7221V19.87ZM28.2555 18.0567C28.2555 18.1366 28.2288 18.19 28.2021 18.27L27.9355 18.6967L27.8555 18.8566H23.2155C22.2022 18.8566 21.7222 19.1233 21.2155 19.39C20.6022 19.71 19.9088 20.0566 17.8822 20.0566H2.68216C2.57549 20.0566 2.44216 20.0033 2.38882 19.8967L1.42882 18.5633C1.37549 18.51 1.34883 18.43 1.34883 18.35C1.34883 17.7367 1.40216 16.9366 1.45549 15.9233H23.4555C23.5088 15.9233 24.0688 15.95 24.7621 15.95C25.9355 15.95 27.5355 15.87 28.2555 15.4966V18.0567ZM28.2555 15.15C27.5622 15.6833 24.5755 15.6833 23.4555 15.6034H1.45549C1.48216 15.5233 1.61549 15.3367 1.69549 15.2033C1.88216 14.9367 2.04216 14.67 2.06883 14.4034C2.28216 11.8167 2.78883 7.97665 3.85549 4.32332C3.88216 4.21666 3.96216 4.13665 4.06882 4.08332C8.09548 2.69665 12.8155 2.16332 16.7089 2.16332C18.3088 2.16332 19.7755 2.24332 21.0022 2.42999L21.4555 2.48332V1.81666C21.4555 1.62999 21.6155 1.49665 21.7755 1.49665H24.5755C24.7621 1.49665 24.8955 1.65666 24.8955 1.81666V3.68332L25.1355 4.02999C26.0955 5.52332 27.8821 8.27 27.7221 13.6834C27.7221 13.95 27.8022 14.2167 27.9621 14.43C28.0688 14.5633 28.1488 14.7233 28.2021 14.8033C28.2288 14.8567 28.2555 14.91 28.2555 14.99V15.15Z" fill="#C41230"/>
+</svg>
+
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Hand Mixers</span>
+                                                                                            <i class="not-italic" data-txt>Shop Hand Mixers</i>
+                                                                                        </span>
+
+                                                                                        
+                                                                                            <span class="expand">
+                                                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                                                </svg>
+                                                                                            </span>
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+                                                                                        <span class="hidden absolute lg:flex lg:flex-wrap lg:pt-2px" data-sub>
+                                                                                            
+                                                                                                
+                                                                                                    
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/hand-mixer">Learn</a>
+                                                                                                </span>
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/hand-mixers-comparison">Compare</a>
+                                                                                                </span>
+                                                                                        </span>
+                                                                                    
+
+                                                                                    
+                                                                                        <div data-nav-dropdown-content="" data-level-03 class="invisible" id="hand-mixers">
+                                                                                            <div class="__box" data-subnav="">
+                                                                                                 <a href="#" class="back" data-back="" data-level-03 aria-controls="hand-mixers">
+                                                                                                    <span class="icon">
+                                                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                                                        </svg>
+                                                                                                    </span>
+                                                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Hand Mixers</span>
+                                                                                                </a>
+
+                                                                                                <div class="__box-wrap">
+                                                                                                    <div class="inner w-1920px">
+                                                                                                        <ul class="ul-sub" xxx>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/collections/kitchenaid-hand-mixer">
+                                                                                                                        <span class="icon-svg hand-mixers">
+                                                                                                                            
+		<svg width="30" height="43" viewBox="0 0 30 43" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.7355 4.90999C15.6688 3.89665 6.54883 5.46999 6.46882 5.49666C5.29549 5.70999 4.62883 6.61666 4.62883 8.0033C4.62883 10.0033 6.28216 10.5367 7.13549 10.5367C7.16216 10.5367 9.29548 10.6433 11.9089 10.6433C13.2155 10.6433 14.6555 10.6167 15.9889 10.5367C19.7755 10.2433 19.8289 7.49665 19.8289 7.46999V6.42999C19.8555 5.73666 19.4022 5.12332 18.7355 4.90999ZM19.0555 7.46999C19.0555 7.54999 18.9755 9.49663 15.9622 9.73663C12.0421 10.0033 7.26883 9.73663 7.18882 9.73663C7.00216 9.73663 5.45549 9.6833 5.45549 8.0033C5.45549 6.48332 6.3355 6.32332 6.62883 6.26999C7.96213 6.00332 12.4422 5.38999 15.6955 5.38999C16.8688 5.38999 17.8555 5.46999 18.4955 5.68333C18.8155 5.78999 19.0288 6.08332 19.0288 6.42999L19.0555 7.46999ZM26.6288 11.07H24.4422C24.4243 11.0688 24.4065 11.0715 24.3898 11.0777C24.373 11.084 24.3579 11.0938 24.3453 11.1064C24.3326 11.119 24.3228 11.1343 24.3165 11.1509C24.3102 11.1676 24.3076 11.1855 24.3088 11.2033C24.3076 11.2211 24.3102 11.239 24.3165 11.2557C24.3228 11.2724 24.3326 11.2876 24.3453 11.3002C24.3579 11.3128 24.373 11.3227 24.3898 11.3289C24.4065 11.3352 24.4243 11.3378 24.4422 11.3367H26.6288C26.6467 11.3378 26.6645 11.3352 26.6812 11.3289C26.698 11.3227 26.7131 11.3128 26.7257 11.3002C26.7384 11.2876 26.7481 11.2724 26.7544 11.2557C26.7607 11.239 26.7634 11.2211 26.7622 11.2033C26.7634 11.1855 26.7607 11.1676 26.7544 11.1509C26.7481 11.1343 26.7384 11.119 26.7257 11.1064C26.7131 11.0938 26.698 11.084 26.6812 11.0777C26.6645 11.0715 26.6467 11.0688 26.6288 11.07ZM26.6288 12.11H24.4422C24.4068 12.11 24.3729 12.124 24.3479 12.1491C24.3229 12.1741 24.3088 12.208 24.3088 12.2434C24.3088 12.2787 24.3229 12.3126 24.3479 12.3376C24.3729 12.3626 24.4068 12.3766 24.4422 12.3766H26.6288C26.6642 12.3766 26.6981 12.3626 26.7231 12.3376C26.7481 12.3126 26.7622 12.2787 26.7622 12.2434C26.7622 12.208 26.7481 12.1741 26.7231 12.1491C26.6981 12.124 26.6642 12.11 26.6288 12.11ZM26.6288 13.1233H24.4422C24.4068 13.1233 24.3729 13.1374 24.3479 13.1624C24.3229 13.1874 24.3088 13.2213 24.3088 13.2567C24.3088 13.292 24.3229 13.3259 24.3479 13.351C24.3729 13.3759 24.4068 13.39 24.4422 13.39H26.6288C26.6642 13.39 26.6981 13.3759 26.7231 13.351C26.7481 13.3259 26.7622 13.292 26.7622 13.2567C26.7622 13.2213 26.7481 13.1874 26.7231 13.1624C26.6981 13.1374 26.6642 13.1233 26.6288 13.1233ZM26.6288 14.1367H24.4422C24.4068 14.1367 24.3729 14.1507 24.3479 14.1757C24.3229 14.2007 24.3088 14.2346 24.3088 14.27C24.3088 14.3053 24.3229 14.3393 24.3479 14.3643C24.3729 14.3893 24.4068 14.4034 24.4422 14.4034H26.6288C26.6642 14.4034 26.6981 14.3893 26.7231 14.3643C26.7481 14.3393 26.7622 14.3053 26.7622 14.27C26.7622 14.2346 26.7481 14.2007 26.7231 14.1757C26.6981 14.1507 26.6642 14.1367 26.6288 14.1367ZM28.8954 14.43L28.6021 13.95C28.5488 13.8967 28.5222 13.8166 28.5222 13.71C28.6821 8.05663 26.8155 5.14999 25.8022 3.60332L25.6955 3.44332V1.81666C25.6934 1.52026 25.5747 1.2366 25.3651 1.02701C25.1556 0.817423 24.8719 0.69875 24.5755 0.696655H21.7755C21.2155 0.696655 20.7622 1.09666 20.6555 1.62999C16.3621 1.12332 9.40213 1.46999 3.77549 3.38999C3.42883 3.52333 3.18883 3.78999 3.08216 4.13665C1.98883 7.84333 1.48216 11.7634 1.26883 14.35C1.24216 14.43 1.10883 14.6434 1.02883 14.7766C0.842161 15.0433 0.682162 15.2833 0.682162 15.5233C0.602161 16.67 0.548828 17.6033 0.548828 18.27C0.548828 18.51 0.628828 18.75 0.762161 18.9634L1.72216 20.2966C1.93549 20.59 2.28216 20.7766 2.65549 20.7766H18.1489C18.1755 20.7766 18.2288 20.7766 18.2555 20.8033C19.7755 21.2833 21.4555 21.47 22.5222 21.55V26.9367C22.2822 26.99 22.1221 27.1767 22.1221 27.4433V28.8034H21.7755C21.0022 28.8034 20.3355 29.3633 20.2021 30.1366L18.8689 38.0033C18.6822 39.0433 18.9755 40.0834 19.6422 40.8833C20.3089 41.6833 21.2955 42.1366 22.3621 42.1366H23.4555C24.4955 42.1366 25.4821 41.6833 26.1755 40.8833C26.8688 40.0834 27.1355 39.0433 26.9488 38.0033L25.6155 30.1366C25.4821 29.3633 24.8155 28.8034 24.0421 28.8034H23.7222V27.4433C23.7222 27.2033 23.5621 26.99 23.3221 26.9367V21.6034H23.6155C25.7755 21.6034 27.2689 21.3367 28.0422 20.83C28.3621 20.6167 28.5488 20.27 28.5488 19.87V19.31C28.5488 19.23 28.5755 19.1767 28.6021 19.0966L28.8688 18.67C29.0022 18.4834 29.0555 18.2434 29.0555 18.03V14.99C29.0555 14.8033 29.0022 14.6167 28.8954 14.43ZM21.6955 38.8834V38.91C21.6955 38.9633 21.6421 39.8967 22.0422 41.31C21.3488 41.23 20.7088 40.8833 20.2555 40.35C19.7221 39.7366 19.5088 38.91 19.6422 38.11L20.9755 30.2434C21.0289 29.87 21.3755 29.5767 21.7755 29.5767L22.4955 33.9766L21.6955 38.8834ZM24.0155 29.6033C24.4155 29.6033 24.7355 29.87 24.8155 30.27L26.1488 38.1367C26.2821 38.9367 26.0688 39.7366 25.5355 40.3767C25.0821 40.91 24.4422 41.2567 23.7488 41.3367C24.1488 39.9233 24.0955 38.9633 24.0955 38.9367L23.2955 34.03L24.0155 29.6033ZM22.9222 41.3367H22.8688C22.4689 40.03 22.4955 39.0967 22.4955 38.99L22.8955 36.5367L23.2955 38.99C23.2955 39.1234 23.2955 40.03 22.9222 41.3367ZM22.5755 29.6033H23.1889L22.8688 31.5233L22.5755 29.6033ZM27.7221 19.87C27.7221 20.0033 27.6688 20.11 27.5622 20.1634C27.1888 20.4034 26.2021 20.8033 23.5888 20.8033C23.5621 20.8033 22.0955 20.8033 20.4155 20.51C20.9221 20.3767 21.2422 20.19 21.5622 20.03C22.0155 19.79 22.3888 19.6033 23.1889 19.6033H27.7221V19.87ZM28.2555 18.0567C28.2555 18.1366 28.2288 18.19 28.2021 18.27L27.9355 18.6967L27.8555 18.8566H23.2155C22.2022 18.8566 21.7222 19.1233 21.2155 19.39C20.6022 19.71 19.9088 20.0566 17.8822 20.0566H2.68216C2.57549 20.0566 2.44216 20.0033 2.38882 19.8967L1.42882 18.5633C1.37549 18.51 1.34883 18.43 1.34883 18.35C1.34883 17.7367 1.40216 16.9366 1.45549 15.9233H23.4555C23.5088 15.9233 24.0688 15.95 24.7621 15.95C25.9355 15.95 27.5355 15.87 28.2555 15.4966V18.0567ZM28.2555 15.15C27.5622 15.6833 24.5755 15.6833 23.4555 15.6034H1.45549C1.48216 15.5233 1.61549 15.3367 1.69549 15.2033C1.88216 14.9367 2.04216 14.67 2.06883 14.4034C2.28216 11.8167 2.78883 7.97665 3.85549 4.32332C3.88216 4.21666 3.96216 4.13665 4.06882 4.08332C8.09548 2.69665 12.8155 2.16332 16.7089 2.16332C18.3088 2.16332 19.7755 2.24332 21.0022 2.42999L21.4555 2.48332V1.81666C21.4555 1.62999 21.6155 1.49665 21.7755 1.49665H24.5755C24.7621 1.49665 24.8955 1.65666 24.8955 1.81666V3.68332L25.1355 4.02999C26.0955 5.52332 27.8821 8.27 27.7221 13.6834C27.7221 13.95 27.8022 14.2167 27.9621 14.43C28.0688 14.5633 28.1488 14.7233 28.2021 14.8033C28.2288 14.8567 28.2555 14.91 28.2555 14.99V15.15Z" fill="#C41230"/>
+</svg>
+
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Shop</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/hand-mixer">
+                                                                                                                        <span class="icon-svg learn">
+                                                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Learn</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/hand-mixers-comparison">
+                                                                                                                        <span class="icon-svg compare">
+                                                                                                                            
+		<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.1732 3.64907C23.1732 4.84963 22.2 5.82287 20.9994 5.82287C19.7989 5.82287 18.8256 4.84963 18.8256 3.64907C18.8256 2.44851 19.7989 1.47526 20.9994 1.47526C22.2 1.47526 23.1732 2.44851 23.1732 3.64907ZM23.6623 4.04977C23.4999 5.13821 22.6861 6.01384 21.6302 6.2673C21.6337 6.29156 21.6355 6.31636 21.6355 6.34158L21.6355 40.0062H38.4412C38.7277 40.0062 38.9599 40.2384 38.9599 40.5249C38.9599 40.8114 38.7277 41.0436 38.4412 41.0436H21.1168H3.78959C3.50311 41.0436 3.27088 40.8114 3.27088 40.5249C3.27088 40.2384 3.50311 40.0062 3.78959 40.0062H20.598L20.598 6.34158C20.598 6.33165 20.5983 6.32179 20.5989 6.312C19.4326 6.13806 18.5106 5.2162 18.3365 4.05C18.3275 4.05047 18.3183 4.05071 18.3091 4.05071H11.7185C11.5993 4.13687 11.4576 4.22324 11.2989 4.29793L19.0258 25.351C19.0373 25.3803 19.046 25.4104 19.052 25.4409C19.0667 25.5158 19.0643 25.5912 19.047 25.6624C19.0285 25.7396 18.992 25.8131 18.9382 25.8763C18.9196 25.8983 18.8991 25.9188 18.8768 25.9375C17.8177 26.865 15.0018 28.8688 9.99698 28.8688C7.44049 28.8688 5.34165 28.3884 3.78934 27.7794C3.0137 27.475 2.37027 27.1369 1.87231 26.807C1.38773 26.486 1.00944 26.1521 0.7938 25.8405C0.78631 25.8299 0.779229 25.8191 0.772569 25.808C0.690714 25.6723 0.678119 25.5122 0.726653 25.3712C0.731138 25.3582 0.736145 25.3453 0.741667 25.3327L9.56676 4.33118C9.42694 4.2607 9.28988 4.16832 9.15842 4.05071H7.07073C6.78426 4.05071 6.55202 3.81848 6.55202 3.532C6.55202 3.24552 6.78426 3.01328 7.07073 3.01328H9.37257H9.6046L9.75926 3.18626C9.82931 3.26461 9.90007 3.3244 9.97108 3.36901L9.98703 3.33104C10.0696 3.1345 10.2641 3.0085 10.4772 3.01341C10.6777 3.01803 10.8563 3.13761 10.9379 3.31839C11.0417 3.26222 11.1317 3.19882 11.1985 3.14064L11.345 3.01328H11.539H18.3091C18.3336 3.01328 18.3576 3.01498 18.3812 3.01825C18.6651 1.83554 19.7296 0.956543 20.9994 0.956543C22.2694 0.956543 23.334 1.83581 23.6178 3.0188C23.6425 3.01517 23.6679 3.01328 23.6936 3.01328H30.4637H30.6219L30.7532 3.10155C30.8505 3.16699 31.0048 3.24588 31.1862 3.30212C31.2712 3.12988 31.4464 3.01664 31.6425 3.01335C31.8321 3.01017 32.0055 3.11032 32.0989 3.2699C32.1651 3.2359 32.2293 3.19285 32.2909 3.1396L32.437 3.01328H32.6302H34.932C35.2185 3.01328 35.4507 3.24552 35.4507 3.532C35.4507 3.81848 35.2185 4.05071 34.932 4.05071H32.808C32.6958 4.12979 32.5807 4.19374 32.4646 4.24459L41.2699 28.2887C41.3341 28.4639 41.2978 28.6513 41.1905 28.788C40.9726 29.0936 40.6004 29.4198 40.1266 29.7337C39.6286 30.0636 38.9852 30.4017 38.2095 30.706C36.6572 31.3151 34.5584 31.7955 32.0019 31.7955C26.984 31.7955 24.1665 29.7812 23.1139 28.857C22.9442 28.708 22.895 28.4729 22.9743 28.2746L30.8573 4.28623C30.6506 4.22034 30.4667 4.13587 30.3172 4.05071H23.6936C23.6831 4.05071 23.6727 4.05039 23.6623 4.04977ZM24.1879 27.9045L24.0596 28.295C24.4883 28.4085 25.0994 28.5135 25.8582 28.6034C27.4553 28.7925 29.6689 28.9102 32.1189 28.9102C34.5688 28.9102 36.7824 28.7925 38.3795 28.6034C39.1326 28.5142 39.7401 28.4101 40.1683 28.2976L40.0219 27.8978C39.6059 27.7993 39.0505 27.708 38.3795 27.6285C36.7824 27.4394 34.5688 27.3217 32.1189 27.3217C29.6689 27.3217 27.4553 27.4394 25.8582 27.6285C25.1721 27.7098 24.6068 27.8034 24.1879 27.9045ZM24.2825 27.6166L31.6777 5.11281L39.9158 27.6081C38.4015 27.2828 35.4775 27.0624 32.1189 27.0624C28.7308 27.0624 25.7851 27.2866 24.2825 27.6166ZM32.0019 30.758C28.2471 30.758 25.8438 29.5622 24.5623 28.6724C26.1331 28.9709 28.93 29.1696 32.1189 29.1696C35.4563 29.1696 38.3646 28.9519 39.887 28.63C39.7905 28.7053 39.6797 28.7853 39.5536 28.8688C39.1239 29.1535 38.5468 29.4593 37.8306 29.7403C36.3993 30.3019 34.429 30.758 32.0019 30.758ZM10.4326 4.9486L17.6748 24.6809C16.1598 24.3559 13.2371 24.1357 9.88002 24.1357C6.5675 24.1357 3.67779 24.3501 2.14625 24.6681L10.4326 4.9486ZM2.02344 24.9603L1.84889 25.3757C2.27603 25.4864 2.87699 25.5888 3.61937 25.6767C5.21647 25.8659 7.43006 25.9835 9.88002 25.9835C12.33 25.9835 14.5436 25.8659 16.1407 25.6767C16.893 25.5876 17.5 25.4836 17.9282 25.3713L17.7812 24.9707C17.3654 24.8723 16.8106 24.7812 16.1407 24.7018C14.5436 24.5127 12.33 24.395 9.88002 24.395C7.43006 24.395 5.21647 24.5127 3.61937 24.7018C2.97309 24.7784 2.43399 24.8659 2.02344 24.9603ZM17.4366 25.7457C16.1551 26.6356 13.7518 27.8314 9.99698 27.8314C7.56993 27.8314 5.59963 27.3752 4.16826 26.8136C3.45207 26.5326 2.87503 26.2269 2.44526 25.9422C2.31922 25.8587 2.20837 25.7786 2.11188 25.7033C3.63428 26.0253 6.54255 26.2429 9.88002 26.2429C13.0688 26.2429 15.8658 26.0442 17.4366 25.7457Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Compare</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+                                                                                                        </ul>
+
+                                                                                                        <!-- mobile_banner -->
+                                                                                                        
+                                                                                                        
+
+                                                                                                        
+                                                                                                        <!-- end mobile_banner -->
+
+                                                                                                        <!-- mobile_sale_banner -->
+                                                                                                        
+                                                                                                            
+
+                                                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                                                            
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                        <div class="img pb-89.250814332">
+                                                                                                                            
+                                                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                </div>
+                                                                                                            
+                                                                                                        
+                                                                                                        <!-- end mobile_sale_banner -->
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                     
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li class="is-dropdown w-hover-state">
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/hand-blenders"  class="no-link" data-expand="" data-sub-name="hand-blenders" aria-expanded="false" aria-haspopup="true" role="button" data-level-03 data-level-03-role >
+                                                                                        <span class="icon-svg hand-blenders">
+                                                                                            
+		<svg width="8" height="43" viewBox="0 0 8 43" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.94238 39.1116C6.36219 38.4304 5.78201 37.7208 5.78201 36.6423V26.1406C5.78201 25.9136 6.05828 25.1472 6.25168 24.5227C6.6661 23.2739 7.24631 21.5993 7.41205 19.9815C7.55021 18.7043 8.21325 12.2614 7.32914 10.53C7.32914 10.5017 7.30156 10.5017 7.30156 10.4732C7.24631 10.3881 7.19106 10.3313 7.1634 10.2462C6.97001 9.93401 6.88712 9.8205 6.88712 9.65015V6.55643C6.88712 6.30099 6.99763 6.07393 7.1634 5.90363C7.32914 5.73333 7.43971 5.50627 7.43971 5.27921V2.9802C7.43971 1.44752 6.30693 0.170297 4.84266 0.028383C4.7874 0.028383 4.73215 0 4.67689 0H3.32312C3.26786 0 3.21261 1.60584e-07 3.15735 0.028383C1.69308 0.170297 0.56033 1.44752 0.56033 2.9802V5.27921C0.56033 5.50627 0.67084 5.76172 0.836605 5.90363C1.03 6.07393 1.11289 6.30099 1.11289 6.55643V9.65015C1.11289 9.79208 1.03 9.93401 0.836605 10.2462C0.78135 10.3313 0.726095 10.3881 0.698471 10.4732C0.698471 10.5017 0.67084 10.5017 0.67084 10.53C-0.24088 12.2614 0.422189 18.7043 0.587954 19.9815C0.753726 21.571 1.33391 23.2739 1.74833 24.4944C1.96935 25.1188 2.218 25.8851 2.218 26.1122V36.6139C2.218 37.6924 1.61019 38.402 1.05763 39.0831C0.477444 39.7644 -0.157997 40.5591 0.0353984 41.6093C0.201169 42.4891 0.78135 43 1.58257 43C1.96935 43 2.32851 42.8865 2.74294 42.773C3.12973 42.6594 3.51651 42.5459 3.87568 42.5459H4.12433C4.4835 42.5459 4.87028 42.6594 5.25707 42.773C5.67149 42.8865 6.03066 43 6.41745 43C7.24631 43 7.79886 42.4891 7.9646 41.6093C8.158 40.5591 7.52254 39.7927 6.94238 39.1116ZM3.29549 0.879868H4.62164C5.31233 0.908254 5.89252 1.30561 6.22406 1.84488C4.73215 1.67459 3.15735 1.67459 1.66545 1.8165C2.05224 1.27723 2.63243 0.908254 3.29549 0.879868ZM1.36154 10.9274C1.63782 10.4732 1.9141 10.161 1.9141 9.65015V6.55643C1.9141 6.04554 1.69308 5.59142 1.36154 5.27921V2.9802C1.36154 2.66799 1.41679 2.38416 1.5273 2.12872C3.12972 1.95841 4.81503 1.95841 6.41745 2.1571C6.52796 2.41254 6.58322 2.69637 6.58322 2.9802V5.27921C6.25168 5.59142 6.03066 6.04554 6.03066 6.55643V9.65015C6.03066 10.161 6.30693 10.4732 6.58322 10.9274C6.77661 11.268 6.85949 11.8924 6.91475 12.6304C4.95667 12.4601 2.98808 12.4601 1.03 12.6304C1.08526 11.8924 1.19577 11.268 1.36154 10.9274ZM1.36154 19.868C1.36154 19.868 0.89186 15.6389 1.00238 12.9142C2.93633 12.7439 5.00842 12.7439 6.91475 12.9142C7.05289 15.6673 6.55559 19.868 6.55559 19.868C6.52796 20.1518 6.47271 20.4356 6.41745 20.7195H1.49968C1.44443 20.4356 1.38917 20.1518 1.36154 19.868ZM1.55494 21.0033H6.41745C5.9754 23.1037 5.03605 25.1756 4.95317 25.9987H3.01921C2.93633 25.1756 1.99698 23.132 1.55494 21.0033ZM0.808981 41.4389C0.753726 41.1835 0.808981 40.928 0.891868 40.701C1.25103 40.6726 1.55494 40.701 1.83121 40.7577C2.16275 40.8429 2.30089 40.9564 2.30089 41.0132C2.32851 41.2119 1.77596 41.5241 0.864236 41.666C0.864236 41.6376 0.836605 41.5525 0.808981 41.4389ZM6.41745 42.1769C5.83726 42.1769 4.9808 41.7512 4.12433 41.7512H3.87568C3.01921 41.7512 2.16275 42.1769 1.58257 42.1769C1.36154 42.1769 1.19577 42.1202 1.05763 41.9782C1.9141 41.8363 2.66005 41.4957 2.6048 41.0416C2.57716 40.8713 2.43903 40.6442 1.9141 40.5307C1.66545 40.474 1.38917 40.4455 1.08526 40.4455C1.66545 39.5089 3.04684 38.5439 3.04684 36.6423V26.3109H4.95317V36.6423C4.95317 38.5439 6.33457 39.5089 6.91475 40.4455C6.61084 40.4455 6.30693 40.474 6.08591 40.5307C5.53336 40.6442 5.39522 40.8713 5.39522 41.0416C5.36758 41.2119 5.45047 41.4673 5.9754 41.6944C6.25168 41.8079 6.58322 41.9215 6.94238 41.9782C6.80424 42.1202 6.61085 42.1769 6.41745 42.1769ZM7.1634 41.4389L7.08052 41.6944C6.73017 41.641 6.3871 41.5458 6.05828 41.4106C5.75438 41.2686 5.64387 41.1267 5.64387 41.0416C5.64387 40.9564 5.80963 40.8429 6.11354 40.7862C6.36219 40.7293 6.69373 40.701 7.05289 40.7294C7.1634 40.9564 7.19106 41.1835 7.1634 41.4389ZM4.81503 10.0759V6.38614C4.81503 5.90363 4.45586 5.53465 3.98619 5.53465C3.51651 5.53465 3.15735 5.90363 3.15735 6.38614V10.0759C3.15735 10.5584 3.51651 10.9274 3.98619 10.9274C4.45586 10.9274 4.81503 10.5584 4.81503 10.0759ZM3.43364 10.0759V6.38614C3.43364 6.07393 3.68229 5.81848 3.98619 5.81848C4.2901 5.81848 4.53875 6.07393 4.53875 6.38614V10.0759C4.53875 10.3881 4.2901 10.6436 3.98619 10.6436C3.68229 10.6436 3.43364 10.3881 3.43364 10.0759Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Hand Blenders</span>
+                                                                                            <i class="not-italic" data-txt>Shop Hand Blenders</i>
+                                                                                        </span>
+
+                                                                                        
+                                                                                            <span class="expand">
+                                                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                                                </svg>
+                                                                                            </span>
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+                                                                                        <span class="hidden absolute lg:flex lg:flex-wrap lg:pt-2px" data-sub>
+                                                                                            
+                                                                                                
+                                                                                                    
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/hand-blenders">Learn</a>
+                                                                                                </span>
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/hand-blenders-comparison">Compare</a>
+                                                                                                </span>
+                                                                                        </span>
+                                                                                    
+
+                                                                                    
+                                                                                        <div data-nav-dropdown-content="" data-level-03 class="invisible" id="hand-blenders">
+                                                                                            <div class="__box" data-subnav="">
+                                                                                                 <a href="#" class="back" data-back="" data-level-03 aria-controls="hand-blenders">
+                                                                                                    <span class="icon">
+                                                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                                                        </svg>
+                                                                                                    </span>
+                                                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Hand Blenders</span>
+                                                                                                </a>
+
+                                                                                                <div class="__box-wrap">
+                                                                                                    <div class="inner w-1920px">
+                                                                                                        <ul class="ul-sub" xxx>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/collections/hand-blenders">
+                                                                                                                        <span class="icon-svg hand-blenders">
+                                                                                                                            
+		<svg width="8" height="43" viewBox="0 0 8 43" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.94238 39.1116C6.36219 38.4304 5.78201 37.7208 5.78201 36.6423V26.1406C5.78201 25.9136 6.05828 25.1472 6.25168 24.5227C6.6661 23.2739 7.24631 21.5993 7.41205 19.9815C7.55021 18.7043 8.21325 12.2614 7.32914 10.53C7.32914 10.5017 7.30156 10.5017 7.30156 10.4732C7.24631 10.3881 7.19106 10.3313 7.1634 10.2462C6.97001 9.93401 6.88712 9.8205 6.88712 9.65015V6.55643C6.88712 6.30099 6.99763 6.07393 7.1634 5.90363C7.32914 5.73333 7.43971 5.50627 7.43971 5.27921V2.9802C7.43971 1.44752 6.30693 0.170297 4.84266 0.028383C4.7874 0.028383 4.73215 0 4.67689 0H3.32312C3.26786 0 3.21261 1.60584e-07 3.15735 0.028383C1.69308 0.170297 0.56033 1.44752 0.56033 2.9802V5.27921C0.56033 5.50627 0.67084 5.76172 0.836605 5.90363C1.03 6.07393 1.11289 6.30099 1.11289 6.55643V9.65015C1.11289 9.79208 1.03 9.93401 0.836605 10.2462C0.78135 10.3313 0.726095 10.3881 0.698471 10.4732C0.698471 10.5017 0.67084 10.5017 0.67084 10.53C-0.24088 12.2614 0.422189 18.7043 0.587954 19.9815C0.753726 21.571 1.33391 23.2739 1.74833 24.4944C1.96935 25.1188 2.218 25.8851 2.218 26.1122V36.6139C2.218 37.6924 1.61019 38.402 1.05763 39.0831C0.477444 39.7644 -0.157997 40.5591 0.0353984 41.6093C0.201169 42.4891 0.78135 43 1.58257 43C1.96935 43 2.32851 42.8865 2.74294 42.773C3.12973 42.6594 3.51651 42.5459 3.87568 42.5459H4.12433C4.4835 42.5459 4.87028 42.6594 5.25707 42.773C5.67149 42.8865 6.03066 43 6.41745 43C7.24631 43 7.79886 42.4891 7.9646 41.6093C8.158 40.5591 7.52254 39.7927 6.94238 39.1116ZM3.29549 0.879868H4.62164C5.31233 0.908254 5.89252 1.30561 6.22406 1.84488C4.73215 1.67459 3.15735 1.67459 1.66545 1.8165C2.05224 1.27723 2.63243 0.908254 3.29549 0.879868ZM1.36154 10.9274C1.63782 10.4732 1.9141 10.161 1.9141 9.65015V6.55643C1.9141 6.04554 1.69308 5.59142 1.36154 5.27921V2.9802C1.36154 2.66799 1.41679 2.38416 1.5273 2.12872C3.12972 1.95841 4.81503 1.95841 6.41745 2.1571C6.52796 2.41254 6.58322 2.69637 6.58322 2.9802V5.27921C6.25168 5.59142 6.03066 6.04554 6.03066 6.55643V9.65015C6.03066 10.161 6.30693 10.4732 6.58322 10.9274C6.77661 11.268 6.85949 11.8924 6.91475 12.6304C4.95667 12.4601 2.98808 12.4601 1.03 12.6304C1.08526 11.8924 1.19577 11.268 1.36154 10.9274ZM1.36154 19.868C1.36154 19.868 0.89186 15.6389 1.00238 12.9142C2.93633 12.7439 5.00842 12.7439 6.91475 12.9142C7.05289 15.6673 6.55559 19.868 6.55559 19.868C6.52796 20.1518 6.47271 20.4356 6.41745 20.7195H1.49968C1.44443 20.4356 1.38917 20.1518 1.36154 19.868ZM1.55494 21.0033H6.41745C5.9754 23.1037 5.03605 25.1756 4.95317 25.9987H3.01921C2.93633 25.1756 1.99698 23.132 1.55494 21.0033ZM0.808981 41.4389C0.753726 41.1835 0.808981 40.928 0.891868 40.701C1.25103 40.6726 1.55494 40.701 1.83121 40.7577C2.16275 40.8429 2.30089 40.9564 2.30089 41.0132C2.32851 41.2119 1.77596 41.5241 0.864236 41.666C0.864236 41.6376 0.836605 41.5525 0.808981 41.4389ZM6.41745 42.1769C5.83726 42.1769 4.9808 41.7512 4.12433 41.7512H3.87568C3.01921 41.7512 2.16275 42.1769 1.58257 42.1769C1.36154 42.1769 1.19577 42.1202 1.05763 41.9782C1.9141 41.8363 2.66005 41.4957 2.6048 41.0416C2.57716 40.8713 2.43903 40.6442 1.9141 40.5307C1.66545 40.474 1.38917 40.4455 1.08526 40.4455C1.66545 39.5089 3.04684 38.5439 3.04684 36.6423V26.3109H4.95317V36.6423C4.95317 38.5439 6.33457 39.5089 6.91475 40.4455C6.61084 40.4455 6.30693 40.474 6.08591 40.5307C5.53336 40.6442 5.39522 40.8713 5.39522 41.0416C5.36758 41.2119 5.45047 41.4673 5.9754 41.6944C6.25168 41.8079 6.58322 41.9215 6.94238 41.9782C6.80424 42.1202 6.61085 42.1769 6.41745 42.1769ZM7.1634 41.4389L7.08052 41.6944C6.73017 41.641 6.3871 41.5458 6.05828 41.4106C5.75438 41.2686 5.64387 41.1267 5.64387 41.0416C5.64387 40.9564 5.80963 40.8429 6.11354 40.7862C6.36219 40.7293 6.69373 40.701 7.05289 40.7294C7.1634 40.9564 7.19106 41.1835 7.1634 41.4389ZM4.81503 10.0759V6.38614C4.81503 5.90363 4.45586 5.53465 3.98619 5.53465C3.51651 5.53465 3.15735 5.90363 3.15735 6.38614V10.0759C3.15735 10.5584 3.51651 10.9274 3.98619 10.9274C4.45586 10.9274 4.81503 10.5584 4.81503 10.0759ZM3.43364 10.0759V6.38614C3.43364 6.07393 3.68229 5.81848 3.98619 5.81848C4.2901 5.81848 4.53875 6.07393 4.53875 6.38614V10.0759C4.53875 10.3881 4.2901 10.6436 3.98619 10.6436C3.68229 10.6436 3.43364 10.3881 3.43364 10.0759Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Shop</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/hand-blenders">
+                                                                                                                        <span class="icon-svg learn">
+                                                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Learn</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/hand-blenders-comparison">
+                                                                                                                        <span class="icon-svg compare">
+                                                                                                                            
+		<svg width="42" height="42" viewBox="0 0 42 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path fill-rule="evenodd" clip-rule="evenodd" d="M23.1732 3.64907C23.1732 4.84963 22.2 5.82287 20.9994 5.82287C19.7989 5.82287 18.8256 4.84963 18.8256 3.64907C18.8256 2.44851 19.7989 1.47526 20.9994 1.47526C22.2 1.47526 23.1732 2.44851 23.1732 3.64907ZM23.6623 4.04977C23.4999 5.13821 22.6861 6.01384 21.6302 6.2673C21.6337 6.29156 21.6355 6.31636 21.6355 6.34158L21.6355 40.0062H38.4412C38.7277 40.0062 38.9599 40.2384 38.9599 40.5249C38.9599 40.8114 38.7277 41.0436 38.4412 41.0436H21.1168H3.78959C3.50311 41.0436 3.27088 40.8114 3.27088 40.5249C3.27088 40.2384 3.50311 40.0062 3.78959 40.0062H20.598L20.598 6.34158C20.598 6.33165 20.5983 6.32179 20.5989 6.312C19.4326 6.13806 18.5106 5.2162 18.3365 4.05C18.3275 4.05047 18.3183 4.05071 18.3091 4.05071H11.7185C11.5993 4.13687 11.4576 4.22324 11.2989 4.29793L19.0258 25.351C19.0373 25.3803 19.046 25.4104 19.052 25.4409C19.0667 25.5158 19.0643 25.5912 19.047 25.6624C19.0285 25.7396 18.992 25.8131 18.9382 25.8763C18.9196 25.8983 18.8991 25.9188 18.8768 25.9375C17.8177 26.865 15.0018 28.8688 9.99698 28.8688C7.44049 28.8688 5.34165 28.3884 3.78934 27.7794C3.0137 27.475 2.37027 27.1369 1.87231 26.807C1.38773 26.486 1.00944 26.1521 0.7938 25.8405C0.78631 25.8299 0.779229 25.8191 0.772569 25.808C0.690714 25.6723 0.678119 25.5122 0.726653 25.3712C0.731138 25.3582 0.736145 25.3453 0.741667 25.3327L9.56676 4.33118C9.42694 4.2607 9.28988 4.16832 9.15842 4.05071H7.07073C6.78426 4.05071 6.55202 3.81848 6.55202 3.532C6.55202 3.24552 6.78426 3.01328 7.07073 3.01328H9.37257H9.6046L9.75926 3.18626C9.82931 3.26461 9.90007 3.3244 9.97108 3.36901L9.98703 3.33104C10.0696 3.1345 10.2641 3.0085 10.4772 3.01341C10.6777 3.01803 10.8563 3.13761 10.9379 3.31839C11.0417 3.26222 11.1317 3.19882 11.1985 3.14064L11.345 3.01328H11.539H18.3091C18.3336 3.01328 18.3576 3.01498 18.3812 3.01825C18.6651 1.83554 19.7296 0.956543 20.9994 0.956543C22.2694 0.956543 23.334 1.83581 23.6178 3.0188C23.6425 3.01517 23.6679 3.01328 23.6936 3.01328H30.4637H30.6219L30.7532 3.10155C30.8505 3.16699 31.0048 3.24588 31.1862 3.30212C31.2712 3.12988 31.4464 3.01664 31.6425 3.01335C31.8321 3.01017 32.0055 3.11032 32.0989 3.2699C32.1651 3.2359 32.2293 3.19285 32.2909 3.1396L32.437 3.01328H32.6302H34.932C35.2185 3.01328 35.4507 3.24552 35.4507 3.532C35.4507 3.81848 35.2185 4.05071 34.932 4.05071H32.808C32.6958 4.12979 32.5807 4.19374 32.4646 4.24459L41.2699 28.2887C41.3341 28.4639 41.2978 28.6513 41.1905 28.788C40.9726 29.0936 40.6004 29.4198 40.1266 29.7337C39.6286 30.0636 38.9852 30.4017 38.2095 30.706C36.6572 31.3151 34.5584 31.7955 32.0019 31.7955C26.984 31.7955 24.1665 29.7812 23.1139 28.857C22.9442 28.708 22.895 28.4729 22.9743 28.2746L30.8573 4.28623C30.6506 4.22034 30.4667 4.13587 30.3172 4.05071H23.6936C23.6831 4.05071 23.6727 4.05039 23.6623 4.04977ZM24.1879 27.9045L24.0596 28.295C24.4883 28.4085 25.0994 28.5135 25.8582 28.6034C27.4553 28.7925 29.6689 28.9102 32.1189 28.9102C34.5688 28.9102 36.7824 28.7925 38.3795 28.6034C39.1326 28.5142 39.7401 28.4101 40.1683 28.2976L40.0219 27.8978C39.6059 27.7993 39.0505 27.708 38.3795 27.6285C36.7824 27.4394 34.5688 27.3217 32.1189 27.3217C29.6689 27.3217 27.4553 27.4394 25.8582 27.6285C25.1721 27.7098 24.6068 27.8034 24.1879 27.9045ZM24.2825 27.6166L31.6777 5.11281L39.9158 27.6081C38.4015 27.2828 35.4775 27.0624 32.1189 27.0624C28.7308 27.0624 25.7851 27.2866 24.2825 27.6166ZM32.0019 30.758C28.2471 30.758 25.8438 29.5622 24.5623 28.6724C26.1331 28.9709 28.93 29.1696 32.1189 29.1696C35.4563 29.1696 38.3646 28.9519 39.887 28.63C39.7905 28.7053 39.6797 28.7853 39.5536 28.8688C39.1239 29.1535 38.5468 29.4593 37.8306 29.7403C36.3993 30.3019 34.429 30.758 32.0019 30.758ZM10.4326 4.9486L17.6748 24.6809C16.1598 24.3559 13.2371 24.1357 9.88002 24.1357C6.5675 24.1357 3.67779 24.3501 2.14625 24.6681L10.4326 4.9486ZM2.02344 24.9603L1.84889 25.3757C2.27603 25.4864 2.87699 25.5888 3.61937 25.6767C5.21647 25.8659 7.43006 25.9835 9.88002 25.9835C12.33 25.9835 14.5436 25.8659 16.1407 25.6767C16.893 25.5876 17.5 25.4836 17.9282 25.3713L17.7812 24.9707C17.3654 24.8723 16.8106 24.7812 16.1407 24.7018C14.5436 24.5127 12.33 24.395 9.88002 24.395C7.43006 24.395 5.21647 24.5127 3.61937 24.7018C2.97309 24.7784 2.43399 24.8659 2.02344 24.9603ZM17.4366 25.7457C16.1551 26.6356 13.7518 27.8314 9.99698 27.8314C7.56993 27.8314 5.59963 27.3752 4.16826 26.8136C3.45207 26.5326 2.87503 26.2269 2.44526 25.9422C2.31922 25.8587 2.20837 25.7786 2.11188 25.7033C3.63428 26.0253 6.54255 26.2429 9.88002 26.2429C13.0688 26.2429 15.8658 26.0442 17.4366 25.7457Z" fill="#C41230"/>
+		</svg>
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Compare</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+                                                                                                        </ul>
+
+                                                                                                        <!-- mobile_banner -->
+                                                                                                        
+                                                                                                        
+
+                                                                                                        
+                                                                                                        <!-- end mobile_banner -->
+
+                                                                                                        <!-- mobile_sale_banner -->
+                                                                                                        
+                                                                                                            
+
+                                                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                                                            
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                        <div class="img pb-89.250814332">
+                                                                                                                            
+                                                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                </div>
+                                                                                                            
+                                                                                                        
+                                                                                                        <!-- end mobile_sale_banner -->
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                     
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li class="is-dropdown w-hover-state">
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/cordless"  class="no-link" data-expand="" data-sub-name="cordless" aria-expanded="false" aria-haspopup="true" role="button" data-level-03 data-level-03-role >
+                                                                                        <span class="icon-svg cordless">
+                                                                                            
+		<svg width="44" height="26" viewBox="0 0 44 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M40.2844 19.0387C39.9489 19.0387 39.6135 18.787 39.6135 18.3677C39.6135 17.9483 39.8651 17.6967 40.2844 17.6967C41.4586 17.6967 42.3812 16.7741 42.3812 15.5999V9.89672C42.3812 8.72252 41.4586 7.79994 40.2844 7.79994C39.9489 7.79994 39.6135 7.54833 39.6135 7.12898C39.6135 6.70962 39.8651 6.45801 40.2844 6.45801C42.1296 6.45801 43.6393 7.96769 43.6393 9.81285V15.5161C43.6393 17.529 42.1296 19.0387 40.2844 19.0387Z" fill="#C41230"/>
+<path d="M21.4122 20.3806C21.3284 20.3806 21.1606 20.3806 21.0768 20.2968L9.92192 12.6645C9.67031 12.4968 9.58644 12.1613 9.67031 11.9097C9.75418 11.658 10.0058 11.4903 10.3413 11.4903L16.6316 12.0774V5.87095C16.6316 5.61933 16.7993 5.45159 16.9671 5.28385C17.1348 5.19998 17.3864 5.19998 17.6381 5.28385L28.709 13C28.9606 13.1677 29.0445 13.5032 28.9606 13.7548C28.8768 14.0064 28.6252 14.1742 28.2897 14.1742L21.9993 13.5871V19.8774C21.9993 20.129 21.8316 20.2968 21.6639 20.4645C21.58 20.3806 21.4961 20.3806 21.4122 20.3806ZM12.6897 13L20.8251 18.6193V12.8322C20.8251 12.6645 20.909 12.4968 20.9929 12.329C21.1606 12.2451 21.3284 12.1613 21.4961 12.1613L26.0252 12.5806L17.8897 6.96127V12.7484C17.8897 12.9161 17.8058 13.0838 17.7219 13.2516C17.5542 13.4193 17.3864 13.4193 17.2187 13.4193L12.6897 13Z" fill="#C41230"/>
+<path d="M33.9103 25.2452H4.72314C3.63282 25.2452 2.62637 24.8259 1.78766 24.071C0.948948 23.3162 0.613464 22.2259 0.613464 21.1356V4.44524C0.613464 3.35492 1.03282 2.34847 1.87153 1.59363C2.62637 0.838788 3.71669 0.419434 4.80702 0.419434H33.9941C35.0845 0.419434 36.0909 0.838788 36.9296 1.59363C37.7683 2.34847 38.1038 3.43879 38.1038 4.52911V21.2194C38.1038 22.3098 37.6845 23.3162 36.9296 24.1549C36.1748 24.9936 35.0006 25.2452 33.9103 25.2452ZM4.72314 1.59363C3.96831 1.59363 3.21347 1.92911 2.71024 2.43234C2.20701 3.01943 1.87153 3.6904 1.87153 4.44524V21.1356C1.87153 21.8904 2.20701 22.6452 2.71024 23.1485C3.21347 23.6517 3.96831 23.9872 4.72314 23.9872H33.9103C34.6651 23.9872 35.4199 23.6517 35.9232 23.1485C36.4264 22.6452 36.7619 21.8904 36.7619 21.1356V4.44524C36.7619 3.6904 36.4264 2.93556 35.9232 2.43234C35.4199 1.92911 34.6651 1.59363 33.9103 1.59363H4.72314Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Cordless</span>
+                                                                                            <i class="not-italic" data-txt>Shop Cordless</i>
+                                                                                        </span>
+
+                                                                                        
+                                                                                            <span class="expand">
+                                                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                                                </svg>
+                                                                                            </span>
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+                                                                                        <span class="hidden absolute lg:flex lg:flex-wrap lg:pt-2px" data-sub>
+                                                                                            
+                                                                                                
+                                                                                                    
+                                                                                                
+<span class="flex-1 px-1px">
+                                                                                                    <a class="sub-link" href="/pages/cordless-collection">Learn</a>
+                                                                                                </span>
+                                                                                        </span>
+                                                                                    
+
+                                                                                    
+                                                                                        <div data-nav-dropdown-content="" data-level-03 class="invisible" id="cordless">
+                                                                                            <div class="__box" data-subnav="">
+                                                                                                 <a href="#" class="back" data-back="" data-level-03 aria-controls="cordless">
+                                                                                                    <span class="icon">
+                                                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                                                        </svg>
+                                                                                                    </span>
+                                                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Cordless</span>
+                                                                                                </a>
+
+                                                                                                <div class="__box-wrap">
+                                                                                                    <div class="inner w-1920px">
+                                                                                                        <ul class="ul-sub" xxx>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/collections/cordless">
+                                                                                                                        <span class="icon-svg cordless">
+                                                                                                                            
+		<svg width="44" height="26" viewBox="0 0 44 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M40.2844 19.0387C39.9489 19.0387 39.6135 18.787 39.6135 18.3677C39.6135 17.9483 39.8651 17.6967 40.2844 17.6967C41.4586 17.6967 42.3812 16.7741 42.3812 15.5999V9.89672C42.3812 8.72252 41.4586 7.79994 40.2844 7.79994C39.9489 7.79994 39.6135 7.54833 39.6135 7.12898C39.6135 6.70962 39.8651 6.45801 40.2844 6.45801C42.1296 6.45801 43.6393 7.96769 43.6393 9.81285V15.5161C43.6393 17.529 42.1296 19.0387 40.2844 19.0387Z" fill="#C41230"/>
+<path d="M21.4122 20.3806C21.3284 20.3806 21.1606 20.3806 21.0768 20.2968L9.92192 12.6645C9.67031 12.4968 9.58644 12.1613 9.67031 11.9097C9.75418 11.658 10.0058 11.4903 10.3413 11.4903L16.6316 12.0774V5.87095C16.6316 5.61933 16.7993 5.45159 16.9671 5.28385C17.1348 5.19998 17.3864 5.19998 17.6381 5.28385L28.709 13C28.9606 13.1677 29.0445 13.5032 28.9606 13.7548C28.8768 14.0064 28.6252 14.1742 28.2897 14.1742L21.9993 13.5871V19.8774C21.9993 20.129 21.8316 20.2968 21.6639 20.4645C21.58 20.3806 21.4961 20.3806 21.4122 20.3806ZM12.6897 13L20.8251 18.6193V12.8322C20.8251 12.6645 20.909 12.4968 20.9929 12.329C21.1606 12.2451 21.3284 12.1613 21.4961 12.1613L26.0252 12.5806L17.8897 6.96127V12.7484C17.8897 12.9161 17.8058 13.0838 17.7219 13.2516C17.5542 13.4193 17.3864 13.4193 17.2187 13.4193L12.6897 13Z" fill="#C41230"/>
+<path d="M33.9103 25.2452H4.72314C3.63282 25.2452 2.62637 24.8259 1.78766 24.071C0.948948 23.3162 0.613464 22.2259 0.613464 21.1356V4.44524C0.613464 3.35492 1.03282 2.34847 1.87153 1.59363C2.62637 0.838788 3.71669 0.419434 4.80702 0.419434H33.9941C35.0845 0.419434 36.0909 0.838788 36.9296 1.59363C37.7683 2.34847 38.1038 3.43879 38.1038 4.52911V21.2194C38.1038 22.3098 37.6845 23.3162 36.9296 24.1549C36.1748 24.9936 35.0006 25.2452 33.9103 25.2452ZM4.72314 1.59363C3.96831 1.59363 3.21347 1.92911 2.71024 2.43234C2.20701 3.01943 1.87153 3.6904 1.87153 4.44524V21.1356C1.87153 21.8904 2.20701 22.6452 2.71024 23.1485C3.21347 23.6517 3.96831 23.9872 4.72314 23.9872H33.9103C34.6651 23.9872 35.4199 23.6517 35.9232 23.1485C36.4264 22.6452 36.7619 21.8904 36.7619 21.1356V4.44524C36.7619 3.6904 36.4264 2.93556 35.9232 2.43234C35.4199 1.92911 34.6651 1.59363 33.9103 1.59363H4.72314Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Shop</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+
+                                                                                                                <li>
+                                                                                                                    
+
+                                                                                                                    <a href="/pages/cordless-collection">
+                                                                                                                        <span class="icon-svg learn">
+                                                                                                                            
+		<svg width="48" height="47" viewBox="0 0 48 47" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M23.9 10.8C16.7 10.8 10.8 16.7 10.8 23.9C10.8 28.7 13.4001 33.1 17.6 35.4V36.7C17.6 37.5 18.1 38.2 18.8 38.5V40.7999C18.8 41.5999 19.3 42.2999 20 42.5999V43C20 45.1 21.7 46.7999 23.8 46.7999C25.9 46.7999 27.6 45.1 27.6 43V42.5999C28.3 42.2999 28.8 41.5999 28.8 40.7999V38.5C29.5 38.2 30 37.5 30 36.7V35.4C34.2 33.1 36.8 28.7 36.8 23.9C37.1 16.6 31.2 10.8 23.9 10.8ZM23.9 38.5999H27.6V40.7999C27.6 41.0999 27.3 41.4 27 41.4H20.8C20.5 41.4 20.2001 41.0999 20.2001 40.7999V38.5999H23.9ZM26.4 43C26.4 44.4 25.3 45.5 23.9 45.5C22.5 45.5 21.4 44.4 21.4 43V42.7H26.3V43H26.4ZM29.2001 34.4C29.0001 34.5 28.8 34.7 28.8 35V36.7C28.8 37 28.5001 37.2999 28.2001 37.2999H24.5V28.9H26.8C27.2 28.9 27.5 28.6 27.5 28.2C27.5 27.9 27.2 27.5 26.8 27.5H20.9C20.5 27.5 20.2001 27.8 20.2001 28.2C20.2001 28.6 20.5 28.9 20.9 28.9H23.1V37.2999H19.4C19.1 37.2999 18.8 37 18.8 36.7V35C18.8 34.7 18.7 34.5 18.4 34.4C14.4 32.4 11.9 28.3 11.9 23.9C11.9 17.4 17.2001 12.1 23.7001 12.1C30.2001 12.1 35.5 17.4 35.5 23.9C35.7 28.3 33.2001 32.4 29.2001 34.4ZM41.8 23.6H41.5V24.2H47.2001H47.5V23.6H41.8ZM6.30005 24.1V23.5H0.600049H0.300049V24.1H6.10005H6.30005ZM41.2001 6.99995L41.4001 6.79995L41 6.39995L36.2001 11.2L36.6 11.6L41.2001 6.99995ZM6.50005 40.9L6.90005 41.2999L11.5 36.7L11.7 36.5L11.3 36.0999L6.50005 40.9ZM24.2001 0.499951V0.199951H23.6V6.19995H24.2001V0.499951ZM11.3 11.6L11.7 11.2L7.10005 6.59995L6.90005 6.39995L6.50005 6.79995L11.1 11.4L11.3 11.6ZM36.6 36.2L36.2001 36.5999L40.8 41.2L41 41.4L41.4001 41L36.8 36.4L36.6 36.2ZM40.3 17.4L42.2001 16.6L42.5 16.5L42.3 16L40.1 16.9L40.3 17.4ZM7.80005 30.9L7.50005 30.2999L5.30005 31.2L5.60005 31.7999L7.50005 31L7.80005 30.9ZM31.8 5.79995L31.9001 5.49995L31.4001 5.19995L30.5 7.39995L31.1 7.59995L31.8 5.79995ZM17 7.69995L17.5 7.49995L16.7001 5.59995L16.5 5.29995L16 5.49995L16.8 7.39995L17 7.69995ZM7.50005 17.4L7.70005 16.9L5.80005 16H5.60005L5.30005 16.5L7.30005 17.2999L7.50005 17.4ZM40.3 30.4L40.1 30.9L42 31.7L42.3 31.7999L42.5 31.2999L40.6 30.5L40.3 30.4Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                                                        </span>
+                                                                                                                        <span class="txt">Learn</span>
+                                                                                                                    </a>
+                                                                                                                </li>
+                                                                                                            
+                                                                                                        </ul>
+
+                                                                                                        <!-- mobile_banner -->
+                                                                                                        
+                                                                                                        
+
+                                                                                                        
+                                                                                                        <!-- end mobile_banner -->
+
+                                                                                                        <!-- mobile_sale_banner -->
+                                                                                                        
+                                                                                                            
+
+                                                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                                                            
+                                                                                                                            
+                                                                                                                            
+                                                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                        <div class="img pb-89.250814332">
+                                                                                                                            
+                                                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                                                            
+                                                                                                                        </div>
+                                                                                                                    </a>
+                                                                                                                </div>
+                                                                                                            
+                                                                                                        
+                                                                                                        <!-- end mobile_sale_banner -->
+                                                                                                    </div>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                     
+                                                                                </li>
+                                                                            
+                                                                                
+                                                                                    
+                                                                                    
+
+                                                                            
+                                                                        </ul>
+
+                                                                        
+                                                                            <div class="shop-by-colour">
+                                                                                <span class="block text-14px leading-19px font-light mb-24px max-w-224px mx-auto lg:max-w-none lg:text-center">Shop By Colour</span>
+                                                                                <ul class="ul-colour">
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-black+colour-cast-iron-black+colour-matte-black+colour-onyx-black+colour-black-shell+colour-radiant-black">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Black_80x_crop_center.png?v=17779125815039517021712290170"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Black">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Black</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-contour-silver+colour-matte-grey+colour-medallion-silver+colour-stainless-steel">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Silver_Grey_80x_crop_center.png?v=148523081079502679671712290191"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Silver & Grey">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Silver & Grey</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-almond-cream+colour-fresh-linen+colour-frosted-pearl+colour-light&shadow+colour-milkshake+colour-white+colour-classic-columms+colour-grey-speckle+colour-white-shell+colour-bread-bowl+colour-speckled-stone+colour-white-chocolate">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_White_Cream_80x_crop_center.png?v=158046024231842864691712290193"
+                                                                                                                class="lazy w-full h-full object-cover" alt="White & Cream">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">White & Cream</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-candy-apple-red+colour-empire-red+colour-passion-red">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Red_80x_crop_center.png?v=138189077129343621011712290189"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Red">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Red</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-honey+colour-majestic-yellow+colour-scorched-orange+colour-radiant-copper+colour-fired-clay+colour-poppy+colour-radiant-gold">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Yellows_Orange_80x_crop_center.png?v=36565329337539341881712290194"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Yellows & Orange">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Yellows & Orange</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-agave+colour-blossom+colour-pebbled-palm+colour-pistachio+colour-shaded-palm+colour-sage-leaf+colour-dew-drop">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Green_80x_crop_center.png?v=89325764147066379891712290175"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Green">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Green</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-blue-velvet+colour-ink-blue+colour-mineral-water+colour-blue-salt">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Blues_80x_crop_center.png?v=178668111473528231751712290170"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Blues">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Blues</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/small-appliances/colour-birds-of-paradise+colour-dried-rose+colour-feathered-pink+colour-pink+colour-hibiscus">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Pink_80x_crop_center.png?v=71142539006687793671712290187"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Pink">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Pink</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                </ul>
+                                                                            </div> 
+                                                                        
+
+                                                                        <!-- desktop_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end desktop_banner -->
+
+                                                                        <!-- desktop_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="hidden lg:block max-w-1048px mx-auto mt-64px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="box-promotion block relative ">
+                                                                                        <div class="absolute z-20 md:top-1/2 md:-translate-y-50 top-0 left-0 w-full pt-20px md:pt-0 px-64px" >
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px lg:text-32px lg:leading-44px">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img h-274px md:h-180px loaded">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end desktop_sale_banner -->
+
+                                                                        <!-- mobile_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end mobile_banner -->
+
+                                                                        <!-- mobile_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                            
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img pb-89.250814332">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end mobile_sale_banner -->
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                     
+                                                </li>
+                                            
+                                                
+                                                <li class="nav-item is-dropdown">
+                                                    <a href="#" class="no-link" data-expand="" data-sub-name="kitchenware" aria-expanded="false" aria-haspopup="true" role="button">
+                                                        
+                                                        <span class="icon-svg">
+                                                            
+		<svg width="44" height="48" viewBox="0 0 44 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M42.6952 8.62858C41.4837 6.36507 39.4116 6.14191 38.2958 6.20565C37.8814 5.15366 36.7656 3.40027 34.2153 3.24088C32.5575 3.14523 31.091 4.38857 29.9752 6.81141C29.0826 8.78791 28.5725 11.1789 28.3813 12.741C28.19 14.335 28.2218 15.2595 28.2538 15.8971C28.2856 16.471 28.2856 16.726 28.1263 17.0448C27.8074 17.6505 27.3611 18.2243 27.1379 18.4793L22.7386 15.9608V15.8971C22.7386 15.8971 22.5792 15.3232 23.2805 14.2713C23.5993 13.7931 24.0456 13.2511 24.4919 12.6772C25.2889 11.689 26.2134 10.5414 26.7872 9.42552C27.0423 8.91549 27.2655 8.37349 27.4886 7.89536C27.9987 6.71574 28.445 5.63182 29.3057 4.77107L30.7404 3.33651V3.11335C30.7404 3.01772 30.7085 1.10493 29.2101 0.116664C29.0826 0.0529053 28.8913 -0.0427366 28.6044 0.0210307C26.7872 0.467339 21.1126 10.4138 19.1362 13.9206L17.4464 12.9323L2.39931 38.1492C2.27178 38.3723 0.582165 40.9864 1.02848 43.6963C1.50668 46.5016 3.86579 48 5.42787 48H25.9265V32.3789L32.653 21.6673L31.9199 21.2529C32.0792 20.9022 32.3661 20.3922 32.685 19.9777C32.9081 19.6908 33.1313 19.5952 33.6733 19.372C34.2471 19.117 35.1078 18.7662 36.4787 17.9374C37.8177 17.1085 39.7942 15.6421 41.1968 13.9844C42.9821 11.944 43.4604 10.095 42.6952 8.62858ZM28.7957 0.977419C29.5608 1.55125 29.7521 2.53952 29.7839 2.95396L28.6362 4.10163C27.648 5.0899 27.1379 6.26941 26.596 7.51274C26.3728 7.99089 26.1816 8.501 25.9265 9.01111C25.4164 10.0631 24.5238 11.147 23.7586 12.1034C23.4717 12.486 23.1848 12.8366 22.9298 13.1554L21.304 12.1671C25.0977 5.53624 27.9987 1.39185 28.7957 0.977419ZM21.1126 12.4541L22.7067 13.4105L22.4517 13.7612C22.0691 14.367 21.8778 14.8451 21.7822 15.2595L20.0606 14.2713C20.4432 13.6337 20.7939 13.0279 21.1126 12.4541ZM32.5575 18.8938C32.3343 19.0213 32.1749 19.1807 31.9837 19.4039C31.633 19.8502 31.3461 20.3922 31.1548 20.7747L30.6766 20.456C30.8679 20.169 30.8998 19.8502 30.836 19.4995C30.8026 19.3375 30.7375 19.1838 30.6445 19.047C30.5515 18.9102 30.4324 18.7932 30.294 18.7025C30.0071 18.5112 29.6883 18.4793 29.3377 18.5431C29.1756 18.5765 29.0219 18.6416 28.885 18.7346C28.7483 18.8276 28.6313 18.9467 28.5407 19.0851L28.6362 19.1488L28.0624 18.7982C28.3175 18.4793 28.6682 17.9692 28.9231 17.4592C29.0508 17.2042 29.1145 16.981 29.1463 16.7579C29.5608 16.8535 29.9752 16.6941 30.2302 16.3434L30.5172 15.8652C30.7085 15.5783 31.091 15.4827 31.4099 15.6739L32.6212 16.471C32.7807 16.5666 32.8762 16.6941 32.9081 16.8854C32.94 17.0448 32.9081 17.2361 32.8125 17.3636L32.5256 17.8418C32.3343 18.1606 32.3661 18.575 32.5575 18.8938ZM30.4216 20.2646L29.6564 19.7227L28.8594 19.2445C28.987 19.0532 29.2101 18.8938 29.4332 18.83C29.6883 18.7662 29.9115 18.83 30.1346 18.9576C30.3578 19.0851 30.4853 19.3082 30.5491 19.5314C30.581 19.8184 30.5491 20.0414 30.4216 20.2646ZM15.6613 47.0755H5.4598C4.2802 47.0755 2.39931 45.8321 2.01675 43.5687C1.63419 41.1777 3.22821 38.723 3.26003 38.691L17.829 14.2393L31.0273 21.8267L31.3461 22.0499L15.6613 47.0755ZM25.002 47.0755H16.7771L25.002 33.941V47.0755ZM36.0323 17.1085C34.7254 17.9055 33.9284 18.2562 33.3545 18.4793C33.1632 18.575 33.0038 18.6387 32.8444 18.7025C32.685 18.4793 32.685 18.1924 32.8125 17.9692L33.0994 17.4911C33.2269 17.2679 33.2907 17.013 33.2269 16.7579C33.1705 16.5107 33.0224 16.2943 32.8125 16.1521L31.6011 15.3552C31.3779 15.2277 31.123 15.1638 30.8679 15.2277C30.6208 15.2841 30.4043 15.4322 30.2621 15.6421L29.9752 16.1203C29.8158 16.3753 29.497 16.471 29.2101 16.3753V15.7696C29.1782 15.132 29.1463 14.3031 29.3377 12.7729C29.6883 9.87184 31.2824 3.94223 34.1515 4.10163C36.3512 4.22916 37.212 5.82316 37.4989 6.77949L37.5626 6.97083L33.8327 12.8366L34.0877 12.9961L37.8177 7.13016L38.0089 7.09833C38.8059 7.00266 40.7506 7.00266 41.8344 9.01111C43.2053 11.6253 38.519 15.5783 36.0323 17.1085Z" fill="#C41230"/>
+<path d="M35.5831 8.18207C35.8701 7.89516 36.0295 7.51254 35.9657 7.12996C35.9338 6.71554 35.7107 6.36488 35.36 6.17363C34.7543 5.79104 33.9892 5.88671 33.4472 6.33296C31.9488 7.64007 31.2156 8.8834 30.7693 10.8599C30.6418 11.4337 30.8969 12.0395 31.4069 12.3582C31.63 12.4858 31.8851 12.5495 32.1401 12.5495C32.3145 12.5488 32.4874 12.5163 32.6502 12.4539C33.0646 12.2944 33.3515 11.9757 33.4791 11.5294C33.9253 10.1586 34.5311 9.17031 35.5831 8.18207ZM33.1922 11.4337C33.1465 11.5916 33.0654 11.7369 32.9549 11.8586C32.8444 11.9801 32.7074 12.0747 32.5546 12.135C32.2358 12.2626 31.8851 12.2307 31.5982 12.0395C31.1838 11.7844 30.9924 11.3382 31.0881 10.8918C31.5025 8.97894 32.2039 7.79947 33.6704 6.52429C34.0848 6.1417 34.7224 6.10978 35.2006 6.3967C35.4557 6.55612 35.6469 6.81121 35.6788 7.12996C35.6949 7.27593 35.6774 7.4236 35.6277 7.56169C35.5779 7.69985 35.4973 7.82487 35.3919 7.92698C34.2442 8.97894 33.6384 9.99915 33.1922 11.4337ZM39.6319 8.85143C39.2812 8.62831 38.8668 8.56452 38.4842 8.69202C38.1016 8.81961 37.8147 9.10652 37.6872 9.48904C37.2409 10.8918 36.6033 11.8481 35.5194 12.8045C35.2006 13.0915 35.0093 13.5059 35.0412 13.9522C35.0731 14.3986 35.2962 14.7811 35.6469 15.0361C35.902 15.1955 36.157 15.2911 36.4439 15.2911C36.7308 15.2911 37.0496 15.1955 37.2728 15.0042C38.8987 13.761 39.6956 12.5814 40.2375 10.6687C40.4926 9.96733 40.2057 9.26585 39.6319 8.85143ZM39.9825 10.573C39.4407 12.4219 38.6755 13.5378 37.1134 14.7492C36.7627 15.0361 36.2526 15.0361 35.8701 14.7811C35.5831 14.5898 35.4238 14.3029 35.3919 13.9522C35.36 13.6016 35.5194 13.2827 35.7745 13.0596C36.8902 12.0713 37.5597 11.0831 38.0379 9.61663C38.1335 9.32972 38.3567 9.10652 38.6436 9.01091C38.7392 8.97894 38.8668 8.94712 38.9624 8.94712C39.1537 8.94712 39.345 9.01091 39.5044 9.10652C39.9188 9.45722 40.142 10.031 39.9825 10.573Z" fill="#C41230"/>
+</svg>
+
+	
+                                                        </span>
+                                                        <span class="txt">Kitchenware</span>
+
+                                                        
+                                                            <span class="expand">
+                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                </svg>
+                                                            </span>
+                                                        
+                                                    </a>
+
+                                                     
+                                                        <div data-nav-dropdown-content="" class="sub-nav invisible" id="kitchenware">
+                                                            <div class="__box" data-subnav="">
+                                                                 <a href="#" class="back" data-back="" data-level-02 aria-controls="kitchenware">
+                                                                    <span class="icon">
+                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                        </svg>
+                                                                    </span>
+                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Kitchenware</span>
+                                                                </a>
+
+                                                                
+                                                                
+
+                                                                <div class="__box-wrap">
+                                                                    <div class="inner w-1920px">
+                                                                        <ul class="sub-nav-group ul-sub">
+                                                                            
+
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/utensils" >
+                                                                                        <span class="icon-svg kitchenware">
+                                                                                            
+		<svg width="44" height="48" viewBox="0 0 44 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M42.6952 8.62858C41.4837 6.36507 39.4116 6.14191 38.2958 6.20565C37.8814 5.15366 36.7656 3.40027 34.2153 3.24088C32.5575 3.14523 31.091 4.38857 29.9752 6.81141C29.0826 8.78791 28.5725 11.1789 28.3813 12.741C28.19 14.335 28.2218 15.2595 28.2538 15.8971C28.2856 16.471 28.2856 16.726 28.1263 17.0448C27.8074 17.6505 27.3611 18.2243 27.1379 18.4793L22.7386 15.9608V15.8971C22.7386 15.8971 22.5792 15.3232 23.2805 14.2713C23.5993 13.7931 24.0456 13.2511 24.4919 12.6772C25.2889 11.689 26.2134 10.5414 26.7872 9.42552C27.0423 8.91549 27.2655 8.37349 27.4886 7.89536C27.9987 6.71574 28.445 5.63182 29.3057 4.77107L30.7404 3.33651V3.11335C30.7404 3.01772 30.7085 1.10493 29.2101 0.116664C29.0826 0.0529053 28.8913 -0.0427366 28.6044 0.0210307C26.7872 0.467339 21.1126 10.4138 19.1362 13.9206L17.4464 12.9323L2.39931 38.1492C2.27178 38.3723 0.582165 40.9864 1.02848 43.6963C1.50668 46.5016 3.86579 48 5.42787 48H25.9265V32.3789L32.653 21.6673L31.9199 21.2529C32.0792 20.9022 32.3661 20.3922 32.685 19.9777C32.9081 19.6908 33.1313 19.5952 33.6733 19.372C34.2471 19.117 35.1078 18.7662 36.4787 17.9374C37.8177 17.1085 39.7942 15.6421 41.1968 13.9844C42.9821 11.944 43.4604 10.095 42.6952 8.62858ZM28.7957 0.977419C29.5608 1.55125 29.7521 2.53952 29.7839 2.95396L28.6362 4.10163C27.648 5.0899 27.1379 6.26941 26.596 7.51274C26.3728 7.99089 26.1816 8.501 25.9265 9.01111C25.4164 10.0631 24.5238 11.147 23.7586 12.1034C23.4717 12.486 23.1848 12.8366 22.9298 13.1554L21.304 12.1671C25.0977 5.53624 27.9987 1.39185 28.7957 0.977419ZM21.1126 12.4541L22.7067 13.4105L22.4517 13.7612C22.0691 14.367 21.8778 14.8451 21.7822 15.2595L20.0606 14.2713C20.4432 13.6337 20.7939 13.0279 21.1126 12.4541ZM32.5575 18.8938C32.3343 19.0213 32.1749 19.1807 31.9837 19.4039C31.633 19.8502 31.3461 20.3922 31.1548 20.7747L30.6766 20.456C30.8679 20.169 30.8998 19.8502 30.836 19.4995C30.8026 19.3375 30.7375 19.1838 30.6445 19.047C30.5515 18.9102 30.4324 18.7932 30.294 18.7025C30.0071 18.5112 29.6883 18.4793 29.3377 18.5431C29.1756 18.5765 29.0219 18.6416 28.885 18.7346C28.7483 18.8276 28.6313 18.9467 28.5407 19.0851L28.6362 19.1488L28.0624 18.7982C28.3175 18.4793 28.6682 17.9692 28.9231 17.4592C29.0508 17.2042 29.1145 16.981 29.1463 16.7579C29.5608 16.8535 29.9752 16.6941 30.2302 16.3434L30.5172 15.8652C30.7085 15.5783 31.091 15.4827 31.4099 15.6739L32.6212 16.471C32.7807 16.5666 32.8762 16.6941 32.9081 16.8854C32.94 17.0448 32.9081 17.2361 32.8125 17.3636L32.5256 17.8418C32.3343 18.1606 32.3661 18.575 32.5575 18.8938ZM30.4216 20.2646L29.6564 19.7227L28.8594 19.2445C28.987 19.0532 29.2101 18.8938 29.4332 18.83C29.6883 18.7662 29.9115 18.83 30.1346 18.9576C30.3578 19.0851 30.4853 19.3082 30.5491 19.5314C30.581 19.8184 30.5491 20.0414 30.4216 20.2646ZM15.6613 47.0755H5.4598C4.2802 47.0755 2.39931 45.8321 2.01675 43.5687C1.63419 41.1777 3.22821 38.723 3.26003 38.691L17.829 14.2393L31.0273 21.8267L31.3461 22.0499L15.6613 47.0755ZM25.002 47.0755H16.7771L25.002 33.941V47.0755ZM36.0323 17.1085C34.7254 17.9055 33.9284 18.2562 33.3545 18.4793C33.1632 18.575 33.0038 18.6387 32.8444 18.7025C32.685 18.4793 32.685 18.1924 32.8125 17.9692L33.0994 17.4911C33.2269 17.2679 33.2907 17.013 33.2269 16.7579C33.1705 16.5107 33.0224 16.2943 32.8125 16.1521L31.6011 15.3552C31.3779 15.2277 31.123 15.1638 30.8679 15.2277C30.6208 15.2841 30.4043 15.4322 30.2621 15.6421L29.9752 16.1203C29.8158 16.3753 29.497 16.471 29.2101 16.3753V15.7696C29.1782 15.132 29.1463 14.3031 29.3377 12.7729C29.6883 9.87184 31.2824 3.94223 34.1515 4.10163C36.3512 4.22916 37.212 5.82316 37.4989 6.77949L37.5626 6.97083L33.8327 12.8366L34.0877 12.9961L37.8177 7.13016L38.0089 7.09833C38.8059 7.00266 40.7506 7.00266 41.8344 9.01111C43.2053 11.6253 38.519 15.5783 36.0323 17.1085Z" fill="#C41230"/>
+<path d="M35.5831 8.18207C35.8701 7.89516 36.0295 7.51254 35.9657 7.12996C35.9338 6.71554 35.7107 6.36488 35.36 6.17363C34.7543 5.79104 33.9892 5.88671 33.4472 6.33296C31.9488 7.64007 31.2156 8.8834 30.7693 10.8599C30.6418 11.4337 30.8969 12.0395 31.4069 12.3582C31.63 12.4858 31.8851 12.5495 32.1401 12.5495C32.3145 12.5488 32.4874 12.5163 32.6502 12.4539C33.0646 12.2944 33.3515 11.9757 33.4791 11.5294C33.9253 10.1586 34.5311 9.17031 35.5831 8.18207ZM33.1922 11.4337C33.1465 11.5916 33.0654 11.7369 32.9549 11.8586C32.8444 11.9801 32.7074 12.0747 32.5546 12.135C32.2358 12.2626 31.8851 12.2307 31.5982 12.0395C31.1838 11.7844 30.9924 11.3382 31.0881 10.8918C31.5025 8.97894 32.2039 7.79947 33.6704 6.52429C34.0848 6.1417 34.7224 6.10978 35.2006 6.3967C35.4557 6.55612 35.6469 6.81121 35.6788 7.12996C35.6949 7.27593 35.6774 7.4236 35.6277 7.56169C35.5779 7.69985 35.4973 7.82487 35.3919 7.92698C34.2442 8.97894 33.6384 9.99915 33.1922 11.4337ZM39.6319 8.85143C39.2812 8.62831 38.8668 8.56452 38.4842 8.69202C38.1016 8.81961 37.8147 9.10652 37.6872 9.48904C37.2409 10.8918 36.6033 11.8481 35.5194 12.8045C35.2006 13.0915 35.0093 13.5059 35.0412 13.9522C35.0731 14.3986 35.2962 14.7811 35.6469 15.0361C35.902 15.1955 36.157 15.2911 36.4439 15.2911C36.7308 15.2911 37.0496 15.1955 37.2728 15.0042C38.8987 13.761 39.6956 12.5814 40.2375 10.6687C40.4926 9.96733 40.2057 9.26585 39.6319 8.85143ZM39.9825 10.573C39.4407 12.4219 38.6755 13.5378 37.1134 14.7492C36.7627 15.0361 36.2526 15.0361 35.8701 14.7811C35.5831 14.5898 35.4238 14.3029 35.3919 13.9522C35.36 13.6016 35.5194 13.2827 35.7745 13.0596C36.8902 12.0713 37.5597 11.0831 38.0379 9.61663C38.1335 9.32972 38.3567 9.10652 38.6436 9.01091C38.7392 8.97894 38.8668 8.94712 38.9624 8.94712C39.1537 8.94712 39.345 9.01091 39.5044 9.10652C39.9188 9.45722 40.142 10.031 39.9825 10.573Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Shop All Kitchenware</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+                                                                                    
+                                                                                    
+
+                                                                            
+                                                                        </ul>
+
+                                                                        
+                                                                            <div class="shop-by-colour">
+                                                                                <span class="block text-14px leading-19px font-light mb-24px max-w-224px mx-auto lg:max-w-none lg:text-center">Shop By Colour</span>
+                                                                                <ul class="ul-colour">
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenware/colour-black+colour-cast-iron-black+colour-matte-black+colour-onyx-black+colour-black-shell+colour-radiant-black">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Black_80x_crop_center.png?v=17779125815039517021712290170"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Black">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Black</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenware/colour-almond-cream+colour-fresh-linen+colour-frosted-pearl+colour-light&shadow+colour-milkshake+colour-white+colour-classic-columms+colour-grey-speckle+colour-white-shell+colour-bread-bowl+colour-speckled-stone+colour-white-chocolate">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_White_Cream_80x_crop_center.png?v=158046024231842864691712290193"
+                                                                                                                class="lazy w-full h-full object-cover" alt="White">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">White</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenware/colour-contour-silver+colour-matte-grey+colour-medallion-silver+colour-stainless-steel">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Silver_Grey_80x_crop_center.png?v=148523081079502679671712290191"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Silver & Grey">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Silver & Grey</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                        
+                                                                                            <li>
+                                                                                                <a href="/collections/kitchenware/colour-candy-apple-red+colour-empire-red+colour-passion-red">
+                                                                                                    
+                                                                                                    
+                                                                                                    <span class="block w-48px h-48px lg:w-60px lg:h-60px lg:mb-28px mx-auto">
+                                                                                                        <div class="img pb-100">
+                                                                                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/t/235/assets/__or_Red_80x_crop_center.png?v=138189077129343621011712290189"
+                                                                                                                class="lazy w-full h-full object-cover" alt="Red">
+                                                                                                        </div>
+                                                                                                    </span>
+                                                                                                    <span class="hidden lg:block text-center text-14px leading-19px font-light tracking-0_01em">Red</span>
+                                                                                                </a>
+                                                                                            </li>
+                                                                                            
+                                                                                        
+                                                                                    
+                                                                                </ul>
+                                                                            </div> 
+                                                                        
+
+                                                                        <!-- desktop_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end desktop_banner -->
+
+                                                                        <!-- desktop_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="hidden lg:block max-w-1048px mx-auto mt-64px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="box-promotion block relative ">
+                                                                                        <div class="absolute z-20 md:top-1/2 md:-translate-y-50 top-0 left-0 w-full pt-20px md:pt-0 px-64px" >
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px lg:text-32px lg:leading-44px">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img h-274px md:h-180px loaded">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end desktop_sale_banner -->
+
+                                                                        <!-- mobile_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end mobile_banner -->
+
+                                                                        <!-- mobile_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                            
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img pb-89.250814332">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end mobile_sale_banner -->
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                     
+                                                </li>
+                                            
+                                                
+                                                <li class="nav-item is-dropdown">
+                                                    <a href="#" class="no-link" data-expand="" data-sub-name="sale" aria-expanded="false" aria-haspopup="true" role="button">
+                                                        
+                                                        <span class="icon-svg">
+                                                            
+		<svg width="33" height="32" viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M25.4829 22.6909C25.4829 19.3745 25.4829 15.4182 25.4829 14.2545C25.4829 12.7418 25.5411 12.3927 24.7266 11.4036C23.912 10.4145 22.3993 8.49452 21.9338 7.9127C21.4684 7.38907 20.9447 7.38907 20.9447 7.38907C20.3629 7.38907 18.5593 7.38907 18.5593 7.38907H17.512C17.512 7.38907 15.7084 7.38907 15.1266 7.38907C15.1266 7.38907 14.6029 7.33089 14.1375 7.9127C13.672 8.43634 12.1011 10.4145 11.3447 11.4036C10.5884 12.3927 10.5884 12.7418 10.5884 14.2545C10.5884 16.2327 10.5884 26.0654 10.5884 27.4618C10.5884 28.8582 11.5193 29.5563 13.2647 29.5563H22.8066C24.552 29.5563 25.4829 28.8582 25.4829 27.4618C25.4829 27.0545 25.4829 26.0654 25.4829 24.7854" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.7197 7.44733C14.7197 7.44733 14.2543 7.2146 13.6725 7.56369C13.0325 7.8546 11.0543 9.01824 10.007 9.65824C8.95973 10.2401 8.90155 10.5891 8.37792 11.9273C8.20337 12.3928 7.73792 13.4401 7.27246 14.7782" stroke="#C41230" stroke-width="0.775855" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.63154 16.2327C6.22426 17.2218 5.81699 18.269 5.40972 19.1999L4.65336 21.0618C4.1879 22.2254 3.83881 23.0981 3.72245 23.389C3.25699 24.669 3.83881 25.5999 5.40972 26.1818L10.5879 28.1599" stroke="#C41230" stroke-width="0.775855" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21.4105 2.26904C21.4105 2.26904 21.4105 6.39995 21.4105 7.50541C21.4105 8.61086 20.3051 9.89086 18.9087 10.1818" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21.4098 16.3491L14.428 23.3891" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.9774 11.4037C18.5236 11.4037 18.9665 10.9609 18.9665 10.4146C18.9665 9.86837 18.5236 9.42554 17.9774 9.42554C17.4311 9.42554 16.9883 9.86837 16.9883 10.4146C16.9883 10.9609 17.4311 11.4037 17.9774 11.4037Z" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15.4173 19.0255C16.1563 19.0255 16.7555 18.4264 16.7555 17.6873C16.7555 16.9482 16.1563 16.3491 15.4173 16.3491C14.6782 16.3491 14.0791 16.9482 14.0791 17.6873C14.0791 18.4264 14.6782 19.0255 15.4173 19.0255Z" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20.7117 23.2145C21.4508 23.2145 22.0499 22.6153 22.0499 21.8763C22.0499 21.1372 21.4508 20.5381 20.7117 20.5381C19.9727 20.5381 19.3735 21.1372 19.3735 21.8763C19.3735 22.6153 19.9727 23.2145 20.7117 23.2145Z" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+
+
+
+	
+                                                        </span>
+                                                        <span class="txt">Sale</span>
+
+                                                        
+                                                            <span class="expand">
+                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                </svg>
+                                                            </span>
+                                                        
+                                                    </a>
+
+                                                     
+                                                        <div data-nav-dropdown-content="" class="sub-nav invisible" id="sale">
+                                                            <div class="__box" data-subnav="">
+                                                                 <a href="#" class="back" data-back="" data-level-02 aria-controls="sale">
+                                                                    <span class="icon">
+                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                        </svg>
+                                                                    </span>
+                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Sale</span>
+                                                                </a>
+
+                                                                
+                                                                
+
+                                                                <div class="__box-wrap">
+                                                                    <div class="inner w-1920px">
+                                                                        <ul class="sub-nav-group ul-sub">
+                                                                            
+
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" >
+                                                                                        <span class="icon-svg all-sale">
+                                                                                            
+	<svg width="37" height="46" viewBox="0 0 37 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M36.3036 33.8727C36.3036 28.4836 36.3036 22.0545 36.3036 20.1636C36.3036 17.7054 36.3982 17.1382 35.0745 15.5309C33.7509 13.9236 31.2927 10.8036 30.5363 9.85817C29.78 9.00727 28.9291 9.00726 28.9291 9.00726C27.9836 9.00726 25.0527 9.00726 25.0527 9.00726H23.3509C23.3509 9.00726 20.42 9.00726 19.4745 9.00726C19.4745 9.00726 18.6236 8.91272 17.8672 9.85817C17.1109 10.7091 14.5582 13.9236 13.3291 15.5309C12.1 17.1382 12.1 17.7054 12.1 20.1636C12.1 23.3782 12.1 39.3564 12.1 41.6255C12.1 43.8945 13.6127 45.0291 16.4491 45.0291H31.9545C34.7909 45.0291 36.3036 43.8945 36.3036 41.6255C36.3036 40.9636 36.3036 39.3564 36.3036 37.2764" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.8135 9.10176C18.8135 9.10176 18.0571 8.72358 17.1117 9.29085C16.0717 9.76358 12.8571 11.6545 11.1553 12.6945C9.45349 13.6399 9.35894 14.2072 8.50803 16.3818C8.2244 17.1381 7.46803 18.8399 6.71167 21.0145" stroke="#C41230" stroke-width="0.775855" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.67038 23.3782C5.00856 24.9854 4.34674 26.6873 3.68493 28.2L2.45584 31.2254C1.69947 33.1164 1.1322 34.5345 0.94311 35.0073C0.186746 37.0873 1.1322 38.6 3.68493 39.5454L12.0995 42.76" stroke="#C41230" stroke-width="0.775855" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M29.6862 0.687256C29.6862 0.687256 29.6862 7.39998 29.6862 9.19634C29.6862 10.9927 27.8898 13.0727 25.6207 13.5454" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M29.685 23.5673L18.3396 35.0073" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M24.1073 15.531C24.9949 15.531 25.7145 14.8113 25.7145 13.9237C25.7145 13.036 24.9949 12.3164 24.1073 12.3164C23.2196 12.3164 22.5 13.036 22.5 13.9237C22.5 14.8113 23.2196 15.531 24.1073 15.531Z" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.9472 27.9164C21.1482 27.9164 22.1218 26.9428 22.1218 25.7418C22.1218 24.5408 21.1482 23.5673 19.9472 23.5673C18.7463 23.5673 17.7727 24.5408 17.7727 25.7418C17.7727 26.9428 18.7463 27.9164 19.9472 27.9164Z" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M28.5505 34.7236C29.7515 34.7236 30.7251 33.75 30.7251 32.5491C30.7251 31.3481 29.7515 30.3745 28.5505 30.3745C27.3496 30.3745 26.376 31.3481 26.376 32.5491C26.376 33.75 27.3496 34.7236 28.5505 34.7236Z" stroke="#C41230" stroke-width="0.824611" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">All Sale</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/collections/bundles" >
+                                                                                        <span class="icon-svg bundle-save">
+                                                                                            
+		<svg width="49" height="44" viewBox="0 0 49 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M27.9765 30.6331V13.5964L27.9482 12.746C27.608 7.58681 24.2914 3.27803 19.7558 1.40711L19.4724 1.29372C19.3589 1.26538 19.2739 1.20868 19.1605 1.18033C19.1322 1.18033 19.1038 1.15198 19.0755 1.15198C18.9054 1.09529 18.7637 1.0386 18.5936 1.01025C18.5369 1.01025 18.5086 0.981903 18.4519 0.981903C18.3101 0.925209 18.14 0.896858 17.9983 0.868516C17.9416 0.868516 17.8849 0.840165 17.8566 0.840165L17.4314 0.755128C17.3746 0.755128 17.3179 0.726778 17.2612 0.726778L16.8361 0.641733C16.7794 0.641733 16.7227 0.613389 16.6376 0.613389C16.4959 0.585041 16.3541 0.585042 16.2124 0.556694C16.1558 0.556694 16.0707 0.528347 16.014 0.528347C15.8722 0.528347 15.7305 0.5 15.5604 0.5H14.0013C13.8595 0.5 13.6895 0.528347 13.5477 0.528347C13.491 0.528347 13.4344 0.556694 13.3494 0.556694C13.2076 0.585042 13.0659 0.585041 12.9241 0.613389C12.8674 0.613389 12.8107 0.641733 12.7541 0.641733L12.3289 0.726778C12.2721 0.726778 12.2154 0.755128 12.1587 0.755128L11.7052 0.840165C11.6485 0.840165 11.6202 0.868516 11.5634 0.868516C11.4217 0.896858 11.2516 0.953552 11.1099 0.981903C11.0816 0.981903 11.0249 1.01025 10.9965 1.01025C10.8264 1.06695 10.6847 1.12364 10.5146 1.18033C10.4862 1.18033 10.4579 1.20868 10.4579 1.20868C10.3446 1.23703 10.2595 1.29372 10.1461 1.32207L9.86261 1.43546C5.32706 3.27803 2.01043 7.61516 1.67027 12.7744L1.64192 13.6531V30.6898C1.10332 31.2851 0.791504 32.0504 0.791504 32.8442V34.9986C0.791504 36.7561 2.20886 38.1735 3.9664 38.1735H25.6804C27.4379 38.1735 28.8552 36.7561 28.8552 34.9986V32.8442C28.8269 31.9938 28.5151 31.2284 27.9765 30.6331ZM15.2202 1.29372H15.5037C15.6455 1.29372 15.7589 1.32207 15.9006 1.32207H16.0423C16.2124 1.35042 16.3825 1.35042 16.5526 1.37877H16.5809L17.1479 1.4638H17.2046C17.3746 1.49215 17.5447 1.5205 17.7148 1.5772C17.7432 1.5772 17.7715 1.60554 17.7999 1.60554C17.9699 1.63389 18.1117 1.69058 18.2817 1.74728C18.3101 1.74728 18.3101 1.74728 18.3384 1.77563C18.5369 1.83232 18.7353 1.88902 18.9337 1.97405V5.09226C18.9337 5.71589 18.4235 6.22614 17.7999 6.22614H16.3825C15.7589 6.22614 15.2486 5.71589 15.2486 5.09226L15.2202 1.29372ZM10.6847 1.97405C10.8831 1.91736 11.0816 1.83232 11.28 1.77563C11.3083 1.77563 11.3084 1.77563 11.3367 1.74728C11.5067 1.69058 11.6485 1.66223 11.8185 1.60554C11.8469 1.60554 11.8753 1.5772 11.9036 1.5772C12.0737 1.54885 12.2438 1.49215 12.4139 1.4638H12.4705L13.0375 1.37877H13.0659C13.2359 1.35042 13.4061 1.32207 13.5761 1.32207H13.7179C13.8595 1.32207 13.973 1.29372 14.1147 1.29372H14.3982V5.1206C14.3982 5.74424 13.8879 6.25449 13.2643 6.25449H11.8469C11.2233 6.25449 10.7131 5.74424 10.7131 5.1206L10.6847 1.97405ZM27.9765 34.9419C27.9735 35.5575 27.7277 36.147 27.2924 36.5823C26.8571 37.0176 26.2676 37.2634 25.6521 37.2664H3.93805C3.32248 37.2634 2.73297 37.0176 2.29769 36.5823C1.86241 36.147 1.61655 35.5575 1.61358 34.9419V32.7875C1.61358 32.1355 1.8687 31.5402 2.32226 31.115L2.46399 31.0016V13.6247L2.49234 12.7744C2.80416 8.06867 5.75227 4.12845 9.83431 2.31422V5.09226C9.83431 6.19779 10.7131 7.07656 11.8185 7.07656H13.2359C13.8596 7.07656 14.4266 6.76474 14.7951 6.31119C15.1636 6.76474 15.7305 7.07656 16.3541 7.07656H17.7715C18.8771 7.07656 19.7558 6.19779 19.7558 5.09226V2.31422C23.8378 4.12845 26.7859 8.06867 27.0978 12.7744L27.1261 13.5964V30.9733L27.2678 31.0867C27.7214 31.5402 27.9765 32.1355 27.9765 32.7591V34.9419ZM13.2359 26.3527C11.9036 26.3527 10.8264 27.4299 10.8264 28.7622C10.8264 30.0945 11.9036 31.1717 13.2359 31.1717C14.5682 31.1717 15.6455 30.0945 15.6455 28.7622C15.6455 27.4299 14.5682 26.3527 13.2359 26.3527ZM13.2359 30.8883C12.0737 30.8883 11.1099 29.9244 11.1099 28.7622C11.1099 27.5999 12.0737 26.6361 13.2359 26.6361C14.3982 26.6361 15.362 27.5999 15.362 28.7622C15.362 29.9244 14.3982 30.8883 13.2359 30.8883ZM22.9874 20.3998H6.60269C6.26252 20.3998 6.0074 20.6549 6.0074 20.9951V22.0723C6.0074 22.4125 6.26252 22.6676 6.60269 22.6676H22.9874C23.3276 22.6676 23.5827 22.4125 23.5827 22.0723V20.9951C23.5827 20.6833 23.3276 20.3998 22.9874 20.3998ZM23.2993 22.0723C23.2985 22.1547 23.2654 22.2336 23.2071 22.2919C23.1487 22.3503 23.0699 22.3834 22.9874 22.3841H6.60269C6.52022 22.3834 6.44133 22.3503 6.38301 22.2919C6.3247 22.2336 6.29161 22.1547 6.29087 22.0723V20.9951C6.29161 20.9126 6.3247 20.8337 6.38301 20.7753C6.44133 20.7171 6.52022 20.684 6.60269 20.6833H22.9874C23.0699 20.684 23.1487 20.7171 23.2071 20.7753C23.2654 20.8337 23.2985 20.9126 23.2993 20.9951V22.0723Z" fill="#C41230"/>
+<path d="M21.8379 14.5208L24.6419 13.8198H31.652L40.064 35.551L40.765 37.654V40.4581C39.5967 41.1591 35.5776 42.7013 28.8479 43.2621C22.1183 43.8229 17.1645 41.6264 15.5288 40.4581V37.654L16.2298 35.551V24.3349L18.3328 20.1289L16.2298 15.9228H20.4359L21.1369 15.2218L21.8379 14.5208Z" fill="#F8F8F8"/>
+<path d="M23.3437 37.2899C22.7227 37.2899 22.2211 37.7676 22.1495 38.3648H20.8358V38.6036H22.1495C22.2211 39.2007 22.7227 39.6784 23.3437 39.6784C23.9648 39.6784 24.4663 39.2007 24.538 38.6036H34.928V38.3648H24.538C24.4663 37.7676 23.9648 37.2899 23.3437 37.2899ZM23.3437 39.4634C22.8182 39.4634 22.3645 39.0335 22.3645 38.5081C22.3645 37.9826 22.7944 37.5527 23.3437 37.5527C23.8692 37.5527 24.2992 37.9826 24.2992 38.5081C24.2992 39.0335 23.8692 39.4634 23.3437 39.4634ZM28.0491 25.2996C30.151 25.2996 31.8707 23.5799 31.8707 21.478C31.8707 19.3761 30.151 17.6563 28.0491 17.6563C25.9472 17.6563 24.2275 19.3761 24.2275 21.478C24.2275 23.5799 25.9472 25.2996 28.0491 25.2996ZM28.0491 18.3729C29.7688 18.3729 31.1542 19.7582 31.1542 21.478C31.1542 23.1977 29.7688 24.583 28.0491 24.583C26.3294 24.583 24.9441 23.1977 24.9441 21.478C24.9441 19.7582 26.3294 18.3729 28.0491 18.3729ZM47.7304 24.3442C46.154 19.7821 44.3149 15.865 43.9566 15.1245C43.8611 14.9095 43.6461 14.7901 43.4072 14.7901H35.2146C35.1908 14.599 35.0475 14.4318 34.8803 14.3602C33.1605 13.572 30.6526 13.1182 28.0252 13.1182C25.3978 13.1182 22.9138 13.572 21.1702 14.3602C20.9791 14.4557 20.8597 14.6229 20.8358 14.814C20.573 14.8618 20.3581 15.0767 20.3342 15.3634C20.3342 15.4111 20.3342 15.4589 20.3103 15.5306H16.4648C16.2498 15.5306 16.0826 15.6261 15.9632 15.7933C15.8438 15.9605 15.8438 16.1755 15.9154 16.3665L17.4202 19.7582C17.468 19.8538 17.5157 19.9254 17.5874 19.9732C16.4648 22.1706 16.0349 24.583 15.9871 24.8935V24.9652L15.5094 35.8568L14.9362 37.0033C14.8406 37.1944 14.7928 37.4332 14.7928 37.6482V40.1323C14.7928 40.5144 14.9362 40.8488 15.1989 41.1354C17.4441 43.5 24.3947 43.5 28.1207 43.5C31.8468 43.5 38.7974 43.5 41.0426 41.1354C41.3053 40.8727 41.4486 40.5144 41.4486 40.1561V37.5765C41.4486 37.3855 41.4009 37.1705 41.3293 37.0033L40.7082 35.5941C44.291 34.0415 49.8801 30.5543 47.7304 24.3442ZM28.0491 13.8347C30.3182 13.8347 32.4679 14.1691 34.0682 14.7901H22.0301C23.6303 14.1691 25.78 13.8347 28.0491 13.8347ZM16.6559 16.2232H20.1431C19.9759 16.5576 19.7371 16.8681 19.4027 17.2742C19.1161 17.6325 18.7817 18.0624 18.3995 18.6356C18.3995 18.6356 18.3995 18.6595 18.3756 18.6595C18.3278 18.7551 18.2562 18.8267 18.1845 18.9223C18.1606 18.9461 18.1606 18.97 18.1368 19.0178C18.089 19.0894 18.0412 19.1611 17.9935 19.2566L16.6559 16.2232ZM40.3022 34.9731C40.1578 35.0458 40.0405 35.163 39.9678 35.3075C39.92 35.4508 39.92 35.618 39.9678 35.7852L40.6366 37.3138C40.6844 37.4093 40.7082 37.5049 40.7082 37.6004V40.1083C40.7082 40.2995 40.6366 40.4667 40.5172 40.61C38.4869 42.7596 31.4886 42.7596 28.1207 42.7596C24.7529 42.7596 17.7546 42.7596 15.7244 40.61C15.6049 40.4667 15.5333 40.2995 15.5333 40.1083V37.6243C15.5333 37.5049 15.5572 37.4093 15.6049 37.2899L16.2021 36.1434C16.2474 36.0719 16.2722 35.9893 16.2737 35.9046L16.7514 24.9891C16.7753 24.8697 17.2769 21.884 18.6384 19.6388C19.1638 18.7789 19.6176 18.2057 19.9998 17.728C20.382 17.2264 20.7164 16.8442 20.9074 16.3427V16.2949C21.003 16.056 21.0746 15.7933 21.0985 15.4828H43.3595C43.7655 16.3665 45.533 20.1643 47.0617 24.5592C48.9486 30.0049 44.4104 33.2294 40.3022 34.9731ZM42.2369 18.5879C42.213 18.5401 41.6397 17.1786 39.9917 17.1786H37.5554C37.3404 17.1786 37.1493 17.2981 37.0299 17.4891C36.9105 17.6802 36.9343 17.8952 37.0299 18.0863C37.9376 19.6149 40.8754 25.0846 40.5888 30.817C40.5888 31.0082 40.6604 31.1992 40.8037 31.3186C40.9232 31.4142 41.0426 31.4619 41.1859 31.4619C41.2337 31.4619 41.2815 31.4619 41.3531 31.4381C43.8372 30.7693 45.3419 28.4524 44.8642 26.0878C44.4104 23.6754 42.3324 18.8028 42.2369 18.5879ZM41.3293 30.6976C41.5442 25.0369 38.7735 19.6866 37.7464 17.9191H39.9917C41.1621 17.9191 41.5442 18.8506 41.5681 18.8984C41.592 18.9461 43.7177 23.9143 44.1716 26.2311C44.5776 28.1658 43.3595 30.0527 41.3293 30.6976Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Bundle & Save</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+
+                                                                            
+                                                                        </ul>
+
+                                                                        
+
+                                                                        <!-- desktop_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end desktop_banner -->
+
+                                                                        <!-- desktop_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="hidden lg:block max-w-1048px mx-auto mt-64px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="box-promotion block relative ">
+                                                                                        <div class="absolute z-20 md:top-1/2 md:-translate-y-50 top-0 left-0 w-full pt-20px md:pt-0 px-64px" >
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px lg:text-32px lg:leading-44px">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img h-274px md:h-180px loaded">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end desktop_sale_banner -->
+
+                                                                        <!-- mobile_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end mobile_banner -->
+
+                                                                        <!-- mobile_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                            
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img pb-89.250814332">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end mobile_sale_banner -->
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                     
+                                                </li>
+                                            
+                                                
+                                                <li class="nav-item is-dropdown">
+                                                    <a href="#" class="no-link" data-expand="" data-sub-name="inspiration" aria-expanded="false" aria-haspopup="true" role="button">
+                                                        
+                                                        <span class="icon-svg">
+                                                            
+		<svg width="27" height="32" viewBox="0 0 27 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.9469 1.01003C11.7291 0.957108 11.5027 1.05558 11.3929 1.25098C11.2831 1.44638 11.3168 1.69096 11.4753 1.84944C11.8535 2.2277 12.3089 2.84821 12.4854 3.4709C12.5718 3.7756 12.5842 4.0549 12.5144 4.30001C12.447 4.53704 12.2911 4.78426 11.9635 5.01551C11.2177 5.54199 10.1009 5.947 8.96641 6.23571C7.84886 6.52011 6.76628 6.67892 6.1146 6.73797C5.34732 6.77331 4.23792 7.05629 3.60899 7.91239C3.00232 8.73819 2.96743 9.90677 3.73629 11.4354C2.82066 11.7968 2.15353 12.2436 1.70321 12.7622C1.15468 13.3939 0.955391 14.1013 0.992624 14.7981C1.06439 16.141 2.00608 17.391 2.78562 18.1179C2.87785 18.2039 2.99392 18.2483 3.11077 18.252L6.05445 29.6061L6.05478 29.6074C6.18257 30.1152 6.84128 30.8256 8.02479 30.9652C8.04218 30.9688 8.06015 30.9708 8.07854 30.9711C8.31034 30.9947 8.56174 30.9966 8.83269 30.9711H18.1021C18.625 31.0166 19.0594 31.0134 19.4203 30.9711H19.5652C19.6239 30.9711 19.6784 30.9534 19.7238 30.9231C19.9452 30.8782 20.1332 30.8156 20.2929 30.7389C20.7708 30.5091 20.9718 30.1628 21.0505 29.8491L21.0508 29.8479L23.9812 18.5387C23.998 18.5344 24.0148 18.5291 24.0314 18.5228C24.853 18.2147 26.3116 17.0096 26.4699 14.5821L26.47 14.5821L26.4705 14.5701C26.5512 12.6074 25.6342 11.3277 24.4647 10.5574C23.3231 9.80552 21.9493 9.53899 21.0273 9.5173C21.0153 9.51702 21.0034 9.51717 20.9917 9.51772C20.906 9.19478 20.775 8.88045 20.6162 8.58147C19.9463 7.31946 18.6967 6.16652 17.6716 5.45728C17.637 5.11753 17.5421 4.7931 17.3975 4.4868C17.079 3.81239 16.5316 3.2495 15.9152 2.79012C14.6857 1.87371 13.0624 1.28108 11.9469 1.01003ZM21.0943 10.52C21.0898 10.5822 21.083 10.6445 21.074 10.7068C20.9646 11.4603 20.5286 12.1372 19.732 12.686C17.966 13.9028 15.8092 14.5462 14.0713 15.0647L14.0713 15.0647L14.0713 15.0647L13.8709 15.1245C12.967 15.3947 12.2077 15.6289 11.6469 15.8935C11.2648 16.0738 11.0426 16.2377 10.9211 16.3821C11.21 16.3023 11.5684 16.2577 12.0081 16.2577C12.876 16.2577 13.4532 16.4957 13.7915 16.8096C13.8346 16.7523 13.8867 16.6966 13.9492 16.6438C14.2402 16.3982 14.7114 16.2577 15.4278 16.2577C16.3481 16.2577 16.9099 16.5709 17.1968 16.9466L17.198 16.9453C17.4857 16.6132 17.9628 16.3782 18.6916 16.3782C19.5797 16.3782 20.1371 16.7299 20.4323 17.1294C20.7542 16.6731 21.3297 16.2221 22.2356 16.2599C22.9107 16.288 23.3697 16.6041 23.6582 16.989C23.7728 17.1419 23.8602 17.3048 23.9251 17.4641C24.4719 17.1328 25.3574 16.2453 25.4716 14.5231C25.534 12.96 24.83 11.9954 23.9147 11.3926C23.0059 10.794 21.882 10.5538 21.0943 10.52ZM23.4342 17.7858C23.3845 17.6367 23.3088 17.477 23.2003 17.3322C23.0034 17.0695 22.6969 16.8518 22.2117 16.8316C21.26 16.7919 20.8113 17.483 20.6954 17.8602C20.6952 17.8696 20.6949 17.8788 20.6944 17.888C20.6925 17.924 20.684 17.9582 20.6702 17.9894L18.4559 30.3989H19.3856C19.6758 30.3622 19.8889 30.2982 20.045 30.2231C20.3521 30.0755 20.4533 29.8785 20.4957 29.7091L20.4963 29.7067L23.4425 18.3363C23.4205 18.3039 23.402 18.2685 23.3877 18.2302C23.3303 18.0772 23.3527 17.9138 23.4342 17.7858ZM9.83476 16.3484C9.81556 16.4238 9.81462 16.4996 9.82915 16.571C9.51079 16.3787 9.06693 16.2577 8.46848 16.2577C7.71123 16.2577 7.20148 16.4514 6.88035 16.7384C6.78383 16.8246 6.70669 16.9174 6.64642 17.0122C6.31195 16.5984 5.75954 16.2233 4.93016 16.2578C4.25504 16.286 3.79601 16.6021 3.50751 16.987C3.44138 17.0752 3.38432 17.1668 3.3354 17.2591C2.67043 16.5969 2.03914 15.6419 1.9912 14.7447C1.96699 14.2917 2.08951 13.8426 2.45829 13.4178C2.83718 12.9815 3.50163 12.5426 4.60977 12.1848C6.03494 11.7246 7.44612 11.4002 8.79246 11.1161C9.11967 11.047 9.44429 10.9801 9.76476 10.914C10.7534 10.7103 11.7026 10.5146 12.5669 10.2892C14.835 9.69746 16.7698 8.84351 17.497 6.8003C17.5192 6.73813 17.5393 6.67628 17.5574 6.61477C18.3866 7.26331 19.2535 8.14715 19.733 9.05033C20.0251 9.60058 20.1497 10.1131 20.0844 10.5631C20.0217 10.9945 19.7739 11.4428 19.1646 11.8626C17.5318 12.9876 15.5094 13.5916 13.7374 14.1207L13.5845 14.1664C12.6994 14.431 11.8624 14.6861 11.2202 14.9891C10.6022 15.2807 10.0027 15.6887 9.83476 16.3484ZM8.58596 10.1376C7.34974 10.3985 6.03401 10.6982 4.69323 11.1101C3.94086 9.68933 4.11211 8.91659 4.41489 8.50444C4.78377 8.00233 5.52721 7.76404 6.16958 7.73651C6.17732 7.73618 6.18505 7.73566 6.19277 7.73497C6.89198 7.67236 8.03342 7.50501 9.21303 7.20482C10.382 6.90735 11.6423 6.46631 12.5402 5.83248C13.0345 5.48357 13.3399 5.05295 13.4763 4.57373C13.6103 4.10259 13.5691 3.62724 13.4475 3.19819C13.3721 2.93226 13.2632 2.6744 13.1354 2.43191C13.8857 2.72162 14.6724 3.11099 15.3176 3.59192C15.858 3.9947 16.2692 4.43953 16.4932 4.91384C16.7099 5.37266 16.763 5.88057 16.5549 6.46498C16.0131 7.98729 14.5637 8.73479 12.3145 9.32153C11.4776 9.53986 10.5648 9.72803 9.5834 9.93034L9.58339 9.93034L9.58338 9.93034L9.58337 9.93035C9.25833 9.99735 8.92577 10.0659 8.58596 10.1376ZM18.6916 16.9504C19.7939 16.9504 20.0908 17.5802 20.1206 17.8115L17.8747 30.3989H16.2748L17.4019 18.0031C17.4241 17.9597 17.4355 17.9101 17.4328 17.8579C17.4264 17.737 17.4646 17.5114 17.6304 17.32C17.7878 17.1384 18.0925 16.9504 18.6916 16.9504ZM14.1672 17.5109C14.1718 17.5557 14.1729 17.5999 14.1706 17.6431L13.8544 30.3989H15.7003L16.8624 17.6168C16.8673 17.4595 16.6837 16.8299 15.4278 16.8299C14.768 16.8299 14.4587 16.9625 14.3183 17.0811C14.1922 17.1875 14.1656 17.3146 14.1724 17.4387C14.1737 17.4634 14.1719 17.4876 14.1672 17.5109ZM13.5986 17.6245L13.282 30.3989H11.6079L10.4695 17.6248C10.4702 17.6006 10.4699 17.5757 10.4686 17.5503C10.4821 17.514 10.4885 17.4744 10.4861 17.4333C10.4815 17.356 10.5076 17.2243 10.6939 17.0978C10.8935 16.9622 11.2846 16.8299 12.0081 16.8299C13.4286 16.8299 13.6065 17.4897 13.5991 17.6146L13.5989 17.6146L13.5986 17.6245ZM7.02626 17.7203L7.03108 17.7375C7.03297 17.7444 7.03459 17.7514 7.03596 17.7584L9.48057 30.3989H11.0334L9.89785 17.657C9.89662 17.6432 9.89639 17.6293 9.89717 17.6155C9.90256 17.5197 9.86288 17.3327 9.67531 17.1651C9.48927 16.9988 9.13165 16.8299 8.46848 16.8299C7.80531 16.8299 7.4477 16.9988 7.26167 17.165C7.07412 17.3327 7.03444 17.5197 7.03984 17.6155C7.0419 17.6521 7.03699 17.6874 7.02626 17.7203ZM8.09206 30.3989H8.80883C8.8375 30.3959 8.86649 30.3926 8.89579 30.3889L6.47632 17.8784C6.37054 17.5063 5.92302 16.7892 4.95399 16.8296C4.46881 16.8498 4.16236 17.0674 3.96539 17.3302C3.775 17.5842 3.68555 17.8844 3.66059 18.0925L6.60898 29.4649L6.6096 29.4673C6.66687 29.6964 7.1054 30.284 8.09206 30.3989Z" fill="#C41230"/>
+</svg>
+	
+                                                        </span>
+                                                        <span class="txt">Inspiration</span>
+
+                                                        
+                                                            <span class="expand">
+                                                               <svg width="8" height="13" viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                    <path d="M0.615723 12.5L6.93151 6.5L0.615723 0.5" stroke="#2E2E2E" stroke-linecap="round"/>
+                                                                </svg>
+                                                            </span>
+                                                        
+                                                    </a>
+
+                                                     
+                                                        <div data-nav-dropdown-content="" class="sub-nav invisible" id="inspiration">
+                                                            <div class="__box" data-subnav="">
+                                                                 <a href="#" class="back" data-back="" data-level-02 aria-controls="inspiration">
+                                                                    <span class="icon">
+                                                                        <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                            <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"/>
+                                                                        </svg>
+                                                                    </span>
+                                                                    <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Inspiration</span>
+                                                                </a>
+
+                                                                
+                                                                
+
+                                                                <div class="__box-wrap">
+                                                                    <div class="inner w-1920px">
+                                                                        <ul class="sub-nav-group ul-sub">
+                                                                            
+
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/pages/videos" >
+                                                                                        <span class="icon-svg videos">
+                                                                                            
+		<svg width="37" height="36" viewBox="0 0 37 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="18.5" cy="18" r="17.5" stroke="#C41230"/>
+<path d="M25.6705 17.1341C26.3372 17.519 26.3372 18.4813 25.6705 18.8662L15.6705 24.6397C15.0039 25.0246 14.1705 24.5435 14.1705 23.7737L14.1705 12.2267C14.1705 11.4569 15.0039 10.9757 15.6705 11.3606L25.6705 17.1341Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Videos</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/blogs/kitchenthusiast" >
+                                                                                        <span class="icon-svg blog">
+                                                                                            
+		<svg width="39" height="44" viewBox="0 0 39 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M30.0709 42.8637H4.47821C4.29276 42.8637 4.01458 43.0492 4.01458 43.3273C4.01458 43.6055 4.20003 43.791 4.47821 43.791H30.1637C30.3491 43.791 30.6273 43.6055 30.6273 43.3273C30.5346 43.1419 30.3491 42.8637 30.0709 42.8637ZM33.4091 35.2601H1.14003C0.954576 35.2601 0.769122 35.3528 0.769122 35.5382C0.676395 35.7237 0.769122 35.9092 0.861849 36.0019L5.77639 41.5655C5.86912 41.6582 5.96185 41.751 6.1473 41.751H28.68C28.7728 41.751 28.9582 41.6582 29.0509 41.5655L33.9655 36.0019C34.0582 35.9092 34.1509 35.7237 34.0582 35.5382C33.6873 35.3528 33.5019 35.2601 33.4091 35.2601ZM28.3091 40.731H6.1473L1.97458 36.0019H32.3891L28.3091 40.731ZM13.2873 28.3055H12.9164C10.0418 28.3055 7.63094 30.6237 7.63094 33.591C7.63094 33.7764 7.8164 34.0546 8.09458 34.0546C8.37276 34.0546 8.55821 33.8692 8.55821 33.591C8.55821 31.1801 10.5982 29.1401 13.0091 29.1401C13.1946 29.1401 13.38 29.1401 13.5655 29.1401C13.7509 29.1401 14.0291 29.0473 14.0291 28.8619C14.4 27.5637 15.6055 26.6364 16.9964 26.6364C17.1819 26.6364 17.46 26.451 17.46 26.1728C17.46 25.8946 17.2746 25.7092 16.9964 25.7092C15.2346 25.8019 13.8437 26.8219 13.2873 28.3055ZM17.3673 32.9419C17.2746 32.8492 17.1819 32.6637 17.1819 32.6637C15.6055 31.0873 13.1018 31.0873 11.4328 32.6637C11.34 32.7564 11.34 32.8492 11.4328 32.9419C11.5255 33.0346 11.6182 33.0346 11.7109 32.9419C13.1019 31.551 15.42 31.551 16.9037 32.9419C16.9964 33.0346 17.0891 33.1273 17.1819 33.3128L17.2746 33.4055L17.46 33.3128C18.48 32.7564 19.6855 32.8492 20.4273 33.7764C20.4273 33.7764 20.52 33.7764 20.6128 33.7764C20.7055 33.7764 20.7055 33.7764 20.7982 33.7764C20.8909 33.6837 20.8909 33.591 20.7982 33.4982C19.7782 32.571 18.48 32.2928 17.3673 32.9419ZM25.8055 33.7764C25.8982 33.9619 25.9909 34.0546 26.2691 34.0546C26.2691 34.0546 26.3619 34.0546 26.4546 34.0546C26.64 33.9619 26.7328 33.7764 26.7328 33.591V33.4982C25.8982 31.4582 23.7655 30.1601 21.54 30.2528C20.9837 28.7692 19.5 27.7492 17.9237 27.7492C17.7382 27.7492 17.46 27.9346 17.46 28.2128C17.46 28.491 17.6455 28.6764 17.9237 28.6764C19.3146 28.6764 20.4273 29.6037 20.8909 30.9019C20.9837 31.0873 21.1691 31.2728 21.3546 31.1801C23.1164 30.8092 25.0637 32.0146 25.8055 33.7764ZM38.1382 0.301875C37.9528 0.209148 37.7673 0.209148 37.5819 0.394602C36.9328 1.13642 35.9128 3.36188 34.8 5.77278C34.5219 6.42188 34.2437 6.97824 34.0582 7.25642L33.6873 7.99824C32.2037 10.8728 29.5146 13.0055 26.3619 13.7473C26.1764 13.7473 26.0837 13.8401 25.8982 13.8401L22.56 14.3037H22.4673L17.6455 16.6219C17.46 16.7146 17.1819 16.8073 16.9037 16.7146L17.6455 16.3437C17.8309 16.251 18.0164 16.0655 18.1091 15.7873C18.1091 15.6019 18.1091 15.3237 17.9237 15.1382L17.8309 15.0455C17.5528 14.7673 17.1819 14.6746 16.8109 14.8601L16.0691 15.231C16.1618 14.9528 16.3473 14.6746 16.6255 14.4892L22.56 11.4292C23.0237 11.151 23.3019 10.6873 23.2091 10.131C23.1164 9.5746 22.7455 9.2037 22.1891 9.01824L19.1291 8.46188C18.5728 8.36915 17.9237 8.64733 17.6455 9.20369L15.0491 15.231C15.0491 15.231 15.0491 15.3237 15.0491 15.4164V17.271C15.0491 18.1055 14.4928 18.8473 13.8437 19.311H13.7509C14.2146 19.1255 14.4928 18.6619 14.4928 18.1982V17.4564C14.4928 17.271 14.4928 17.1782 14.3073 16.9928C14.1219 16.8073 13.9364 16.8073 13.7509 16.8073H13.4728L13.2873 14.6746L14.0291 11.3364C14.0291 11.2437 14.1219 11.151 14.1219 11.0582L14.5855 9.20369L17.7382 4.19642C18.2019 3.54733 18.8509 3.17642 19.5928 3.17642L26.1764 3.4546C29.1437 3.54733 30.9982 2.71278 32.1109 0.950966C32.2037 0.765512 32.2037 0.48733 31.9255 0.394602C31.74 0.209148 31.4619 0.209148 31.3691 0.48733C30.4419 2.06369 28.7728 2.71278 26.1764 2.62006L19.5 2.34188C18.48 2.34188 17.5528 2.80551 16.9964 3.54733L11.6182 4.75278C10.6909 5.03097 10.0419 5.4946 8.92912 6.5146L8.1873 7.25642C8.09458 7.34915 8.00185 7.5346 8.00185 7.72006V7.81279C7.90912 8.18369 8.00185 8.5546 8.1873 8.83279C8.74367 9.5746 9.85639 9.5746 10.5055 9.01824L12.7309 7.44188L14.1219 7.16369L9.76367 10.8728C9.48549 11.151 9.30003 11.4291 9.2073 11.8001L7.90912 14.8601C7.72367 15.231 7.8164 15.6019 8.00185 15.9728C8.1873 16.3437 8.55821 16.5292 8.8364 16.5292C8.92912 16.5292 9.02185 16.5292 9.2073 16.5292C10.0418 16.5292 10.8764 16.0655 11.2473 15.3237L12.1746 13.2837L12.8237 12.6346L12.36 14.5819V14.6746L12.6382 19.2182C12.6382 19.5891 12.8237 19.8673 13.1946 19.9601C13.38 20.0528 13.5655 20.1455 13.6582 20.1455C13.8437 20.1455 13.9364 20.1455 14.1219 20.0528C15.1419 19.4964 15.7909 18.4764 15.8837 17.3637V17.0855C16.44 17.6419 17.3673 17.8273 18.1091 17.4564L22.7455 15.0455L25.9909 14.4892C26.1764 14.4892 26.3619 14.3964 26.4546 14.3964C29.7928 13.7473 32.76 11.4291 34.3364 8.27642L35.4491 6.05097C36.1909 4.38188 37.5819 1.50733 38.1382 0.858239C38.3237 0.765511 38.3237 0.48733 38.1382 0.301875ZM18.3873 9.5746C18.48 9.38915 18.6655 9.29642 18.8509 9.29642H18.9437L22.0037 9.85279C22.2819 9.85279 22.3746 10.131 22.3746 10.2237C22.3746 10.3164 22.3746 10.5019 22.1891 10.6873L16.8109 13.4691L18.3873 9.5746ZM13.5655 17.1782C13.6582 17.1782 13.7509 17.1782 13.7509 17.271V17.3637V18.1055C13.7509 18.3837 13.5655 18.6619 13.2873 18.8473L13.1946 17.1782H13.5655C13.5655 17.271 13.5655 17.1782 13.5655 17.1782ZM9.57821 7.07097C9.57821 7.16369 9.67094 7.25642 9.67094 7.25642C9.67094 7.34915 9.67094 7.5346 9.48549 7.62733L8.8364 8.36915L8.55821 8.09097V7.99824L9.39276 7.25642L9.48549 7.16369L9.57821 7.07097ZM12.2673 6.70006C12.1746 6.70006 12.1746 6.70006 12.0819 6.79279L9.76367 8.46188C9.57821 8.64733 9.30003 8.64733 9.11458 8.64733L9.8564 7.99824C10.0419 7.81279 10.1346 7.5346 10.1346 7.34915C10.1346 7.16369 10.0419 6.97824 9.94912 6.88551C10.6909 6.14369 11.1546 5.77278 11.8037 5.68006L16.2546 4.56733L15.3273 6.14369C15.3273 6.05097 12.2673 6.70006 12.2673 6.70006ZM9.30003 13.8401C9.39276 13.8401 9.48549 13.9328 9.57821 14.1182C9.57821 14.3037 9.57821 14.3964 9.57821 14.4892L9.39276 14.8601C9.2073 15.0455 8.8364 15.1382 8.55821 15.0455L9.11458 13.7473C9.2073 13.7473 9.30003 13.8401 9.30003 13.8401ZM11.4328 12.7273C11.4328 12.7273 11.4328 12.8201 11.34 12.8201L10.4128 14.8601C10.1346 15.4164 9.48549 15.6946 8.92912 15.6019C8.8364 15.6019 8.74367 15.5091 8.65094 15.4164H8.8364C9.2073 15.4164 9.57821 15.231 9.67094 14.8601L9.8564 14.4892C9.94912 14.3037 10.0419 14.0255 9.94912 13.7473C9.8564 13.5619 9.67094 13.2837 9.39276 13.2837H9.30003L9.8564 11.8928C9.94912 11.7073 10.0419 11.4291 10.32 11.3364L13.8437 8.27642L13.6582 8.5546C13.6582 8.5546 13.6582 8.64733 13.6582 8.74006L13.1946 10.7801C13.1019 10.9655 11.4328 12.7273 11.4328 12.7273ZM16.9037 15.231C17.0891 15.1382 17.3673 15.231 17.46 15.3237L17.5528 15.4164C17.6455 15.5091 17.6455 15.6019 17.6455 15.6946C17.6455 15.7873 17.5528 15.8801 17.46 15.9728L16.44 16.4364C16.44 16.4364 16.3473 16.3437 16.2546 16.3437C16.1619 16.251 16.0691 16.1582 16.0691 16.0655L15.9764 15.6946L16.9037 15.231ZM16.9964 19.5891C16.5328 19.5891 16.2546 19.9601 16.2546 20.331C16.2546 20.7946 16.6255 21.0728 16.9964 21.0728C17.46 21.0728 17.7382 20.7019 17.7382 20.331C17.8309 19.9601 17.46 19.5891 16.9964 19.5891ZM16.9964 20.7019C16.8109 20.7019 16.6255 20.5164 16.6255 20.331C16.6255 20.1455 16.8109 19.9601 16.9964 19.9601C17.1819 19.9601 17.3673 20.0528 17.3673 20.2382C17.3673 20.5164 17.2746 20.7019 16.9964 20.7019C17.0891 20.7019 17.0891 20.7019 16.9964 20.7019ZM16.0691 22.7419C16.0691 22.2782 15.6982 22.0001 15.3273 22.0001C14.9564 22.0001 14.5855 22.371 14.5855 22.7419C14.5855 23.2055 14.9564 23.4837 15.3273 23.4837C15.6982 23.4837 16.0691 23.1128 16.0691 22.7419ZM14.9564 22.7419C14.9564 22.5564 15.1419 22.371 15.3273 22.371C15.5128 22.371 15.6982 22.4637 15.6982 22.6492C15.6982 22.8346 15.5128 23.0201 15.3273 23.0201C15.1419 23.1128 14.9564 22.9273 14.9564 22.7419ZM17.7382 23.391C17.2746 23.391 16.9964 23.7619 16.9964 24.1328C16.9964 24.5964 17.3673 24.8746 17.7382 24.8746C18.2019 24.8746 18.48 24.5037 18.48 24.1328C18.48 23.6691 18.1091 23.391 17.7382 23.391ZM17.7382 24.5037C17.5528 24.5037 17.3673 24.3182 17.3673 24.1328C17.3673 23.9473 17.46 23.7619 17.6455 23.7619C17.8309 23.7619 18.0164 23.8546 18.0164 24.0401C18.1091 24.3182 17.9237 24.411 17.7382 24.5037Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Blog</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/blogs/kitchenthusiast/tagged/blog-category-recipes" >
+                                                                                        <span class="icon-svg recipes">
+                                                                                            
+		<svg width="33" height="42" viewBox="0 0 33 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M31.5 41H1.5M1.5 41V5.36364C1.5 3.90909 2.64286 1 7.21429 1C11.7857 1 25.3095 1 31.5 1V34.4545H7.21429C5.30952 34.4545 1.5 35.7636 1.5 41Z" stroke="#C41230" stroke-width="1.42857" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M16.3446 9.37597C16.2255 9.34651 16.1014 9.39971 16.0406 9.50623C15.9798 9.61275 15.9972 9.74667 16.0831 9.83417C16.3012 10.0562 16.565 10.4214 16.6676 10.7901C16.7179 10.9709 16.7257 11.1386 16.6842 11.287C16.644 11.4308 16.5516 11.5784 16.3615 11.715C15.9317 12.024 15.2892 12.261 14.6379 12.4298C13.9959 12.5961 13.374 12.689 12.9996 12.7235C12.5594 12.7441 11.927 12.9095 11.5699 13.4044C11.2255 13.8817 11.2048 14.5616 11.6547 15.461C11.1211 15.673 10.7345 15.9356 10.4752 16.2396C10.1635 16.6052 10.051 17.0132 10.0721 17.4144C10.1128 18.1905 10.6485 18.9166 11.0953 19.3408C11.1478 19.3906 11.2147 19.4156 11.2817 19.4162L12.975 26.0663L12.9752 26.067C13.0471 26.3581 13.4222 26.7727 14.101 26.8536C14.1089 26.8552 14.1171 26.8561 14.1254 26.8564C14.2605 26.8707 14.4073 26.8719 14.5659 26.8565H15.9863C15.9969 26.8578 16.0078 26.858 16.0189 26.857L16.0239 26.8565H17.2544C17.2593 26.8571 17.2643 26.8574 17.2694 26.8575C17.277 26.8577 17.2846 26.8574 17.292 26.8565H18.6359L18.6406 26.857C18.6518 26.858 18.6628 26.8578 18.6735 26.8565H19.8713L19.876 26.857C20.184 26.8846 20.4384 26.8824 20.6486 26.8565H20.7211C20.7528 26.8565 20.7823 26.8471 20.807 26.8309C20.9362 26.8046 21.0457 26.7678 21.1383 26.7224C21.4107 26.5891 21.524 26.389 21.5683 26.2091L21.5685 26.2084L23.2543 19.5839C23.2638 19.5814 23.2733 19.5783 23.2827 19.5747C23.7511 19.3959 24.5822 18.6964 24.6725 17.2878L24.6725 17.2878L24.6728 17.2814C24.7187 16.144 24.1975 15.4018 23.5292 14.9537C22.8762 14.5158 22.0896 14.3602 21.5613 14.3476C21.551 14.3473 21.5408 14.3477 21.5307 14.3485C21.4821 14.1573 21.4063 13.9708 21.3136 13.793C20.9292 13.0557 20.2093 12.3808 19.6203 11.9674C19.6013 11.7684 19.5472 11.5786 19.4641 11.3994C19.2831 11.0091 18.9713 10.6821 18.6183 10.4143C17.9145 9.88015 16.9843 9.53423 16.3446 9.37597ZM21.5867 14.8969C21.5842 14.9384 21.5801 14.9799 21.5741 15.0215C21.5124 15.4545 21.2661 15.846 20.8111 16.1652C19.799 16.8752 18.5625 17.2508 17.5646 17.5539L17.4502 17.5887C16.9316 17.7466 16.495 17.8836 16.1723 18.0387C15.9247 18.1576 15.7904 18.2659 15.7252 18.3625C15.896 18.3098 16.112 18.28 16.3818 18.28C16.8867 18.28 17.2175 18.4225 17.4083 18.6074C17.4338 18.5717 17.465 18.5369 17.5032 18.5041C17.6684 18.3621 17.9372 18.28 18.3482 18.28C18.8816 18.28 19.2021 18.4663 19.3631 18.6859L19.3685 18.6795C19.5317 18.4877 19.8035 18.3506 20.2211 18.3506C20.7359 18.3506 21.0543 18.56 21.2203 18.794C21.4025 18.5268 21.7321 18.259 22.2552 18.2812C22.6414 18.2976 22.903 18.4816 23.0669 18.7043C23.1354 18.7973 23.1867 18.8967 23.2241 18.9933C23.5409 18.8002 24.0587 18.2766 24.1251 17.256C24.1614 16.3329 23.7522 15.7634 23.2239 15.4091C22.6949 15.0543 22.0403 14.9144 21.5867 14.8969ZM22.954 19.1708C22.9253 19.0791 22.8802 18.9798 22.8142 18.8903C22.6995 18.7345 22.5218 18.6065 22.2419 18.5947C21.6909 18.5713 21.4304 18.9809 21.3638 19.205C21.3638 19.2107 21.3636 19.2163 21.3633 19.2218C21.3623 19.2415 21.3577 19.26 21.3502 19.277L20.077 26.5427H20.6286C20.7914 26.5211 20.9116 26.4841 21.0003 26.4406C21.1785 26.3534 21.2387 26.236 21.2638 26.1336L21.2641 26.1323L22.9587 19.4735C22.9468 19.4561 22.9367 19.437 22.9288 19.4164C22.8966 19.332 22.9088 19.2415 22.954 19.1708ZM15.1481 18.3272C15.1355 18.3779 15.1378 18.4288 15.1523 18.4752C14.9697 18.3561 14.7098 18.28 14.3536 18.28C13.9195 18.28 13.6285 18.3931 13.446 18.5592C13.3886 18.6113 13.3435 18.6675 13.3087 18.7247C13.1188 18.4818 12.8021 18.2589 12.3229 18.2792C11.9368 18.2956 11.6752 18.4796 11.5113 18.7023C11.4697 18.7587 11.4345 18.8176 11.4048 18.8767C11.0193 18.4885 10.6478 17.9219 10.6196 17.3857C10.6054 17.1151 10.6777 16.8472 10.8924 16.5954C11.1123 16.3376 11.4961 16.0802 12.1328 15.8709C12.9512 15.6018 13.7615 15.4122 14.5343 15.2461C14.7222 15.2057 14.9086 15.1666 15.0925 15.128L15.0926 15.128C15.66 15.0089 16.2044 14.8947 16.7003 14.763C18.0036 14.4168 19.1065 13.9186 19.5204 12.7344C19.5354 12.6915 19.5487 12.649 19.5605 12.6067C20.0416 12.9874 20.548 13.5105 20.8275 14.0465C20.9962 14.3701 21.0698 14.6745 21.0313 14.9441C20.9943 15.2036 20.8481 15.4695 20.4962 15.7164C19.5575 16.3749 18.3955 16.7282 17.379 17.0373L17.2905 17.0642C16.7823 17.2189 16.3027 17.3678 15.9349 17.5444C15.5793 17.7153 15.2422 17.9513 15.1481 18.3272ZM14.4192 14.7101C13.7073 14.863 12.9498 15.0387 12.178 15.2806C11.7385 14.4404 11.8334 13.9762 12.0145 13.7252C12.2303 13.4262 12.6615 13.2871 13.0303 13.271L13.0303 13.2713L13.0432 13.2701C13.4441 13.2335 14.0988 13.1358 14.7754 12.9605C15.4461 12.7867 16.168 12.5293 16.6815 12.1602C16.9632 11.9578 17.1355 11.7093 17.2123 11.4345C17.2878 11.1643 17.2648 10.891 17.1958 10.643C17.1487 10.474 17.0785 10.3103 16.9963 10.1578C17.4382 10.3288 17.9053 10.5615 18.2869 10.8511C18.5979 11.0871 18.8363 11.349 18.9667 11.6301C19.0933 11.9031 19.1243 12.2062 19.0029 12.5535C18.6885 13.4528 17.849 13.8906 16.5596 14.2331C16.079 14.3607 15.5547 14.4707 14.9914 14.589C14.8049 14.6281 14.6141 14.6682 14.4192 14.7101ZM20.2211 18.6643C20.8579 18.6643 21.0329 19.0377 21.0489 19.1789L19.7584 26.5427H18.8261L19.4742 19.2853C19.4864 19.2615 19.4927 19.2343 19.4913 19.2056C19.4875 19.132 19.5102 18.997 19.6074 18.8828C19.6997 18.7744 19.8765 18.6643 20.2211 18.6643ZM17.6145 19.012C17.6164 19.0347 17.6168 19.0569 17.6157 19.0787L17.4339 26.5427H18.5112L19.1789 19.0647C19.1824 18.9631 19.0696 18.5937 18.3482 18.5937C17.9693 18.5937 17.7902 18.6711 17.7077 18.742C17.6325 18.8067 17.6163 18.8849 17.6203 18.9605C17.6213 18.9784 17.6192 18.9957 17.6145 19.012ZM17.3021 19.0687L17.1201 26.5427H16.1489L15.4947 19.0689C15.4953 19.0515 15.4949 19.0335 15.4936 19.015C15.4994 18.9969 15.5021 18.9775 15.5009 18.9574C15.498 18.9071 15.5155 18.8266 15.6245 18.7513C15.7406 18.671 15.9663 18.5937 16.3818 18.5937C17.1961 18.5937 17.3072 18.9793 17.3023 19.0634L17.3022 19.0634L17.3021 19.0687ZM13.518 19.1238L13.5217 19.137L13.5247 19.1482L13.5242 19.1483L14.9288 26.5427H15.8339L15.1813 19.0862C15.1806 19.0788 15.1805 19.0713 15.1809 19.0639C15.1843 19.0037 15.1598 18.891 15.0501 18.7912C14.9416 18.6925 14.7348 18.5937 14.3536 18.5937C13.9725 18.5937 13.7657 18.6925 13.6571 18.7912C13.5475 18.891 13.523 19.0037 13.5263 19.0639C13.5275 19.0848 13.5245 19.1051 13.518 19.1238ZM14.1351 26.5427H14.5521C14.5705 26.5408 14.5892 26.5385 14.6081 26.536L13.2172 19.2129C13.1555 18.9912 12.8955 18.569 12.3362 18.5927C12.0564 18.6046 11.8786 18.7325 11.7639 18.8883C11.6527 19.0394 11.6007 19.2183 11.5865 19.342L13.2793 25.9902L13.2797 25.9915C13.314 26.1312 13.5686 26.4748 14.1351 26.5427Z" fill="#C41230"/>
+</svg>
+
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">Recipes</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+                                                                                
+
+                                                                                
+                                                                                <li >
+                                                                                    
+
+                                                                                    
+
+                                                                                    <a href="/pages/kitchenaid-academy" >
+                                                                                        <span class="icon-svg kitchenaid-academy">
+                                                                                            
+		<svg width="43" height="43" viewBox="0 0 43 43" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M42.08 21.3418C42.08 21.3418 42.08 23.8364 40.5655 25.0837C39.8527 25.6182 38.8727 25.8855 37.7146 25.6182C35.3982 25.2618 34.24 23.3018 33.7946 21.6982L33.7055 18.7582L30.8546 9.31457L29.6073 5.75093H27.38C27.2909 4.41457 26.6673 3.0782 25.6873 2.0982C24.44 0.850931 22.9255 0.227295 21.3218 0.227295C19.6291 0.227295 18.2037 0.850931 16.9564 2.0982C15.9764 3.0782 15.4418 4.32548 15.2637 5.75093H13.0364L11.9673 9.31457L9.11639 18.7582C7.60184 19.1146 3.86002 20.4509 3.23639 24.2818C2.52366 28.6473 0.296387 29.4491 0.296387 29.4491L0.474569 30.0727C0.563659 30.0727 2.96911 29.1818 3.77093 24.3709C4.39457 20.9855 7.60184 19.7382 9.0273 19.3818L8.84911 26.6873L8.22548 42.9018H34.4182L33.8837 26.5982V23.3018C34.5964 24.6382 35.7546 25.8855 37.7146 26.1527C38.0709 26.1527 38.3382 26.2418 38.6055 26.2418C39.5855 26.2418 40.2982 25.9746 41.0109 25.44C42.7037 24.0146 42.7037 21.3418 42.7037 21.2527C42.7037 21.3418 42.08 21.3418 42.08 21.3418ZM17.9364 3.16729C18.9164 2.18729 20.0746 1.74184 21.3218 1.74184C22.6582 1.74184 23.8164 2.27639 24.7073 3.16729C25.42 3.88002 25.8655 4.86002 26.0437 5.84002H16.6891C16.7782 4.86002 17.3127 3.88002 17.9364 3.16729ZM14.1055 7.08729H28.7164L29.34 8.86911H13.5709C13.5709 8.9582 14.1055 7.08729 14.1055 7.08729ZM10.3637 19.0255L13.1255 10.2946H29.6073L32.28 19.0255L32.4582 26.3309H27.8255C29.34 25.6182 30.4982 24.46 30.5873 23.3909C30.5873 22.9455 30.5873 22.0546 29.0727 21.6982C28.0037 21.4309 27.0237 21.7873 26.2218 22.8564C26.1327 22.3218 25.9546 21.8764 25.6873 21.52C25.0637 20.8964 24.3509 20.8964 24.3509 20.8964C23.46 20.8964 21.6782 21.2527 21.6782 22.7673C21.6782 24.0146 23.2818 25.5291 24.2618 26.3309H10.0073C10.1855 26.42 10.3637 19.0255 10.3637 19.0255ZM25.7764 24.0146C25.7764 24.46 25.5982 25.2618 25.1527 26.0637L24.9746 26.2418C23.9946 25.44 22.3018 23.9255 22.3018 22.8564C22.3018 21.6091 24.2618 21.6091 24.3509 21.6091C24.44 21.6091 24.8855 21.6091 25.3309 22.0546C25.7764 22.5 25.9546 23.1237 25.7764 24.0146ZM26.4 24.1037C27.1127 22.6782 28.0037 22.0546 29.0727 22.4109C29.7855 22.5891 30.2309 22.9455 30.1418 23.5691C30.0527 24.7273 28.1818 26.3309 25.7764 26.5091C26.1327 25.44 26.3109 24.6382 26.4 24.1037ZM9.65093 41.6546L10.1855 27.0437H24.9746L23.46 34.4382L24.0837 34.5273L25.42 27.5782L27.38 31.4982L27.9146 31.2309L25.7764 26.9546H32.6364L33.1709 41.5655C33.0818 41.6546 9.65093 41.6546 9.65093 41.6546Z" fill="#C41230"/>
+</svg>
+	
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">KitchenAid Academy</span>
+                                                                                            
+                                                                                        </span>
+
+                                                                                        
+                                                                                    </a>
+
+                                                                                    
+
+                                                                                    
+                                                                                </li>
+                                                                            
+
+                                                                            
+                                                                                <li>
+                                                                                    <a href="/pages/world-of-colour" class="">
+                                                                                        <span class="icon-svg">
+                                                                                            <svg width="41" height="42" viewBox="0 0 41 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                                                <path d="M6.94833 15.7912C13.8022 16.0522 17.0731 18.2824 17.5601 23.0232C17.5629 23.0496 17.5684 23.0757 17.5766 23.101C18.7427 26.4539 21.9275 28.4802 25.788 28.4802C26.3987 28.4795 27.0083 28.4307 27.6112 28.3342C35.4851 27.0862 40.002 22.1168 40.002 14.6967C40.0062 9.39326 36.769 5.03615 30.8842 2.42506C21.7354 -1.63038 8.94092 -0.467746 2.94938 4.97348C2.04723 5.78754 1.41122 6.85448 1.12423 8.03524C0.837236 9.21601 0.912576 10.4558 1.34043 11.5932C1.74524 12.7753 2.49677 13.8081 3.49706 14.5569C4.49736 15.3057 5.70003 15.7358 6.94833 15.7912ZM3.41292 5.4811C9.12344 0.299536 21.8297 -0.833478 30.6087 3.05734C36.2276 5.54859 39.3195 9.68186 39.3153 14.6974C39.3153 21.7414 35.0106 26.4629 27.5058 27.6524C23.2011 28.3329 19.4873 26.4291 18.2427 22.9109C17.5394 16.2712 11.4783 15.2746 6.98139 15.1031C5.86929 15.053 4.7981 14.6689 3.90757 14.0009C3.01705 13.3329 2.34853 12.412 1.98924 11.3583C1.60842 10.3491 1.54056 9.24848 1.79451 8.2001C2.04847 7.15171 2.61246 6.20419 3.41292 5.4811Z" fill="#C41230"/>
+                                                                                                <path d="M10.7318 11.5387C11.3219 11.5387 11.8988 11.3637 12.3895 11.0358C12.8802 10.7079 13.2626 10.2419 13.4884 9.69667C13.7142 9.15143 13.7733 8.55146 13.6581 7.97266C13.5429 7.39386 13.2587 6.86221 12.8413 6.44496C12.424 6.0277 11.8923 5.74359 11.3134 5.62854C10.7346 5.51349 10.1347 5.57267 9.58947 5.79861C9.04428 6.02455 8.57833 6.40708 8.25056 6.89784C7.92279 7.38861 7.74791 7.96554 7.74805 8.5557C7.74896 9.34669 8.06363 10.105 8.62301 10.6643C9.18238 11.2235 9.94078 11.538 10.7318 11.5387ZM10.7318 6.26074C11.1857 6.26074 11.6294 6.39534 12.0068 6.64751C12.3842 6.89968 12.6783 7.25811 12.852 7.67746C13.0257 8.0968 13.0712 8.55824 12.9826 9.00342C12.8941 9.4486 12.6755 9.85752 12.3545 10.1785C12.0336 10.4994 11.6247 10.718 11.1795 10.8066C10.7343 10.8951 10.2729 10.8497 9.85352 10.676C9.43418 10.5023 9.07575 10.2081 8.82358 9.83071C8.57141 9.4533 8.43681 9.0096 8.43681 8.5557C8.43736 7.9472 8.67932 7.36379 9.10959 6.93352C9.53986 6.50325 10.1233 6.26129 10.7318 6.26074Z" fill="#C41230"/>
+                                                                                                <path d="M21.0807 9.94205C21.6708 9.94218 22.2478 9.76731 22.7385 9.43954C23.2293 9.11176 23.6118 8.64582 23.8378 8.10063C24.0637 7.55543 24.1229 6.95549 24.0078 6.37666C23.8928 5.79783 23.6087 5.26611 23.1914 4.84876C22.7742 4.43142 22.2425 4.14718 21.6637 4.03199C21.0849 3.91681 20.485 3.97586 19.9397 4.20167C19.3945 4.42748 18.9284 4.80991 18.6006 5.30059C18.2727 5.79128 18.0977 6.36818 18.0977 6.95833C18.0986 7.74926 18.4131 8.50755 18.9723 9.06689C19.5315 9.62623 20.2898 9.94095 21.0807 9.94205ZM21.0807 4.66337C21.5346 4.66324 21.9784 4.79772 22.3559 5.04981C22.7334 5.3019 23.0276 5.66027 23.2014 6.07961C23.3752 6.49895 23.4208 6.96041 23.3323 7.40563C23.2438 7.85085 23.0253 8.25984 22.7044 8.58086C22.3835 8.90189 21.9745 9.12053 21.5294 9.20914C21.0842 9.29775 20.6227 9.25234 20.2033 9.07866C19.7839 8.90498 19.4254 8.61083 19.1732 8.23341C18.921 7.85599 18.7864 7.41226 18.7864 6.95833C18.7871 6.35001 19.0291 5.76681 19.4592 5.3366C19.8892 4.90639 20.4724 4.66428 21.0807 4.66337Z" fill="#C41230"/>
+                                                                                                <path d="M30.6126 13.6999C31.2027 13.6999 31.7796 13.5249 32.2703 13.197C32.761 12.8692 33.1434 12.4032 33.3692 11.858C33.5951 11.3128 33.6541 10.7128 33.539 10.134C33.4239 9.55526 33.1397 9.02361 32.7224 8.60633C32.3051 8.18905 31.7735 7.90488 31.1947 7.78975C30.6159 7.67463 30.016 7.73371 29.4708 7.95955C28.9256 8.18538 28.4596 8.56781 28.1318 9.05848C27.8039 9.54915 27.6289 10.126 27.6289 10.7161C27.6298 11.5072 27.9445 12.2656 28.5038 12.8249C29.0632 13.3843 29.8216 13.6989 30.6126 13.6999ZM30.6126 8.42119C31.0665 8.42119 31.5102 8.55578 31.8876 8.80796C32.265 9.06013 32.5592 9.41855 32.7329 9.8379C32.9066 10.2572 32.952 10.7187 32.8635 11.1639C32.7749 11.609 32.5564 12.018 32.2354 12.3389C31.9144 12.6599 31.5055 12.8784 31.0603 12.967C30.6152 13.0556 30.1537 13.0101 29.7344 12.8364C29.315 12.6627 28.9566 12.3686 28.7044 11.9912C28.4523 11.6137 28.3177 11.17 28.3177 10.7161C28.3182 10.1076 28.5602 9.52424 28.9904 9.09397C29.4207 8.6637 30.0041 8.42173 30.6126 8.42119Z" fill="#C41230"/>
+                                                                                                <path d="M21.2461 18.6694C21.1517 19.205 21.1947 19.7558 21.371 20.2703C21.5474 20.7847 21.8513 21.2461 22.2544 21.6111C23.2024 22.5463 24.3996 23.1886 25.703 23.4612C26.2678 23.5916 26.8454 23.6581 27.4249 23.6595C29.6235 23.6595 31.4384 22.6608 31.8 21.0836C32.2504 19.1116 30.2503 16.9668 27.3402 16.3015C26.0489 15.98 24.6925 16.0362 23.4322 16.4633C22.9108 16.6159 22.4367 16.8984 22.0544 17.2842C21.672 17.6701 21.3939 18.1467 21.2461 18.6694ZM25.5853 16.7877C26.1236 16.7894 26.6601 16.8515 27.1846 16.973C29.7234 17.553 31.4921 19.3286 31.1257 20.93C30.7592 22.5313 28.3947 23.3689 25.8539 22.7896C24.6819 22.5475 23.6041 21.9738 22.7489 21.1366C22.4271 20.8521 22.182 20.4912 22.0362 20.0872C21.8903 19.6831 21.8483 19.2489 21.9142 18.8244C22.0389 18.4142 22.2651 18.0421 22.5719 17.7426C22.8787 17.443 23.2561 17.2257 23.6691 17.1108C24.2846 16.8902 24.9343 16.7809 25.588 16.7877H25.5853Z" fill="#C41230"/>
+                                                                                                <path d="M5.13812 25.4351C6.50875 26.4972 7.69824 27.0275 8.74654 27.0275C9.29259 27.027 9.82741 26.8723 10.2894 26.5812C12.3869 28.8244 14.6302 30.9268 17.0048 32.8744C17.4986 33.2773 28.2117 41.9902 31.1368 41.9902C31.2437 41.9997 31.3514 41.9852 31.452 41.9478C31.5525 41.9104 31.6435 41.851 31.7181 41.7739C31.7767 41.6997 31.8195 41.6143 31.844 41.523C31.8685 41.4317 31.8742 41.3364 31.8607 41.2429C31.6899 39.4845 25.8093 33.8387 20.0891 29.1702C17.678 27.2154 15.1394 25.4234 12.49 23.8062C12.7374 23.3686 12.8868 22.8824 12.9277 22.3813C12.9686 21.8803 12.9001 21.3763 12.7269 20.9044C12.2544 19.9629 11.1138 19.5372 9.3437 19.6398C6.18773 19.7494 3.08959 18.7736 0.566111 16.8751C0.508024 16.827 0.435733 16.7993 0.360347 16.7962C0.284962 16.7931 0.210654 16.8149 0.148845 16.8582C0.0870352 16.9014 0.0411449 16.9638 0.0182263 17.0357C-0.00469218 17.1076 -0.00337056 17.185 0.0219883 17.256C0.106706 17.4937 2.13442 23.1071 5.13812 25.4351ZM19.6531 29.7054C27.3783 36.0083 31.3669 40.5954 31.2078 41.3173C30.499 41.6575 25.1914 38.6662 17.4401 32.3406C15.1082 30.4281 12.904 28.365 10.8418 26.1645C11.0139 26.0099 11.175 25.8435 11.3239 25.6665C11.6445 25.2783 11.9294 24.862 12.1752 24.4226C14.7813 26.0154 17.2794 27.7786 19.6531 29.7006V29.7054ZM9.38296 20.3272C10.8617 20.2425 11.7743 20.5407 12.1111 21.213C12.6105 22.2075 11.8081 24.0217 10.8025 25.2243C9.86509 26.3401 8.51098 27.1735 5.56377 24.891C3.48095 23.2765 1.83757 19.8389 1.09921 18.0922C3.56395 19.6735 6.45731 20.4542 9.38296 20.3272Z" fill="#C41230"/>
+                                                                                                </svg>
+                                                                                        </span>
+                                                                                        <span class="relative block overflow-hidden">
+                                                                                            <span class="txt">World Of Colour</span>
+                                                                                        </span>
+                                                                                    </a>
+                                                                                </li>
+                                                                            
+                                                                        </ul>
+
+                                                                        
+
+                                                                        <!-- desktop_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end desktop_banner -->
+
+                                                                        <!-- desktop_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="hidden lg:block max-w-1048px mx-auto mt-64px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="box-promotion block relative ">
+                                                                                        <div class="absolute z-20 md:top-1/2 md:-translate-y-50 top-0 left-0 w-full pt-20px md:pt-0 px-64px" >
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px lg:text-32px lg:leading-44px">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img h-274px md:h-180px loaded">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-Navdesktop_2096x360_2_x400.jpg?v=1712291197" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end desktop_sale_banner -->
+
+                                                                        <!-- mobile_banner -->
+                                                                        
+                                                                        
+
+                                                                        
+                                                                        <!-- end mobile_banner -->
+
+                                                                        <!-- mobile_sale_banner -->
+                                                                        
+                                                                            
+                                                                            
+<div class="-mx-24px lg:hidden mt-56px">
+                                                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                                                            
+                                                                                            
+                                                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                                                            
+                                                                                            
+                                                                                            
+                                                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                                                            
+                                                                                        </div>
+                                                                                        <div class="img pb-89.250814332">
+                                                                                            
+                                                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                                                            
+                                                                                        </div>
+                                                                                    </a>
+                                                                                </div>
+                                                                            
+                                                                        
+                                                                        <!-- end mobile_sale_banner -->
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                     
+                                                </li>
+                                            
+                                        </ul>
+                                        <div class="flex items-center justify-center py-36px lg:hidden">
+                                            <div class="mr-60px">
+                                                
+
+                                                    <a href="#" class="block text-center lg:hidden" data-expand-element data-kb-element data-name="support" aria-expanded="false" aria-haspopup="true" role="button">
+                                                        <span class="new-home-icon-headphones-mic w-32px h-32px text-26px mx-auto mb-14px"></span>
+                                                        <span class="block text-14px leading-19px font-light tracking-0_01em">Support</span>
+                                                    </a>
+
+                                                    <div data-expand-content data-kb-content class="invisible" data-name="support" id="support">
+                                                        <div class="sticky top-0">
+                                                            <a href="#" class="back" data-back-expand data-name="support" aria-controls="support">
+                                                                <span class="icon">
+                                                                    <svg width="16" height="27" viewBox="0 0 16 27" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                                                        <path d="M14.7136 25.7271L2.08204 13.7271L14.7136 1.72705" stroke="#2E2E2E" stroke-width="1.5" stroke-linecap="round"></path>
+                                                                    </svg>
+                                                                </span>
+                                                                <span class="text-14px leading-19px font-light tracking-0_01em pl-26px">Support</span>
+                                                            </a>
+                                                        </div>
+
+                                                        <div class="px-24px">
+                                                            
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            
+
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/faqs" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Frequently asked questions</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="https://kitchenaid.com.au/blogs/kitchenthusiast/tagged/blog-category-hints-tips" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Product Hints & Tips</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/delivery" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Delivery</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/returns-policy" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Returns</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/register-my-product" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Register My Product</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/stockists" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Stockist & Service Centre Finder</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/user-guides" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">User Guides</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="https://cdn.shopify.com/s/files/1/0172/8692/2294/files/KA_2021_Warranty_Flyer_updated_30.07.21.pdf?v=1627614148" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Warranty Information</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/product-safety-recall" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Product Safety Recall</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="/pages/price-match-policy" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Price Match Policy</a>
+                                                                            </div>
+                                                                    
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                            <div class="flex">
+                                                                                <a href="https://giftcards.kitchenaid.com.au/" class="capitalize text-14px leading-19px tracking-0_01em font-light text-black-100 px-15px py-15px">Gift Cards</a>
+                                                                            </div>
+                                                                    
+                                                                
+
+                                                                <!-- close new group when last -->
+                                                                
+
+                                                                
+
+                                                                
+
+                                                            
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+                                                                            
+                                                                                <div class="capitalize flex items-center px-15px pt-16px border-t border-black-8">
+                                                                                    <span class="text-15px leading-24px tracking-0.2px font-light text-black-38">Track my order</span>
+                                                                                </div>
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            
+
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            <a href="/pages/track-my-order"  class="capitalize flex items-center px-15px py-15px">
+                                                                                <span class="new-home-icon-track-order text-18px text-red-100 mr-12px"></span>
+                                                                                <span class="text-14px leading-19px tracking-0_01em font-light text-black-100">Check my order status</span>
+                                                                            </a>
+                                                                            
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                                <div class="capitalize flex items-center px-15px pt-16px border-t border-black-8">
+                                                                                    <span class="text-15px leading-24px tracking-0.2px font-light text-black-38"> <span class="normal-case">CUSTOMER SERVICE FOR SMALL APPLIANCES (STAND MIXER, FOOD PROCESSOR, BLENDERS, BREAKFAST)</span></span>
+                                                                                </div>
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            
+
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            <a href="/pages/contact-us"  class="capitalize flex items-center px-15px py-15px">
+                                                                                <span class="new-home-icon-form-fill text-18px text-red-100 mr-12px"></span>
+                                                                                <span class="text-14px leading-19px tracking-0_01em font-light text-black-100">Online Enquiry Form</span>
+                                                                            </a>
+                                                                            
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            <a href="tel:1800990990"  class="capitalize flex items-center px-15px py-15px">
+                                                                                <span class="new-home-icon-headphones-mic text-18px text-red-100 mr-12px"></span>
+                                                                                <span class="text-14px leading-19px tracking-0_01em font-light text-black-100">1800 990 990</span>
+                                                                            </a>
+                                                                            
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+                                                                                
+
+                                                                                
+
+                                                                                
+
+                                                                            
+
+                                                                            
+                                                                            
+                                                                                <div class="capitalize flex items-center px-15px pt-16px border-t border-black-8">
+                                                                                    <span class="text-15px leading-24px tracking-0.2px font-light text-black-38"> <span class="normal-case">CUSTOMER SERVICE FOR KITCHENWARE & OVENWARE (COOKWARE & BAKEWARE))</span></span>
+                                                                                </div>
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            
+
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            <a href="tel:1800918480"  class="capitalize flex items-center px-15px py-15px">
+                                                                                <span class="new-home-icon-headphones-mic text-18px text-red-100 mr-12px"></span>
+                                                                                <span class="text-14px leading-19px tracking-0_01em font-light text-black-100">1800 918 480 (Hours of Operation: Mon-Fri; 9am – 6pm)</span>
+                                                                            </a>
+                                                                            
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+
+                                                                            
+
+                                                                            
+
+                                                                            
+                                                                            
+
+                                                                            <a href="https://support.kitchenaidtools.com/hc/en-au"  class="capitalize flex items-center px-15px py-15px">
+                                                                                <span class="new-home-icon-web text-18px text-red-100 mr-12px"></span>
+                                                                                <span class="text-14px leading-19px tracking-0_01em font-light text-black-100">Kitchenware Information</span>
+                                                                            </a>
+                                                                            
+                                                                        
+                                                                
+
+                                                                <!-- close new group when last -->
+                                                                
+
+                                                                
+
+                                                                
+
+                                                            
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+                                                                
+
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+                                                                            
+
+                                                                        
+                                                                
+                                                                    
+
+                                                                    
+                                                                            
+                                                                            
+
+                                                                        
+                                                                
+
+                                                                <!-- close new group when last -->
+                                                                
+
+                                                                
+
+                                                                
+
+                                                            
+                                                        </div>
+                                                    </div>
+                                                
+                                            </div>
+                                            
+                                            <a href="" class="block text-center lg:hidden"  data-account-element>
+                                                <span class="new-home-icon-user w-32px h-32px text-26px mx-auto mb-14px"></span>
+                                                <span class="block text-14px leading-19px font-light tracking-0_01em">Account</span>
+                                            </a>
+                                        </div>
+
+                                        <!-- mobile banner -->
+                                        
+                                        
+
+                                        
+                                        <!-- end mobile banner -->
+
+                                        <!-- mobile_sale_banner -->
+                                        
+                                            
+                                            
+<div class="-mx-24px lg:hidden mt-4px">
+                                                    <a href="https://kitchenaid.com.au/collections/mothers-day-sale" class="block relative " data-promotion_banner>
+                                                        <div class="absolute z-20 pt-20px left-0 top-0 w-full px-24px md:px-64px" >
+                                                            
+                                                            
+                                                                <span class="block text-24px leading-32px text-grey-100">Mother's Day Sale</span>
+                                                            
+                                                            
+                                                            
+                                                                <span class="mt-20px lg:mt-30px block txt text-14px leading-16px lg:text-16px lg:leading-19px tracking-0_01em font-light uppercase">SHOP NOW</span>
+                                                            
+                                                        </div>
+                                                        <div class="img pb-89.250814332">
+                                                            
+                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" data-retina="//kitchenaid.com.au/cdn/shop/files/KSM195DR-navmobile_654x548_5cf651cd-1394-44d4-a52e-96f92036fe8e_x548.jpg?v=1712274749" class="lazy object-cover w-full h-full" alt="">
+                                                            
+                                                        </div>
+                                                    </a>
+                                                </div>
+                                            
+                                        
+                                        <!-- end mobile_sale_banner -->
+
+                                        <span class="block lg:hidden h-100px"></span>
+                                    </nav>
+                                </div>
+                            </div>
+
+                            <a href="#" class="flex items-center justify-center w-40px h-56px lg:hidden" data-search-element data-name="search" data-kb-element aria-expanded="false">
+                                <span class="new-home-icon-search text-16px text-black-100"></span>
+                                <span class="sr-only">Search</span>
+                            </a>
+
+                            <a href="/" class="logo ml-15px">
+                                <svg width="159" height="16" viewBox="0 0 159 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M39.3614 13.286C38.8539 13.286 38.3672 13.0839 38.008 12.7239C37.6489 12.3639 37.4468 11.8755 37.446 11.366V8.55246H40.5612V5.92H37.446V2.29736H31.2667V5.92H29.4023V8.55246H31.2667V12.3291V12.4589C31.2667 14.3396 33.3445 15.8672 35.9124 15.8672C37.517 15.8909 39.1058 15.5471 40.5582 14.8619V12.8543C40.2207 13.1324 39.7979 13.2849 39.3614 13.286Z" fill="#C41230" />
+                                    <path d="M27.4117 5.92004H21.3076V15.3087H27.4117V5.92004Z" fill="#C41230" />
+                                    <path d="M24.3565 4.54925C26.0404 4.54925 27.4026 3.54095 27.4026 2.29416C27.4026 1.04736 26.0404 0.0390625 24.3565 0.0390625C22.6726 0.0390625 21.3135 1.05038 21.3135 2.29416C21.3135 3.53793 22.6756 4.54925 24.3565 4.54925Z" fill="#C41230" />
+                                    <path d="M80.5384 11.3992H89.1323C89.1323 11.3992 89.3668 9.13812 88.2542 7.70416C87.0514 6.16755 84.6459 5.28906 81.9817 5.28906C79.3175 5.28906 74.3621 5.94718 74.3621 10.6506C74.3621 15.354 78.9988 15.8762 81.9697 15.8762C87.6619 15.8762 88.9609 14.5479 88.9609 14.5479V12.6309C87.156 13.228 85.2682 13.5337 83.3679 13.5366C80.2226 13.5366 80.5384 11.7494 80.5384 11.3992ZM80.5384 9.1985V8.88152C80.5384 8.48119 80.6968 8.09726 80.9787 7.81418C81.2607 7.53111 81.6431 7.37208 82.0418 7.37208C82.4406 7.37208 82.823 7.53111 83.105 7.81418C83.3869 8.09726 83.5453 8.48119 83.5453 8.88152C83.5453 8.88152 83.5453 9.20453 83.5453 9.20755V9.23774H80.5384V9.1985Z" fill="#C41230" />
+                                    <path d="M67.2146 5.62712C65.9435 5.67424 64.7162 6.10565 63.6935 6.86485V0.902588H57.5894V15.3056H63.6845V10.7441C63.6845 10.3438 63.8429 9.95984 64.1248 9.67677C64.4068 9.39369 64.7892 9.23466 65.1879 9.23466C65.5867 9.23466 65.9691 9.39369 66.2511 9.67677C66.533 9.95984 66.6914 10.3438 66.6914 10.7441V15.3056H72.2874V9.85353C72.2814 8.86032 71.1177 5.62712 67.2146 5.62712Z" fill="#C41230" />
+                                    <path d="M101.064 5.62714C99.7937 5.67374 98.5672 6.10523 97.5459 6.86487V5.91997H91.4387V15.3056H97.5338V10.7441C97.5338 10.3438 97.6922 9.95986 97.9742 9.67679C98.2561 9.39371 98.6386 9.23468 99.0373 9.23468C99.4361 9.23468 99.8185 9.39371 100.1 9.67679C100.382 9.95986 100.541 10.3438 100.541 10.7441V15.3056H106.137V9.85355C106.131 8.86034 104.967 5.62714 101.064 5.62714Z" fill="#C41230" />
+                                    <path d="M134.571 5.92004H128.467V15.3087H134.571V5.92004Z" fill="#C41230" />
+                                    <path d="M131.518 4.54925C133.202 4.54925 134.565 3.54095 134.565 2.29416C134.565 1.04736 133.202 0.0390625 131.518 0.0390625C129.835 0.0390625 128.472 1.05038 128.472 2.29416C128.472 3.53793 129.838 4.54925 131.518 4.54925Z" fill="#C41230" />
+                                    <path d="M119.437 15.3057H126.743L120.176 0H112.869L113.642 1.81132L107.866 15.3057H111.504L112.677 12.6068H118.294L119.437 15.3057ZM114.108 9.23773L115.47 6.06189L116.832 9.23773H114.108Z" fill="#C41230" />
+                                    <path d="M16.4121 7.93962C16.2032 7.43305 15.8754 6.98476 15.4565 6.63307C15.0376 6.28137 14.5401 6.03671 14.0065 5.92L18.126 0H12.6564L8.95481 5.31924C8.81477 5.50671 8.63317 5.65887 8.4244 5.76366C8.21564 5.86846 7.98544 5.92302 7.75203 5.92302C7.59266 5.92302 7.47238 5.92302 7.42126 5.92302V0H0.300781V15.3057H7.43329V9.96528C7.73406 9.81846 8.06409 9.74207 8.39852 9.74189C8.84323 9.74454 9.27739 9.87809 9.64724 10.126C10.0171 10.3739 10.3064 10.7253 10.4793 11.1366L12.2835 15.3057H19.5904L16.4121 7.93962Z" fill="#C41230" />
+                                    <path d="M51.8611 12.5435C49.8404 12.5435 48.2016 11.9096 48.2016 10.5752C48.2016 9.2409 49.8404 8.60996 51.8611 8.60996C53.0639 8.60996 54.1283 8.83637 54.7959 9.29826V6.59335C53.4398 5.70279 51.5875 5.27411 49.5307 5.27411C45.4292 5.27411 42.1035 6.97977 42.1035 10.5752C42.1035 14.1707 45.4292 15.8764 49.5307 15.8764C51.5875 15.8764 53.4398 15.4477 54.7959 14.5662V11.8492C54.1283 12.3292 53.0639 12.5435 51.8611 12.5435Z" fill="#C41230" />
+                                    <path d="M146.087 0.881287V6.16732C145.045 5.57529 143.869 5.26333 142.671 5.26166C139.144 5.26166 136.573 6.8828 136.573 10.3002C136.573 13.7175 139.138 15.3266 142.671 15.3266C143.868 15.3234 145.045 15.0116 146.087 14.4209V15.2903H152.191V0.881287H146.087ZM144.421 12.0934C143.976 12.0485 143.564 11.8393 143.264 11.5063C142.964 11.1732 142.797 10.7402 142.797 10.2911C142.797 9.84203 142.964 9.40896 143.264 9.07594C143.564 8.74292 143.976 8.53368 144.421 8.48883C145.047 8.49315 145.646 8.74603 146.087 9.19223V11.3869C145.647 11.834 145.048 12.0879 144.421 12.0934Z" fill="#C41230" />
+                                    <path d="M156.879 1.60302C156.879 1.12302 156.536 0.857361 155.977 0.857361H155.138V3.31774H155.676V2.36679H155.857L156.506 3.33585L157.069 3.23925L156.41 2.27321C156.55 2.22753 156.671 2.13751 156.756 2.01665C156.841 1.8958 156.884 1.75065 156.879 1.60302ZM155.926 1.99547H155.676V1.29812H155.932C156.191 1.29812 156.335 1.42189 156.335 1.64227C156.335 1.86264 156.179 1.99547 155.92 1.99547H155.926Z" fill="#C41230" />
+                                    <path d="M155.956 0.0390138C155.679 0.0302938 155.404 0.0793198 155.147 0.182995C154.89 0.286669 154.657 0.442738 154.463 0.641338C154.269 0.839938 154.118 1.07675 154.02 1.33681C153.922 1.59687 153.879 1.87452 153.893 2.15222C153.893 3.42015 154.738 4.26543 155.956 4.26543C156.233 4.27507 156.509 4.22667 156.767 4.12332C157.024 4.01997 157.257 3.86392 157.451 3.66513C157.645 3.46634 157.796 3.22915 157.894 2.96867C157.991 2.7082 158.034 2.43014 158.019 2.15222C158.019 0.896372 157.18 0.0390138 155.956 0.0390138ZM155.956 3.92128C155.036 3.92128 154.299 3.28732 154.299 2.1643C154.299 1.04128 155.036 0.398259 155.956 0.398259C156.876 0.398259 157.622 1.03524 157.622 2.1643C157.622 3.29335 156.879 3.92128 155.956 3.92128Z" fill="#C41230" />
+                                </svg>
+                                <span class="sr-only">Logo Kitchenaid</span>
+                            </a>
+                        </div>
+
+                        <div class="flex items-center justify-end lg:hidden">
+                            
+	
+    <a href="/apps/iwish" class="flex items-center justify-center w-40px h-40px lg:w-38px lg:h-38px rounded-full lg:ml-15px" data-btn-control arial-label="View wishlist">
+        <span class="new-home-icon-favourire text-16px lg:text-18px"></span>
+        <span class="sr-only">Wishlist</span>
+    </a>
+
+
+
+                            <a href="/cart" class="flex items-center justify-center w-40px h-40px rounded-full -mr-12px" data-btn-control data-shopping-cart-element role="button" arial-label="Open popup cart" >
+                                <span class="new-home-icon-cart text-16px lg:text-20px"></span>
+                                <span class="sr-only">Cart</span>
+                                <div id="CartCount" class="site-header__cart-count text-12px hidden">
+                                    (0)
+                                </div>
+                            </a>
+                        </div>
+                        
+                    </div>
+                </div>
+            </div>
+    </header>
+</div>
+
+
+
+<!-- search mb -->
+<div data-search-content data-name="search" class="lg:hidden" data-height-equal-to-header data-kb-content data-kb-mobile="true">
+    <span class="overlay" data-search-close data-name="search"></span>
+
+    
+    <form method="get" action="/collections/shop" class="bg-gray-200 p-8px">
+        <div class="form-group bg-white rounded-full flex">
+            <div class="input">
+                <label class="sr-only" for="search-accordion-term">Search</label>
+                <input type="text" placeholder="Search" name="s" id="search-accordion-term" class="ss__autocomplete__input form-control text-15px leading-24px py-8px pl-24px">
+            </div>
+            <button>
+                <span class="sr-only">Search</span>
+                <icon class="icon-search text-14px text-grey-100 w-40px h-40px"></icon>
+            </button>
+        </div>
+    </form>
+    
+
+</div>
+<!-- end search mb -->
+
+<!-- cart popup -->
+<span class="no-scroll hidden"></span>
+<div id="cart-popup" data-shopping-cart-content="" class="fixed left-0 top-0 w-full h-full">
+    <span class="overlay bg-black-40 z-10 absolute" data-shopping-cart-close=""></span>
+    <div class="box z-20 absolute right-0 top-0 h-full bg-white sidebar">
+        <span data-cart-loading data-shopping-cart-loading class="absolute z-50 left-0 top-0 w-full h-full bg-black-8"></span>
+        <div class="h-full flex flex-col">
+            <div data-cart-top="">
+                <div class="px-24px">
+                    <div class="flex items-center justify-between py-16px">
+                        <span class="block text-black-100 text-28px leading-38px lg:text-32px lg:leading-44px tracking-0.5px font-medium">Cart <i class="not-italic text-12px leading-16px tracking-1px uppercase">(<span data-cart-count>0</span> item<span data-cart-count-plural class="hidden">s</span>)</i></span>
+                        <a href="#" class="flex items-center justify-center" data-shopping-cart-close="" data-name="shopping-cart">
+                            <span class="sr-only">Close cart popup</span>
+                            <span class="icon-close text-14px w-24px h-24px text-black-100"></span>
+                        </a>
+                    </div>
+                </div>
+                <div class="border-t border-solid border-light-grey-100 bg-light-grey-100" data-cart-mss data-sale='You qualify for <i class="not-italic text-red-100">free delivery!</i>' data-empty="Your cart is empty">
+                    <span class="block text-12px leading-12px tracking-1px font-medium uppercase pt-13px pb-11px border-b-3 border-solid border-red-100 text-center " data-cart-mss-content>Your cart is empty</span>
+                </div>
+            </div>
+            <div data-cart-bottom="" class="relative h-full flex flex-col overflow-hidden">
+                <div data-cart-list class="h-full overflow-auto hide-scrollbar px-24px flex flex-col gap-16px py-16px md:gap-20px md:py-20px xl:gap-24px xl:py-24px">
+                    
+                    <div class="text-center py-47px" data-cart-empty-content>
+                        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://cdn.shopify.com/s/files/1/0172/8692/2294/files/Price_2_small_crop_center.png?v=1635389075" alt="PRICE MATCH POLIC" class="lazy w-48px h-48px mx-auto mb-28px">
+                        <p class="text-12px leading-16px tracking-1px text-black-100 uppercase mb-7px">PRICE MATCH POLICY</p>
+                        <p class="text-12px leading-18px tracking-1px text-black-100">Our price promise.<br/><a href="/pages/price-match-policy" class="underline transition-colors duration-250 hover:text-red-100">Learn more</a></p>
+                    </div>
+                </div>
+                <div id="farage-cart-popup-summary-wrapper" data-cart-sumary="" class="sticky w-full left-0 bottom-0 z-40">
+                    <div class="personalise-box w-mobile" style="display: none;">
+                        <a href="/pages/personalise-tool" class="flex items-center justify-between py-8px pl-16px pr-21px bg-grey-100 text-light-grey-100" data-cart-personalise-popup-link>
+                            <span class="txt text-16px leading-22px font-medium" data-text="Personalise your %short_type%"></span>
+                            <span class="svg">
+                                <svg width="7" height="14" viewBox="0 0 7 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path opacity="0.9" d="M1.00024 0.76001L5.99219 6.99994L1.00024 13.2399" stroke="inherit" stroke-width="1.24799" stroke-linecap="round" class="stroke-current" />
+                                </svg>
+                            </span>
+                        </a>
+                    </div>
+                    <div class="panel panel-tab w-skin-01 promotion-wrapper">
+                        <div id="shopify-section-kitchenaid-cart-promotion" ><div class="box-content px-15px md:px-16px py-16px relative bg-white hidden"data-cart-promotion="kitchenaid-mixers||stand-mixer-attachments-accessories"><button class="no-outline w-full flex justify-between items-center text-12px leading-16px tracking-1px text-black-100 font-medium mb-2px on" data-toogle-element data-name="toggle-cart-promotion">
+	        		<span class="flex-1 text-left pr-10px">SAVE <span class="text-red-100">5%</span> ON AN  ATTACHMENT</span>
+	        		<i class="toogle-btn small w-bg-red block rounded-full w-21px h-21px"></i>
+	        	</button><div class="wrap overflow-visible" style="height: auto;">
+	        	<div data-toogle-content-element data-name="toggle-cart-promotion" aria-expanded="true" class="on">
+		        	<p class="text-12px leading-16px text-black-100 font-light mb-20px">When you add now. Discount will be shown at cart.</p><div class="swiper" data-cart-promotion-slider>
+				            <div class="swiper-wrapper"><div class="swiper-slide bg-white"><form method="post" action="/cart/add" id="product_form_2262122561590" accept-charset="UTF-8" class="shopify-product-form flex flex-wrap items-center" enctype="multipart/form-data" novalidate="novalidate" data-cart-product=""><input type="hidden" name="form_type" value="product" /><input type="hidden" name="utf8" value="✓" />
+<a href="/products/3-piece-pasta-roller-and-cutter-attachment-ksmpra" class="block w-80px"><div class="img pb-100">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/products/KitchenAid-Stand-Mixer-Attachment-KSMPRA-01_160x_crop_center.jpg?v=1570028358" alt="3-Piece Pasta Roller and Cutter Attachment KSMPRA" class="lazy object-contain">
+                </div></a>
+        <div class="flex-1 pl-5px">
+            <a href="/products/3-piece-pasta-roller-and-cutter-attachment-ksmpra" class="block text-12px leading-16px text-black-100 font-medium">3-Piece Pasta Roller and Cutter Attachment KSMPRA</a>
+            
+<p class="text-12px leading-16px text-black-100 font-light mt-6px" data-cart-product-price>$249.00</p>
+            <button type="submit" name="add" class="bg-light-grey-100 text-black-100 transition-background-color duration-250 hover:bg-red-100 hover:text-white text-center py-3px rounded-30px w-94px mt-9px">
+                <span class="txt block text-14px leading-22px uppercase px-25px">add</span>
+            </button>
+        </div>
+        <select name="id" data-variants-list class="hidden"><option selected="selected" value="21078282108982" data-price="$249.00">default title</option></select>
+    <input type="hidden" name="product-id" value="2262122561590" /><input type="hidden" name="section-id" value="kitchenaid-cart-promotion" /></form>
+</div><div class="swiper-slide bg-white"><form method="post" action="/cart/add" id="product_form_2262077341750" accept-charset="UTF-8" class="shopify-product-form flex flex-wrap items-center" enctype="multipart/form-data" novalidate="novalidate" data-cart-product=""><input type="hidden" name="form_type" value="product" /><input type="hidden" name="utf8" value="✓" />
+<a href="/products/metal-food-grinder-attachment-5ksmmga" class="block w-80px"><div class="img pb-100">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/products/KitchenAid-Stand-Mixer-Attachment-KSMMGAA-01_160x_crop_center.jpg?v=1570029998" alt="Metal Food Grinder Attachment 5KSMMGAA" class="lazy object-contain">
+                </div></a>
+        <div class="flex-1 pl-5px">
+            <a href="/products/metal-food-grinder-attachment-5ksmmga" class="block text-12px leading-16px text-black-100 font-medium">Metal Food Grinder Attachment 5KSMMGAA</a>
+            
+<p class="text-12px leading-16px text-black-100 font-light mt-6px" data-cart-product-price>$199.00</p>
+            <button type="submit" name="add" class="bg-light-grey-100 text-black-100 transition-background-color duration-250 hover:bg-red-100 hover:text-white text-center py-3px rounded-30px w-94px mt-9px">
+                <span class="txt block text-14px leading-22px uppercase px-25px">add</span>
+            </button>
+        </div>
+        <select name="id" data-variants-list class="hidden"><option selected="selected" value="21078124298294" data-price="$199.00">default title</option></select>
+    <input type="hidden" name="product-id" value="2262077341750" /><input type="hidden" name="section-id" value="kitchenaid-cart-promotion" /></form>
+</div>
+<div class="swiper-slide bg-white"><form method="post" action="/cart/add" id="product_form_6605614743624" accept-charset="UTF-8" class="shopify-product-form flex flex-wrap items-center" enctype="multipart/form-data" novalidate="novalidate" data-cart-product=""><input type="hidden" name="form_type" value="product" /><input type="hidden" name="utf8" value="✓" />
+<a href="/products/ice-shaver-attachment" class="block w-80px"><div class="img pb-100">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/products/iceshave_01_160x_crop_center.jpg?v=1666345034" alt="Shave Ice Attachment for Stand Mixer 5KSMSIA" class="lazy object-contain">
+                </div></a>
+        <div class="flex-1 pl-5px">
+            <a href="/products/ice-shaver-attachment" class="block text-12px leading-16px text-black-100 font-medium">Shave Ice Attachment for Stand Mixer 5KSMSIA</a>
+            
+<p class="text-12px leading-16px text-black-100 font-light mt-6px" data-cart-product-price>$149.00</p>
+            <button type="submit" name="add" class="bg-light-grey-100 text-black-100 transition-background-color duration-250 hover:bg-red-100 hover:text-white text-center py-3px rounded-30px w-94px mt-9px">
+                <span class="txt block text-14px leading-22px uppercase px-25px">add</span>
+            </button>
+        </div>
+        <select name="id" data-variants-list class="hidden"><option selected="selected" value="39412253786184" data-price="$149.00">default title</option></select>
+    <input type="hidden" name="product-id" value="6605614743624" /><input type="hidden" name="section-id" value="kitchenaid-cart-promotion" /></form>
+</div><div class="swiper-slide bg-white"><form method="post" action="/cart/add" id="product_form_2262078554166" accept-charset="UTF-8" class="shopify-product-form flex flex-wrap items-center" enctype="multipart/form-data" novalidate="novalidate" data-cart-product=""><input type="hidden" name="form_type" value="product" /><input type="hidden" name="utf8" value="✓" />
+<a href="/products/fresh-prep-slicer-shredder-attachment-5ksmvsa" class="block w-80px"><div class="img pb-100">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/products/KitchenAid-Stand-Mixer-Attachment-KSMVSA-01_160x_crop_center.jpeg?v=1570028372" alt="Fresh Prep Slicer & Shredder Attachment 5KSMVSA" class="lazy object-contain">
+                </div></a>
+        <div class="flex-1 pl-5px">
+            <a href="/products/fresh-prep-slicer-shredder-attachment-5ksmvsa" class="block text-12px leading-16px text-black-100 font-medium">Fresh Prep Slicer & Shredder Attachment 5KSMVSA</a>
+            
+<p class="text-12px leading-16px text-black-100 font-light mt-6px" data-cart-product-price>$149.00</p>
+            <button type="submit" name="add" class="bg-light-grey-100 text-black-100 transition-background-color duration-250 hover:bg-red-100 hover:text-white text-center py-3px rounded-30px w-94px mt-9px">
+                <span class="txt block text-14px leading-22px uppercase px-25px">add</span>
+            </button>
+        </div>
+        <select name="id" data-variants-list class="hidden"><option selected="selected" value="21078127312950" data-price="$149.00">default title</option></select>
+    <input type="hidden" name="product-id" value="2262078554166" /><input type="hidden" name="section-id" value="kitchenaid-cart-promotion" /></form>
+</div></div>
+				            <div class="flex items-center justify-between mt-30px">
+				                <div class="swiper-pagination relative flex items-center lg:hidden"></div>
+				                <div class="hidden lg:flex lg:items-center">
+				                    <div class="new-home-icon-arrow-left text-17px text-black-100 w-20px h-20px" data-cart-promotion-slider-btn-prev></div>
+				                    <div class="new-home-icon-arrow-right text-17px text-black-100 w-20px h-20px ml-15px" data-cart-promotion-slider-btn-next></div>
+				                </div><a href="/collections/stand-mixer-attachments-accessories" class="text-12px leading-16px tracking-1px text-black-100 uppercase transition-colors duration-250 hover:text-red-100">see all attachments</a></div>
+				        </div></div>
+		    </div>
+	    </div>
+</div>
+                    </div>
+                    <!-- countdown timmer -->
+                    <div class="cart-countdown-timer-wrapper" style="display: none;"><div class="countdown-timer-wrapper" data-countdown-timer='{"start": "2024-02-01T10:53:00", "end": "2024-02-14T23:59:00"}' data-type="mini-cart" style="display: none;">
+		<div class="flex items-center justify-center px-12px py-16px bg-light-grey-100" style="border: 1px solid #F0F0F0; border-top: 3px solid #F0F0F0;"><p class="text-14px leading-17px tracking-0.02em pb-4px mr-10px text-grey-100">VALENTINES DAY SALE ENDS IN</p><div class="flex">
+				<div class="">
+					<div class="flex justify-center items-center shadow-countdown bg-white w-27px h-27px">
+						<p class="text-14px leading-17px text-grey-100" data-countdown-timer-days>00</p>
+					</div>
+					<p class="text-8px leading-1 tracking-0.1em mt-2px text-grey-100 font-medium uppercase text-center">days</p>
+				</div>
+				<p class="text-20px leading-22px mx-4px text-grey-100">:</p>
+				<div class="">
+					<div class="flex justify-center items-center shadow-countdown bg-white w-27px h-27px">
+						<p class="text-14px leading-17px text-grey-100" data-countdown-timer-hours>00</p>
+					</div>
+					<p class="text-8px leading-1 tracking-0.1em mt-2px text-grey-100 font-medium uppercase text-center">HRS</p>
+				</div>
+				<p class="text-20px leading-22px mx-4px text-grey-100">:</p>
+				<div class="">
+					<div class="flex justify-center items-center shadow-countdown bg-white w-27px h-27px">
+						<p class="text-14px leading-17px text-grey-100" data-countdown-timer-minutes>00</p>
+					</div>
+					<p class="text-8px leading-1 tracking-0.1em mt-2px text-grey-100 font-medium uppercase text-center">MIN</p>
+				</div>
+			</div>
+		</div>
+	</div></div>
+                    <!-- end countdown timmer -->
+                    <div class="px-15px md:px-16px py-16px relative flex items-center bg-white cart-btn-wrapper">
+                        <!-- <a href="/cart" class="btn btn-link block w-full w-bg medium gray-outline-w-dark-red mb-16px">
+                            <span class="txt w-custom block uppercase text-center whitespace-nowrap" style="white-space: nowrap;">view cart</span>
+                        </a> -->
+                        <a href="/checkout" class="block btn btn-link w-bg medium dark-red text-center flex-1">
+                            <span class="txt block text-15px leading-18px tracking-1px uppercase py-14px">checkout · <i class="not-italic" data-subtotal-price>$0.00 </i></span>
+                        </a>
+                        <a href="/cart" class="text-12px leading-16px tracking-1px text-black-100 uppercase border-b border-black-100 transition-colors duration-250 hover:text-red-100 hover:border-red-100 ml-16px">view cart</a>
+                        <div class="absolute z-10 w-full left-0 bottom-0 px-15px md:px-16px py-16px " data-continue-shopping>
+                            <a href="/" class="block btn btn-link btn btn-link w-bg medium dark-black text-center">
+                                <span class="txt block text-15px leading-20px tracking-1px uppercase py-14px text-center">continue shopping</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="personalise-box w-desktop" style="display: none;">
+        <div class="flex flex-wrap w-500px bg-light-grey-100 rounded-6px overflow-hidden">
+            <div class="w-262px">
+                <div class="img pb-68.3206106870229">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt="personalise" class="lazy object-cover w-full h-full" data-mixer-image="https://cdn.shopify.com/s/files/1/0753/3894/0727/files/personalise-cart-popup_524x_crop_center.png?v=1702539370" data-blender-image="https://cdn.shopify.com/s/files/1/0172/8692/2294/files/blender_personalise_popup_524x_crop_center.jpg?v=1680516587">
+                </div>
+            </div>
+            <div class="flex-1 pl-20px pr-16px py-26px">
+                <p class="text-18px leading-25px font-medium text-grey-100 mb-8px" data-text="Personalise your %short_type%"></p>
+                <p class="text-14px leading-19px font-medium text-grey-100 mb-8px" data-text="Our complimentary service enables you to engrave the %type% band."></p>
+                <a href="/pages/personalise-tool" class="inline-flex items-center gap-12px py-4px text-grey-100 transition-colors duration-250 hover:text-red-100" data-cart-personalise-popup-link>
+                    <span class="txt text-14px leading-19px tracking-0.01em font-light">PERSONALISE NOW</span>
+                    <span class="svg">
+                        <svg width="7" height="15" viewBox="0 0 7 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path opacity="0.9" d="M1.00024 1.26001L5.99219 7.49994L1.00024 13.7399" stroke="inherit" stroke-width="1.24799" stroke-linecap="round" class="stroke-current" />
+                        </svg>
+                    </span>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+<!-- end cart -->
+<span class="hidden"></span>
+</div>
+
+  
+    
+       <main class="main-content js-focus-hidden" id="main" role="main">
+        
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="">
+    <div class="inner w-1920px">
+        <div class="flex">
+            <a href="/blogs/kitchenthusiast" class="flex items-center text-grey-200 py-10px lg:py-18px">
+                <span class="new-home-icon-arrow-left text-14px w-16px h-16px mr-8px"></span>
+                <span class="block text-15px leading-20px font-normal tracking-1px uppercase">Back</span>
+            </a>
+        </div>
+    </div>
+</div>
+<section class="blog-recipe-banner">
+    <div class="inner w-1920px px-0">
+        <div class="md:flex md:items-center md:flex-wrap ">
+            <div class="md:w-62.7777777778 xxxl:w-63.333333333">
+                
+                <div class="img pb-62.9333333333 md:pb-63.053097345">
+                    <img src="//kitchenaid.com.au/cdn/shop/articles/1U9A1839_BM_1_750x472_crop_center.jpg?v=1649313257" alt="Hot Cross Buns" class="object-cover h-full w-full md:hidden">
+                    
+                    <img src="//kitchenaid.com.au/cdn/shop/articles/1U9A1839_BM_1_1356x855_crop_center.jpg?v=1649313257" alt="Hot Cross Buns" class="object-cover h-full w-full hidden md:block" style="">
+                </div>
+                
+            </div>
+            <div class="p-40px md:p-0 md:flex-1 ">
+                <div class="md:max-w-408px xxxl:max-w-464px  md:pr-20px md:pl-32px xl:pl-48px xxxl:pl-64px xxl:pr-0 ">
+                    <p class="text-12px leading-16px tracking-1px uppercase text-grey-200 mb-8px">Apr 15th 2019 · kitchenaid</p>
+                    <h1 class="text-32px leading-44px tracking-0.5px font-normal md:text-36px md:leading-48px lg:text-42px lg:leading-54px xl:text-52px xl:leading-64px text-black-100 mb-16px">Hot Cross Buns</h1>
+                    <div class="copy w-blog text-15px leading-24px tracking-0.2px font-light text-grey-100">
+                        <p>An everyday classic Easter treat! Ben Milbourne shares his recipe for hot cross buns, filled with fruit and spices. Serve fresh with a dollop of butter!</p>
+<p>Explore our <a href="https://kitchenaid.com.au/blogs/kitchenthusiast/easter-desserts" target="_blank" rel="noopener noreferrer">Easter dessert</a> and <a href="https://kitchenaid.com.au/blogs/kitchenthusiast/easter-lunch-ideas" target="_blank" rel="noopener noreferrer">lunch recipe</a> ideas too!</p>
+                    </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<div class="blog-recipe-content">
+    <section class="blogRecipe">
+<div class="inner">
+<div class="blogRecipe-summary">
+<ul>
+<li>
+<strong>Makes</strong>
+<p>12 servings</p>
+</li>
+<li>
+<strong>Prep &amp; Cook Time</strong>
+<p>1 hour 20 minutes</p>
+</li>
+</ul>
+</div>
+<article class="blogRecipe-article">
+<div class="leftPanel">
+<h2>Ingredients</h2>
+<ul>
+<li>4 cups plain flour</li>
+<li>¼ cup caster sugar</li>
+<li>1 tsp cinnamon</li>
+<li>pinch of salt</li>
+<li>¾ cup sultanas</li>
+<li>2 x 7g sachets dried yeast</li>
+<li>3½ teaspoon ground allspice</li>
+<li>3¼ teaspoon grated nutmeg</li>
+<li>¾ cup currants</li>
+<li>300ml milk</li>
+<li>50g butter</li>
+<li>2 eggs</li>
+</ul>
+<p> </p>
+<p> </p>
+<h2>Crosses</h2>
+<ul>
+<li>4 Tbs plain flour</li>
+<li>4 Tbs water</li>
+</ul>
+<p> </p>
+<h2>Glaze</h2>
+<ul>
+<ul>
+<li>1/3 cup sugar</li>
+<li>½ cup hot water</li>
+<li>¼ tsp cinnamon</li>
+</ul>
+</ul>
+</div>
+<div class="rightPanel">
+<h2>Method</h2>
+<ol>
+<li>Pre-heated oven to 220 degrees</li>
+<li>Using the <a href="https://kitchenaid.com.au/products/sifter-scale-attachment-ksmsftaa" target="_blank" rel="noopener noreferrer">KitchenAid Sifter + Scale Attachment</a>, sift flour, sugar, salt and spices into <a href="https://kitchenaid.com.au/products/4-8l-artisan-stand-mixer-ksm192?variant=39465599762504" target="_blank" rel="noopener noreferrer">KitchenAid stand mixer</a> bowl with dough hook attachment.</li>
+<li>Add yeast</li>
+<li>In a saucepan heat the milk over a low temperature, add butter, stir until melted</li>
+<li>Add milk and butter mixture to dry mix and turn stand mixer to level 2 until mixed thoroughly. Add the eggs and then the dried fruit continue mixing for 3-4 minutes until the dough is smooth and no longer sticky.</li>
+<li>Remove bowl from mixer, shape dough into a ball and cover with plastic wrap and place in a warm spot to prove for 1 hour or until doubled in size.</li>
+<li>Portion dough into 12 equal sized buns, placed closely together on a greased baking tray. Leave to rise for 1 hour</li>
+<li>To make the crosses, mix the flour and water thoroughly to form a thick paste. Spoon into a piping bag and pipe the paste in crosses on the buns</li>
+<li>Bake in oven for 20 minutes or until golden</li>
+<li>Mix glaze ingredients together until sugar has dissolved. Brush glaze over buns while still hot.</li>
+</ol>
+</div>
+</article>
+</div>
+</section>
+    
+
+
+
+
+
+    
+    <section class="panel-featured-collection w-white custom custom-border py-24px md:py-64px bg-light-grey-100">
+        <div class="inner px-0 md:px-18px max-w-1352px">
+            
+            
+
+            <div class="swiper-container px-24px md:px-2px" data-featured-colour-swatch-slider>
+                <div class="swiper-wrapper justify-center">
+                    
+                        
+                        
+
+                        
+                        
+                    
+                        
+                        
+
+                        
+                        
+                            
+                            
+                            
+                                
+                                
+                            
+<div class="swiper-slide w-304px">
+                            <form method="post" action="/cart/add" id="21078126788662" accept-charset="UTF-8" class="block pt-22px pb-24px px-14px bg-white border border-gray-200 h-full shopify-product-form" enctype="multipart/form-data" novalidate="novalidate" data-product-box="" data-product=""><input type="hidden" name="form_type" value="product" /><input type="hidden" name="utf8" value="✓" />
+                                <div class="relative overflow-hidden">
+                                    <a href="/products/sifter-scale-attachment-ksmsftaa?variant=21078126788662" class="block mb-12px">
+                                        <div class="img original-size pb-100 blog-custom">
+                                            <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/products/KitchenAid-Sifter-Scale-Attachment-5KSMSFTAA-01_408x.jpg?v=1587422206" alt="" class="lazy object-cover w-full h-full">
+                                        </div>
+                                    </a>        
+
+                                    <a href="/products/sifter-scale-attachment-ksmsftaa?variant=21078126788662" class="block mb-20px text-center" data-product-title>
+                                        <span class="block text-15px leading-20px tracking-0.2px text-black-100 text-center hover:text-red-100 transition-colors duration-250">Sifter + Scale Attachment KSMSFTAA</span>
+                                        
+                                    </a>
+
+                                    <div class="absolute z-1 top-0 left-0 w-full h-full on-box bg-white ">
+                                        <div class="w-120px mx-auto">
+                                            <div class="swiper-container" data-new-product-slider-for="21078126788662">
+                                                <div class="swiper-wrapper">
+                                                    
+                                                        <div class="swiper-slide">
+                                                            <div class="img original-size pb-100">
+                                                                <img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="//kitchenaid.com.au/cdn/shop/products/KitchenAid-Sifter-Scale-Attachment-5KSMSFTAA-01_240x.jpg?v=1587422206" alt="Sifter + Scale Attachment KSMSFTAA" class="lazy object-cover h-full w-full">
+                                                            </div>
+                                                        </div>
+                                                    
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="flex items-center justify-center my-8px">
+                                            <p class="text-15px leading-24px tracking-0.2px font-light line-through text-black-100 text-opacity-38 mr-8px" data-product-compare-price></p>
+                                            <p class="text-15px leading-24px tracking-0.2px font-light text-grey-100" data-product-price>$259.00</p>
+                                        </div>
+                                        <div data-equa-color>
+                                        
+                                        </div>
+                                        <div class="mt-24px px-8px">
+                                            <div class="flex flex-wrap">
+                                                <button type="submit" name="add"disabled="disabled" class="flex-1 block bg-red-100 text-white text-center hover:bg-black-100 transition-colors duration-250 py-12px md:py-14px mr-2px">
+                                                    <span class="txt block text-12px leading-16px font-normal tracking-1px md:text-15px md:leading-20px uppercase px-24px">Sold out</span>
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div class="mt-24px text-center">
+                                            <a href="/products/sifter-scale-attachment-ksmsftaa" class="text-15px leading-20px tracking-1px text-black-100 uppercase border-b border-black-100 hover:text-red-100 hover:border-red-100 transition-colors duration-250">view product details</a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="block w-24px h-24px flex justify-center items-center mx-auto mt-8px text-black-100 hover:text-red-100 transition-colors duration-250 cursor-pointer" data-product-box-btn>
+                                    <span class="new-home-icon-close text-8px rotate-45 transition-none"></span>
+                                </div>
+                                <select name="id" data-variants-list class="hidden">
+                                    
+                                        <option selected="selected" value="21078126788662" data-sku="5KSMSFTAA" data-quantity="0" data-price="$219.00" data-compare-price="$259.00">Default Title</option>
+                                    
+                                </select>
+                            <input type="hidden" name="product-id" value="2262078226486" /></form>
+                            </div>
+                        
+                    
+                </div>
+            </div>
+        </div>
+    </section>
+    
+</div>
+<div class="py-24px lg:py-40px">
+    <div class="inner w-1920px">
+        <div class="flex flex-wrap justify-between items-center md:-mb-20px">
+            <div class="w-full md:w-auto flex items-center mb-40px md:mb-20px">
+                <span class="block uppercase text-12px leading-16px tracking-1px text-grey-200 min-w-56px">tags</span>
+                <ul class="flex flex-wrap -m-4px">
+                    
+                      
+      
+      <li class="px-4px my-4px"><a class="block px-8px py-6px text-13px leading-20px text-black-100 bg-gray-200" href="/blogs/kitchenthusiast/tagged/blog-category-recipes">Recipes
+</a></li>
+      
+      
+    
+
+                      
+      
+      <li class="px-4px my-4px"><a class="block px-8px py-6px text-13px leading-20px text-black-100 bg-gray-200" href="/blogs/kitchenthusiast/tagged/blog-category-recipes+recipe-type-dessert">Dessert</a></li>
+    
+
+                      
+                    
+                </ul>
+            </div>
+            <div class="w-full md:w-auto flex items-center justify-between md:mb-20px" data-hide-on-print>
+                <div class="flex items-center md:mr-35px">
+                    <span class="block uppercase text-12px leading-16px tracking-1px text-grey-200 min-w-56px">share</span>
+                    <ul class="flex flex-wrap -mx-4px">
+                        <li class="px-4px">
+                            <a href="http://www.facebook.com/sharer/sharer.php?u=https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns" class="block p-4px text-13px leading-20px text-black-100 bg-gray-200">
+                                <span class="new-home-icon-facebook w-24px h-24px text-16px"></span>
+                            </a>
+                        </li>
+                        <li class="px-4px">
+                            <a href="https://twitter.com/intent/tweet?text=https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns&via=KitchenAidAusNZ" class="block p-4px text-13px leading-20px text-black-100 bg-gray-200">
+                                <span class="new-home-icon-twitter w-24px h-24px text-14px"></span>
+                            </a>
+                        </li>
+                        <li class="px-4px">
+                            <a href="http://pinterest.com/pin/create/button/?url=https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns&description=KitchenAid&media=articles/1U9A1839_BM_1.jpg" class="block p-4px text-13px leading-20px text-black-100 bg-gray-200">
+                                <span class="new-home-icon-pinterest w-24px h-24px text-19px"></span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="flex items-center">
+                    <span class="block uppercase text-12px leading-16px tracking-1px text-grey-200 min-w-56px">print</span>
+                    <ul class="flex flex-wrap">
+                        <li class="">
+                            <a href="#" class="block p-4px text-13px leading-20px text-black-100 bg-gray-200" data-btn-print>
+                                <span class="new-home-icon-printer w-24px h-24px text-20px"></span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+  
+  
+  
+    
+      
+        
+          
+          
+          
+    
+  
+  <div data-blog-redemption="/blogs/kitchenthusiast/tagged/blog-category-recipes+recipe-type-dessert" data-blog-except-article="Hot Cross Buns">
+    <section class="py-40px md:pt-64px md:pb-124px xxxl:pt-80px xxxl:pb-144px bg-grey-100" data-hide-on-print>
+        <div class="inner max-w-none px-0">
+            <div class="lg:flex lg:flex-wrap">
+                <div class="md:flex-1 mb-40px lg:mb-0 px-40px md:px-20px lg:pr-20px xl:pr-32px xxl:pl-64px xxxxl:pl-80px xxl:pr-48px lg:flex-1 lg:flex lg:flex-col lg:justify-center">
+                    <div class="lg:max-w-352px lg:ml-auto">
+                        <p class="uppercase text-12px leading-16px tracking-1px text-white mb-8px">blog</p>
+                        <h2 class="text-24px leading-32px -tracking-0.5px font-normal md:text-28px md:leaing-37px lg:text-30px lg:leading-41px lg:tracking-0.5px xl:text-32px xl:leading-44px text-white mb-16px">Our most adored dishes</h2>
+                    </div>
+                </div>
+                <div class="" data-sideway-right>
+                    <div class="swiper-container px-24px md:px-20px md:pb-64px md:-mb-64px lg:px-0 w-white" data-blog-slider>
+                        <div class="swiper-wrapper" data-list>
+                        </div>
+                        <div class="flex flex-wrap items-center justify-center mt-24px -mx-24px md:mx-0 md:absolute md:w-full md:bottom-0 md:left-0">
+                            <a href="#" class="w-40px h-40px flex justify-center items-center mr-12px mb-45px md:mb-0 md:mr-16px md:order-1 lg:-ml-10px" data-blog-slider-previous-btn>
+                                <svg width="20" height="15" viewBox="0 0 22 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M0.25 8C0.25 7.58579 0.585786 7.25 1 7.25H21C21.4142 7.25 21.75 7.58579 21.75 8C21.75 8.41421 21.4142 8.75 21 8.75H1C0.585786 8.75 0.25 8.41421 0.25 8Z" fill="white"/>
+                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M8.53033 0.46967C8.82322 0.762563 8.82322 1.23744 8.53033 1.53033L2.06066 8L8.53033 14.4697C8.82322 14.7626 8.82322 15.2374 8.53033 15.5303C8.23744 15.8232 7.76256 15.8232 7.46967 15.5303L0.46967 8.53033C0.176777 8.23744 0.176777 7.76256 0.46967 7.46967L7.46967 0.46967C7.76256 0.176777 8.23744 0.176777 8.53033 0.46967Z" fill="white"/>
+                                </svg>
+                            </a>
+                            <a href="#" class="w-40px h-40px flex justify-center items-center ml-12px mb-45px md:mb-0 md:ml-16px md:order-3" data-blog-slider-next-btn>
+                                <svg width="20" height="15" viewBox="0 0 22 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M0.25 8C0.25 7.58579 0.585786 7.25 1 7.25H21C21.4142 7.25 21.75 7.58579 21.75 8C21.75 8.41421 21.4142 8.75 21 8.75H1C0.585786 8.75 0.25 8.41421 0.25 8Z" fill="white"/>
+                                    <path fill-rule="evenodd" clip-rule="evenodd" d="M13.4697 0.46967C13.7626 0.176777 14.2374 0.176777 14.5303 0.46967L21.5303 7.46967C21.8232 7.76256 21.8232 8.23744 21.5303 8.53033L14.5303 15.5303C14.2374 15.8232 13.7626 15.8232 13.4697 15.5303C13.1768 15.2374 13.1768 14.7626 13.4697 14.4697L19.9393 8L13.4697 1.53033C13.1768 1.23744 13.1768 0.762563 13.4697 0.46967Z" fill="white"/>
+                                </svg>
+                            </a>
+                            <div class="w-full md:w-auto md:flex-1 swiper-scrollbar md:order-2" data-blog-slider-scrollbar></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+  </div>
+
+
+
+    <script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": "Recipe",
+        "name": "Hot Cross Buns","description": "An everyday classic Easter treat! Ben Milbourne shares his recipe for hot cross buns, filled with fruit and spices. Serve fresh with a dollop of butter!\nExplore our Easter dessert and lunch recipe ideas too!",
+            "image": ["https://kitchenaid.com.au/cdn/shop/articles/1U9A1839_BM_1_1356x.jpg?v=1649313257"],"recipeCategory": "Dessert","datePublished": "2019-04-15T19:41:00Z",
+        "author": {
+            "@type": "Organization",
+            "name": "KitchenAid"
+        }
+    }
+    </script>
+
+      </main>
+    
+  
+
+  <div id="shopify-section-kitchenaid-footer-v2" class="shopify-section"><footer class="relative z-20 bg-white">
+	<span class="block h-1px bg-grey-200" data-footer-line></span>
+	
+	
+    <div class="border-b border-gray-200">
+        <div class="inner w-1920px px-0 md:px-20px">
+        	
+        	<div class="max-w-400px py-30px px-24px md:pt-30px md:pb-32px md:max-w-919px md:mx-auto">
+		        <form action="/pages/join-kitchenaid-newsletter" method="get" class="form form-newsletter block mb-32px formNewletter md:text-center">
+		            <span class="block uppercase text-12px leading-16px tracking-1px text-black-38 mb-8px md:tracking-2px md:mb-15px">sign up to our newsletter</span>
+		            <div class="text-13px leading-20px lg:text-16px lg:leading-26px font-light text-grey-100 mb-15px">
+		                <p>Receive delicious recipes, tips & tricks and videos. Exclusive offers and competitions - just for you! and so much more.</p>
+		            </div>
+		            <div class="flex md:max-w-352px md:mx-auto">
+		                <div class="input flex-1">
+		                    <input type="text" class="form-control px-16px py-8px bg-gray-200 border border-gray-200 text-grey-100" placeholder="Email address" name="email" required>
+		                </div>
+		                <button type="submit" class="block bg-red-100 hover:bg-black-100 transition-colors duration-250 w-102px text-12px leading-16px tracking-1px uppercase text-white">sign up</button>
+		            </div>
+					<i class="email_err" style="font-style: normal; font-size: 14px; line-height: 19px; color: #ac1f2d; display: none;"></i>
+		        </form>
+		        <div>
+		            <span class="block uppercase text-12px leading-16px tracking-1px text-black-38 mb-20px md:hidden">connect with us</span>
+		            <ul class="ul-socials flex flex-wrap md:justify-center">
+		            	
+		                    <li class="mr-16px">
+		                        <a href="https://www.facebook.com/KitchenAidAusNZ" aria-label="Go to facebook page" target="_blank" class="flex items-center justify-center w-32px h-32px rounded-full bg-gray-200">
+		                            <span class="new-home-icon-facebook text-16px"></span>
+		                        </a>
+		                    </li>
+		            	
+		            	
+		                
+		                    <li class="mr-16px">
+		                        <a href="https://www.youtube.com/user/KitchenaidAustralia" aria-label="Go to youtube page" target="_blank" class="flex items-center justify-center w-32px h-32px rounded-full bg-gray-200">
+		                            <span class="new-home-icon-youtube text-15px"></span>
+		                        </a>
+		                    </li>
+		                
+		                
+		                    <li class="mr-16px">
+		                        <a href="https://www.instagram.com/kitchenaidausnz/" aria-label="Go to instagram page" target="_blank" class="flex items-center justify-center w-32px h-32px rounded-full bg-gray-200">
+		                            <span class="new-home-icon-instagram text-15px"></span>
+		                        </a>
+		                    </li>
+		                
+		                
+		                    <li>
+		                        <a href="https://www.pinterest.com.au/kitchenaidausnz/_created/" aria-label="Go to pinterest page" target="_blank" class="flex items-center justify-center w-32px h-32px rounded-full bg-gray-200">
+		                            <span class="new-home-icon-pinterest text-19px"></span>
+		                        </a>
+		                    </li>
+		                
+		            </ul>
+		        </div>
+		    </div>
+		    
+
+            <div class="border-t border-gray-200 md:pt-32px md:pb-48px md:max-w-1140px md:mx-auto">
+            	<div class="md:flex md:flex-wrap md:-mx-10px">
+            		
+<div class="md:px-10px lg:text-center md:w-1/3 xl:w-1/5">
+	                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-100 md:text-black-38 py-20px pl-24px pr-56px md:px-0 md:py-0 md:mb-20px" data-mb-dropdown-element data-name="OurProducts">Our Products <i class="new-home-icon-arrow-sm-down text-8px w-24px h-24px md:hidden"></i></span>
+	                        <div data-mb-dropdown-content class="bg-light-grey-100 md:bg-transparent" data-name="OurProducts">
+		                        <ul class="ul-main">
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/kitchenaid-mixers" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Stand mixers</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/stand-mixer-attachments" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Stand Mixer Attachments</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/stand-mixer-accessories" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Stand Mixer Accessories</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/kitchenaid-food-processors" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Food Processors</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/kitchenaid-blender" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Blenders</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/cordless" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Cordless</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/hand-blenders" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Hand Blenders</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/kitchenaid-hand-mixer" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Hand Mixers</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/kitchenaid-toasters" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Toasters</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/kitchenaid-kettles" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Kettles</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/collections/utensils" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Utensils</a>
+			                            </li>
+		                        	
+			                            <li class="">
+			                                <a href="https://giftcards.kitchenaid.com.au/" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Gift Cards</a>
+			                            </li>
+		                        	
+		                        </ul>
+	                        </div></div>
+            		
+<div class="md:flex md:flex-wrap md:w-2/3 xl:w-4/5"><div class="md:px-10px lg:text-center md:w-1/2 xl:w-1/4">
+	                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-100 md:text-black-38 py-20px pl-24px pr-56px md:px-0 md:py-0 md:mb-20px" data-mb-dropdown-element data-name="DeliveryReturns">Delivery & Returns <i class="new-home-icon-arrow-sm-down text-8px w-24px h-24px md:hidden"></i></span>
+	                        <div data-mb-dropdown-content class="bg-light-grey-100 md:bg-transparent" data-name="DeliveryReturns">
+		                        <ul class="ul-main">
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/delivery" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Delivery</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/returns-policy" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Returns</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/warranty-information" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Warranty</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/track-my-order" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Track my order</a>
+			                            </li>
+		                        	
+			                            <li class="">
+			                                <a href="/pages/price-match-policy" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Price match promise</a>
+			                            </li>
+		                        	
+		                        </ul>
+	                        </div></div>
+            		
+<div class="md:px-10px lg:text-center md:w-1/2 xl:w-1/4">
+	                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-100 md:text-black-38 py-20px pl-24px pr-56px md:px-0 md:py-0 md:mb-20px" data-mb-dropdown-element data-name="Support">Support <i class="new-home-icon-arrow-sm-down text-8px w-24px h-24px md:hidden"></i></span>
+	                        <div data-mb-dropdown-content class="bg-light-grey-100 md:bg-transparent" data-name="Support">
+		                        <ul class="ul-main">
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/contact-us" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Contact us</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/faqs" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">FAQs</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/register-my-product" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Register my product</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/user-guides" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">User guides</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/promotion-terms-conditions" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Promotion T&C's</a>
+			                            </li>
+		                        	
+			                            <li class="">
+			                                <a href="/pages/stockists" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Stockist/service finder</a>
+			                            </li>
+		                        	
+		                        </ul>
+	                        </div></div>
+            		
+<div class="md:px-10px lg:text-center md:w-1/2 xl:w-1/4 md:mt-56px xl:mt-0">
+	                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-100 md:text-black-38 py-20px pl-24px pr-56px md:px-0 md:py-0 md:mb-20px" data-mb-dropdown-element data-name="Inspiration">Inspiration <i class="new-home-icon-arrow-sm-down text-8px w-24px h-24px md:hidden"></i></span>
+	                        <div data-mb-dropdown-content class="bg-light-grey-100 md:bg-transparent" data-name="Inspiration">
+		                        <ul class="ul-main">
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/blogs/kitchenthusiast" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Blog</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="https://kitchenaid.com.au/blogs/kitchenthusiast/tagged/blog-category-recipes" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Recipes</a>
+			                            </li>
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/videos" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Videos</a>
+			                            </li>
+		                        	
+			                            <li class="">
+			                                <a href="/pages/kitchenaid-academy" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">KitchenAid Academy</a>
+			                            </li>
+		                        	
+		                        </ul>
+	                        </div></div>
+            		
+<div class="md:px-10px lg:text-center md:w-1/2 xl:w-1/4 md:mt-56px xl:mt-0">
+	                        <span class="block uppercase text-12px leading-16px tracking-1px text-black-100 md:text-black-38 py-20px pl-24px pr-56px md:px-0 md:py-0 md:mb-20px" data-mb-dropdown-element data-name="AboutUs">About us <i class="new-home-icon-arrow-sm-down text-8px w-24px h-24px md:hidden"></i></span>
+	                        <div data-mb-dropdown-content class="bg-light-grey-100 md:bg-transparent" data-name="AboutUs">
+		                        <ul class="ul-main">
+		                        	
+			                            <li class="md:mb-15px lg:mb-20px">
+			                                <a href="/pages/about-us" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">About KitchenAid</a>
+			                            </li>
+		                        	
+			                            <li class="">
+			                                <a href="/pages/sustainability" class="block text-15px leading-20px md:text-13px lg:text-15px font-light py-14px px-46px md:px-0 md:py-0 capitalize">Sustainability</a>
+			                            </li>
+		                        	
+		                        </ul>
+	                        </div></div></div>
+            		
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="pt-24px md:pt-10px pb-13px">
+        <div class="inner w-1920px">
+            <div class="md:flex md:items-center md:justify-between md:-mx-10px lg:-mx-15px">
+                <div class="md:flex-1 xl:flex-none md:px-10px lg:px-15px mb-32px md:mb-0">
+                    <ul class="ul-main md:flex md:flex-wrap md:items-center text-center md:text-left">
+                    	
+	                        <li class="mb-8px md:mb-0 md:mr-25px xxl:mr-30px xxxl:mr-40px">
+	                            <a href="/pages/privacy-policy" class="block text-13px leading-20px font-light text-grey-100">Privacy Policy</a>
+	                        </li>
+                    	
+	                        <li class="mb-8px md:mb-0 md:mr-25px xxl:mr-30px xxxl:mr-40px">
+	                            <a href="/pages/terms-and-conditions-of-sale" class="block text-13px leading-20px font-light text-grey-100">Terms and Conditions of Sale</a>
+	                        </li>
+                    	
+	                        <li class="mb-8px md:mb-0 md:mr-25px xxl:mr-30px xxxl:mr-40px">
+	                            <a href="/pages/k400-promotion-terms-and-conditions" class="block text-13px leading-20px font-light text-grey-100">K400 Promotion Terms and Conditions</a>
+	                        </li>
+                    	
+	                        <li class="">
+	                            <a href="/pages/website-terms-of-use" class="block text-13px leading-20px font-light text-grey-100">Website Terms of Use</a>
+	                        </li>
+                    	
+                    </ul>
+                </div>
+                
+                <div class="md:w-40 xl:w-auto md:max-w-480px xl:max-w-none md:px-10px lg:px-15px">
+                    <ul class="ul-main flex items-center justify-center -m-4px xl:-mx-8px md:justify-end flex-wrap">
+                    	
+<li class="p-4px xl:px-8px" #>
+	                            <div class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="38" height="24" viewbox="0 0 38 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect width="37.5" height="24" rx="3" fill="#F2F2F2"></rect>
+                                    <mask id="mask0" mask-type="alpha" maskunits="userSpaceOnUse" x="0" y="0" width="38" height="24">
+                                        <rect width="37.5" height="24" rx="3" fill="url(#paint0_linear)"></rect>
+                                    </mask>
+                                    <g mask="url(#mask0)">
+                                        <path d="M16.2296 17.5758V14.082L14.6144 15.8027L16.2296 17.5758Z" fill="#306FC8"></path>
+                                        <path d="M9.45996 14.5205V15.307L11.7695 15.3022V16.2031H9.45996V17.0658H12.0492L13.2546 15.7884L12.0974 14.5205H9.45996Z" fill="#306FC8"></path>
+                                        <path d="M19.2721 7.90035C19.4071 7.82408 19.489 7.67156 19.489 7.48567C19.489 7.29978 19.4022 7.16631 19.2721 7.09482C19.1467 7.02332 18.9586 7.01855 18.7706 7.01855H17.4688V7.99091H18.7561C18.9586 7.99091 19.1274 7.98138 19.2721 7.90035Z" fill="#306FC8"></path>
+                                        <path d="M1.93823 8.58655H3.37991L2.65666 6.85156L1.93823 8.58655Z" fill="#306FC8"></path>
+                                        <path d="M18.6598 14.5205H17.2856V15.6168H18.6502C19.0504 15.6168 19.3011 15.4261 19.3011 15.0496C19.2963 14.673 19.0359 14.5205 18.6598 14.5205Z" fill="#306FC8"></path>
+                                        <path d="M2.2082 10.3549H3.11467L3.52452 11.332H7.06844V10.5884L7.38667 11.332H9.2189L9.53713 10.5789V11.332H18.3415V9.73999H18.5151C18.6404 9.73999 18.6742 9.75429 18.6742 9.94971V11.332H23.2258V10.9554C23.5875 11.1509 24.1564 11.332 24.9182 11.332H26.8324L27.2471 10.3549H28.1536L28.5634 11.332H32.2424V10.4073L32.8065 11.332H35.7622V5.25H32.8402V5.96497L32.4208 5.25H29.4169V5.96497L29.0504 5.25H24.9906C24.3059 5.25 23.7032 5.34056 23.2258 5.59795V5.25H20.4293V5.59795C20.1014 5.3358 19.6916 5.25 19.2287 5.25H8.99228L8.29796 6.81816L7.60364 5.25H4.38277V5.96497L4.01632 5.25H1.26798L-0.00012207 8.1337V11.332H1.79836L2.2082 10.3549ZM23.4235 6.61797C23.761 6.27002 24.3011 6.10796 25.0291 6.10796H26.0369V7.04218H25.0484C24.6579 7.04218 24.4409 7.09938 24.2336 7.30434C24.0503 7.48546 23.925 7.83341 23.925 8.29099C23.925 8.7581 24.0166 9.08699 24.2239 9.31578C24.3782 9.48737 24.6723 9.5398 24.9568 9.5398H25.4293L26.9144 6.10796H28.4863L30.2751 10.2357V6.10796H31.8855L33.7371 9.14419V6.10796H34.8219V10.474H33.3176L31.3262 7.20424V10.474H29.1806L28.7756 9.4969H26.5817L26.1767 10.474H24.952C24.4361 10.474 23.7852 10.3549 23.4187 9.98785C23.0474 9.61606 22.8594 9.11559 22.8594 8.32436C22.8594 7.67612 22.9751 7.08508 23.4235 6.61797ZM21.2634 6.10796H22.3435V10.474H21.2634V6.10796ZM16.4176 6.10796H18.8478C19.383 6.10796 19.7783 6.12703 20.1159 6.31768C20.4534 6.51311 20.6607 6.79909 20.6607 7.28527C20.6607 7.97641 20.1882 8.33389 19.9085 8.44352C20.14 8.52931 20.3377 8.68661 20.4293 8.8153C20.5787 9.02502 20.6029 9.22522 20.6029 9.60653V10.474H19.5421V9.92112C19.5421 9.66373 19.5662 9.28241 19.3685 9.07746C19.219 8.92016 18.9876 8.8868 18.6019 8.8868H17.4688V10.474H16.4128V6.10796H16.4176ZM12.1649 6.10796H15.6848V7.01835H13.2161V7.80481H15.6221V8.70091H13.2161V9.56363L15.6848 9.55887V10.4693H12.1649V6.10796ZM1.15708 10.474H0.00952126L1.89479 6.10796H3.46666L5.25549 10.2357V6.10796H6.98165L8.35582 9.06792L9.62392 6.10796H11.379V10.474H10.299V7.05648L8.77049 10.474H7.84473L6.31144 7.05172V10.474H4.16097L3.75596 9.4969H1.5621L1.15708 10.474Z" fill="#306FC8"></path>
+                                        <path d="M27.6762 6.85156L26.9578 8.58655H28.3946L27.6762 6.85156Z" fill="#306FC8"></path>
+                                        <path d="M35.1642 14.6207C35.0533 14.6922 35.0051 14.7971 35.0051 14.9353C35.0051 15.0973 35.1016 15.2117 35.2366 15.2594C35.3426 15.2975 35.4632 15.3071 35.6416 15.3071L36.2057 15.3214C36.7891 15.3357 37.1749 15.431 37.4111 15.6741C37.4449 15.7074 37.4738 15.7408 37.4979 15.7742V14.5444H35.5837C35.3957 14.5444 35.2655 14.554 35.1642 14.6207Z" fill="#306FC8"></path>
+                                        <path d="M36.0756 17.9712H34.0408V17.037H36.0659C36.2636 17.037 36.4034 17.0084 36.4902 16.9321C36.5626 16.8654 36.6156 16.7701 36.6156 16.6461C36.6156 16.5174 36.5626 16.4173 36.4854 16.3554C36.4083 16.2887 36.2974 16.2601 36.119 16.2601C35.1353 16.2315 33.8962 16.2934 33.8962 14.9064C33.8962 14.282 34.2964 13.6099 35.4054 13.6099H37.5028V12.752H35.55C34.9666 12.752 34.5278 12.8854 34.2289 13.0999V12.752H31.3503C30.8923 12.752 30.3426 12.8616 30.0871 13.0999V12.752H24.9327V13.0999C24.5229 12.8139 23.8334 12.752 23.5055 12.752H20.1062V13.0999C19.7832 12.7901 19.0696 12.752 18.6308 12.752H14.8217L13.9489 13.6862L13.1389 12.752H7.45898V18.8339H13.0377L13.9297 17.8854L14.7783 18.8292L18.2113 18.8339V17.3992H18.5536C19.0069 17.3992 19.5469 17.3897 20.0146 17.1895V18.8339H22.8594V17.2419H22.9992C23.1728 17.2419 23.1873 17.2562 23.1873 17.4183V18.8339H31.7939C32.334 18.8339 32.9174 18.6957 33.2356 18.4479V18.8339H35.9647C36.5288 18.8339 37.0881 18.7529 37.5124 18.5527V17.4231C37.2376 17.7948 36.7554 17.9712 36.0756 17.9712ZM18.5922 16.5127H17.2807V17.9712H15.2267L13.9345 16.5365L12.5844 17.976H8.40403V13.6099H12.6471L13.9393 15.0446L15.2845 13.6099H18.6597C19.489 13.6099 20.4293 13.8482 20.4293 15.0541C20.4244 16.2601 19.5131 16.5127 18.5922 16.5127ZM24.9375 16.3173C25.087 16.527 25.1111 16.7272 25.1159 17.1085V17.9712H24.0552V17.4183C24.0552 17.1609 24.0793 16.7796 23.8816 16.5746C23.7273 16.4173 23.5007 16.384 23.1149 16.384H21.9818V17.9712H20.9259V13.6051H23.356C23.8912 13.6051 24.2818 13.6242 24.6241 13.8196C24.9616 14.0151 25.169 14.301 25.169 14.7872C25.169 15.4784 24.6964 15.8358 24.4216 15.9455C24.653 16.0313 24.8507 16.1886 24.9375 16.3173ZM29.2722 14.5203H26.8083V15.3068H29.2192V16.2076H26.8083V17.0704H29.277V17.976H25.7572V13.6099H29.277V14.5203H29.2722ZM31.953 17.9712H29.899V17.037H31.9434C32.1411 17.037 32.2809 17.0084 32.3677 16.9321C32.44 16.8654 32.4931 16.7701 32.4931 16.6461C32.4931 16.5174 32.44 16.4173 32.3629 16.3554C32.2857 16.2887 32.1748 16.2601 31.9964 16.2601C31.0128 16.2315 29.7737 16.2934 29.7737 14.9064C29.7737 14.2772 30.1738 13.6099 31.2828 13.6099H33.3947V14.5441H31.4612C31.2684 14.5441 31.143 14.5489 31.0369 14.6156C30.926 14.6871 30.8826 14.792 30.8826 14.9302C30.8826 15.0923 30.9791 15.2067 31.1141 15.2543C31.225 15.2925 31.3407 15.302 31.5191 15.302L32.0832 15.3163C32.6667 15.3306 33.0524 15.4259 33.2886 15.669C33.496 15.8883 33.6069 16.1409 33.6069 16.5937C33.6117 17.5279 33.0235 17.9712 31.953 17.9712Z" fill="#306FC8"></path>
+                                        <path d="M23.7852 14.592C23.6599 14.5253 23.467 14.5205 23.2838 14.5205H21.9819V15.4929H23.2693C23.4718 15.4929 23.6454 15.4881 23.7852 15.4071C23.9202 15.3308 24.0022 15.1783 24.0022 14.9924C23.9974 14.8017 23.9154 14.6683 23.7852 14.592Z" fill="#306FC8"></path>
+                                    </g>
+                                    <defs>
+                                        <lineargradient id="paint0_linear" x1="18.75" y1="0" x2="18.75" y2="24" gradientunits="userSpaceOnUse">
+                                            <stop stop-color="#F9F9F9"></stop>
+                                            <stop offset="1" stop-color="#005D9C"></stop>
+                                        </lineargradient>
+                                    </defs>
+                                </svg>
+	                            </div>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" #>
+	                            <div class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="38" height="24" viewbox="0 0 38 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect x="0.5" width="37.5" height="24" rx="3" fill="#F2F2F2"></rect>
+                                    <path d="M22.5224 17.8983H15.9604V6.10547H22.5224V17.8983Z" fill="#FF5F00"></path>
+                                    <path d="M16.3808 12.001C16.3808 9.60874 17.5009 7.4778 19.2451 6.10454C17.9696 5.10035 16.3598 4.50098 14.6104 4.50098C10.4687 4.50098 7.11133 7.85879 7.11133 12.001C7.11133 16.1432 10.4687 19.501 14.6104 19.501C16.3598 19.501 17.9696 18.9016 19.2451 17.8974C17.5009 16.5242 16.3808 14.3932 16.3808 12.001Z" fill="#EB001B"></path>
+                                    <path d="M31.3723 12.001C31.3723 16.1432 28.015 19.501 23.8733 19.501C22.1238 19.501 20.514 18.9016 19.238 17.8974C20.9827 16.5242 22.1028 14.3932 22.1028 12.001C22.1028 9.60874 20.9827 7.4778 19.238 6.10454C20.514 5.10035 22.1238 4.50098 23.8733 4.50098C28.015 4.50098 31.3723 7.85879 31.3723 12.001Z" fill="#F79E1B"></path>
+                                    <path d="M12.7544 12.0486C12.7544 11.721 12.9691 11.4518 13.3199 11.4518C13.655 11.4518 13.8813 11.7094 13.8813 12.0486C13.8813 12.3878 13.655 12.6453 13.3199 12.6453C12.9691 12.6453 12.7544 12.3762 12.7544 12.0486ZM14.2634 12.0486V11.1167H13.8581V11.3429C13.7296 11.1751 13.5345 11.0698 13.2694 11.0698C12.7468 11.0698 12.3371 11.4795 12.3371 12.0486C12.3371 12.6181 12.7468 13.0273 13.2694 13.0273C13.5345 13.0273 13.7296 12.922 13.8581 12.7542V12.9805H14.2634V12.0486ZM27.9582 12.0486C27.9582 11.721 28.1729 11.4518 28.5237 11.4518C28.8593 11.4518 29.0852 11.7094 29.0852 12.0486C29.0852 12.3878 28.8593 12.6453 28.5237 12.6453C28.1729 12.6453 27.9582 12.3762 27.9582 12.0486ZM29.4677 12.0486V10.3682H29.062V11.3429C28.9334 11.1751 28.7384 11.0698 28.4733 11.0698C27.9506 11.0698 27.5409 11.4795 27.5409 12.0486C27.5409 12.6181 27.9506 13.0273 28.4733 13.0273C28.7384 13.0273 28.9334 12.922 29.062 12.7542V12.9805H29.4677V12.0486ZM19.2938 11.4326C19.5549 11.4326 19.7227 11.5964 19.7656 11.8848H18.7984C18.8417 11.6156 19.0051 11.4326 19.2938 11.4326ZM19.3019 11.0698C18.7556 11.0698 18.3735 11.4675 18.3735 12.0486C18.3735 12.6413 18.7712 13.0273 19.3291 13.0273C19.6098 13.0273 19.8669 12.9573 20.0932 12.7662L19.8946 12.4659C19.7384 12.5904 19.5393 12.6609 19.3523 12.6609C19.0912 12.6609 18.8533 12.54 18.7949 12.2043H20.1789C20.1829 12.1539 20.1869 12.103 20.1869 12.0486C20.1829 11.4675 19.8241 11.0698 19.3019 11.0698ZM24.1953 12.0486C24.1953 11.721 24.41 11.4518 24.7608 11.4518C25.096 11.4518 25.3223 11.7094 25.3223 12.0486C25.3223 12.3878 25.096 12.6453 24.7608 12.6453C24.41 12.6453 24.1953 12.3762 24.1953 12.0486ZM25.7043 12.0486V11.1167H25.2991V11.3429C25.1701 11.1751 24.9755 11.0698 24.7104 11.0698C24.1877 11.0698 23.778 11.4795 23.778 12.0486C23.778 12.6181 24.1877 13.0273 24.7104 13.0273C24.9755 13.0273 25.1701 12.922 25.2991 12.7542V12.9805H25.7043V12.0486ZM21.9066 12.0486C21.9066 12.6141 22.3002 13.0273 22.901 13.0273C23.1817 13.0273 23.3687 12.9649 23.5714 12.8051L23.3768 12.4775C23.2246 12.5868 23.0648 12.6453 22.8889 12.6453C22.5654 12.6413 22.3275 12.4074 22.3275 12.0486C22.3275 11.6897 22.5654 11.4559 22.8889 11.4518C23.0648 11.4518 23.2246 11.5103 23.3768 11.6197L23.5714 11.2921C23.3687 11.1323 23.1817 11.0698 22.901 11.0698C22.3002 11.0698 21.9066 11.4831 21.9066 12.0486ZM27.1316 11.0698C26.8978 11.0698 26.7456 11.1791 26.6402 11.3429V11.1167H26.2386V12.9805H26.6443V11.9356C26.6443 11.6272 26.7768 11.4559 27.0419 11.4559C27.1241 11.4559 27.2097 11.4675 27.2954 11.5027L27.4204 11.1207C27.3307 11.0854 27.2138 11.0698 27.1316 11.0698ZM16.2678 11.2648C16.0728 11.1363 15.8041 11.0698 15.5077 11.0698C15.0355 11.0698 14.7316 11.2961 14.7316 11.6665C14.7316 11.9705 14.9579 12.1579 15.3747 12.2164L15.5662 12.2436C15.7885 12.2749 15.8933 12.3333 15.8933 12.4386C15.8933 12.5828 15.7452 12.6649 15.4684 12.6649C15.1877 12.6649 14.9851 12.5752 14.8485 12.4699L14.6575 12.7854C14.8797 12.9492 15.1605 13.0273 15.4644 13.0273C16.0027 13.0273 16.3147 12.7738 16.3147 12.419C16.3147 12.0914 16.0692 11.92 15.6635 11.8616L15.4725 11.8339C15.2971 11.8107 15.1565 11.7759 15.1565 11.6509C15.1565 11.5143 15.289 11.4326 15.5113 11.4326C15.7492 11.4326 15.9795 11.5224 16.0924 11.5924L16.2678 11.2648ZM21.4969 11.0698C21.263 11.0698 21.1108 11.1791 21.0059 11.3429V11.1167H20.6042V12.9805H21.0095V11.9356C21.0095 11.6272 21.142 11.4559 21.4072 11.4559C21.4893 11.4559 21.575 11.4675 21.6607 11.5027L21.7856 11.1207C21.6959 11.0854 21.579 11.0698 21.4969 11.0698ZM18.0383 11.1167H17.3756V10.5512H16.9658V11.1167H16.5878V11.4871H16.9658V12.3373C16.9658 12.7698 17.1337 13.0273 17.613 13.0273C17.7889 13.0273 17.9915 12.9729 18.12 12.8832L18.0031 12.5359C17.8821 12.606 17.7496 12.6413 17.6442 12.6413C17.4416 12.6413 17.3756 12.5163 17.3756 12.3293V11.4871H18.0383V11.1167ZM11.9787 12.9805V11.8107C11.9787 11.3702 11.6979 11.0738 11.2454 11.0698C11.0075 11.0658 10.762 11.1399 10.5902 11.4014C10.4616 11.1948 10.259 11.0698 9.97426 11.0698C9.7752 11.0698 9.5806 11.1283 9.42841 11.3465V11.1167H9.02271V12.9805H9.43198V11.9473C9.43198 11.6237 9.6114 11.4518 9.88856 11.4518C10.1577 11.4518 10.2938 11.6272 10.2938 11.9432V12.9805H10.7035V11.9473C10.7035 11.6237 10.8905 11.4518 11.1597 11.4518C11.4364 11.4518 11.569 11.6272 11.569 11.9432V12.9805H11.9787Z" fill="white"></path>
+                                </svg>
+	                            </div>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" #>
+	                            <div class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="38" height="24" viewbox="0 0 38 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect width="37.5" height="24" rx="3" fill="#F2F2F2"></rect>
+                                    <path d="M16.85 16.1516H14.5413L15.9853 7.875H18.2939L16.85 16.1516Z" fill="#00579F"></path>
+                                    <path d="M25.2192 8.07747C24.7638 7.91 24.0415 7.7251 23.1484 7.7251C20.8685 7.7251 19.263 8.85207 19.2532 10.4633C19.2342 11.6521 20.4027 12.3123 21.2766 12.7087C22.1698 13.1137 22.4734 13.3781 22.4734 13.7391C22.4643 14.2936 21.7516 14.5492 21.0869 14.5492C20.1652 14.5492 19.6713 14.4174 18.9208 14.1089L18.6168 13.9767L18.2937 15.8346C18.8352 16.0633 19.8328 16.2662 20.8685 16.2751C23.291 16.2751 24.8681 15.1656 24.8868 13.4485C24.896 12.5064 24.279 11.7844 22.9488 11.1945C22.1414 10.8158 21.6469 10.5604 21.6469 10.173C21.6563 9.8207 22.0651 9.45991 22.9766 9.45991C23.7272 9.44224 24.2786 9.60947 24.6964 9.77682L24.9052 9.8647L25.2192 8.07747Z" fill="#00579F"></path>
+                                    <path d="M28.2876 13.2195C28.4778 12.744 29.2094 10.9038 29.2094 10.9038C29.1998 10.9214 29.3991 10.4195 29.5131 10.1114L29.6745 10.8246C29.6745 10.8246 30.1117 12.8057 30.2066 13.2195C29.8458 13.2195 28.7436 13.2195 28.2876 13.2195ZM31.1374 7.875H29.3517C28.801 7.875 28.3826 8.02456 28.145 8.56172L24.7157 16.1515H27.1381C27.1381 16.1515 27.537 15.13 27.6227 14.91C27.8884 14.91 30.245 14.91 30.5869 14.91C30.6531 15.2005 30.8623 16.1515 30.8623 16.1515H33L31.1374 7.875Z" fill="#00579F"></path>
+                                    <path d="M12.6129 7.875L10.352 13.5189L10.1049 12.3742C9.68689 11.0535 8.37593 9.61847 6.91296 8.90496L8.98394 16.1428H11.4253L15.0542 7.875H12.6129Z" fill="#00579F"></path>
+                                    <path d="M8.25247 7.875H4.538L4.5 8.04223C7.39752 8.72906 9.31649 10.3846 10.1049 12.3746L9.29743 8.57073C9.16449 8.04211 8.75595 7.89244 8.25247 7.875Z" fill="#FAA61A"></path>
+                                </svg>
+	                            </div>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" #>
+	                            <div class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="38" height="24" viewbox="0 0 38 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect x="0.5" width="37.5" height="24" rx="3" fill="#F2F2F2"></rect>
+                                    <path d="M11.6554 15.6753H10.1009C9.99449 15.6753 9.90402 15.7526 9.88743 15.8576L9.25871 19.8438C9.24621 19.9224 9.30713 19.9934 9.38691 19.9934H10.1291C10.2354 19.9934 10.3259 19.9161 10.3425 19.8108L10.5121 18.7357C10.5284 18.6304 10.6191 18.5532 10.7253 18.5532H11.2174C12.2414 18.5532 12.8324 18.0576 12.9867 17.0757C13.0562 16.6461 12.9896 16.3086 12.7885 16.0722C12.5675 15.8126 12.1757 15.6753 11.6554 15.6753ZM11.8347 17.1312C11.7497 17.689 11.3235 17.689 10.9114 17.689H10.6768L10.8414 16.6472C10.8512 16.5843 10.9057 16.5379 10.9694 16.5379H11.0769C11.3576 16.5379 11.6224 16.5379 11.7593 16.6979C11.8409 16.7934 11.8659 16.9352 11.8347 17.1312Z" fill="#253B80"></path>
+                                    <path d="M16.3022 17.1125H15.5577C15.4943 17.1125 15.4395 17.1589 15.4298 17.2218L15.3968 17.43L15.3448 17.3546C15.1836 17.1207 14.8242 17.0425 14.4656 17.0425C13.6429 17.0425 12.9404 17.6655 12.8035 18.5395C12.7324 18.9755 12.8335 19.3923 13.0808 19.6831C13.3077 19.9504 13.6323 20.0617 14.0184 20.0617C14.6813 20.0617 15.0488 19.6355 15.0488 19.6355L15.0156 19.8424C15.0031 19.9215 15.064 19.9924 15.1434 19.9924H15.8139C15.9205 19.9924 16.0105 19.9151 16.0273 19.8099L16.4297 17.2621C16.4424 17.1836 16.3817 17.1125 16.3022 17.1125ZM15.2645 18.5613C15.1927 18.9866 14.8551 19.2721 14.4246 19.2721C14.2085 19.2721 14.0357 19.2028 13.9248 19.0714C13.8148 18.9409 13.773 18.7552 13.808 18.5484C13.875 18.1267 14.2182 17.8319 14.6422 17.8319C14.8536 17.8319 15.0254 17.9021 15.1386 18.0347C15.252 18.1685 15.297 18.3554 15.2645 18.5613Z" fill="#253B80"></path>
+                                    <path d="M20.2667 17.1123H19.5187C19.4473 17.1123 19.3802 17.1478 19.3398 17.2071L18.3081 18.7268L17.8707 17.2664C17.8432 17.175 17.7589 17.1123 17.6634 17.1123H16.9283C16.839 17.1123 16.7769 17.1996 16.8054 17.2837L17.6293 19.7017L16.8547 20.7953C16.7938 20.8814 16.8551 20.9999 16.9604 20.9999H17.7075C17.7784 20.9999 17.8448 20.9653 17.885 20.9071L20.3731 17.3157C20.4326 17.2298 20.3715 17.1123 20.2667 17.1123Z" fill="#253B80"></path>
+                                    <path d="M22.7433 15.6743H21.1886C21.0824 15.6743 20.992 15.7516 20.9754 15.8566L20.3467 19.8428C20.3342 19.9215 20.3951 19.9924 20.4744 19.9924H21.2722C21.3463 19.9924 21.4098 19.9383 21.4214 19.8646L21.5998 18.7347C21.6161 18.6295 21.7068 18.5522 21.813 18.5522H22.3049C23.3291 18.5522 23.9199 18.0567 24.0744 17.0747C24.1442 16.6451 24.0771 16.3076 23.876 16.0712C23.6553 15.8116 23.2636 15.6743 22.7433 15.6743ZM22.9227 17.1302C22.8379 17.688 22.4117 17.688 21.9994 17.688H21.765L21.9298 16.6463C21.9396 16.5833 21.9937 16.5369 22.0576 16.5369H22.1651C22.4456 16.5369 22.7106 16.5369 22.8474 16.6969C22.929 16.7924 22.9538 16.9343 22.9227 17.1302Z" fill="#179BD7"></path>
+                                    <path d="M27.3899 17.1125H26.646C26.5821 17.1125 26.5278 17.1589 26.5182 17.2218L26.4853 17.43L26.433 17.3546C26.2718 17.1207 25.9127 17.0425 25.554 17.0425C24.7314 17.0425 24.029 17.6655 23.8922 18.5395C23.8213 18.9755 23.922 19.3923 24.1693 19.6831C24.3966 19.9504 24.7207 20.0617 25.1069 20.0617C25.7697 20.0617 26.1373 19.6355 26.1373 19.6355L26.1041 19.8424C26.0916 19.9215 26.1525 19.9924 26.2323 19.9924H26.9026C27.0087 19.9924 27.0992 19.9151 27.1158 19.8099L27.5184 17.2621C27.5306 17.1836 27.4697 17.1125 27.3899 17.1125ZM26.3523 18.5613C26.2809 18.9866 25.9429 19.2721 25.5124 19.2721C25.2967 19.2721 25.1235 19.2028 25.0126 19.0714C24.9026 18.9409 24.8612 18.7552 24.8957 18.5484C24.9632 18.1267 25.306 17.8319 25.7299 17.8319C25.9413 17.8319 26.1132 17.9021 26.2264 18.0347C26.3402 18.1685 26.3853 18.3554 26.3523 18.5613Z" fill="#179BD7"></path>
+                                    <path d="M28.2675 15.7839L27.6295 19.843C27.617 19.9217 27.6779 19.9926 27.7572 19.9926H28.3987C28.5053 19.9926 28.5958 19.9153 28.6121 19.8101L29.2413 15.8241C29.2538 15.7455 29.1929 15.6743 29.1136 15.6743H28.3953C28.3319 15.6745 28.2773 15.7209 28.2675 15.7839Z" fill="#179BD7"></path>
+                                    <path d="M17.8015 12.7633L17.9766 11.6508L17.5865 11.6418H15.7234L17.0181 3.43252C17.0222 3.40774 17.0352 3.38464 17.0543 3.36823C17.0734 3.35182 17.0979 3.34277 17.1233 3.34277H20.2646C21.3075 3.34277 22.0271 3.55978 22.4029 3.98811C22.5791 4.18905 22.6912 4.39903 22.7455 4.6301C22.8024 4.87257 22.8034 5.16225 22.7478 5.51556L22.7438 5.54135V5.76774L22.92 5.86753C23.0683 5.94623 23.1862 6.03632 23.2766 6.13947C23.4273 6.31127 23.5248 6.52962 23.566 6.78849C23.6085 7.05473 23.5944 7.37154 23.5248 7.73021C23.4444 8.1428 23.3145 8.50214 23.139 8.79618C22.9776 9.0671 22.7719 9.29182 22.5278 9.46596C22.2947 9.6314 22.0178 9.75699 21.7046 9.83736C21.4012 9.91639 21.0553 9.95625 20.6759 9.95625H20.4314C20.2566 9.95625 20.0868 10.0192 19.9535 10.1321C19.8199 10.2473 19.7315 10.4047 19.7043 10.5768L19.6859 10.6769L19.3765 12.6377L19.3624 12.7097C19.3587 12.7325 19.3524 12.7439 19.343 12.7516C19.3346 12.7586 19.3225 12.7633 19.3108 12.7633H17.8015Z" fill="#253B80"></path>
+                                    <path d="M23.0866 5.56738C23.0772 5.62733 23.0665 5.68861 23.0545 5.75157C22.6402 7.87848 21.2229 8.61324 19.4128 8.61324H18.4912C18.2698 8.61324 18.0833 8.77399 18.0488 8.99234L17.577 11.9849L17.4433 12.8332C17.4209 12.9766 17.5314 13.1058 17.6761 13.1058H19.3107C19.5043 13.1058 19.6687 12.9652 19.6992 12.7743L19.7152 12.6912L20.023 10.7381L20.0428 10.631C20.0729 10.4394 20.2377 10.2988 20.4312 10.2988H20.6757C22.2594 10.2988 23.4992 9.65576 23.8616 7.79509C24.0129 7.01781 23.9346 6.36878 23.534 5.91232C23.4128 5.77468 23.2624 5.66048 23.0866 5.56738Z" fill="#179BD7"></path>
+                                    <path d="M22.6533 5.39479C22.59 5.37637 22.5247 5.35962 22.4578 5.34455C22.3904 5.32982 22.3215 5.31676 22.2505 5.30537C22.002 5.26518 21.7297 5.24609 21.438 5.24609H18.9759C18.9153 5.24609 18.8577 5.25982 18.8061 5.28461C18.6926 5.33919 18.6082 5.44669 18.5877 5.57831L18.064 8.89576L18.0489 8.99255C18.0834 8.77419 18.2699 8.61345 18.4913 8.61345H19.4129C21.223 8.61345 22.6403 7.87836 23.0545 5.75178C23.0669 5.68882 23.0773 5.62754 23.0867 5.56759C22.9819 5.512 22.8683 5.46444 22.7461 5.42392C22.716 5.41388 22.6848 5.40416 22.6533 5.39479Z" fill="#222D65"></path>
+                                    <path d="M18.5877 5.57834C18.6081 5.44673 18.6925 5.33923 18.8061 5.28498C18.858 5.2602 18.9152 5.24646 18.9758 5.24646H21.438C21.7297 5.24646 22.0019 5.26555 22.2504 5.30574C22.3214 5.31713 22.3904 5.33019 22.4577 5.34492C22.5247 5.35999 22.59 5.37674 22.6533 5.39516C22.6848 5.40453 22.7159 5.41425 22.7464 5.42396C22.8686 5.46448 22.9822 5.51237 23.087 5.56763C23.2102 4.78163 23.086 4.24647 22.661 3.76188C22.1925 3.2284 21.3469 3 20.2648 3H17.1235C16.9025 3 16.714 3.16075 16.6798 3.37943L15.3714 11.6731C15.3456 11.8372 15.4722 11.9852 15.6376 11.9852H17.577L18.0639 8.8958L18.5877 5.57834Z" fill="#253B80"></path>
+                                </svg>
+	                            </div>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" https://www.afterpay.com/en-AU/how-it-works>
+	                            <a href="https://www.afterpay.com/en-AU/how-it-works" aria-label="Checkout with Afterpay"  class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="25" height="18" viewbox="0 0 25 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M17.4773 2.01813L15.9105 1.12153L14.3211 0.211342C13.2705 -0.390919 11.9573 0.365303 11.9573 1.57888V1.78266C11.9573 1.89586 12.0162 2.00001 12.1158 2.05435L12.8539 2.47548C13.0577 2.59322 13.3113 2.44379 13.3113 2.20832V1.72379C13.3113 1.48379 13.5694 1.33436 13.7777 1.45209L15.2268 2.2853L16.6713 3.11397C16.8796 3.23171 16.8796 3.5351 16.6713 3.65284L15.2268 4.48151L13.7777 5.31472C13.5694 5.43245 13.3113 5.28302 13.3113 5.04302V4.80302C13.3113 3.58944 11.9981 2.82869 10.9475 3.43548L9.3581 4.34566L7.79132 5.24226C6.73623 5.84905 6.73623 7.37508 7.79132 7.98187L9.3581 8.87847L10.9475 9.78866C11.9981 10.3909 13.3113 9.6347 13.3113 8.42112V8.21734C13.3113 8.10414 13.2524 7.99999 13.1528 7.94565L12.4147 7.52452C12.2109 7.40678 11.9573 7.55622 11.9573 7.79169V8.27621C11.9573 8.51621 11.6992 8.66565 11.4909 8.54791L10.0419 7.7147L8.59735 6.88603C8.38905 6.76829 8.38905 6.4649 8.59735 6.34716L10.0419 5.51849L11.4909 4.68528C11.6992 4.56755 11.9573 4.71698 11.9573 4.95698V5.19698C11.9573 6.41056 13.2705 7.17131 14.3211 6.56452L15.9105 5.65434L17.4773 4.75774C18.5324 4.14642 18.5324 2.62492 17.4773 2.01813Z" fill="black"></path>
+                                    <path d="M2.56753 15.0039C2.56753 14.4605 2.17357 14.0802 1.68995 14.0802C1.20633 14.0802 0.812373 14.4687 0.812373 15.0039C0.812373 15.5338 1.20633 15.9277 1.68995 15.9277C2.17357 15.9277 2.56753 15.5473 2.56753 15.0039ZM2.57569 16.6178V16.1994C2.33659 16.4901 1.98067 16.6694 1.55682 16.6694C0.671091 16.6694 0 15.9603 0 15.0039C0 14.0557 0.698261 13.333 1.57584 13.333C1.98882 13.333 2.33659 13.515 2.57569 13.7976V13.3901H3.36904V16.6178H2.57569Z" fill="black"></path>
+                                    <path d="M7.22714 15.9007C6.95001 15.9007 6.87122 15.7975 6.87122 15.5258V14.094H7.38201V13.3903H6.87122V12.6024H6.05885V13.3903H5.0101V13.0697C5.0101 12.798 5.11334 12.6947 5.39862 12.6947H5.57794V12.0698H5.1867C4.51561 12.0698 4.19772 12.2899 4.19772 12.961V13.393H3.7467V14.094H4.19772V16.618H5.0101V14.094H6.05885V15.6752C6.05885 16.3327 6.31152 16.618 6.96903 16.618H7.38744V15.9007H7.22714Z" fill="black"></path>
+                                    <path d="M10.1451 14.713C10.0881 14.2946 9.74571 14.0419 9.3436 14.0419C8.94421 14.0419 8.61274 14.2865 8.53123 14.713H10.1451ZM8.52308 15.2157C8.58013 15.6938 8.92247 15.9655 9.35719 15.9655C9.69952 15.9655 9.96307 15.8052 10.1179 15.5471H10.952C10.7591 16.2318 10.1451 16.6692 9.33817 16.6692C8.36278 16.6692 7.6781 15.9846 7.6781 15.0092C7.6781 14.0338 8.40081 13.3301 9.35719 13.3301C10.319 13.3301 11.0173 14.0392 11.0173 15.0092C11.0173 15.0798 11.0118 15.1504 10.9982 15.2157H8.52308Z" fill="black"></path>
+                                    <path d="M16.1904 15.0037C16.1904 14.4821 15.7964 14.08 15.3128 14.08C14.8292 14.08 14.4352 14.4685 14.4352 15.0037C14.4352 15.5335 14.8292 15.9275 15.3128 15.9275C15.7964 15.9275 16.1904 15.5281 16.1904 15.0037ZM13.6337 17.9353V13.3899H14.4271V13.8083C14.6662 13.5121 15.0221 13.3301 15.4459 13.3301C16.3181 13.3301 17.0028 14.0474 17.0028 14.9956C17.0028 15.9438 16.3045 16.6665 15.4269 16.6665C15.0194 16.6665 14.6852 16.5062 14.4515 16.2345V17.9326H13.6337V17.9353Z" fill="black"></path>
+                                    <path d="M19.8637 15.0039C19.8637 14.4605 19.4698 14.0802 18.9862 14.0802C18.5025 14.0802 18.1086 14.4687 18.1086 15.0039C18.1086 15.5338 18.5025 15.9277 18.9862 15.9277C19.4698 15.9277 19.8637 15.5473 19.8637 15.0039ZM19.8719 16.6178V16.1994C19.6328 16.4901 19.2769 16.6694 18.853 16.6694C17.9673 16.6694 17.2962 15.9603 17.2962 15.0039C17.2962 14.0557 17.9945 13.333 18.872 13.333C19.285 13.333 19.6328 13.515 19.8719 13.7976V13.3901H20.6652V16.6178H19.8719Z" fill="black"></path>
+                                    <path d="M12.202 13.705C12.202 13.705 12.403 13.3301 12.9002 13.3301C13.1121 13.3301 13.248 13.4034 13.248 13.4034V14.2267C13.248 14.2267 12.9491 14.0419 12.6747 14.08C12.4003 14.118 12.2264 14.368 12.2264 14.7049V16.6149H11.4059V13.3899H12.1992V13.705H12.202Z" fill="black"></path>
+                                    <path d="M24.5722 13.3901L22.3715 17.9356H21.4586L22.2818 16.2375L20.9858 13.3901H21.9232L22.7546 15.2974L23.6621 13.3901H24.5722Z" fill="black"></path>
+                                </svg>
+	                            </a>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" https://kitchenaid.com.au/pages/checkout-with-zippay>
+	                            <a href="https://kitchenaid.com.au/pages/checkout-with-zippay" aria-label="Checkout with Zip"  class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="32" height="23" viewbox="0 0 32 23" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="32" height="23" rx="3" fill="#F2F2F2"></rect>
+<path d="M4.54042 13.7854L4.74991 15.5923H12.0845L11.8445 13.5229H8.42462L8.39474 13.2665L11.5444 10.9365L11.334 9.12622H4L4.24001 11.1952H7.66558L7.69547 11.454L4.54042 13.7854Z" fill="#2E2E2E"></path>
+<path d="M12.1862 9.12622L12.9364 15.5923H20.2764L19.5261 9.12622H12.1862Z" fill="#AA8FFF"></path>
+<path d="M27.9734 11.454C27.8042 10.0007 26.7258 9.11993 25.26 9.12625H20.3777L21.1276 15.5926H23.3242L23.1738 14.2992H25.4981C27.3273 14.2989 28.1643 13.0924 27.9734 11.454ZM25.2606 12.4863L22.9643 12.489L22.7844 10.9372L25.0936 10.9392C25.6365 10.9461 25.9143 11.2698 25.9593 11.7127C25.9869 11.9978 25.8636 12.486 25.2606 12.486V12.4863Z" fill="#2E2E2E"></path>
+<path d="M14.379 8.267C14.7653 7.82797 14.698 7.09685 14.2286 6.63399C13.7593 6.17113 13.0656 6.15181 12.6793 6.59084C12.293 7.02987 12.3604 7.76099 12.8297 8.22385C13.2991 8.6867 13.9928 8.70602 14.379 8.267Z" fill="#2E2E2E"></path>
+</svg>
+	                            </a>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" #>
+	                            <div class="block w-33px md:w-38px">
+	                                <svg width="38" height="24" viewbox="0 0 38 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" width="37.5" height="24" rx="2" fill="#F2F2F2"></rect>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M25.4999 6.23645C25.503 6.47854 25.434 6.71609 25.3016 6.91889C25.1692 7.1217 24.9794 7.28061 24.7564 7.37541C24.5334 7.47021 24.2872 7.49663 24.0491 7.45131C23.811 7.40599 23.5917 7.29097 23.4193 7.12088C23.2468 6.95079 23.1288 6.7333 23.0804 6.49608C23.0319 6.25885 23.0552 6.01259 23.1472 5.78861C23.2392 5.56462 23.3958 5.37303 23.5972 5.23818C23.7985 5.10333 24.0354 5.03132 24.2777 5.0313C24.5992 5.03128 24.9077 5.15774 25.1364 5.38331C25.3652 5.60888 25.4958 5.91539 25.4999 6.23645ZM24.2777 8.85802C24.0342 8.85647 23.7956 8.92721 23.5923 9.06127C23.389 9.19532 23.2301 9.38666 23.1358 9.61102C23.0415 9.83538 23.016 10.0827 23.0626 10.3215C23.1092 10.5603 23.2257 10.78 23.3974 10.9526C23.5691 11.1252 23.7883 11.243 24.0271 11.291C24.2659 11.3391 24.5136 11.3152 24.7388 11.2225C24.964 11.1297 25.1565 10.9722 25.2921 10.77C25.4276 10.5678 25.4999 10.33 25.4999 10.0866C25.5009 9.92567 25.4701 9.76608 25.4091 9.61706C25.3482 9.46804 25.2583 9.33254 25.1447 9.21835C25.0311 9.10415 24.8961 9.01353 24.7473 8.95169C24.5985 8.88985 24.4389 8.85802 24.2777 8.85802ZM16.5766 7.45724C16.8202 7.45723 17.0583 7.38497 17.2608 7.24962C17.4632 7.11427 17.6209 6.92192 17.7137 6.69697C17.8066 6.47201 17.8305 6.22458 17.7824 5.98604C17.7343 5.7475 17.6164 5.52859 17.4436 5.35708C17.2708 5.18557 17.0509 5.06918 16.8117 5.02266C16.5726 4.97614 16.3251 5.00159 16.1005 5.09579C15.8759 5.18998 15.6843 5.34867 15.5501 5.55174C15.4159 5.75481 15.3451 5.99312 15.3466 6.23645C15.3466 6.39742 15.3785 6.55681 15.4404 6.70544C15.5023 6.85406 15.593 6.98899 15.7074 7.10246C15.8217 7.21592 15.9573 7.30568 16.1065 7.36657C16.2557 7.42746 16.4155 7.45827 16.5766 7.45724ZM24.2777 12.7082C24.0338 12.7067 23.7949 12.7776 23.5915 12.912C23.388 13.0464 23.2291 13.2382 23.1351 13.463C23.041 13.6879 23.016 13.9355 23.0632 14.1746C23.1104 14.4136 23.2277 14.6333 23.4002 14.8056C23.5727 14.9779 23.7926 15.095 24.0319 15.1422C24.2712 15.1894 24.5192 15.1644 24.7442 15.0704C24.9693 14.9764 25.1613 14.8178 25.2959 14.6145C25.4304 14.4113 25.5014 14.1727 25.4999 13.929C25.4999 13.6052 25.3711 13.2947 25.1419 13.0658C24.9127 12.8368 24.6019 12.7082 24.2777 12.7082ZM20.4233 7.45724C20.6672 7.45879 20.9061 7.38785 21.1095 7.25344C21.313 7.11904 21.4719 6.92724 21.5659 6.70242C21.66 6.4776 21.685 6.22992 21.6378 5.99087C21.5906 5.75181 21.4733 5.53217 21.3008 5.35988C21.1283 5.18758 20.9084 5.07041 20.6691 5.02325C20.4298 4.9761 20.1818 5.00109 19.9568 5.09505C19.7317 5.18901 19.5397 5.34769 19.4051 5.55093C19.2706 5.75417 19.1996 5.99279 19.2011 6.23645C19.2011 6.56022 19.3299 6.87073 19.5591 7.09968C19.7883 7.32862 20.0991 7.45724 20.4233 7.45724ZM13.9835 5.0313H11.5V19H25.4999V16.5506H13.9835V5.0313Z" fill="#0046AA"></path>
+</svg>
+	                            </div>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" #>
+	                            <div class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="38" height="24" viewbox="0 0 38 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect width="37.5" height="24" rx="3" fill="#F2F2F2"></rect>
+                                    <path d="M17.9786 12.6203V15.9377H16.9261V7.74518H19.7173C20.0505 7.73822 20.3818 7.79731 20.692 7.91904C21.0022 8.04077 21.2852 8.22273 21.5247 8.45442C21.7667 8.67204 21.9592 8.93893 22.0895 9.23715C22.2197 9.53537 22.2846 9.85801 22.2797 10.1834C22.2867 10.5105 22.2228 10.8353 22.0925 11.1354C21.9622 11.4355 21.7685 11.7039 21.5247 11.9222C21.0367 12.3876 20.4342 12.6201 19.7173 12.6196H17.9786V12.6203ZM17.9786 8.7538V11.6136H19.7435C19.937 11.6194 20.1295 11.5846 20.3088 11.5117C20.4881 11.4388 20.6502 11.3292 20.7848 11.19C20.9186 11.0599 21.025 10.9043 21.0977 10.7323C21.1703 10.5604 21.2077 10.3756 21.2077 10.1889C21.2077 10.0023 21.1703 9.8175 21.0977 9.64555C21.025 9.4736 20.9186 9.31796 20.7848 9.18784C20.6519 9.04573 20.4904 8.93349 20.3109 8.85855C20.1313 8.78361 19.9379 8.74768 19.7435 8.75315H17.9786V8.7538Z" fill="#5F6368"></path>
+                                    <path d="M24.7049 10.1494C25.4828 10.1494 26.0968 10.3573 26.5469 10.773C26.9971 11.1888 27.222 11.7588 27.2215 12.483V15.9377H26.2149V15.1598H26.1691C25.7333 15.8004 25.1537 16.1207 24.4303 16.1207C23.8128 16.1207 23.2962 15.9377 22.8805 15.5716C22.681 15.4036 22.5215 15.1932 22.4136 14.9557C22.3057 14.7183 22.2522 14.4597 22.2569 14.1989C22.2569 13.6189 22.4761 13.1576 22.9145 12.8151C23.3529 12.4726 23.9381 12.3009 24.6702 12.3C25.2952 12.3 25.8098 12.4144 26.2142 12.6432V12.4026C26.2154 12.2248 26.177 12.049 26.1018 11.8879C26.0267 11.7268 25.9166 11.5844 25.7795 11.4711C25.5012 11.2201 25.1385 11.083 24.7637 11.0874C24.1758 11.0874 23.7106 11.3354 23.3681 11.8313L22.4412 11.2476C22.9511 10.5155 23.7056 10.1494 24.7049 10.1494ZM23.3433 14.2218C23.3426 14.3557 23.3739 14.4879 23.4346 14.6073C23.4953 14.7267 23.5837 14.8298 23.6923 14.9082C23.9251 15.0913 24.214 15.1882 24.5101 15.1827C24.9542 15.182 25.3799 15.0052 25.6939 14.6911C26.0425 14.363 26.2168 13.978 26.2168 13.5361C25.8887 13.2746 25.4311 13.1439 24.8441 13.1439C24.4166 13.1439 24.0601 13.247 23.7747 13.4531C23.4864 13.6623 23.3433 13.9165 23.3433 14.2218Z" fill="#5F6368"></path>
+                                    <path d="M33 10.3325L29.4858 18.4087H28.3994L29.7035 15.5828L27.3928 10.3325H28.5367L30.2068 14.3592H30.2297L31.8541 10.3325H33Z" fill="#5F6368"></path>
+                                    <path d="M13.7257 11.9052C13.7261 11.5845 13.699 11.2643 13.6447 10.9482H9.20624V12.7609H11.7484C11.6964 13.0504 11.5863 13.3264 11.4247 13.5722C11.2632 13.818 11.0535 14.0285 10.8084 14.1911V15.3677H12.3256C13.2139 14.5487 13.7257 13.3374 13.7257 11.9052Z" fill="#4285F4"></path>
+                                    <path d="M9.20625 16.5044C10.4763 16.5044 11.5457 16.0874 12.3256 15.3683L10.8084 14.1917C10.3861 14.478 9.84227 14.6415 9.20625 14.6415C7.97865 14.6415 6.93669 13.8139 6.5641 12.6987H5.00116V13.9113C5.39289 14.6908 5.99355 15.3461 6.7361 15.804C7.47865 16.2619 8.33386 16.5044 9.20625 16.5044Z" fill="#34A853"></path>
+                                    <path d="M6.56409 12.6987C6.36711 12.1143 6.36711 11.4815 6.56409 10.8971V9.68457H5.00115C4.67162 10.3403 4.5 11.064 4.5 11.7979C4.5 12.5318 4.67162 13.2555 5.00115 13.9112L6.56409 12.6987Z" fill="#FBBC04"></path>
+                                    <path d="M9.20625 8.95459C9.87743 8.94362 10.526 9.19722 11.0117 9.66056L12.355 8.31726C11.5032 7.51721 10.3748 7.07797 9.20625 7.09162C8.33386 7.09166 7.47865 7.33417 6.7361 7.79207C5.99355 8.24997 5.39289 8.90525 5.00116 9.68474L6.5641 10.8973C6.93669 9.78214 7.97865 8.95459 9.20625 8.95459Z" fill="#EA4335"></path>
+                                </svg>
+	                            </div>
+	                        </li>
+                    	
+<li class="p-4px xl:px-8px" #>
+	                            <div class="block w-33px md:w-38px">
+	                                <svg class="block w-full h-auto" width="38" height="24" viewbox="0 0 38 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect x="0.5" width="37.5" height="24" rx="3" fill="#F2F2F2"></rect>
+                                    <path d="M10.2075 7.64498C9.87347 8.04141 9.33903 8.35409 8.80459 8.30942C8.73779 7.7734 8.99944 7.20388 9.30563 6.85211C9.63965 6.44452 10.2242 6.15417 10.6974 6.13184C10.7531 6.69019 10.5359 7.23738 10.2075 7.64498ZM10.6918 8.41551C9.918 8.37084 9.25552 8.85661 8.8881 8.85661C8.51511 8.85661 7.95283 8.43784 7.34046 8.44901C6.54437 8.46018 5.80396 8.91245 5.39756 9.63273C4.56251 11.0733 5.18045 13.2062 5.98767 14.3787C6.38293 14.9594 6.85613 15.596 7.47964 15.5736C8.06974 15.5513 8.30356 15.1884 9.01614 15.1884C9.73429 15.1884 9.94027 15.5736 10.5638 15.5625C11.2096 15.5513 11.616 14.9818 12.0112 14.4011C12.4621 13.7422 12.6459 13.1001 12.657 13.0666C12.6459 13.0554 11.41 12.5808 11.3988 11.1515C11.3877 9.95657 12.3731 9.38705 12.4176 9.35355C11.8609 8.52718 10.9924 8.43785 10.6918 8.41551ZM15.1622 6.79628V15.501H16.5094V12.525H18.3743C20.0779 12.525 21.2748 11.3525 21.2748 9.65506C21.2748 7.95766 20.1001 6.79628 18.4189 6.79628H15.1622ZM16.5094 7.93532H18.0626C19.2317 7.93532 19.8997 8.56068 19.8997 9.66064C19.8997 10.7606 19.2317 11.3915 18.057 11.3915H16.5094V7.93532ZM23.7354 15.568C24.5816 15.568 25.3665 15.1381 25.7228 14.4569H25.7507V15.501H26.9977V11.1682C26.9977 9.9119 25.9956 9.10229 24.4536 9.10229C23.0228 9.10229 21.9651 9.92307 21.9261 11.0509H23.1397C23.2399 10.5149 23.7354 10.1632 24.4146 10.1632C25.2385 10.1632 25.7006 10.5484 25.7006 11.2575V11.7377L24.0193 11.8382C22.455 11.9332 21.6088 12.5753 21.6088 13.692C21.6088 14.8199 22.4828 15.568 23.7354 15.568ZM24.0973 14.5351C23.3791 14.5351 22.9226 14.1889 22.9226 13.6585C22.9226 13.1113 23.3624 12.793 24.203 12.7428L25.7006 12.6478V13.1392C25.7006 13.9544 25.0103 14.5351 24.0973 14.5351ZM28.6622 17.8685C29.9761 17.8685 30.594 17.366 31.134 15.8416L33.5 9.18604H32.1305L30.5439 14.3285H30.5161L28.9295 9.18604H27.521L29.8035 15.5234L29.681 15.9086C29.475 16.5619 29.141 16.8132 28.5453 16.8132C28.4396 16.8132 28.2336 16.802 28.1501 16.7908V17.835C28.228 17.8573 28.562 17.8685 28.6622 17.8685Z" fill="#888888"></path>
+                                </svg>
+	                            </div>
+	                        </li>
+                    	
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+	    <div class="text-13px leading-20px font-light text-grey-100 text-center bg-gray-50 py-14px">
+	    	<div class="inner w-1350px w-1960px">
+		    	<p><p>©2023 KitchenAid. The design of the stand mixer is a trademark in the U.S. and elsewhere. All rights reserved.</p></p>
+		    </div>
+	    </div>
+    
+</footer>
+
+
+
+</div>
+<script>const countDownTextList = document.querySelectorAll('.maintenance-message-countdown');for (let i = 0; i < countDownTextList.length; i++) {
+		countDownTextList[i].innerText = '3';
+	}
+</script><ul hidden>
+    <li id="a11y-refresh-page-message">choosing a selection results in a full page refresh</li>
+    <li id="a11y-selection-message">press the space key then arrow keys to make a selection</li>
+  </ul>
+
+  
+  
+
+<style type="text/css">
+    #SI_trigger_wrapper {margin: 10px 0 0 !important;}
+.appikon-bis-inline-form-wrapper {border: 0; border-radius: 0; padding: 0; margin: 8px 0 0; max-width: none;}
+.appikon-bis-inline-form-wrapper .appikon-bis-inline-form-title, .appikon-bis-inline-form-wrapper .appikon-bis-inline-form-description, .appikon-bis-inline-form-wrapper .appikon-bis-inline-form-footer {display: none;}
+.appikon-bis-inline-form-wrapper #customer-contact-container {display: flex; flex-wrap: wrap;}
+.appikon-bis-inline-form-wrapper #email-address {flex: 1 1 auto; margin: 0;}
+.appikon-bis-inline-form-wrapper .appikon-bis-inline-form-submit {font-size: 12px; line-height: 16px; letter-spacing: 1px; text-transform: uppercase; transition: background .25s; width: 105px; height: 40px; margin: 0 0 0 -1px;}
+.appikon-bis-inline-form-wrapper .appikon-bis-inline-form-submit:hover {background: #C41230 !important;}
+.appikon-bis-inline-input-section input{font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E; padding: 10px 16px; border: 0;}
+.appikon-bis-inline-input-section input:focus {outline: none;}
+.appikon-bis-inline-form-wrapper *::-webkit-input-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}
+.appikon-bis-inline-form-wrapper *:-moz-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}
+.appikon-bis-inline-form-wrapper *::-moz-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}
+.appikon-bis-inline-form-wrapper *:-ms-input-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}
+.appikon-bis-form-warning {display: block; color: #C41230;}
+.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message {text-align: left;}
+.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message > p {padding: 16px 16px 16px 38px; border-radius: 0; font-weight: normal; color: #000000;}
+.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-success {border: 2px solid #60935D; background: rgba(96, 147, 93, 0.1); position: relative;}
+.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-success:before {position: absolute; z-index: 1; top: 17px; left: 13px; font-family: 'icomoon_new_home' !important; content: '\e911'; speak: none; font-size: 16px; font-style: normal; font-weight: normal; font-variant: normal; text-transform: none; line-height: 1; color: #60935D;}
+.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-error {border: 2px solid #C41230; background: rgba(196,18,48, 0.1); position: relative;}
+.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-error:before {position: absolute; z-index: 1; top: 17px; left: 13px; font-family: 'icomoon_new_home' !important; content: '\e943'; speak: none; font-size: 16px; font-style: normal; font-weight: normal; font-variant: normal; text-transform: none; line-height: 1; color: #C41230;}
+.oos-notification.one .appikon-bis-inline-input-section input {padding: 9px 16px !important; border: 1px solid #000 !important}
+.oos-notification .oos-loading:first-child {position: relative; height: 50px;}
+.oos-notification .oos-loading:first-child:before {content: ''; position: absolute; z-index: 2; top: 50%; right: 50%; width: 20px; height: 20px; margin-top: -15px; margin-right: -15px; border: 2px solid transparent; border-top-color: #54595f; border-left-color: #54595f; border-radius: 50%; -webkit-pointer-events: none; pointer-events: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; -webkit-animation: pace-spinner .4s linear infinite; animation: pace-spinner .4s linear infinite;}
+.oos-notification .oos-loading:first-child:after {content: ''; position: absolute; z-index: 1; width: calc(100% + 4px); height: 100%; left: -2px; top: 0; background: #f8f8f8; -webkit-pointer-events: none; pointer-events: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;}
+</style>
+
+<script id="subscribe-it-helper">
+    var _SIConfig = _SIConfig || {};
+
+    _SIConfig = {
+        "app_hostname": "xsy6rdr4zb.execute-api.us-west-1.amazonaws.com",
+        "conversions_hostname": "ifouxf840g.execute-api.us-west-1.amazonaws.com",
+        "instock_qty_level": 1,
+        "preorder_enabled": false,
+        "require_inventory_management": true,
+        "ignore_duplicate_skus": false,
+        "generic_trigger_handler": true,
+        "quantity_field_enabled": false,
+        "labels": {
+            "headline": "NOTIFY WHEN AVAILABLE",
+            "email_address_label": "Email address",
+            "product_field_label": "Select product",
+            "button_label": "Notify Me",
+            "body_copy": "We will send you a notification as soon as this product is available again.",
+            "footer_copy": "We respect your privacy and don't share your email with anybody.",
+            "registration_complete": "You have great taste! We'll let you know via email if/when this product becomes available again.",
+            "email_invalid": "Invalid email address",
+            "uniqueness_of_email": "You have already registered for a notification for that item.",
+            "close_label": "Close",
+            "quantity_required_label": "Quantity required",
+            "email_tab_text": "Email",
+            "sms_tab_text": "SMS",
+            "fb_instruction_message": "Click below to receive notification on Facebook Messenger",
+            "fb_cta_button_text": "GET_THIS_IN_MESSENGER",
+            "fb_cta_button_language": "en_US",
+            "push_notification_label": "Also notify me via push notification",
+            "empty_email_phone_validation_message": "Uh-oh, please check your email address and try again.",
+            "terms_and_conditions_text": "I accept the terms and conditions"
+        },
+        "form_display_type": "INLINE",
+        "madeby_link_visible": false,
+        "hide_for_product_tag": "notify-it-hidden",
+        "hide_for_collections": "",
+        "recaptcha_enabled": null,
+        "content_for_body": "",
+        "show_phone_number_field": false,
+        "only_sms_enabled": false,
+        "show_notify_me_button_on_collection_page": false,
+        "show_sms_first": false,
+        "push_owl_enabled" : false,
+        "show_fb" : false,
+        "fb_page_id" : "",
+        "newsletter_permission_enabled": false,
+        "show_terms_and_conditions": false,
+        "newsletter_permission_default_checked": false,
+        "newsletter_permission_text": "Signup for newsletter?",
+        "popup_theme": {
+            "text_font_name": "Helvetica",
+            "background_color": "#ffffff",
+            "border_color": "#ffffff",
+            "border_width": 0,
+            "text_color": "#2e2e2e",
+            "button_background_color": "#000000",
+            "button_text_color": "#ffffff",
+            "button_corner_radius": 0,
+            "input_border_radius": 0,
+            "input_border_width": 1,
+            "input_border_color": "#000000",
+            "success_background_color": "#dff0d8",
+            "success_text_color": "#000000",
+            "failure_background_color": "#f2dede",
+            "failure_text_color": "#000000",
+            "close_button_color": "#2e2e2e",
+            "fade_color": "#000000",
+            "fade_color_rgb": "0,0,0",
+            "selected_tab_text_color": "#ffffff",
+            "selected_tab_background_color": "#000000",
+            "signup_form_custom_css": "#SI_trigger_wrapper {margin: 10px 0 0 !important;}\n.appikon-bis-inline-form-wrapper {border: 0; border-radius: 0; padding: 0; margin: 8px 0 0; max-width: none;}\n.appikon-bis-inline-form-wrapper .appikon-bis-inline-form-title, .appikon-bis-inline-form-wrapper .appikon-bis-inline-form-description, .appikon-bis-inline-form-wrapper .appikon-bis-inline-form-footer {display: none;}\n.appikon-bis-inline-form-wrapper #customer-contact-container {display: flex; flex-wrap: wrap;}\n.appikon-bis-inline-form-wrapper #email-address {flex: 1 1 auto; margin: 0;}\n.appikon-bis-inline-form-wrapper .appikon-bis-inline-form-submit {font-size: 12px; line-height: 16px; letter-spacing: 1px; text-transform: uppercase; transition: background .25s; width: 105px; height: 40px; margin: 0 0 0 -1px;}\n.appikon-bis-inline-form-wrapper .appikon-bis-inline-form-submit:hover {background: #C41230 !important;}\n.appikon-bis-inline-input-section input{font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E; padding: 10px 16px; border: 0;}\n.appikon-bis-inline-input-section input:focus {outline: none;}\n.appikon-bis-inline-form-wrapper *::-webkit-input-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}\n.appikon-bis-inline-form-wrapper *:-moz-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}\n.appikon-bis-inline-form-wrapper *::-moz-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}\n.appikon-bis-inline-form-wrapper *:-ms-input-placeholder {font-size: 13px; line-height: 20px; font-weight: 300; color: #2E2E2E;}\n.appikon-bis-form-warning {display: block; color: #C41230;}\n.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message {text-align: left;}\n.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message > p {padding: 16px 16px 16px 38px; border-radius: 0; font-weight: normal; color: #000000;}\n.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-success {border: 2px solid #60935D; background: rgba(96, 147, 93, 0.1); position: relative;}\n.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-success:before {position: absolute; z-index: 1; top: 17px; left: 13px; font-family: 'icomoon_new_home' !important; content: '\\e911'; speak: none; font-size: 16px; font-style: normal; font-weight: normal; font-variant: normal; text-transform: none; line-height: 1; color: #60935D;}\n.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-error {border: 2px solid #C41230; background: rgba(196,18,48, 0.1); position: relative;}\n.appikon-bis-inline-form-wrapper #appikon-bis-inline-form-message .appikon-bis-inline-form-error:before {position: absolute; z-index: 1; top: 17px; left: 13px; font-family: 'icomoon_new_home' !important; content: '\\e943'; speak: none; font-size: 16px; font-style: normal; font-weight: normal; font-variant: normal; text-transform: none; line-height: 1; color: #C41230;}\n.oos-notification.one .appikon-bis-inline-input-section input {padding: 9px 16px !important; border: 1px solid #000 !important}\n.oos-notification .oos-loading:first-child {position: relative; height: 50px;}\n.oos-notification .oos-loading:first-child:before {content: ''; position: absolute; z-index: 2; top: 50%; right: 50%; width: 20px; height: 20px; margin-top: -15px; margin-right: -15px; border: 2px solid transparent; border-top-color: #54595f; border-left-color: #54595f; border-radius: 50%; -webkit-pointer-events: none; pointer-events: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; -webkit-animation: pace-spinner .4s linear infinite; animation: pace-spinner .4s linear infinite;}\n.oos-notification .oos-loading:first-child:after {content: ''; position: absolute; z-index: 1; width: calc(100% + 4px); height: 100%; left: -2px; top: 0; background: #f8f8f8; -webkit-pointer-events: none; pointer-events: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none;}"
+        },
+        "button": {
+            "use_image": false,
+            "caption": "NOTIFY WHEN AVAILABLE",
+            "font_size": 16,
+            "bold": true,
+            "position": "right-top",
+            "corner_offset": 100,
+            "selected_selector": ".oos-notification",
+            "placement": "FIRST_CHILD",
+            "background_color": "#000000",
+            "text_color": "#ffffff",
+            "border_color": "#000000",
+            "border_width": 1,
+            "border_radius": 3,
+            "image": "//static.back-in-stock.appikon.com/assets/widget/notify-btn-vertical-f46bd7ac1b51e7d3c6a766d843fe60b46f8628e13e717124d83ffe65be466f4d.png",
+            "visible": false,
+            "always_show_widget": false,
+            "widget_button_enabled": true,
+            "countdown_timer_enabled": false,
+            "countdown_timer_reset_enabled": false,
+            "countdown_timer_expiration": "-1",
+            "countdown_timer_products": "[]"
+        },
+        "main_button": {
+            "main_caption": "NOTIFY WHEN AVAILABLE",
+            "main_css_classes": "  _in_stock_add_to_cart  add_to_cart  w-full block bg-red-100 text-white hover:bg-black-100 transition-colors duration-250 py-12px md:py-14px",
+            "main_button_width": "",
+            "main_button_height": "",
+            "main_caption_size": "",
+            "main_margin_top": "",
+            "main_margin_bottom": "",
+            "main_margin_left": "",
+            "main_margin_right": "",
+            "main_text_color": "",
+            "main_hover_text_color": "",
+            "main_text_style": "",
+            "main_background_color": "",
+            "main_hover_background_color": "",
+            "main_border_color": "",
+            "main_hover_border_color": "",
+            "main_border_size": "",
+            "main_border_radius": ""
+        },
+        "partials": {},
+        "preferredCountries": ["AU"],
+        "multivariant_dropdown_container": "document",
+        "shop": "kitchenaid-australia.myshopify.com",
+        "styles": "/*!\n * Bootstrap v3.4.1 (https://getbootstrap.com/)\n * Copyright 2011-2019 Twitter, Inc.\n * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)\n *//*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,details,figcaption,figure,footer,header,hgroup,main,menu,nav,section,summary{display:block}audio,canvas,progress,video{display:inline-block;vertical-align:baseline}audio:not([controls]){display:none;height:0}[hidden],template{display:none}a{background-color:transparent}a:active,a:hover{outline:0}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:bold}dfn{font-style:italic}h1{font-size:2em;margin:0.67em 0}mark{background:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:1em 40px}hr{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box;height:0}pre{overflow:auto}code,kbd,pre,samp{font-family:monospace, monospace;font-size:1em}button,input,optgroup,select,textarea{color:inherit;font:inherit;margin:0}button{overflow:visible}button,select{text-transform:none}button,html input[type=\"button\"],input[type=\"reset\"],input[type=\"submit\"]{-webkit-appearance:button;cursor:pointer}button[disabled],html input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}input{line-height:normal}input[type=\"checkbox\"],input[type=\"radio\"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:0}input[type=\"number\"]::-webkit-inner-spin-button,input[type=\"number\"]::-webkit-outer-spin-button{height:auto}input[type=\"search\"]{-webkit-appearance:textfield;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}input[type=\"search\"]::-webkit-search-cancel-button,input[type=\"search\"]::-webkit-search-decoration{-webkit-appearance:none}fieldset{border:1px solid #c0c0c0;margin:0 2px;padding:0.35em 0.625em 0.75em}legend{border:0;padding:0}textarea{overflow:auto}optgroup{font-weight:bold}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}*:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}html{font-size:10px;-webkit-tap-highlight-color:transparent}body{font-family:\"Helvetica Neue\", Helvetica, Arial, sans-serif;font-size:14px;line-height:1.42857143;color:#333333;background-color:#ffffff}input,button,select,textarea{font-family:inherit;font-size:inherit;line-height:inherit}a{color:#337ab7;text-decoration:none}a:hover,a:focus{color:#23527c;text-decoration:underline}a:focus{outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}figure{margin:0}img{vertical-align:middle}.img-responsive{display:block;max-width:100%;height:auto}.img-rounded{border-radius:6px}.img-thumbnail{padding:4px;line-height:1.42857143;background-color:#ffffff;border:1px solid #dddddd;border-radius:4px;-webkit-transition:all 0.2s ease-in-out;-o-transition:all 0.2s ease-in-out;transition:all 0.2s ease-in-out;display:inline-block;max-width:100%;height:auto}.img-circle{border-radius:50%}hr{margin-top:20px;margin-bottom:20px;border:0;border-top:1px solid #eeeeee}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0, 0, 0, 0);border:0}.sr-only-focusable:active,.sr-only-focusable:focus{position:static;width:auto;height:auto;margin:0;overflow:visible;clip:auto}[role=\"button\"]{cursor:pointer}h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6{font-family:inherit;font-weight:500;line-height:1.1;color:inherit}h1 small,h2 small,h3 small,h4 small,h5 small,h6 small,.h1 small,.h2 small,.h3 small,.h4 small,.h5 small,.h6 small,h1 .small,h2 .small,h3 .small,h4 .small,h5 .small,h6 .small,.h1 .small,.h2 .small,.h3 .small,.h4 .small,.h5 .small,.h6 .small{font-weight:400;line-height:1;color:#777777}h1,.h1,h2,.h2,h3,.h3{margin-top:20px;margin-bottom:10px}h1 small,.h1 small,h2 small,.h2 small,h3 small,.h3 small,h1 .small,.h1 .small,h2 .small,.h2 .small,h3 .small,.h3 .small{font-size:65%}h4,.h4,h5,.h5,h6,.h6{margin-top:10px;margin-bottom:10px}h4 small,.h4 small,h5 small,.h5 small,h6 small,.h6 small,h4 .small,.h4 .small,h5 .small,.h5 .small,h6 .small,.h6 .small{font-size:75%}h1,.h1{font-size:36px}h2,.h2{font-size:30px}h3,.h3{font-size:24px}h4,.h4{font-size:18px}h5,.h5{font-size:14px}h6,.h6{font-size:12px}p{margin:0 0 10px}.lead{margin-bottom:20px;font-size:16px;font-weight:300;line-height:1.4}@media (min-width: 768px){.lead{font-size:21px}}small,.small{font-size:85%}mark,.mark{padding:.2em;background-color:#fcf8e3}.text-left{text-align:left}.text-right{text-align:right}.text-center{text-align:center}.text-justify{text-align:justify}.text-nowrap{white-space:nowrap}.text-lowercase{text-transform:lowercase}.text-uppercase{text-transform:uppercase}.text-capitalize{text-transform:capitalize}.text-muted{color:#777777}.text-primary{color:#337ab7}a.text-primary:hover,a.text-primary:focus{color:#286090}.text-success{color:#3c763d}a.text-success:hover,a.text-success:focus{color:#2b542c}.text-info{color:#31708f}a.text-info:hover,a.text-info:focus{color:#245269}.text-warning{color:#8a6d3b}a.text-warning:hover,a.text-warning:focus{color:#66512c}.text-danger{color:#a94442}a.text-danger:hover,a.text-danger:focus{color:#843534}.bg-primary{color:#fff;background-color:#337ab7}a.bg-primary:hover,a.bg-primary:focus{background-color:#286090}.bg-success{background-color:#dff0d8}a.bg-success:hover,a.bg-success:focus{background-color:#c1e2b3}.bg-info{background-color:#d9edf7}a.bg-info:hover,a.bg-info:focus{background-color:#afd9ee}.bg-warning{background-color:#fcf8e3}a.bg-warning:hover,a.bg-warning:focus{background-color:#f7ecb5}.bg-danger{background-color:#f2dede}a.bg-danger:hover,a.bg-danger:focus{background-color:#e4b9b9}.page-header{padding-bottom:9px;margin:40px 0 20px;border-bottom:1px solid #eeeeee}ul,ol{margin-top:0;margin-bottom:10px}ul ul,ol ul,ul ol,ol ol{margin-bottom:0}.list-unstyled{padding-left:0;list-style:none}.list-inline{padding-left:0;list-style:none;margin-left:-5px}.list-inline\u003eli{display:inline-block;padding-right:5px;padding-left:5px}dl{margin-top:0;margin-bottom:20px}dt,dd{line-height:1.42857143}dt{font-weight:700}dd{margin-left:0}@media (min-width: 768px){.dl-horizontal dt{float:left;width:160px;clear:left;text-align:right;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.dl-horizontal dd{margin-left:180px}}abbr[title],abbr[data-original-title]{cursor:help}.initialism{font-size:90%;text-transform:uppercase}blockquote{padding:10px 20px;margin:0 0 20px;font-size:17.5px;border-left:5px solid #eeeeee}blockquote p:last-child,blockquote ul:last-child,blockquote ol:last-child{margin-bottom:0}blockquote footer,blockquote small,blockquote .small{display:block;font-size:80%;line-height:1.42857143;color:#777777}blockquote footer:before,blockquote small:before,blockquote .small:before{content:\"\\2014 \\00A0\"}.blockquote-reverse,blockquote.pull-right{padding-right:15px;padding-left:0;text-align:right;border-right:5px solid #eeeeee;border-left:0}.blockquote-reverse footer:before,blockquote.pull-right footer:before,.blockquote-reverse small:before,blockquote.pull-right small:before,.blockquote-reverse .small:before,blockquote.pull-right .small:before{content:\"\"}.blockquote-reverse footer:after,blockquote.pull-right footer:after,.blockquote-reverse small:after,blockquote.pull-right small:after,.blockquote-reverse .small:after,blockquote.pull-right .small:after{content:\"\\00A0 \\2014\"}address{margin-bottom:20px;font-style:normal;line-height:1.42857143}.container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto}@media (min-width: 768px){.container{width:750px}}@media (min-width: 992px){.container{width:970px}}@media (min-width: 1200px){.container{width:1170px}}.container-fluid{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto}.row{margin-right:-15px;margin-left:-15px}.row-no-gutters{margin-right:0;margin-left:0}.row-no-gutters [class*=\"col-\"]{padding-right:0;padding-left:0}.col-xs-1,.col-sm-1,.col-md-1,.col-lg-1,.col-xs-2,.col-sm-2,.col-md-2,.col-lg-2,.col-xs-3,.col-sm-3,.col-md-3,.col-lg-3,.col-xs-4,.col-sm-4,.col-md-4,.col-lg-4,.col-xs-5,.col-sm-5,.col-md-5,.col-lg-5,.col-xs-6,.col-sm-6,.col-md-6,.col-lg-6,.col-xs-7,.col-sm-7,.col-md-7,.col-lg-7,.col-xs-8,.col-sm-8,.col-md-8,.col-lg-8,.col-xs-9,.col-sm-9,.col-md-9,.col-lg-9,.col-xs-10,.col-sm-10,.col-md-10,.col-lg-10,.col-xs-11,.col-sm-11,.col-md-11,.col-lg-11,.col-xs-12,.col-sm-12,.col-md-12,.col-lg-12{position:relative;min-height:1px;padding-right:15px;padding-left:15px}.col-xs-1,.col-xs-2,.col-xs-3,.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9,.col-xs-10,.col-xs-11,.col-xs-12{float:left}.col-xs-12{width:100%}.col-xs-11{width:91.66666667%}.col-xs-10{width:83.33333333%}.col-xs-9{width:75%}.col-xs-8{width:66.66666667%}.col-xs-7{width:58.33333333%}.col-xs-6{width:50%}.col-xs-5{width:41.66666667%}.col-xs-4{width:33.33333333%}.col-xs-3{width:25%}.col-xs-2{width:16.66666667%}.col-xs-1{width:8.33333333%}.col-xs-pull-12{right:100%}.col-xs-pull-11{right:91.66666667%}.col-xs-pull-10{right:83.33333333%}.col-xs-pull-9{right:75%}.col-xs-pull-8{right:66.66666667%}.col-xs-pull-7{right:58.33333333%}.col-xs-pull-6{right:50%}.col-xs-pull-5{right:41.66666667%}.col-xs-pull-4{right:33.33333333%}.col-xs-pull-3{right:25%}.col-xs-pull-2{right:16.66666667%}.col-xs-pull-1{right:8.33333333%}.col-xs-pull-0{right:auto}.col-xs-push-12{left:100%}.col-xs-push-11{left:91.66666667%}.col-xs-push-10{left:83.33333333%}.col-xs-push-9{left:75%}.col-xs-push-8{left:66.66666667%}.col-xs-push-7{left:58.33333333%}.col-xs-push-6{left:50%}.col-xs-push-5{left:41.66666667%}.col-xs-push-4{left:33.33333333%}.col-xs-push-3{left:25%}.col-xs-push-2{left:16.66666667%}.col-xs-push-1{left:8.33333333%}.col-xs-push-0{left:auto}.col-xs-offset-12{margin-left:100%}.col-xs-offset-11{margin-left:91.66666667%}.col-xs-offset-10{margin-left:83.33333333%}.col-xs-offset-9{margin-left:75%}.col-xs-offset-8{margin-left:66.66666667%}.col-xs-offset-7{margin-left:58.33333333%}.col-xs-offset-6{margin-left:50%}.col-xs-offset-5{margin-left:41.66666667%}.col-xs-offset-4{margin-left:33.33333333%}.col-xs-offset-3{margin-left:25%}.col-xs-offset-2{margin-left:16.66666667%}.col-xs-offset-1{margin-left:8.33333333%}.col-xs-offset-0{margin-left:0%}@media (min-width: 768px){.col-sm-1,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-sm-10,.col-sm-11,.col-sm-12{float:left}.col-sm-12{width:100%}.col-sm-11{width:91.66666667%}.col-sm-10{width:83.33333333%}.col-sm-9{width:75%}.col-sm-8{width:66.66666667%}.col-sm-7{width:58.33333333%}.col-sm-6{width:50%}.col-sm-5{width:41.66666667%}.col-sm-4{width:33.33333333%}.col-sm-3{width:25%}.col-sm-2{width:16.66666667%}.col-sm-1{width:8.33333333%}.col-sm-pull-12{right:100%}.col-sm-pull-11{right:91.66666667%}.col-sm-pull-10{right:83.33333333%}.col-sm-pull-9{right:75%}.col-sm-pull-8{right:66.66666667%}.col-sm-pull-7{right:58.33333333%}.col-sm-pull-6{right:50%}.col-sm-pull-5{right:41.66666667%}.col-sm-pull-4{right:33.33333333%}.col-sm-pull-3{right:25%}.col-sm-pull-2{right:16.66666667%}.col-sm-pull-1{right:8.33333333%}.col-sm-pull-0{right:auto}.col-sm-push-12{left:100%}.col-sm-push-11{left:91.66666667%}.col-sm-push-10{left:83.33333333%}.col-sm-push-9{left:75%}.col-sm-push-8{left:66.66666667%}.col-sm-push-7{left:58.33333333%}.col-sm-push-6{left:50%}.col-sm-push-5{left:41.66666667%}.col-sm-push-4{left:33.33333333%}.col-sm-push-3{left:25%}.col-sm-push-2{left:16.66666667%}.col-sm-push-1{left:8.33333333%}.col-sm-push-0{left:auto}.col-sm-offset-12{margin-left:100%}.col-sm-offset-11{margin-left:91.66666667%}.col-sm-offset-10{margin-left:83.33333333%}.col-sm-offset-9{margin-left:75%}.col-sm-offset-8{margin-left:66.66666667%}.col-sm-offset-7{margin-left:58.33333333%}.col-sm-offset-6{margin-left:50%}.col-sm-offset-5{margin-left:41.66666667%}.col-sm-offset-4{margin-left:33.33333333%}.col-sm-offset-3{margin-left:25%}.col-sm-offset-2{margin-left:16.66666667%}.col-sm-offset-1{margin-left:8.33333333%}.col-sm-offset-0{margin-left:0%}}@media (min-width: 992px){.col-md-1,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-md-10,.col-md-11,.col-md-12{float:left}.col-md-12{width:100%}.col-md-11{width:91.66666667%}.col-md-10{width:83.33333333%}.col-md-9{width:75%}.col-md-8{width:66.66666667%}.col-md-7{width:58.33333333%}.col-md-6{width:50%}.col-md-5{width:41.66666667%}.col-md-4{width:33.33333333%}.col-md-3{width:25%}.col-md-2{width:16.66666667%}.col-md-1{width:8.33333333%}.col-md-pull-12{right:100%}.col-md-pull-11{right:91.66666667%}.col-md-pull-10{right:83.33333333%}.col-md-pull-9{right:75%}.col-md-pull-8{right:66.66666667%}.col-md-pull-7{right:58.33333333%}.col-md-pull-6{right:50%}.col-md-pull-5{right:41.66666667%}.col-md-pull-4{right:33.33333333%}.col-md-pull-3{right:25%}.col-md-pull-2{right:16.66666667%}.col-md-pull-1{right:8.33333333%}.col-md-pull-0{right:auto}.col-md-push-12{left:100%}.col-md-push-11{left:91.66666667%}.col-md-push-10{left:83.33333333%}.col-md-push-9{left:75%}.col-md-push-8{left:66.66666667%}.col-md-push-7{left:58.33333333%}.col-md-push-6{left:50%}.col-md-push-5{left:41.66666667%}.col-md-push-4{left:33.33333333%}.col-md-push-3{left:25%}.col-md-push-2{left:16.66666667%}.col-md-push-1{left:8.33333333%}.col-md-push-0{left:auto}.col-md-offset-12{margin-left:100%}.col-md-offset-11{margin-left:91.66666667%}.col-md-offset-10{margin-left:83.33333333%}.col-md-offset-9{margin-left:75%}.col-md-offset-8{margin-left:66.66666667%}.col-md-offset-7{margin-left:58.33333333%}.col-md-offset-6{margin-left:50%}.col-md-offset-5{margin-left:41.66666667%}.col-md-offset-4{margin-left:33.33333333%}.col-md-offset-3{margin-left:25%}.col-md-offset-2{margin-left:16.66666667%}.col-md-offset-1{margin-left:8.33333333%}.col-md-offset-0{margin-left:0%}}@media (min-width: 1200px){.col-lg-1,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-lg-10,.col-lg-11,.col-lg-12{float:left}.col-lg-12{width:100%}.col-lg-11{width:91.66666667%}.col-lg-10{width:83.33333333%}.col-lg-9{width:75%}.col-lg-8{width:66.66666667%}.col-lg-7{width:58.33333333%}.col-lg-6{width:50%}.col-lg-5{width:41.66666667%}.col-lg-4{width:33.33333333%}.col-lg-3{width:25%}.col-lg-2{width:16.66666667%}.col-lg-1{width:8.33333333%}.col-lg-pull-12{right:100%}.col-lg-pull-11{right:91.66666667%}.col-lg-pull-10{right:83.33333333%}.col-lg-pull-9{right:75%}.col-lg-pull-8{right:66.66666667%}.col-lg-pull-7{right:58.33333333%}.col-lg-pull-6{right:50%}.col-lg-pull-5{right:41.66666667%}.col-lg-pull-4{right:33.33333333%}.col-lg-pull-3{right:25%}.col-lg-pull-2{right:16.66666667%}.col-lg-pull-1{right:8.33333333%}.col-lg-pull-0{right:auto}.col-lg-push-12{left:100%}.col-lg-push-11{left:91.66666667%}.col-lg-push-10{left:83.33333333%}.col-lg-push-9{left:75%}.col-lg-push-8{left:66.66666667%}.col-lg-push-7{left:58.33333333%}.col-lg-push-6{left:50%}.col-lg-push-5{left:41.66666667%}.col-lg-push-4{left:33.33333333%}.col-lg-push-3{left:25%}.col-lg-push-2{left:16.66666667%}.col-lg-push-1{left:8.33333333%}.col-lg-push-0{left:auto}.col-lg-offset-12{margin-left:100%}.col-lg-offset-11{margin-left:91.66666667%}.col-lg-offset-10{margin-left:83.33333333%}.col-lg-offset-9{margin-left:75%}.col-lg-offset-8{margin-left:66.66666667%}.col-lg-offset-7{margin-left:58.33333333%}.col-lg-offset-6{margin-left:50%}.col-lg-offset-5{margin-left:41.66666667%}.col-lg-offset-4{margin-left:33.33333333%}.col-lg-offset-3{margin-left:25%}.col-lg-offset-2{margin-left:16.66666667%}.col-lg-offset-1{margin-left:8.33333333%}.col-lg-offset-0{margin-left:0%}}fieldset{min-width:0;padding:0;margin:0;border:0}legend{display:block;width:100%;padding:0;margin-bottom:20px;font-size:21px;line-height:inherit;color:#333333;border:0;border-bottom:1px solid #e5e5e5}label{display:inline-block;max-width:100%;margin-bottom:5px;font-weight:700}input[type=\"search\"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;-webkit-appearance:none;appearance:none}input[type=\"radio\"],input[type=\"checkbox\"]{margin:4px 0 0;margin-top:1px \\9;line-height:normal}input[type=\"radio\"][disabled],input[type=\"checkbox\"][disabled],input[type=\"radio\"].disabled,input[type=\"checkbox\"].disabled,fieldset[disabled] input[type=\"radio\"],fieldset[disabled] input[type=\"checkbox\"]{cursor:not-allowed}input[type=\"file\"]{display:block}input[type=\"range\"]{display:block;width:100%}select[multiple],select[size]{height:auto}input[type=\"file\"]:focus,input[type=\"radio\"]:focus,input[type=\"checkbox\"]:focus{outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}output{display:block;padding-top:7px;font-size:14px;line-height:1.42857143;color:#555555}.form-control{display:block;width:100%;height:34px;padding:6px 12px;font-size:14px;line-height:1.42857143;color:#555555;background-color:#ffffff;background-image:none;border:1px solid #cccccc;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);-webkit-transition:border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;-o-transition:border-color ease-in-out .15s, box-shadow ease-in-out .15s;transition:border-color ease-in-out .15s, box-shadow ease-in-out .15s}.form-control:focus{border-color:#66afe9;outline:0;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6)}.form-control::-moz-placeholder{color:#999999;opacity:1}.form-control:-ms-input-placeholder{color:#999999}.form-control::-webkit-input-placeholder{color:#999999}.form-control::-ms-expand{background-color:transparent;border:0}.form-control[disabled],.form-control[readonly],fieldset[disabled] .form-control{background-color:#eeeeee;opacity:1}.form-control[disabled],fieldset[disabled] .form-control{cursor:not-allowed}textarea.form-control{height:auto}@media screen and (-webkit-min-device-pixel-ratio: 0){input[type=\"date\"].form-control,input[type=\"time\"].form-control,input[type=\"datetime-local\"].form-control,input[type=\"month\"].form-control{line-height:34px}input[type=\"date\"].input-sm,input[type=\"time\"].input-sm,input[type=\"datetime-local\"].input-sm,input[type=\"month\"].input-sm,.input-group-sm input[type=\"date\"],.input-group-sm input[type=\"time\"],.input-group-sm input[type=\"datetime-local\"],.input-group-sm input[type=\"month\"]{line-height:30px}input[type=\"date\"].input-lg,input[type=\"time\"].input-lg,input[type=\"datetime-local\"].input-lg,input[type=\"month\"].input-lg,.input-group-lg input[type=\"date\"],.input-group-lg input[type=\"time\"],.input-group-lg input[type=\"datetime-local\"],.input-group-lg input[type=\"month\"]{line-height:46px}}.form-group{margin-bottom:15px}.radio,.checkbox{position:relative;display:block;margin-top:10px;margin-bottom:10px}.radio.disabled label,.checkbox.disabled label,fieldset[disabled] .radio label,fieldset[disabled] .checkbox label{cursor:not-allowed}.radio label,.checkbox label{min-height:20px;padding-left:20px;margin-bottom:0;font-weight:400;cursor:pointer}.radio input[type=\"radio\"],.radio-inline input[type=\"radio\"],.checkbox input[type=\"checkbox\"],.checkbox-inline input[type=\"checkbox\"]{position:absolute;margin-top:4px \\9;margin-left:-20px}.radio+.radio,.checkbox+.checkbox{margin-top:-5px}.radio-inline,.checkbox-inline{position:relative;display:inline-block;padding-left:20px;margin-bottom:0;font-weight:400;vertical-align:middle;cursor:pointer}.radio-inline.disabled,.checkbox-inline.disabled,fieldset[disabled] .radio-inline,fieldset[disabled] .checkbox-inline{cursor:not-allowed}.radio-inline+.radio-inline,.checkbox-inline+.checkbox-inline{margin-top:0;margin-left:10px}.form-control-static{min-height:34px;padding-top:7px;padding-bottom:7px;margin-bottom:0}.form-control-static.input-lg,.form-control-static.input-sm{padding-right:0;padding-left:0}.input-sm{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}select.input-sm{height:30px;line-height:30px}textarea.input-sm,select[multiple].input-sm{height:auto}.form-group-sm .form-control{height:30px;padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}.form-group-sm select.form-control{height:30px;line-height:30px}.form-group-sm textarea.form-control,.form-group-sm select[multiple].form-control{height:auto}.form-group-sm .form-control-static{height:30px;min-height:32px;padding:6px 10px;font-size:12px;line-height:1.5}.input-lg{height:46px;padding:10px 16px;font-size:18px;line-height:1.3333333;border-radius:6px}select.input-lg{height:46px;line-height:46px}textarea.input-lg,select[multiple].input-lg{height:auto}.form-group-lg .form-control{height:46px;padding:10px 16px;font-size:18px;line-height:1.3333333;border-radius:6px}.form-group-lg select.form-control{height:46px;line-height:46px}.form-group-lg textarea.form-control,.form-group-lg select[multiple].form-control{height:auto}.form-group-lg .form-control-static{height:46px;min-height:38px;padding:11px 16px;font-size:18px;line-height:1.3333333}.has-feedback{position:relative}.has-feedback .form-control{padding-right:42.5px}.form-control-feedback{position:absolute;top:0;right:0;z-index:2;display:block;width:34px;height:34px;line-height:34px;text-align:center;pointer-events:none}.input-lg+.form-control-feedback,.input-group-lg+.form-control-feedback,.form-group-lg .form-control+.form-control-feedback{width:46px;height:46px;line-height:46px}.input-sm+.form-control-feedback,.input-group-sm+.form-control-feedback,.form-group-sm .form-control+.form-control-feedback{width:30px;height:30px;line-height:30px}.has-success .help-block,.has-success .control-label,.has-success .radio,.has-success .checkbox,.has-success .radio-inline,.has-success .checkbox-inline,.has-success.radio label,.has-success.checkbox label,.has-success.radio-inline label,.has-success.checkbox-inline label{color:#3c763d}.has-success .form-control{border-color:#3c763d;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-success .form-control:focus{border-color:#2b542c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168}.has-success .input-group-addon{color:#3c763d;background-color:#dff0d8;border-color:#3c763d}.has-success .form-control-feedback{color:#3c763d}.has-warning .help-block,.has-warning .control-label,.has-warning .radio,.has-warning .checkbox,.has-warning .radio-inline,.has-warning .checkbox-inline,.has-warning.radio label,.has-warning.checkbox label,.has-warning.radio-inline label,.has-warning.checkbox-inline label{color:#8a6d3b}.has-warning .form-control{border-color:#8a6d3b;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-warning .form-control:focus{border-color:#66512c;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b}.has-warning .input-group-addon{color:#8a6d3b;background-color:#fcf8e3;border-color:#8a6d3b}.has-warning .form-control-feedback{color:#8a6d3b}.has-error .help-block,.has-error .control-label,.has-error .radio,.has-error .checkbox,.has-error .radio-inline,.has-error .checkbox-inline,.has-error.radio label,.has-error.checkbox label,.has-error.radio-inline label,.has-error.checkbox-inline label{color:#a94442}.has-error .form-control{border-color:#a94442;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);box-shadow:inset 0 1px 1px rgba(0,0,0,0.075)}.has-error .form-control:focus{border-color:#843534;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483;box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483}.has-error .input-group-addon{color:#a94442;background-color:#f2dede;border-color:#a94442}.has-error .form-control-feedback{color:#a94442}.has-feedback label ~ .form-control-feedback{top:25px}.has-feedback label.sr-only ~ .form-control-feedback{top:0}.help-block{display:block;margin-top:5px;margin-bottom:10px;color:#737373}@media (min-width: 768px){.form-inline .form-group{display:inline-block;margin-bottom:0;vertical-align:middle}.form-inline .form-control{display:inline-block;width:auto;vertical-align:middle}.form-inline .form-control-static{display:inline-block}.form-inline .input-group{display:inline-table;vertical-align:middle}.form-inline .input-group .input-group-addon,.form-inline .input-group .input-group-btn,.form-inline .input-group .form-control{width:auto}.form-inline .input-group\u003e.form-control{width:100%}.form-inline .control-label{margin-bottom:0;vertical-align:middle}.form-inline .radio,.form-inline .checkbox{display:inline-block;margin-top:0;margin-bottom:0;vertical-align:middle}.form-inline .radio label,.form-inline .checkbox label{padding-left:0}.form-inline .radio input[type=\"radio\"],.form-inline .checkbox input[type=\"checkbox\"]{position:relative;margin-left:0}.form-inline .has-feedback .form-control-feedback{top:0}}.form-horizontal .radio,.form-horizontal .checkbox,.form-horizontal .radio-inline,.form-horizontal .checkbox-inline{padding-top:7px;margin-top:0;margin-bottom:0}.form-horizontal .radio,.form-horizontal .checkbox{min-height:27px}.form-horizontal .form-group{margin-right:-15px;margin-left:-15px}@media (min-width: 768px){.form-horizontal .control-label{padding-top:7px;margin-bottom:0;text-align:right}}.form-horizontal .has-feedback .form-control-feedback{right:15px}@media (min-width: 768px){.form-horizontal .form-group-lg .control-label{padding-top:11px;font-size:18px}}@media (min-width: 768px){.form-horizontal .form-group-sm .control-label{padding-top:6px;font-size:12px}}.btn{display:inline-block;margin-bottom:0;font-weight:normal;text-align:center;white-space:nowrap;vertical-align:middle;-ms-touch-action:manipulation;touch-action:manipulation;cursor:pointer;background-image:none;border:1px solid transparent;padding:6px 12px;font-size:14px;line-height:1.42857143;border-radius:4px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.btn:focus,.btn:active:focus,.btn.active:focus,.btn.focus,.btn:active.focus,.btn.active.focus{outline:5px auto -webkit-focus-ring-color;outline-offset:-2px}.btn:hover,.btn:focus,.btn.focus{color:#333333;text-decoration:none}.btn:active,.btn.active{background-image:none;outline:0;-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn.disabled,.btn[disabled],fieldset[disabled] .btn{cursor:not-allowed;filter:alpha(opacity=65);opacity:0.65;-webkit-box-shadow:none;box-shadow:none}a.btn.disabled,fieldset[disabled] a.btn{pointer-events:none}.btn-default{color:#333333;background-color:#ffffff;border-color:#cccccc}.btn-default:focus,.btn-default.focus{color:#333333;background-color:#e6e6e6;border-color:#8c8c8c}.btn-default:hover{color:#333333;background-color:#e6e6e6;border-color:#adadad}.btn-default:active,.btn-default.active,.open\u003e.dropdown-toggle.btn-default{color:#333333;background-color:#e6e6e6;background-image:none;border-color:#adadad}.btn-default:active:hover,.btn-default.active:hover,.open\u003e.dropdown-toggle.btn-default:hover,.btn-default:active:focus,.btn-default.active:focus,.open\u003e.dropdown-toggle.btn-default:focus,.btn-default:active.focus,.btn-default.active.focus,.open\u003e.dropdown-toggle.btn-default.focus{color:#333333;background-color:#d4d4d4;border-color:#8c8c8c}.btn-default.disabled:hover,.btn-default[disabled]:hover,fieldset[disabled] .btn-default:hover,.btn-default.disabled:focus,.btn-default[disabled]:focus,fieldset[disabled] .btn-default:focus,.btn-default.disabled.focus,.btn-default[disabled].focus,fieldset[disabled] .btn-default.focus{background-color:#ffffff;border-color:#cccccc}.btn-default .badge{color:#ffffff;background-color:#333333}.btn-primary{color:#ffffff;background-color:#337ab7;border-color:#2e6da4}.btn-primary:focus,.btn-primary.focus{color:#ffffff;background-color:#286090;border-color:#122b40}.btn-primary:hover{color:#ffffff;background-color:#286090;border-color:#204d74}.btn-primary:active,.btn-primary.active,.open\u003e.dropdown-toggle.btn-primary{color:#ffffff;background-color:#286090;background-image:none;border-color:#204d74}.btn-primary:active:hover,.btn-primary.active:hover,.open\u003e.dropdown-toggle.btn-primary:hover,.btn-primary:active:focus,.btn-primary.active:focus,.open\u003e.dropdown-toggle.btn-primary:focus,.btn-primary:active.focus,.btn-primary.active.focus,.open\u003e.dropdown-toggle.btn-primary.focus{color:#ffffff;background-color:#204d74;border-color:#122b40}.btn-primary.disabled:hover,.btn-primary[disabled]:hover,fieldset[disabled] .btn-primary:hover,.btn-primary.disabled:focus,.btn-primary[disabled]:focus,fieldset[disabled] .btn-primary:focus,.btn-primary.disabled.focus,.btn-primary[disabled].focus,fieldset[disabled] .btn-primary.focus{background-color:#337ab7;border-color:#2e6da4}.btn-primary .badge{color:#337ab7;background-color:#ffffff}.btn-success{color:#ffffff;background-color:#000000;border-color:#000000}.btn-success:focus,.btn-success.focus{color:#ffffff;background-color:#000000;border-color:#000000}.btn-success:hover{color:#ffffff;background-color:#000000;border-color:#000000}.btn-success:active,.btn-success.active,.open\u003e.dropdown-toggle.btn-success{color:#ffffff;background-color:#000000;background-image:none;border-color:#000000}.btn-success:active:hover,.btn-success.active:hover,.open\u003e.dropdown-toggle.btn-success:hover,.btn-success:active:focus,.btn-success.active:focus,.open\u003e.dropdown-toggle.btn-success:focus,.btn-success:active.focus,.btn-success.active.focus,.open\u003e.dropdown-toggle.btn-success.focus{color:#ffffff;background-color:#000000;border-color:#000000}.btn-success.disabled:hover,.btn-success[disabled]:hover,fieldset[disabled] .btn-success:hover,.btn-success.disabled:focus,.btn-success[disabled]:focus,fieldset[disabled] .btn-success:focus,.btn-success.disabled.focus,.btn-success[disabled].focus,fieldset[disabled] .btn-success.focus{background-color:#000000;border-color:#000000}.btn-success .badge{color:#000000;background-color:#000000}.btn-info{color:#ffffff;background-color:#5bc0de;border-color:#46b8da}.btn-info:focus,.btn-info.focus{color:#ffffff;background-color:#31b0d5;border-color:#1b6d85}.btn-info:hover{color:#ffffff;background-color:#31b0d5;border-color:#269abc}.btn-info:active,.btn-info.active,.open\u003e.dropdown-toggle.btn-info{color:#ffffff;background-color:#31b0d5;background-image:none;border-color:#269abc}.btn-info:active:hover,.btn-info.active:hover,.open\u003e.dropdown-toggle.btn-info:hover,.btn-info:active:focus,.btn-info.active:focus,.open\u003e.dropdown-toggle.btn-info:focus,.btn-info:active.focus,.btn-info.active.focus,.open\u003e.dropdown-toggle.btn-info.focus{color:#ffffff;background-color:#269abc;border-color:#1b6d85}.btn-info.disabled:hover,.btn-info[disabled]:hover,fieldset[disabled] .btn-info:hover,.btn-info.disabled:focus,.btn-info[disabled]:focus,fieldset[disabled] .btn-info:focus,.btn-info.disabled.focus,.btn-info[disabled].focus,fieldset[disabled] .btn-info.focus{background-color:#5bc0de;border-color:#46b8da}.btn-info .badge{color:#5bc0de;background-color:#ffffff}.btn-warning{color:#ffffff;background-color:#f0ad4e;border-color:#eea236}.btn-warning:focus,.btn-warning.focus{color:#ffffff;background-color:#ec971f;border-color:#985f0d}.btn-warning:hover{color:#ffffff;background-color:#ec971f;border-color:#d58512}.btn-warning:active,.btn-warning.active,.open\u003e.dropdown-toggle.btn-warning{color:#ffffff;background-color:#ec971f;background-image:none;border-color:#d58512}.btn-warning:active:hover,.btn-warning.active:hover,.open\u003e.dropdown-toggle.btn-warning:hover,.btn-warning:active:focus,.btn-warning.active:focus,.open\u003e.dropdown-toggle.btn-warning:focus,.btn-warning:active.focus,.btn-warning.active.focus,.open\u003e.dropdown-toggle.btn-warning.focus{color:#ffffff;background-color:#d58512;border-color:#985f0d}.btn-warning.disabled:hover,.btn-warning[disabled]:hover,fieldset[disabled] .btn-warning:hover,.btn-warning.disabled:focus,.btn-warning[disabled]:focus,fieldset[disabled] .btn-warning:focus,.btn-warning.disabled.focus,.btn-warning[disabled].focus,fieldset[disabled] .btn-warning.focus{background-color:#f0ad4e;border-color:#eea236}.btn-warning .badge{color:#f0ad4e;background-color:#ffffff}.btn-danger{color:#ffffff;background-color:#d9534f;border-color:#d43f3a}.btn-danger:focus,.btn-danger.focus{color:#ffffff;background-color:#c9302c;border-color:#761c19}.btn-danger:hover{color:#ffffff;background-color:#c9302c;border-color:#ac2925}.btn-danger:active,.btn-danger.active,.open\u003e.dropdown-toggle.btn-danger{color:#ffffff;background-color:#c9302c;background-image:none;border-color:#ac2925}.btn-danger:active:hover,.btn-danger.active:hover,.open\u003e.dropdown-toggle.btn-danger:hover,.btn-danger:active:focus,.btn-danger.active:focus,.open\u003e.dropdown-toggle.btn-danger:focus,.btn-danger:active.focus,.btn-danger.active.focus,.open\u003e.dropdown-toggle.btn-danger.focus{color:#ffffff;background-color:#ac2925;border-color:#761c19}.btn-danger.disabled:hover,.btn-danger[disabled]:hover,fieldset[disabled] .btn-danger:hover,.btn-danger.disabled:focus,.btn-danger[disabled]:focus,fieldset[disabled] .btn-danger:focus,.btn-danger.disabled.focus,.btn-danger[disabled].focus,fieldset[disabled] .btn-danger.focus{background-color:#d9534f;border-color:#d43f3a}.btn-danger .badge{color:#d9534f;background-color:#ffffff}.btn-link{font-weight:400;color:#337ab7;border-radius:0}.btn-link,.btn-link:active,.btn-link.active,.btn-link[disabled],fieldset[disabled] .btn-link{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}.btn-link,.btn-link:hover,.btn-link:focus,.btn-link:active{border-color:transparent}.btn-link:hover,.btn-link:focus{color:#23527c;text-decoration:underline;background-color:transparent}.btn-link[disabled]:hover,fieldset[disabled] .btn-link:hover,.btn-link[disabled]:focus,fieldset[disabled] .btn-link:focus{color:#777777;text-decoration:none}.btn-lg,.btn-group-lg\u003e.btn{padding:10px 16px;font-size:18px;line-height:1.3333333;border-radius:6px}.btn-sm,.btn-group-sm\u003e.btn{padding:5px 10px;font-size:12px;line-height:1.5;border-radius:3px}.btn-xs,.btn-group-xs\u003e.btn{padding:1px 5px;font-size:12px;line-height:1.5;border-radius:3px}.btn-block{display:block;width:100%}.btn-block+.btn-block{margin-top:5px}input[type=\"submit\"].btn-block,input[type=\"reset\"].btn-block,input[type=\"button\"].btn-block{width:100%}.btn-group,.btn-group-vertical{position:relative;display:inline-block;vertical-align:middle}.btn-group\u003e.btn,.btn-group-vertical\u003e.btn{position:relative;float:left}.btn-group\u003e.btn:hover,.btn-group-vertical\u003e.btn:hover,.btn-group\u003e.btn:focus,.btn-group-vertical\u003e.btn:focus,.btn-group\u003e.btn:active,.btn-group-vertical\u003e.btn:active,.btn-group\u003e.btn.active,.btn-group-vertical\u003e.btn.active{z-index:2}.btn-group .btn+.btn,.btn-group .btn+.btn-group,.btn-group .btn-group+.btn,.btn-group .btn-group+.btn-group{margin-left:-1px}.btn-toolbar{margin-left:-5px}.btn-toolbar .btn,.btn-toolbar .btn-group,.btn-toolbar .input-group{float:left}.btn-toolbar\u003e.btn,.btn-toolbar\u003e.btn-group,.btn-toolbar\u003e.input-group{margin-left:5px}.btn-group\u003e.btn:not(:first-child):not(:last-child):not(.dropdown-toggle){border-radius:0}.btn-group\u003e.btn:first-child{margin-left:0}.btn-group\u003e.btn:first-child:not(:last-child):not(.dropdown-toggle){border-top-right-radius:0;border-bottom-right-radius:0}.btn-group\u003e.btn:last-child:not(:first-child),.btn-group\u003e.dropdown-toggle:not(:first-child){border-top-left-radius:0;border-bottom-left-radius:0}.btn-group\u003e.btn-group{float:left}.btn-group\u003e.btn-group:not(:first-child):not(:last-child)\u003e.btn{border-radius:0}.btn-group\u003e.btn-group:first-child:not(:last-child)\u003e.btn:last-child,.btn-group\u003e.btn-group:first-child:not(:last-child)\u003e.dropdown-toggle{border-top-right-radius:0;border-bottom-right-radius:0}.btn-group\u003e.btn-group:last-child:not(:first-child)\u003e.btn:first-child{border-top-left-radius:0;border-bottom-left-radius:0}.btn-group .dropdown-toggle:active,.btn-group.open .dropdown-toggle{outline:0}.btn-group\u003e.btn+.dropdown-toggle{padding-right:8px;padding-left:8px}.btn-group\u003e.btn-lg+.dropdown-toggle{padding-right:12px;padding-left:12px}.btn-group.open .dropdown-toggle{-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);box-shadow:inset 0 3px 5px rgba(0,0,0,0.125)}.btn-group.open .dropdown-toggle.btn-link{-webkit-box-shadow:none;box-shadow:none}.btn .caret{margin-left:0}.btn-lg .caret{border-width:5px 5px 0;border-bottom-width:0}.dropup .btn-lg .caret{border-width:0 5px 5px}.btn-group-vertical\u003e.btn,.btn-group-vertical\u003e.btn-group,.btn-group-vertical\u003e.btn-group\u003e.btn{display:block;float:none;width:100%;max-width:100%}.btn-group-vertical\u003e.btn-group\u003e.btn{float:none}.btn-group-vertical\u003e.btn+.btn,.btn-group-vertical\u003e.btn+.btn-group,.btn-group-vertical\u003e.btn-group+.btn,.btn-group-vertical\u003e.btn-group+.btn-group{margin-top:-1px;margin-left:0}.btn-group-vertical\u003e.btn:not(:first-child):not(:last-child){border-radius:0}.btn-group-vertical\u003e.btn:first-child:not(:last-child){border-top-left-radius:4px;border-top-right-radius:4px;border-bottom-right-radius:0;border-bottom-left-radius:0}.btn-group-vertical\u003e.btn:last-child:not(:first-child){border-top-left-radius:0;border-top-right-radius:0;border-bottom-right-radius:4px;border-bottom-left-radius:4px}.btn-group-vertical\u003e.btn-group:not(:first-child):not(:last-child)\u003e.btn{border-radius:0}.btn-group-vertical\u003e.btn-group:first-child:not(:last-child)\u003e.btn:last-child,.btn-group-vertical\u003e.btn-group:first-child:not(:last-child)\u003e.dropdown-toggle{border-bottom-right-radius:0;border-bottom-left-radius:0}.btn-group-vertical\u003e.btn-group:last-child:not(:first-child)\u003e.btn:first-child{border-top-left-radius:0;border-top-right-radius:0}.btn-group-justified{display:table;width:100%;table-layout:fixed;border-collapse:separate}.btn-group-justified\u003e.btn,.btn-group-justified\u003e.btn-group{display:table-cell;float:none;width:1%}.btn-group-justified\u003e.btn-group .btn{width:100%}.btn-group-justified\u003e.btn-group .dropdown-menu{left:auto}[data-toggle=\"buttons\"]\u003e.btn input[type=\"radio\"],[data-toggle=\"buttons\"]\u003e.btn-group\u003e.btn input[type=\"radio\"],[data-toggle=\"buttons\"]\u003e.btn input[type=\"checkbox\"],[data-toggle=\"buttons\"]\u003e.btn-group\u003e.btn input[type=\"checkbox\"]{position:absolute;clip:rect(0, 0, 0, 0);pointer-events:none}.alert{padding:15px;margin-bottom:20px;border:1px solid transparent;border-radius:4px}.alert h4{margin-top:0;color:inherit}.alert .alert-link{font-weight:bold}.alert\u003ep,.alert\u003eul{margin-bottom:0}.alert\u003ep+p{margin-top:5px}.alert-dismissable,.alert-dismissible{padding-right:35px}.alert-dismissable .close,.alert-dismissible .close{position:relative;top:-2px;right:-21px;color:inherit}.alert-success{color:#3c763d;background-color:#dff0d8;border-color:#d6e9c6}.alert-success hr{border-top-color:#c9e2b3}.alert-success .alert-link{color:#2b542c}.alert-info{color:#31708f;background-color:#d9edf7;border-color:#bce8f1}.alert-info hr{border-top-color:#a6e1ec}.alert-info .alert-link{color:#245269}.alert-warning{color:#8a6d3b;background-color:#fcf8e3;border-color:#faebcc}.alert-warning hr{border-top-color:#f7e1b5}.alert-warning .alert-link{color:#66512c}.alert-danger{color:#a94442;background-color:#f2dede;border-color:#ebccd1}.alert-danger hr{border-top-color:#e4b9c0}.alert-danger .alert-link{color:#843534}.close{float:right;font-size:21px;font-weight:bold;line-height:1;color:#000000;text-shadow:0 1px 0 #ffffff;filter:alpha(opacity=20);opacity:0.2}.close:hover,.close:focus{color:#000000;text-decoration:none;cursor:pointer;filter:alpha(opacity=50);opacity:0.5}button.close{padding:0;cursor:pointer;background:transparent;border:0;-webkit-appearance:none;appearance:none}.modal-open{overflow:hidden}.modal{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1050;display:none;overflow:hidden;-webkit-overflow-scrolling:touch;outline:0}.modal.fade .modal-dialog{-webkit-transform:translate(0, -25%);-ms-transform:translate(0, -25%);-o-transform:translate(0, -25%);transform:translate(0, -25%);-webkit-transition:-webkit-transform 0.3s ease-out;-o-transition:-o-transform 0.3s ease-out;transition:transform 0.3s ease-out}.modal.in .modal-dialog{-webkit-transform:translate(0, 0);-ms-transform:translate(0, 0);-o-transform:translate(0, 0);transform:translate(0, 0)}.modal-open .modal{overflow-x:hidden;overflow-y:auto}.modal-dialog{position:relative;width:auto;margin:10px}.modal-content{position:relative;background-color:#ffffff;-webkit-background-clip:padding-box;background-clip:padding-box;border:1px solid #999999;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-box-shadow:0 3px 9px rgba(0,0,0,0.5);box-shadow:0 3px 9px rgba(0,0,0,0.5);outline:0}.modal-backdrop{position:fixed;top:0;right:0;bottom:0;left:0;z-index:1040;background-color:#000000}.modal-backdrop.fade{filter:alpha(opacity=0);opacity:0}.modal-backdrop.in{filter:alpha(opacity=50);opacity:0.5}.modal-header{padding:15px;border-bottom:1px solid #e5e5e5}.modal-header .close{margin-top:-2px}.modal-title{margin:0;line-height:1.42857143}.modal-body{position:relative;padding:15px}.modal-footer{padding:15px;text-align:right;border-top:1px solid #e5e5e5}.modal-footer .btn+.btn{margin-bottom:0;margin-left:5px}.modal-footer .btn-group .btn+.btn{margin-left:-1px}.modal-footer .btn-block+.btn-block{margin-left:0}.modal-scrollbar-measure{position:absolute;top:-9999px;width:50px;height:50px;overflow:scroll}@media (min-width: 768px){.modal-dialog{width:600px;margin:30px auto}.modal-content{-webkit-box-shadow:0 5px 15px rgba(0,0,0,0.5);box-shadow:0 5px 15px rgba(0,0,0,0.5)}.modal-sm{width:300px}}@media (min-width: 992px){.modal-lg{width:900px}}.clearfix:before,.clearfix:after,.dl-horizontal dd:before,.dl-horizontal dd:after,.container:before,.container:after,.container-fluid:before,.container-fluid:after,.row:before,.row:after,.form-horizontal .form-group:before,.form-horizontal .form-group:after,.btn-toolbar:before,.btn-toolbar:after,.btn-group-vertical\u003e.btn-group:before,.btn-group-vertical\u003e.btn-group:after,.modal-header:before,.modal-header:after,.modal-footer:before,.modal-footer:after{display:table;content:\" \"}.clearfix:after,.dl-horizontal dd:after,.container:after,.container-fluid:after,.row:after,.form-horizontal .form-group:after,.btn-toolbar:after,.btn-group-vertical\u003e.btn-group:after,.modal-header:after,.modal-footer:after{clear:both}.center-block{display:block;margin-right:auto;margin-left:auto}.pull-right{float:right !important}.pull-left{float:left !important}.hide{display:none !important}.show{display:block !important}.invisible{visibility:hidden}.text-hide{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}.hidden{display:none !important}.affix{position:fixed}.iti{width:100%}body,html{background:transparent;-webkit-font-smoothing:antialiased;height:100%}body{overflow:hidden;-moz-transition:background-color 0.15s linear;-webkit-transition:background-color 0.15s linear;-o-transition:background-color 0.15s linear;transition:background-color 0.15s cubic-bezier(0.785, 0.135, 0.15, 0.86)}body.fadein{background:rgba(0,0,0,0.65)}#container{background:white;padding:12px 18px 40px 18px}@media only screen and (min-width: 500px){#container{border-radius:5px;padding:30px 40px}}@media only screen and (min-width: 992px){#container{position: fixed; width: 460px; top: 50%; left: 50%; transform:translate(-50%, -50%); margin: auto}}.fade{opacity:0;-webkit-transition:opacity 0.15s linear;-o-transition:opacity 0.15s linear;transition:opacity 0.15s linear}.fade.in{opacity:1}.modal{overflow-x:hidden;overflow-y:auto}.modal-content{position:relative;background-color:#fff;border:1px solid #999;border:1px solid rgba(0,0,0,0.2);border-radius:6px;-webkit-background-clip:padding-box;background-clip:padding-box;outline:0}.modal-title{margin:0;line-height:1.42857143}h3{font-size:24px}h4{font-size:18px;margin-top:10px;margin-bottom:10px}h3,h4{font-family:inherit;font-weight:500;line-height:1.1;color:inherit}@media screen and (-webkit-min-device-pixel-ratio: 0){select:focus,textarea:focus,input:focus{font-size:16px;background:#eee}}#variant-select-container .input-lg{font-size:15px}#customer-contact-container a.btn{font-weight:bold}#customer-contact-container .input-lg{font-size:15px}#quantity-field-container label{font-weight:normal;font-size:14px;padding-top:13px}#quantity-field-container input{font-size:15px}#submit-btn{font-weight:bold;font-size:15px;padding:14px;border-radius:3px}.alert{padding:6px 11px;font-size:13px;margin:15px 0}.alert-success a{color:#244825}.modal-body{padding:22px 40px;font-size:13px;line-height:180%}.modal-body h3:first-child{margin-top:0}.modal-title{margin:0;font-size:22px}.modal-content .close{font-size:30px}.modal-backdrop.in{filter:alpha(opacity=65);opacity:.65}.small-print{opacity:0.835;font-size:13px;line-height:150%}.small-print a{color:inherit;text-decoration:underline}.product-name{margin-bottom:20px}label.accepts-marketing{filter:alpha(opacity=825);opacity:0.825}@media only screen and (max-width: 786px){.modal-body{padding:20px 30px}}@media only screen and (max-width: 500px){.modal-dialog{margin:0}.modal-content{border-radius:0}}@media only screen and (min-width: 500px){#SIModal{max-width:460px;margin:auto}}.ie8 #SIModal{width:100%;max-width:460px;margin:auto;border:1px solid #999}select.default_variant{display:none}.ie8 .modal-dialog{width:460px !important;margin:10px auto}.completed_message{display:none}.complete .completed_message{display:block}#SIModal.in{position:relative;z-index:1050;height:100%;overflow:hidden;overflow-y:auto;-webkit-overflow-scrolling:touch}\n"
+    };
+
+    _SIConfig.multivariantDropdownContainer = document;
+    _SIConfig.shop = 'kitchenaid-australia.myshopify.com';
+
+
+    
+
+    
+</script>
+
+<script type="text/javascript">
+'use strict';
+(function () {
+  if(window.location.search.indexOf('selector_section_mode') > -1){
+    var head = document.getElementsByTagName('head')[0];
+    var script = document.createElement('script');
+    window.selector_section_mode = true;
+    script.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'back-in-stock.appikon.com/theme-settings/element-selector.js';
+    script.type = 'text/javascript';
+    head.appendChild(script);
+  }
+})();
+</script>
+
+
+  
+<style>
+  .iWishAdd .new-home-icon-favourite-fill, .iWishAddClone .new-home-icon-favourite-fill {
+  	transition: opacity .25s, visibility .25s;
+  }
+  .iwishAdded .new-home-icon-favourite-fill, .iWishAdd:not(.iwishAdded):hover .new-home-icon-favourite-fill, .iwishAddedClone .new-home-icon-favourite-fill, .iWishAddClone:not(.iwishAddedClone):hover .new-home-icon-favourite-fill {
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+</style>
+<script type="text/javascript">
+var iwish_shop = "kitchenaid-australia.myshopify.com";
+var iwish_pro_template = false;
+var iwish_cid = "";
+//Add to Wishlist - Product Page Text
+var iwish_added_txt = '<span class="new-home-icon-favourire text-16px md:text-18px absolute w-full h-full"></span><span class="new-home-icon-favourite-fill text-16px md:text-18px absolute w-full h-full opacity-0 invisible"></span>';
+var iwish_add_txt = '<span class="new-home-icon-favourire text-16px md:text-18px absolute w-full h-full"></span><span class="new-home-icon-favourite-fill text-16px md:text-18px absolute w-full h-full opacity-0 invisible"></span>';
+//Add to Wishlist - Collection Page Text
+var iwish_added_txt_col = '<span class="new-home-icon-favourire text-16px md:text-18px absolute w-full h-full"></span><span class="new-home-icon-favourite-fill text-16px md:text-18px absolute w-full h-full opacity-0 invisible"></span>';
+var iwish_add_txt_col = '<span class="new-home-icon-favourire text-16px md:text-18px absolute w-full h-full"></span><span class="new-home-icon-favourite-fill text-16px md:text-18px absolute w-full h-full opacity-0 invisible"></span>';
+//Quick View - Classes
+//var iwish_qvButton = '.quick_view';
+//var iwish_qvWrapper = '.reveal-modal';
+</script>
+<script type="text/javascript">
+(function(){
+function iWishLoadScript(e,t){for(var a=0;a<e.length;a++){var n=document.createElement("script");n.type="text/javascript",n.async=!0,n.src=e[a],document.getElementsByTagName("head")[0].appendChild(n),0==a&&(n.readyState?n.onreadystatechange=function(){"loaded"!==n.readyState&&"complete"!==n.readyState||(n.onreadystatechange=null,t())}:n.onload=function(){t()})}}
+function asyncLoadshopapps(){
+	var iWishUrls=["https://cdn.myshopapps.com/iwish/iwishlist_v2.js"];
+	iWishLoadScript(iWishUrls, function() {
+		jQuery("a[href='/apps/iwish']").click(function(e) {
+		if(typeof(Storage) !== "undefined") {
+			e.preventDefault();
+			iWishPost('/apps/iwish',{iwishlist:JSON.stringify(iWishlistmain),cId:iwish_cid});
+		}
+		});
+		// jQuery(".iWishAdd").click(function() {
+		// 	var iWishvId = jQuery(this).parents(iwishWrapperClass).find(iWishVarSelector).val();
+		// 	iwish_add(jQuery(this), iWishvId);
+		// 	return false;
+		// });
+		jQuery("body").on("click", ".iWishAdd", function() {
+			var iWishvId = jQuery(this).parents(iwishWrapperClass).find(iWishVarSelector).val();
+			var iWishpId = jQuery(this).attr("data-product");
+			if(isInWishlist(iWishpId,iWishvId)){
+				iwish_remove(jQuery(this), iWishvId, false);
+				jQuery(this).html(iwish_add_txt);
+				jQuery(".iWishLoginMsg").fadeOut();
+			} else {
+				iwish_add(jQuery(this), iWishvId);
+			}
+			return false;
+		});
+		jQuery(".iWishAddClone").click(function() {
+			jQuery(this).parents(iwishWrapperClass).find('.iWishAdd').trigger('click');
+			return false;
+		});
+		jQuery(".iWishAdd").each(function() {
+			var iWishElement = this;
+			var iWishObserver = new MutationObserver(function(mutations) {
+						mutations.forEach(function(mutation) {
+				    if (mutation.attributeName === "class") {
+				      var attributeValue = $(mutation.target).prop(mutation.attributeName);
+				      if (attributeValue.indexOf('iwishAdded') !== -1) {
+				      	jQuery(iWishElement).parents(iwishWrapperClass).find('.iWishAddClone').addClass('iwishAddedClone');
+								jQuery(iWishElement).parents(iwishWrapperClass).find('.iWishAddCloneV2 .txt').html('added to wishlist');
+				      } else {
+				      	jQuery(iWishElement).parents(iwishWrapperClass).find('.iWishAddClone').removeClass('iwishAddedClone');
+								jQuery(iWishElement).parents(iwishWrapperClass).find('.iWishAddCloneV2 .txt').html('add to wishlist');
+				      }
+				    }
+					});
+				});
+			iWishObserver.observe(iWishElement, {attributes: true});
+			var iWishvId = jQuery(this).parents(iwishWrapperClass).find(iWishVarSelector).val();
+			var iWishpId = jQuery(this).attr("data-product");
+			if(isInWishlist(iWishpId,iWishvId)){
+				jQuery(this).addClass('iwishAdded').html(iwish_added_txt);
+			} 
+		});
+		jQuery("[data-product-list]").on("updateProduct", ".item", function() {
+			var iWishAddItem = jQuery(this).find('.iWishAdd');
+			var iWishvId = jQuery(iWishAddItem).parents(iwishWrapperClass).find(iWishVarSelector).val();
+			var iWishpId = jQuery(iWishAddItem).attr("data-product");
+			if(isInWishlist(iWishpId,iWishvId)){
+				jQuery(iWishAddItem).addClass('iwishAdded').html(iwish_added_txt);
+			} 
+		});
+		jQuery(".iwishAddWrap").parent('.hidden').removeClass('hidden');
+		jQuery(".iWishAddColl").click(function() {
+			var iWishvId = jQuery(this).attr("data-variant");
+			iwish_addCollection(jQuery(this),iWishvId);
+			return false;
+		});
+	});
+}
+if (window.addEventListener){ window.addEventListener("load", asyncLoadshopapps, true); }
+else if (window.attachEvent){ window.attachEvent("onload", asyncLoadshopapps); }
+else { window.onload = asyncLoadshopapps; }
+})();
+</script>
+
+
+
+  <!-- Emarsys Tracking code -->
+<script type="text/javascript">
+var ScarabQueue = ScarabQueue || [];
+(function(id) {
+  if (document.getElementById(id)) return;
+  var js = document.createElement('script'); js.id = id;
+  js.src = '//cdn.scarabresearch.com/js/1721ED42F7DAF7CF/scarab-v2.js';
+  var fs = document.getElementsByTagName('script')[0];
+  fs.parentNode.insertBefore(js, fs);
+})('scarab-js-api');
+</script>
+<script type="text/javascript">var cart_email = localStorage.getItem("cart_email");
+    if((cart_email != "undefined") && (cart_email != "") && (cart_email != null)){
+      ScarabQueue.push(['setEmail', `${cart_email}`]);
+    }window.cartItems = window.cartItems || [];ScarabQueue.push(['cart', []]);
+
+ScarabQueue.push(['tag', 'content_pageview', {
+        content_category: 'Blog article page',
+        content_url:'https://kitchenaid.com.au/blogs/kitchenthusiast/hot-cross-buns',
+        content_title: 'Hot Cross Buns',
+        content_tag: 'Recipes,Dessert',
+        page_type: 'article'
+      }]);
+    
+  
+    ScarabQueue.push(['go']);
+  
+</script>
+
+  <script type="text/javascript">
+	const KA_STAGE_API_URL = 'https://api.stg.kitchenaid-anchorbuild.com/v2';
+	const KA_LIVE_API_URL = 'https://api.prod.kitchenaid-anchorbuild.com/v2';
+	let KA_API_URL = KA_STAGE_API_URL;
+
+	var TIMER = 7000;
+	
+
+
+	if(window.location.hostname == "kitchenaid.com.au" || window.location.hostname == "kitchenaid-australia.myshopify.com"){
+	    KA_API_URL = KA_LIVE_API_URL;
+	} 
+
+	var TOTAL_APP_DEPENDENCIES = 0;
+	var TOTAL_APP_DEPENDENCIES_LOADED = 0;
+ 
+	var MODULES = [];
+	var STYLESHEETS = [];
+	var APPS = [];
+
+//var TIMER = 7000;
+//	var TIMER = 0;
+ 
+	function lazyLoadModules(modules = [],apps){
+		var loaderScriptSrc = "//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-moduleLoader.js?v=150584880670806218461712290031"; 
+		var loaderScript = document.createElement('script');
+		loaderScript.setAttribute('src', loaderScriptSrc); 
+	    loaderScript.setAttribute('defer', "defer");
+	    loaderScript.onload = function(){
+	    	modules.map(function(params){
+	    		if(params.isAppDependencies){
+					TOTAL_APP_DEPENDENCIES++;
+				}
+	    	});
+	    	console.log('TOTAL_APP_DEPENDENCIES: '+ TOTAL_APP_DEPENDENCIES);
+			modules.map(function(params){
+				moduleLoader.lazyLoadModule(params.moduleFileName, params.timer, params.options, params.hasInitCallback).then(() => {
+					if(params.isAppDependencies){
+						TOTAL_APP_DEPENDENCIES_LOADED++;
+						if(TOTAL_APP_DEPENDENCIES_LOADED == TOTAL_APP_DEPENDENCIES){
+							apps.map(function(params){
+								moduleLoader.lazyLoadModule(params.moduleFileName,50,{},false).then(() => {});
+							});
+						}
+					}
+				});
+			});
+		}
+		document.head.appendChild(loaderScript);		
+	}
+
+	function lazyLoadStyleSheets(styleSheets){
+		styleSheets.map(function(href){
+			//avoid duplicates
+	    for(var i = 0; i < document.styleSheets.length; i++){
+	        if(document.styleSheets[i].href == href){
+	            return;
+	        }
+	    }
+	    var head  = document.getElementsByTagName('head')[0];
+	    var link  = document.createElement('link');
+	    link.rel  = 'stylesheet';
+	    link.type = 'text/css';
+	    link.href = href;
+	    head.appendChild(link);
+		});
+	}
+	
+	function addVendor(fileUrl){
+		MODULES.push(
+			{ moduleFileName: fileUrl, timer: TIMER, options: {}, isAppDependencies: true, hasInitCallback: false}
+		);
+	}
+	function addModule(fileUrl,options, isAppDependencies = false){
+		MODULES.push(
+			{ moduleFileName: fileUrl, timer: TIMER, options, isAppDependencies, hasInitCallback: true}
+		);
+	}
+	function addApp(fileUrl){
+		APPS.push({ moduleFileName: fileUrl});
+	}
+	function addStyleSheet(fileUrl){
+		STYLESHEETS.push(fileUrl);
+	}
+
+</script> 
+<script defer src="//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-0-jquery-3.5.0.min.js?v=93796423766296382451712290008"></script>
+
+<script defer src="//kitchenaid.com.au/cdn/shopifycloud/shopify/assets/themes_support/api.jquery-b0af070cfe3f5cf7c92f9e2a5da2665ee07ed2aad63bb408f8d6672f894a5996.js"></script>
+
+
+
+
+<script type="text/javascript">
+	//App(s) will be loaded after all dependencies modules are loaded
+	
+	addApp("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-slider.js?v=80059863112124688071712290038");addApp("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-app.js?v=153187045131883582831712290010");
+	addApp("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-cart-attribute.js?v=16412632782720096461712290012");
+
+	
+	addVendor("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-jquery.lazy.min.js?v=120151035538442188301712290020");
+	
+	
+		addVendor("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-new-swiper.min.js?v=105711584985474897931712290033");
+	
+	
+	addVendor("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-mega.js?v=78091819847352719451712290025");
+	addVendor("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-jquery.matchHeight.js?v=158915208133426399851712290021");
+	addVendor("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-validator.js?v=121977483206690666191712290040");
+
+	
+		addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-googleoptimize.js?v=138137938061779894471712290027",{ID:'OPT-TFQ4PRM'});
+		//addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-gtm.js?v=67714141710213341841712290028",{gtmID:'GTM-MJJKCRS'});
+		addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-gtag.js?v=30345702618723995511712290028",{ID:'AW-790793421'});
+		addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-survey.js?v=7213127267302685811712290031",{site:'24nygigg7qvfo2a22fiiaczjbu'});
+	
+
+	addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-genesys.js?v=55335766546112137681712290026",{deploymentId: '6e038acf-c412-4724-ab4c-5bbe5459aa0b'});
+
+	var customerId = '';
+	var customerEmail = '';
+	
+
+	addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-impact.js?v=173703804254521023351712290029",{ID: 'A2003978-9da9-44f4-b399-2e729f15fbdd1', customerId, customerEmail});
+
+	//addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-crazyegg.js?v=46265515706725144141712290026");
+
+	
+		addModule("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-module-bv.js?v=33244768814978467861712290025",{environment:'production'});
+	
+
+	
+
+
+	
+
+
+
+ 
+	
+
+	
+	
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+	
+	
+
+	
+
+
+	
+		addVendor("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-video.js?v=130768310774023426571712538402");
+		addApp("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-article.js?v=67320486462907040571712290010");
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+
+	
+
+	
+
+	
+
+	
+
+	
+ 
+	//App(s) will be loaded after all dependencies modules are loaded
+
+	addApp("//kitchenaid.com.au/cdn/shop/t/235/assets/js-build-backorder-update-cart.js?v=149530638761373415211712290011");
+
+	var waitForJQuery = setInterval(function () {
+	    if (typeof $ != 'undefined') {
+	    	lazyLoadModules(MODULES,APPS);
+	        clearInterval(waitForJQuery);
+	    }
+	}, 10);
+
+	lazyLoadStyleSheets(STYLESHEETS);
+
+</script> 
+  
+
+  
+    
+
+  
+  
+</body>
+</html>


### PR DESCRIPTION
This PR adds support for KitchenAid Australia recipes. There was some `Recipe` schema support, however only for basic metadata. Ingredients, instructions, time and yield were all scraped manually.

`total_time()` was particularly difficult, as across different recipes there are different fields for time. The approach I took was to get all the time related fields from the summary and then use the last one as the total, which was the case in all the recipes I checked. If you think it is necessary I'm happy to add some test cases for this.

Resolves #1057 