### PR TITLE
v14: add deprecation warning about scraper 'options' keyword arguments.

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from typing import Any
+import warnings
 
 from ._abstract import AbstractScraper
 from ._exceptions import NoSchemaFoundInWildMode, WebsiteNotImplementedError
@@ -665,6 +666,17 @@ def scraper_exists_for(url_path: str) -> bool:
 def scrape_me(url_path: str, **options: Any) -> AbstractScraper:
     host_name = get_host_name(url_path)
 
+    if options:
+        msg = (
+            "Scraper options arguments (e.g. proxies=, timeout=) are deprecated, and "
+            "support for them will be dropped in future.  To migrate, please use an "
+            "HTTP client (such as 'requests' or 'httpx') configured with the "
+            "proxies/timeout settings you want, use that client to retrieve the "
+            "recipe HTML, and scrape that using the 'recipe_scrapers.scrape_html' "
+            "function."
+        )
+        warnings.warn(msg, DeprecationWarning)
+
     try:
         scraper = SCRAPERS[host_name]
     except KeyError:
@@ -701,6 +713,16 @@ def scrape_html(
     """
 
     host_name = get_host_name(org_url) if org_url is not None else None
+
+    if options:
+        msg = (
+            "Scraper options arguments (e.g. proxies=, timeout=) are deprecated, and "
+            "support for them will be dropped in future.  To migrate, please use an "
+            "HTTP client (such as 'requests' or 'httpx') configured with the "
+            "proxies/timeout settings you want, use that client to retrieve the "
+            "recipe HTML."
+        )
+        warnings.warn(msg, DeprecationWarning)
 
     scraper = None
     if host_name:


### PR DESCRIPTION
Add some deprecation warnings about usage of the `**options` keyword arguments (currently used for: `timeout=`, `proxies=`) to the `v14` (current mainline) branch.

Relates to #1022.