### PR TITLE
Dependencies: increase baseline 'extruct' version to >= 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version", "readme"]
 requires-python = ">= 3.8"
 dependencies = [
     "beautifulsoup4 >= 4.10.0",
-    "extruct >= 0.8.0",
+    "extruct >= 0.15.0",
     "isodate >= 0.6.1",
     "requests >= 2.19.1",
 ]


### PR DESCRIPTION
Version `0.15.0` of `extruct` declared support for Python 3.10 and 3.11, so it seems worthwhile to upgrade our baseline dependency to that version or greater.