### PR TITLE
Dependencies: increase baseline 'requests' version to >= 2.31.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "beautifulsoup4 >= 4.10.0",
     "extruct >= 0.8.0",
     "isodate >= 0.6.1",
-    "requests >= 2.19.1",
+    "requests >= 2.31.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ responses>=0.21.0
 # language-tags>=1.0.0
 # tld>=0.12.3
 types-beautifulsoup4>=4.10.0
-types-requests>=2.19.1
+types-requests>=2.31.0


### PR DESCRIPTION
Version `2.31.0` of `requests` was released in May of Y2023, includes a [security fix](https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q), and remains [compatible](https://github.com/psf/requests/blob/147c8511ddbfa5e8f71bbf5c18ede0c4ceb3bba4/setup.py#L10) with all the versions of Python supported by this library (`py3.8+`), so it seems worthwhile to upgrade.