### PR TITLE
Development dependencies: increase baseline responses version to >= 0.25.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -e .
 coverage>=4.5.1
 lxml<5.1.1  # https://github.com/scrapinghub/extruct/issues/215
-responses>=0.21.0
+responses>=0.25.0
 types-beautifulsoup4>=4.12.0
 types-requests>=2.31.0


### PR DESCRIPTION
This includes [various improvements](https://github.com/getsentry/responses/blob/82d1e53f0ceee444c4208e19c2bad69e3a3780c0/CHANGES#L1-L77), including declared support up to Py3.12 while retaining support for Py3.8 as we provide here.

In practice our continuous integration has already been running since mid-February with this version; the change here is a strong-ish recommendation to use that version onwards during development.