### PR TITLE
MarleySpoon: add precautionary check for unexpected API URLs.

### DIFF
--- a/tests/legacy/test_data/faulty.testhtml
+++ b/tests/legacy/test_data/faulty.testhtml
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<script>
+gon.current_brand="test_invalid"; gon.current_country="XX"; gon.api_token=" ".trim() || null; gon.api_host="http://api.marlarkey.invalid";
+</script>
+</html>

--- a/tests/legacy/test_marleyspoon_invalid.py
+++ b/tests/legacy/test_marleyspoon_invalid.py
@@ -1,0 +1,24 @@
+import unittest
+
+import responses
+
+from recipe_scrapers._exceptions import RecipeScrapersExceptions
+from recipe_scrapers.marleyspoon import MarleySpoon
+
+
+class TestFaultyAPIURLResponse(unittest.TestCase):
+
+    @responses.activate
+    def test_invalid_scraper(self):
+        valid_url = "https://marleyspoon.de/menu/113813-glasierte-veggie-burger-mit-roestkartoffeln-und-apfel-gurken-salat"
+        with open("tests/legacy/test_data/faulty.testhtml", "r") as faulty_data:
+            faulty_response = faulty_data.read()
+
+        responses.add(
+            method=responses.GET,
+            url=valid_url,
+            body=faulty_response,
+        )
+
+        with self.assertRaises(RecipeScrapersExceptions):
+            scraper = MarleySpoon(url=valid_url)


### PR DESCRIPTION
Adds a sense-checking step to ensure that the API URL returned in the MarleySpoon script elements refers to a second-level-domain containing `marleyspoon`.

As far as I know, there's currently no standardized and machine-readable way to declare inter-related ownership of a group of distinct Internet domain names.  I could be mistaken though; and if so, perhaps we could use that as a better alternative than checking for the brand name, as found in the scraper name.