### PR TITLE
Data-driven tests: create subtests only for optional fields with expectations.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -99,16 +99,16 @@ def test_func_factory(
                         scraper_func()
 
         # Optional tests
-        # If the key isn't present, skip
         for key in OPTIONAL_TESTS:
+            if key not in expect:
+                continue  # If the key isn't present, skip
             with self.subTest(key):
                 scraper_func = getattr(actual, key)
-                if key in expect.keys():
-                    self.assertEqual(
-                        expect[key],
-                        scraper_func(),
-                        msg=f"The actual value for .{key}() did not match the expected value.",
-                    )
+                self.assertEqual(
+                    expect[key],
+                    scraper_func(),
+                    msg=f"The actual value for .{key}() did not match the expected value.",
+                )
 
         # Assert that the ingredients returned by the ingredient_groups() function
         # are the same as the ingredients return by the ingredients() function.


### PR DESCRIPTION
A fairly nitpicky change, this one - and it doesn't affect the report output when running `python -m unittest`, so it's not expected to have much effect.

Basically the principle here is that a unit test requires at least one assertion to be made, so in cases where we know that we won't be making an assertion, we should skip the subtest creation.

Noticed during code review at https://github.com/hhursev/recipe-scrapers/pull/1061#discussion_r1584590732