### PR TITLE
v14: README: add reference to a couple of HTTP clients.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,8 @@ Notes:
 
 - ``scraper.links()`` returns a list of dictionaries containing all of the <a> tag attributes. The attribute names are the dictionary keys.
 
+Some Python HTTP clients that you can use to retrieve HTML include `requests <https://pypi.org/project/requests/>`_ and `httpx <https://pypi.org/project/httpx/>`_.  Please refer to their documentation to find out what options (timeout configuration, proxy support, etc) are available.
+
 
 Scrapers available for:
 -----------------------


### PR DESCRIPTION
The idea here is to provide some additional documentation about HTML-based scraping into the `v14` branch, so that deprecation warnings added by #1079 are easier for users to understand and resolve, and to ease the transition towards `v15` (where providing HTML is the recommended usage pattern).

Relates to #1022.