### PR TITLE
Development dependencies: increase baseline 'coverage' version to >= 7.4.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -e .
-coverage>=4.5.1
+coverage>=7.4.4
 lxml<5.1.1  # https://github.com/scrapinghub/extruct/issues/215
 responses>=0.25.0
 types-beautifulsoup4>=4.12.0


### PR DESCRIPTION
We haven't upgraded our dev baseline requirement for `coverage` for quite a while; but `pip` and other tools do generally install the latest-available version, and it has always been a version-or-greater spec.

That half-apology aside: there are _lots_ of improvements in [the `coverage` changelog](https://github.com/nedbat/coveragepy/blob/bc5e2d7453f9766a143243d9fa72b0acd75f517e/CHANGES.rst) since v4.5.1 - so many in fact that that file's content has been archived to the [project documentation website](https://coverage.readthedocs.io/en/latest/changes.html).

Python 3.8+ remains supported, and Python 3.11 and 3.12 are declared supported also.