### PR TITLE
Refactor: consistency: use a separate scraper classname per brandname.

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -65,6 +65,7 @@ from .coopse import CoopSE
 from .copykat import CopyKat
 from .costco import Costco
 from .countryliving import CountryLiving
+from .creativecanning import CreativeCanning
 from .cucchiaio import Cucchiaio
 from .cuisineaz import CuisineAZ
 from .cybercook import Cybercook
@@ -384,6 +385,7 @@ SCRAPERS = {
     CopyKat.host(): CopyKat,
     Costco.host(): Costco,
     CountryLiving.host(): CountryLiving,
+    CreativeCanning.host(): CreativeCanning,
     Cucchiaio.host(): Cucchiaio,
     CuisineAZ.host(): CuisineAZ,
     Cybercook.host(): Cybercook,
@@ -572,7 +574,6 @@ SCRAPERS = {
     PlowingThroughLife.host(): PlowingThroughLife,
     PopSugar.host(): PopSugar,
     PracticalSelfReliance.host(): PracticalSelfReliance,
-    PracticalSelfReliance.host(domain="creativecanning.com"): PracticalSelfReliance,
     PressureLuckCooking.host(): PressureLuckCooking,
     PrimalEdgeHealth.host(): PrimalEdgeHealth,
     ProjectGezond.host(): ProjectGezond,

--- a/recipe_scrapers/creativecanning.py
+++ b/recipe_scrapers/creativecanning.py
@@ -1,9 +1,9 @@
 # mypy: allow-untyped-defs
 
-from .creativecanning import CreativeCanning
+from ._abstract import AbstractScraper
 
 
-class PracticalSelfReliance(CreativeCanning):
+class CreativeCanning(AbstractScraper):
     @classmethod
     def host(cls):
         return "practicalselfreliance.com"

--- a/tests/test_data/creativecanning.com/creativecanning.json
+++ b/tests/test_data/creativecanning.com/creativecanning.json
@@ -1,0 +1,59 @@
+{
+  "author": "Ashley Adamant",
+  "canonical_url": "https://creativecanning.com/zucchini-relish/",
+  "category": null,
+  "host": "creativecanning.com",
+  "image": "https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-720x720.jpg",
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "2 cups zucchini, diced (about 3 medium)",
+        "1 cup onion, diced (about 1 medium)",
+        "1 cup red bell pepper, diced (about 2 small or 1 large)",
+        "2 Tablespoons Salt (pickling and canning salt, or kosher salt)",
+        "1 3/4 cups sugar",
+        "2 teaspoons celery seed (whole)",
+        "1 teaspoon mustard seed (whole)",
+        "1 cup cider vinegar (5% acidity)",
+        "Pickle Crisp Granules (optional, helps veggies stay firm after canning)"
+      ],
+      "purpose": null
+    }
+  ],
+  "ingredients": [
+    "2 cups zucchini, diced (about 3 medium)",
+    "1 cup onion, diced (about 1 medium)",
+    "1 cup red bell pepper, diced (about 2 small or 1 large)",
+    "2 Tablespoons Salt (pickling and canning salt, or kosher salt)",
+    "1 3/4 cups sugar",
+    "2 teaspoons celery seed (whole)",
+    "1 teaspoon mustard seed (whole)",
+    "1 cup cider vinegar (5% acidity)",
+    "Pickle Crisp Granules (optional, helps veggies stay firm after canning)"
+  ],
+  "instructions": "Wash vegetables.\nRemove stem and blossom ends from zucchini and dice into 1/4 to 1/2 inch pieces. Measure 2 cups.\nPeel and dice onion. Measure 1 cup.\nPeel and dice onion. Measure 1 cup.\nStem and seed peppers, then dice. Measure 1...\nStem and seed peppers, then dice. Measure 1 cup.\nImportant, don't skip this step! Combine diced vegetables in a large bowl and sprinkle salt over the top. Stir gently to distribute the salt, then add water until vegetables are completely submerged. Allow the vegetables to soak in the saltwater for 2 hours, then drain completely.\nPrepare a water bath canner (optional, only if canning).\nIn a separate saucepan or stockpot, bring vinegar, sugar, and spices to a gentle simmer (180 degrees F). Do not add salt, the salt is only used to soak veggies before draining.\nAdd drained vegetables to the simmering vinegar/spices and gently simmer for 10 minutes.\nPack hot relish into prepared half-pint or pint jars, leaving 1/2 inch headspace.\nIf not canning, just seal jars and allow them to cool on the counter before storing in the refrigerator.\nIf canning, de-bubble jars, wipe rims, and adjust headspace to ensure 1/2 inch. Seal with 2 part canning lids.\nProcess in a water bath canner for 10 minutes, then turn off the heat. Allow the jars to sit in the canner for another 5 minutes to cool slightly, then remove the jars to cool on a towel on the counter.\nLeave the jars undisturbed for 24 hours, then check seals. Store any unsealed jars in the refrigerator for immediate use. Properly canned and sealed jars should maintain peak quality on the pantry shelf for 12-18 months.",
+  "instructions_list": [
+    "Wash vegetables.",
+    "Remove stem and blossom ends from zucchini and dice into 1/4 to 1/2 inch pieces. Measure 2 cups.",
+    "Peel and dice onion. Measure 1 cup.",
+    "Peel and dice onion. Measure 1 cup.",
+    "Stem and seed peppers, then dice. Measure 1...",
+    "Stem and seed peppers, then dice. Measure 1 cup.",
+    "Important, don't skip this step! Combine diced vegetables in a large bowl and sprinkle salt over the top. Stir gently to distribute the salt, then add water until vegetables are completely submerged. Allow the vegetables to soak in the saltwater for 2 hours, then drain completely.",
+    "Prepare a water bath canner (optional, only if canning).",
+    "In a separate saucepan or stockpot, bring vinegar, sugar, and spices to a gentle simmer (180 degrees F). Do not add salt, the salt is only used to soak veggies before draining.",
+    "Add drained vegetables to the simmering vinegar/spices and gently simmer for 10 minutes.",
+    "Pack hot relish into prepared half-pint or pint jars, leaving 1/2 inch headspace.",
+    "If not canning, just seal jars and allow them to cool on the counter before storing in the refrigerator.",
+    "If canning, de-bubble jars, wipe rims, and adjust headspace to ensure 1/2 inch. Seal with 2 part canning lids.",
+    "Process in a water bath canner for 10 minutes, then turn off the heat. Allow the jars to sit in the canner for another 5 minutes to cool slightly, then remove the jars to cool on a towel on the counter.",
+    "Leave the jars undisturbed for 24 hours, then check seals. Store any unsealed jars in the refrigerator for immediate use. Properly canned and sealed jars should maintain peak quality on the pantry shelf for 12-18 months."
+  ],
+  "language": "en-US",
+  "ratings": 4.4,
+  "ratings_count": 11,
+  "site_name": "Creative Canning",
+  "title": "Zucchini Relish Recipe for Canning",
+  "total_time": 150,
+  "yields": "4 servings"
+}

--- a/tests/test_data/creativecanning.com/creativecanning.testhtml
+++ b/tests/test_data/creativecanning.com/creativecanning.testhtml
@@ -1,0 +1,621 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head >
+<meta charset="UTF-8" />
+<title>Zucchini Relish Recipe for Canning</title>		<meta name="robots" content="noodp,noydir" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name='robots' content='max-image-preview:large' />
+<!-- Hubbub v.1.33.2 https://morehubbub.com/ -->
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Zucchini Relish Recipe for Canning" />
+<meta property="og:description" content="Zucchini relish one of my favorite ways to use up zucchini from the garden. Considerably more flavorful than straight dill pickle relish, homemade zucchini relish is a real hit at summer barbeques. When this zucchini" />
+<meta property="og:url" content="https://creativecanning.com/zucchini-relish/" />
+<meta property="og:site_name" content="Creative Canning" />
+<meta property="og:updated_time" content="2023-03-03T12:36:00+00:00" />
+<meta property="article:published_time" content="2021-08-16T17:13:58+00:00" />
+<meta property="article:modified_time" content="2023-03-03T12:36:00+00:00" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Zucchini Relish Recipe for Canning" />
+<meta name="twitter:description" content="Zucchini relish one of my favorite ways to use up zucchini from the garden. Considerably more flavorful than straight dill pickle relish, homemade zucchini relish is a real hit at summer barbeques. When this zucchini" />
+<meta property="og:image" content="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-21.jpg" />
+<meta name="twitter:image" content="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-21.jpg" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="800" />
+<!-- Hubbub v.1.33.2 https://morehubbub.com/ -->
+<link rel='dns-prefetch' href='//scripts.mediavine.com' />
+<link rel='dns-prefetch' href='//stats.wp.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel="alternate" type="application/rss+xml" title="Creative Canning &raquo; Feed" href="https://creativecanning.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Creative Canning &raquo; Comments Feed" href="https://creativecanning.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Creative Canning &raquo; Zucchini Relish Recipe for Canning Comments Feed" href="https://creativecanning.com/zucchini-relish/feed/" />
+<link rel="canonical" href="https://creativecanning.com/zucchini-relish/" />
+<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/creativecanning.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.4.4"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+<link rel='stylesheet' id='foodie-pro-theme-css' href='https://creativecanning.com/wp-content/themes/foodie-pro/style.css?ver=3.0.0' type='text/css' media='all' />
+<style id='foodie-pro-theme-inline-css' type='text/css'>
+body, .site-description, .sidebar .featured-content .entry-title{font-family:"Karla","Helvetica Neue",sans-serif;font-size:21px;}.genesis-nav-menu{font-family:"Karla","Helvetica Neue",sans-serif;font-weight:700;}h1, h2, h3, h4, h5, h6, .site-title, .entry-title, .widgettitle{font-family:"Karla","Helvetica Neue",sans-serif;}.entry-title{font-family:"Karla","Helvetica Neue",sans-serif;font-size:27px;}.button, .button-secondary, button, input[type="button"], input[type="reset"], input[type="submit"], a.more-link, .more-from-category a{font-family:"Karla","Helvetica Neue",sans-serif;}
+</style>
+<style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://creativecanning.com/wp-includes/css/dist/block-library/style.min.css?ver=6.4.4' type='text/css' media='all' />
+<style id='wp-block-library-inline-css' type='text/css'>
+.has-text-align-justify{text-align:justify;}
+</style>
+<link rel='stylesheet' id='mediaelement-css' href='https://creativecanning.com/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.17' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-mediaelement-css' href='https://creativecanning.com/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=6.4.4' type='text/css' media='all' />
+<style id='jetpack-sharing-buttons-style-inline-css' type='text/css'>
+.jetpack-sharing-buttons__services-list{display:flex;flex-direction:row;flex-wrap:wrap;gap:0;list-style-type:none;margin:5px;padding:0}.jetpack-sharing-buttons__services-list.has-small-icon-size{font-size:12px}.jetpack-sharing-buttons__services-list.has-normal-icon-size{font-size:16px}.jetpack-sharing-buttons__services-list.has-large-icon-size{font-size:24px}.jetpack-sharing-buttons__services-list.has-huge-icon-size{font-size:36px}@media print{.jetpack-sharing-buttons__services-list{display:none!important}}.editor-styles-wrapper .wp-block-jetpack-sharing-buttons{gap:0;padding-inline-start:0}ul.jetpack-sharing-buttons__services-list.has-background{padding:1.25em 2.375em}
+</style>
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='dpsp-frontend-style-pro-css' href='https://creativecanning.com/wp-content/plugins/social-pug/assets/dist/style-frontend-pro.css?ver=1.33.2' type='text/css' media='all' />
+<style id='dpsp-frontend-style-pro-inline-css' type='text/css'>
+
+				@media screen and ( max-width : 720px ) {
+					.dpsp-content-wrapper.dpsp-hide-on-mobile,
+					.dpsp-share-text.dpsp-hide-on-mobile,
+					.dpsp-content-wrapper .dpsp-network-label {
+						display: none;
+					}
+					.dpsp-has-spacing .dpsp-networks-btns-wrapper li {
+						margin:0 2% 10px 0;
+					}
+					.dpsp-network-btn.dpsp-has-label:not(.dpsp-has-count) {
+						max-height: 40px;
+						padding: 0;
+						justify-content: center;
+					}
+					.dpsp-content-wrapper.dpsp-size-small .dpsp-network-btn.dpsp-has-label:not(.dpsp-has-count){
+						max-height: 32px;
+					}
+					.dpsp-content-wrapper.dpsp-size-large .dpsp-network-btn.dpsp-has-label:not(.dpsp-has-count){
+						max-height: 46px;
+					}
+				}
+			
+			@media screen and ( max-width : 720px ) {
+				aside#dpsp-floating-sidebar.dpsp-hide-on-mobile.opened {
+					display: none;
+				}
+			}
+			
+</style>
+<link rel='stylesheet' id='google-fonts-css' href='//fonts.googleapis.com/css?family=Karla%3Aregular%2Citalic%2C700%26subset%3Dlatin%2C&#038;ver=3.0.0' type='text/css' media='all' />
+<script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="https://scripts.mediavine.com/tags/creative-canning.js?ver=6.4.4" id="mv-script-wrapper-js"></script>
+<!--[if lt IE 9]>
+<script type="text/javascript" src="https://creativecanning.com/wp-content/themes/genesis/lib/js/html5shiv.js?ver=3.7.3" id="html5shiv-js"></script>
+<![endif]-->
+<script type="text/javascript" src="https://creativecanning.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://creativecanning.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
+<link rel="https://api.w.org/" href="https://creativecanning.com/wp-json/" /><link rel="alternate" type="application/json" href="https://creativecanning.com/wp-json/wp/v2/posts/15600" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://creativecanning.com/xmlrpc.php?rsd" />
+<link rel="alternate" type="application/json+oembed" href="https://creativecanning.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fcreativecanning.com%2Fzucchini-relish%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://creativecanning.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fcreativecanning.com%2Fzucchini-relish%2F&#038;format=xml" />
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-111170048-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-111170048-1');
+</script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-MT4HHFPPK2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-MT4HHFPPK2');
+</script>
+
+<meta name="p:domain_verify" content="2a9de4321a82f46044048a5a74596429"/>		<style>
+			:root {
+				--mv-create-radius: 0;
+			}
+		</style>
+		<script type="application/ld+json" class="mv-create-json-ld mv-create-json-ld-recipe">{"@context":"http:\/\/schema.org","@type":"Recipe","name":"Zucchini Relish Recipe for Canning","author":{"@type":"Person","name":"Ashley Adamant"},"datePublished":"2022-08-08","recipeYield":4,"description":"Zucchini relish is a flavorful topping for summer grilling, and the perfect way to use up extra zucchini from the garden.","image":["https:\/\/creativecanning.com\/wp-content\/uploads\/2021\/02\/Zucchini-Relish-61-720x720.jpg","https:\/\/creativecanning.com\/wp-content\/uploads\/2021\/02\/Zucchini-Relish-61-720x540.jpg","https:\/\/creativecanning.com\/wp-content\/uploads\/2021\/02\/Zucchini-Relish-61-540x720.jpg","https:\/\/creativecanning.com\/wp-content\/uploads\/2021\/02\/Zucchini-Relish-61-720x405.jpg","https:\/\/creativecanning.com\/wp-content\/uploads\/2021\/02\/Zucchini-Relish-61-735x490.jpg"],"prepTime":"PT2H10M","cookTime":"PT10M","performTime":"PT20M","totalTime":"PT2H30M","recipeIngredient":["2 cups zucchini, diced (about 3 medium)","1 cup onion, diced (about 1 medium)","1 cup red bell pepper, diced (about 2 small or 1 large)","2 Tablespoons Salt (pickling and canning salt, or kosher salt)\t","1 3\/4 cups sugar","2 teaspoons celery seed (whole)","1 teaspoon mustard seed (whole)","1 cup cider vinegar (5% acidity)","Pickle Crisp Granules (optional, helps veggies stay firm after canning)\t"],"recipeInstructions":[{"@type":"HowToStep","text":"Wash vegetables.","position":1,"name":"Wash vegetables.","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_1"},{"@type":"HowToStep","text":"Remove stem and blossom ends from zucchini and dice into 1\/4 to 1\/2 inch pieces.  Measure 2 cups.","position":2,"name":"Remove stem and blossom ends from zucchini and...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_2"},{"@type":"HowToStep","text":"Peel and dice onion.  Measure 1 cup.","position":3,"name":"Peel and dice onion. Measure 1 cup.","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_3"},{"@type":"HowToStep","text":"Stem and seed peppers, then dice.  Measure 1 cup.","position":4,"name":"Stem and seed peppers, then dice. Measure 1...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_4"},{"@type":"HowToStep","text":"Important, don't skip this step! Combine diced vegetables in a large bowl and sprinkle salt over the top.  Stir gently to distribute the salt, then add water until vegetables are completely submerged.  Allow the vegetables to soak in the saltwater for 2 hours, then drain completely.","position":5,"name":"Important, don't skip this step! Combine diced vegetables...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_5"},{"@type":"HowToStep","text":"Prepare a water bath canner (optional, only if canning).","position":6,"name":"Prepare a water bath canner (optional, only if...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_6"},{"@type":"HowToStep","text":"In a separate saucepan or stockpot, bring vinegar, sugar, and spices to a gentle simmer (180 degrees F).  Do not add salt, the salt is only used to soak veggies before draining.","position":7,"name":"In a separate saucepan or stockpot, bring vinegar,...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_7"},{"@type":"HowToStep","text":"Add drained vegetables to the simmering vinegar\/spices and gently simmer for 10 minutes.","position":8,"name":"Add drained vegetables to the simmering vinegar\/spices and...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_8"},{"@type":"HowToStep","text":"Pack hot relish into prepared half-pint or pint jars, leaving 1\/2 inch headspace.","position":9,"name":"Pack hot relish into prepared half-pint or pint...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_9"},{"@type":"HowToStep","text":"If not canning, just seal jars and allow them to cool on the counter before storing in the refrigerator.","position":10,"name":"If not canning, just seal jars and allow...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_10"},{"@type":"HowToStep","text":"If canning, de-bubble jars, wipe rims, and adjust headspace to ensure 1\/2 inch.  Seal with 2 part canning lids.","position":11,"name":"If canning, de-bubble jars, wipe rims, and adjust...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_11"},{"@type":"HowToStep","text":"Process in a water bath canner for 10 minutes, then turn off the heat.  Allow the jars to sit in the canner for another 5 minutes to cool slightly, then remove the jars to cool on a towel on the counter.","position":12,"name":"Process in a water bath canner for 10...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_12"},{"@type":"HowToStep","text":"Leave the jars undisturbed for 24 hours, then check seals.  Store any unsealed jars in the refrigerator for immediate use.  Properly canned and sealed jars should maintain peak quality on the pantry shelf for 12-18 months.","position":13,"name":"Leave the jars undisturbed for 24 hours, then...","url":"https:\/\/creativecanning.com\/zucchini-relish\/#mv_create_41_13"}],"aggregateRating":{"@type":"AggregateRating","ratingValue":"4.4","reviewCount":11},"url":"https:\/\/creativecanning.com\/zucchini-relish\/"}</script><meta name="hubbub-info" description="Hubbub 1.33.2"><style type="text/css"> .tippy-box[data-theme~="wprm"] { background-color: #333333; color: #FFFFFF; } .tippy-box[data-theme~="wprm"][data-placement^="top"] > .tippy-arrow::before { border-top-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="bottom"] > .tippy-arrow::before { border-bottom-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="left"] > .tippy-arrow::before { border-left-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="right"] > .tippy-arrow::before { border-right-color: #333333; } .tippy-box[data-theme~="wprm"] a { color: #FFFFFF; } .wprm-comment-rating svg { width: 18px !important; height: 18px !important; } img.wprm-comment-rating { width: 90px !important; height: 18px !important; } body { --comment-rating-star-color: #343434; } body { --wprm-popup-font-size: 16px; } body { --wprm-popup-background: #ffffff; } body { --wprm-popup-title: #000000; } body { --wprm-popup-content: #444444; } body { --wprm-popup-button-background: #444444; } body { --wprm-popup-button-text: #ffffff; }</style><style type="text/css">.wprm-glossary-term {color: #5A822B;text-decoration: underline;cursor: help;}</style>	<style>img#wpstats{display:none}</style>
+		<link rel="icon" href="https://creativecanning.com/wp-content/themes/foodie-pro/images/favicon.ico" />
+<link rel="pingback" href="https://creativecanning.com/xmlrpc.php" />
+		<style type="text/css" id="wp-custom-css">
+			/* MV CSS */
+
+@media only screen and (max-width: 424px) {
+
+.mv-create-instructions ol li > .mv-ad-box {
+
+margin-left: -67px !important;
+
+}
+
+}
+
+@media only screen and (max-width: 359px) {
+
+.site-inner {
+
+padding-left: 10px !important;
+
+padding-right: 10px !important;
+
+}
+
+}
+
+/* end of fix */		</style>
+		</head>
+<body class="post-template-default single single-post postid-15600 single-format-standard has-grow-sidebar header-full-width content-sidebar foodie-pro" itemscope itemtype="https://schema.org/WebPage"><div class="site-container"><ul class="genesis-skip-link"><li><a href="#genesis-nav-primary" class="screen-reader-shortcut"> Skip to primary navigation</a></li><li><a href="#genesis-content" class="screen-reader-shortcut"> Skip to content</a></li><li><a href="#genesis-sidebar-primary" class="screen-reader-shortcut"> Skip to primary sidebar</a></li><li><a href="#genesis-footer-widgets" class="screen-reader-shortcut"> Skip to footer</a></li></ul><header class="site-header" itemscope itemtype="https://schema.org/WPHeader"><div class="wrap"><div class="title-area"><p class="site-title" itemprop="headline"><a href="https://creativecanning.com/">Creative Canning</a></p><p class="site-description" itemprop="description">Create Your Own Safe Home Canned Recipes</p></div></div></header><h2 class="screen-reader-text">Main navigation</h2><nav class="nav-primary" itemscope itemtype="https://schema.org/SiteNavigationElement" id="genesis-nav-primary" aria-label="Main navigation"><div class="wrap"><ul id="menu-top-menu" class="menu genesis-nav-menu menu-primary"><li id="menu-item-15" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-home menu-item-15"><a href="https://creativecanning.com/" itemprop="url"><span itemprop="name">Home</span></a></li>
+<li id="menu-item-23527" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor menu-item-has-children menu-item-23527"><a href="https://creativecanning.com/category/water-bath-canning/" itemprop="url"><span itemprop="name">Water Bath Canning</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-23538" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23538"><a href="https://creativecanning.com/category/water-bath-canning/jam-recipes/" itemprop="url"><span itemprop="name">Jam Recipes</span></a></li>
+	<li id="menu-item-23540" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23540"><a href="https://creativecanning.com/category/water-bath-canning/jelly-recipes/" itemprop="url"><span itemprop="name">Jelly Recipes</span></a></li>
+	<li id="menu-item-23537" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23537"><a href="https://creativecanning.com/category/water-bath-canning/canning-fruit/" itemprop="url"><span itemprop="name">Fruit Canning Recipes</span></a></li>
+	<li id="menu-item-23539" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23539"><a href="https://creativecanning.com/category/water-bath-canning/pickle-canning-recipes/" itemprop="url"><span itemprop="name">Pickle Canning Recipes</span></a></li>
+</ul>
+</li>
+<li id="menu-item-23528" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-23528"><a href="https://creativecanning.com/category/pressure-canning/" itemprop="url"><span itemprop="name">Pressure Canning</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-23543" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23543"><a href="https://creativecanning.com/category/pressure-canning/soup-canning-recipes/" itemprop="url"><span itemprop="name">Soup Canning Recipes</span></a></li>
+	<li id="menu-item-23541" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23541"><a href="https://creativecanning.com/category/pressure-canning/meal-canning-recipes/" itemprop="url"><span itemprop="name">Meal In A Jar Canning Recipes</span></a></li>
+	<li id="menu-item-23542" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23542"><a href="https://creativecanning.com/category/pressure-canning/meat-canning-recipes/" itemprop="url"><span itemprop="name">Meat Canning Recipes</span></a></li>
+</ul>
+</li>
+<li id="menu-item-23536" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-23536"><a href="https://creativecanning.com/category/canning/" itemprop="url"><span itemprop="name">Canning Guides</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-23545" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23545"><a href="https://creativecanning.com/category/canning/canning-tips-guides/" itemprop="url"><span itemprop="name">Canning Tips &amp; Guides</span></a></li>
+	<li id="menu-item-23544" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-23544"><a href="https://creativecanning.com/category/canning/canning-recipe-lists/" itemprop="url"><span itemprop="name">Canning Recipe Lists</span></a></li>
+</ul>
+</li>
+<li id="menu-item-16" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16"><a href="https://creativecanning.com/about/" itemprop="url"><span itemprop="name">About</span></a></li>
+<li id="foodie-social" class="foodie-social menu-item"><form class="search-form" itemprop="potentialAction" itemscope itemtype="https://schema.org/SearchAction" method="get" action="https://creativecanning.com/" role="search"><meta itemprop="target" content="https://creativecanning.com/?s={s}"/><label class="search-form-label screen-reader-text" for="searchform-6635531104d9d8.71921380">Search</label><input itemprop="query-input" type="search" name="s" id="searchform-6635531104d9d8.71921380" placeholder="Search" /><input type="submit" value="Search" /></form></li></ul></div></nav><div class="site-inner"><div class="content-sidebar-wrap"><main class="content" id="genesis-content"><div class="breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">You are here: <span class="breadcrumb-link-wrap" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a href="https://creativecanning.com/" itemprop="item"><span itemprop="name">Home</span></a></span> <span aria-label="breadcrumb separator">/</span> <span class="breadcrumb-link-wrap" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a href="https://creativecanning.com/category/water-bath-canning/" itemprop="item"><span itemprop="name">Water Bath Canning</span></a></span> <span aria-label="breadcrumb separator">/</span> <span class="breadcrumb-link-wrap" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a href="https://creativecanning.com/category/water-bath-canning/relish-canning-recipes/" itemprop="item"><span itemprop="name">Relish Canning Recipes</span></a></span> <span aria-label="breadcrumb separator">/</span> Zucchini Relish Recipe for Canning</div><article class="post-15600 post type-post status-publish format-standard has-post-thumbnail category-relish-canning-recipes mv-content-wrapper grow-content-body entry" itemscope itemtype="https://schema.org/CreativeWork"><header class="entry-header"><h1 class="entry-title" itemprop="headline">Zucchini Relish Recipe for Canning</h1>
+<p class="entry-meta"><time class="entry-time" itemprop="datePublished" datetime="2021-08-16T17:13:58-04:00">August 16, 2021</time> by <span class="entry-author" itemprop="author" itemscope itemtype="https://schema.org/Person"><a href="https://creativecanning.com/author/ashley/" class="entry-author-link" itemprop="url" rel="author"><span class="entry-author-name" itemprop="name">Ashley Adamant</span></a></span> <span class="entry-comments-link"><a href="https://creativecanning.com/zucchini-relish/#comments">5 Comments</a></span> </p></header><em>This post may contain affiliate links.  Read full disclosure <a href="https://creativecanning.com/disclosures-privacy-policy/">here</a>.</em>	<p class="dpsp-share-text dpsp-hide-on-mobile" style="margin-bottom:10px">
+		Sharing is caring!	</p>
+	<div id="dpsp-content-top" class="dpsp-content-wrapper dpsp-shape-rounded dpsp-size-medium dpsp-hide-on-mobile dpsp-button-style-6" style="min-height:40px;position:relative">
+	<ul class="dpsp-networks-btns-wrapper dpsp-networks-btns-share dpsp-networks-btns-content dpsp-column-auto dpsp-has-button-icon-animation" style="padding:0;margin:0;list-style-type:none">
+<li class="dpsp-network-list-item dpsp-network-list-item-facebook" style="float:left">
+	<a rel="nofollow noopener" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fcreativecanning.com%2Fzucchini-relish%2F&#038;t=Zucchini%20Relish%20Recipe%20for%20Canning" class="dpsp-network-btn dpsp-facebook dpsp-first dpsp-has-label" target="_blank" aria-label="Share on Facebook" title="Share on Facebook" style="font-size:14px;padding:0rem;max-height:40px">	<span class="dpsp-network-icon ">
+		<span class="dpsp-network-icon-inner"></span>
+	</span>
+	<span class="dpsp-network-label">Facebook</span></a></li>
+
+<li class="dpsp-network-list-item dpsp-network-list-item-x" style="float:left">
+	<a rel="nofollow noopener" href="https://x.com/intent/tweet?text=Zucchini%20Relish%20Recipe%20for%20Canning&#038;url=https%3A%2F%2Fcreativecanning.com%2Fzucchini-relish%2F" class="dpsp-network-btn dpsp-x dpsp-has-label" target="_blank" aria-label="Share on X" title="Share on X" style="font-size:14px;padding:0rem;max-height:40px">	<span class="dpsp-network-icon ">
+		<span class="dpsp-network-icon-inner"></span>
+	</span>
+	<span class="dpsp-network-label">Twitter</span></a></li>
+
+<li class="dpsp-network-list-item dpsp-network-list-item-pinterest" style="float:left">
+	<button data-href="#" class="dpsp-network-btn dpsp-pinterest dpsp-last dpsp-has-label" aria-label="Save to Pinterest" title="Save to Pinterest" style="font-size:14px;padding:0rem;max-height:40px">	<span class="dpsp-network-icon ">
+		<span class="dpsp-network-icon-inner"></span>
+	</span>
+	<span class="dpsp-network-label">Pinterest</span></button></li>
+</ul></div>
+<div class="entry-content" itemprop="text"><p><em>Zucchini relish one of my favorite ways to use up zucchini from the garden. Considerably more flavorful than straight dill pickle relish, homemade zucchini relish is a real hit at summer barbeques.</em></p>
+<p><em>When this zucchini relish is made as a canning recipe, you can preserve zucchini right on the pantry shelf for year-round eating.&nbsp; It&#8217;s also perfectly fine to make a small batch for the refrigerator, and it&#8217;ll last for several months so you can enjoy it all summer long.</em></p>
+<p><img decoding="async" class="aligncenter size-full wp-image-15608" src="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-21.jpg" alt="" width="1200" height="800" srcset="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-21.jpg 1200w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-21-300x200.jpg 300w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-21-1024x683.jpg 1024w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-21-768x512.jpg 768w" sizes="(max-width: 1200px) 100vw, 1200px" /></p>
+<p><span id="more-15600"></span></p>
+<p>Every gardener knows what happens when you grow zucchini&#8230;</p>
+<p>It starts out slow, with just a few tiny squash and you add them to dinner as a quick side dish.&nbsp; Then they start to come in by the bucket load, and you make zucchini bread for the whole neighborhood.</p>
+<p>Then you&#8217;re carrying bags of zucchini to neighbors, begging them to take them off your hands.</p>
+<p>You get desperate and start grating and freezing zucchini for winter baking, but the freezer fills up.</p>
+<p>Then you really start to pannic.</p>
+<p>Ok, well maybe it&#8217;s not all that bad.&nbsp; But it&#8217;s still always good to know a few good ways to use up extra zucchini, especially if they don&#8217;t require precious freezer space.</p>
+<p>This simple zucchini relish is on of my favorite zucchini canning recipes, and it&#8217;s bright, festive, and incredibly tasty.</p>
+<p>A bit of red pepper adds color, while onion and whole mustard seed gives it a pleasant crunch.&nbsp;&nbsp;</p>
+<p>Don&#8217;t worry, it&#8217;s still mostly zucchini, so you can make a couple of batches to use up those extra squash on the counter.</p>
+<p><img decoding="async" class="aligncenter size-full wp-image-15603" src="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-31.jpg" alt="" width="1200" height="802" srcset="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-31.jpg 1200w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-31-300x201.jpg 300w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-31-1024x684.jpg 1024w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-31-768x513.jpg 768w" sizes="(max-width: 1200px) 100vw, 1200px" /></p>
+<p>This recipe for Zucchini Relish is adapted from <a href="https://amzn.to/3CS9ghn" target="_blank" rel="nofollow noopener noreferrer">The Ball Blue Book Guide to Preserving</a>, which has literally hundreds of safe, tested canning recipes.</p>
+<h2>Ingredients for Zucchini Relish</h2>
+<p>Relish is one of those condiments we eat with our eyes as much as our mouths, and adding a variety of colors and textures is key to a good relish recipe.</p>
+<p>Of course, in a zucchini relish recipe, part of the goal is to use up as much zucchini as possible.&nbsp; The problem is, zucchini tends to fall apart and get soggy during canning, especially when diced finely.&nbsp;</p>
+<p>Using no more than half zucchini ensures good texture, but also allows you to incorporate other colors and flavors into the finished relish.</p>
+<p>The vegetables in this relish include two parts zucchini, and then one part each diced onion and diced red pepper.</p>
+<p>To yield about 4 half-pints (8 oz) jars, you&#8217;ll need:</p>
+<ul>
+<li>2 cups zucchini, diced <em>(about 3 medium)</em></li>
+<li>1 cup onion, diced <em>(about 1 medium)</em></li>
+<li>1 cup red bell pepper, diced <em>(about 2 small or 1 large)</em></li>
+<li>2 Tablespoons Salt <em>(pickling and canning salt, or kosher salt)</em></li>
+<li>1 3/4 cups sugar</li>
+<li>2 teaspoons celery seed <em>(whole)</em></li>
+<li>1 teaspoon mustard seed <em>(whole)</em></li>
+<li>1 cup cider vinegar <em>(5% acidity)</em></li>
+<li><a href="https://amzn.to/3kfNSdB" target="_blank" rel="nofollow noopener noreferrer">Pickle Crisp Granules</a> <em>(optional, helps veggies stay firm after canning)</em></li>
+</ul>
+<p>This is a tested canning recipe, and you should not change the total amount of vegetables (or the proportions), and you cannot reduce the total amount of vinegar.&nbsp;&nbsp;</p>
+<p>That said, the salt, sugar, and spices are for flavor/texture and are not what makes this a safe canning recipe.&nbsp; Feel to skip the spices, or replace them with others that are more suited to your tastes.&nbsp;</p>
+<p>You can also reduce the salt or sugar, but know that they are calculated to balance the acidity in the recipe and create a well-rounded relish.&nbsp; Reducing them will also negatively impact the texture of the finished relish.&nbsp; &nbsp;</p>
+<p>While in most canning recipes you can use sodium-free salt substitutes, I wouldn&#8217;t recommend it for this zucchini relish.&nbsp; The salt is used to soak the vegetables before making the relish, and it is what&#8217;s responsible for keeping the diced veggies firm during canning.&nbsp; Most of it is rinsed out before actually making the relish.</p>
+<p><img loading="lazy" decoding="async" class="aligncenter size-full wp-image-15613" src="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Ingredients-1.jpg" alt="" width="1200" height="800" srcset="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Ingredients-1.jpg 1200w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Ingredients-1-300x200.jpg 300w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Ingredients-1-1024x683.jpg 1024w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Ingredients-1-768x512.jpg 768w" sizes="(max-width: 1200px) 100vw, 1200px" /></p>
+<h2>How to Make Zucchini Relish</h2>
+<p>Making zucchini relish starts with washing and then dicing the vegetables.&nbsp; Try for consistent size, right around 1/4 to 1/2 inch dice.</p>
+<p>After dicing, <span style="text-decoration: underline;"><strong>this is the important part, so pay attention:</strong></span></p>
+<p>Combine diced zucchini, onion, and red bell pepper in a large bowl.&nbsp; Sprinkle 2 tablespoons of <a href="https://amzn.to/3xSdGkL" target="_blank" rel="nofollow noopener noreferrer">pickling/canning salt</a> over the veggies, and gently stir with your hands to evenly distribute the salt.&nbsp; Then, add water until the veggies are completely submerged.</p>
+<p>Allow the veggies to stand in the saltwater for 2 hours, then drain.</p>
+<p>This causes the veggies to lose liquid and firms them up so that they stay intact during canning.&nbsp;</p>
+<p>It also infuses the salt into the vegetables, but then allows most of it to drain away.&nbsp; Two tablespoons is a lot of salt across just 4 half-pint jars, but most of it will drain away with the water, leaving the finished zucchini relish just right.</p>
+<p><img loading="lazy" decoding="async" class="aligncenter size-full wp-image-15607" src="https://creativecanning.com/wp-content/uploads/2021/08/Salting-Zucchini-Relish-1.jpg" alt="" width="1200" height="1800"></p>
+<p>After the veggies have soaked in saltwater and then drained, prepare a water bath canner (if canning).</p>
+<p>In a separate pot, combine sugar, spices, and vinegar.</p>
+<p>Bring the mixture to a simmer (180 degrees F), and add the soaked/drained veggies.&nbsp; Simmer gently for 10 minutes until the vegetables are completely heated and cooked.</p>
+<p>Pack the hot relish into prepared jars, leaving 1/2 inch headspace.&nbsp;</p>
+<p>Add 1/16 tsp <a href="https://amzn.to/3kfNSdB" target="_blank" rel="nofollow noopener noreferrer">pickle crisp</a> to each half-pint jar (or 1/8 tsp per pint jar), if using.&nbsp; Pickle crisp is optional, but it helps keep the veggies firm after canning.&nbsp; It&#8217;s all-natural, just calcium chloride, which firms up the cell walls of the veggies.</p>
+<p>(Pickle crisp, as the name implies, also works great for homemade pickles, not just relish.)</p>
+<p>The finished relish should hold up well on a spoon, and the bright colors will add a festive look to just about anything.</p>
+<p><img loading="lazy" decoding="async" class="aligncenter size-full wp-image-15605" src="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-51.jpg" alt="" width="1200" height="1796" srcset="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-51.jpg 1200w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-51-200x300.jpg 200w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-51-684x1024.jpg 684w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-51-768x1149.jpg 768w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-Spoon-51-1026x1536.jpg 1026w" sizes="(max-width: 1200px) 100vw, 1200px" /></p>
+<h2>Canning Zucchini Relish</h2>
+<p>It&#8217;s perfectly fine to make zucchini relish as a refrigerator recipe, canning is not required.</p>
+<p>For refrigerator zucchini relish, simply cap the jars and then allow them to cool to room temperature before storing in the refrigerator.&nbsp; They should keep several weeks (possibly several months) in the refrigerator, as the acid from the vinegar is really good and preserving vegetables even without canning.</p>
+<p>That said, water bath canning is incredibly simple, and allows you to store the relish on the pantry shelf until it&#8217;s needed.&nbsp; Refrigerator space is always scarce in my house, especially in the busy summer months when the garden&#8217;s bounty is coming ripe all at once.</p>
+<p>To can zucchini relish, fill the jars with hot relish leaving 1/2 inch headspace.&nbsp; Wipe rims, de-bubble jars, and adjust headspace before capping with 2 part canning lids.</p>
+<p>Process in a water bath canner for 10 minutes.&nbsp; Once the processing time is complete, turn off the heat but don&#8217;t remove the jars yet.&nbsp;&nbsp;</p>
+<p>Allow the jars to sit for another 5 minutes in the canner before removing them to cool on a towel on the counter.&nbsp; This extra 5 minutes allows the jars to cool slightly before they&#8217;re removed from the canner, which in turn helps prevent siphoning (or liquid loss due to thermal shock as the jars are removed).</p>
+<p>Leave the jars undisturbed for 24 hours, then check seals.&nbsp; Store any unsealed jars in the refrigerator for immediate use.&nbsp; Sealed jars should maintain peak quality on the pantry shelf for 12-18 months.&nbsp; Refrigerate after opening.</p>
+<p><img loading="lazy" decoding="async" class="aligncenter size-full wp-image-15610" src="https://creativecanning.com/wp-content/uploads/2021/08/Zucchini-Relish-41.jpg" alt="" width="1200" height="1800"></p>
+<h2>Ways to Preserve Zucchini</h2>
+<p>Looking for more ways to preserve a bumper crop of zucchini?</p>
+<ul>
+<li><a href="https://downshiftology.com/recipes/how-to-freeze-zucchini/" target="_blank" rel="noopener noreferrer">Freezing Zucchini</a></li>
+<li><a href="https://practicalselfreliance.com/zucchini-marmalade/">Zucchini Marmalade</a></li>
+<li><a href="https://practicalselfreliance.com/canning-zucchini/">Zucchini Canning Recipes</a></li>
+<li><a href="https://www.culturesforhealth.com/learn/recipe/lacto-fermentation-recipes/grated-zucchini-kraut/" target="_blank" rel="nofollow noopener noreferrer">Grated Zucchini Kraut</a> (Preserved Using <a href="https://practicalselfreliance.com/lacto-fermentation/">Lacto-Fermentation</a>)</li>
+</ul>
+	<section id="mv-creation-41" class="mv-create-card mv-create-card-41 mv-recipe-card mv-create-card-style-big-image mv-no-js mv-create-center-cards mv-create-has-uppercase mv-create-has-image " style="position: relative;">
+		
+		<div class="mv-create-wrapper">
+
+			
+			<header class="mv-create-header">
+				<img decoding="async" src="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-735x490.jpg" class="mv-create-image no_pin ggnoads" data-pin-nopin="true" data-pin-description="" alt="Zucchini Relish Recipe for Canning" srcset="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-735x490.jpg 735w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-300x200.jpg 300w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-1024x683.jpg 1024w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-768x512.jpg 768w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61.jpg 1200w" sizes="(max-width: 735px) 100vw, 735px" data-pin-media="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61.jpg"><div class="mv-pinterest-btn mv-pinterest-btn-right" data-mv-pinterest-desc="Zucchini%20Relish%20Recipe%20for%20Canning" data-mv-pinterest-img-src="https%3A%2F%2Fcreativecanning.com%2Fwp-content%2Fuploads%2F2021%2F02%2FZucchini-Relish-61.jpg" data-mv-pinterest-url="https%3A%2F%2Fcreativecanning.com%2Fzucchini-relish%2F"></div>
+
+<div class="mv-create-title-container">
+
+			<span class="mv-create-yield mv-create-uppercase"><span class="screen-reader-text">Yield:</span> Makes 4 Half Pint (8 oz) Jars</span>
+	
+	
+	<h2 class="mv-create-title mv-create-title-primary"><span>Zucchini Relish Recipe for Canning</span></h2>
+
+</div>
+			</header>
+
+			
+<div class="mv-create-times mv-create-times-4">
+
+			<div class="mv-create-time mv-create-time-prep">
+			<em class="mv-create-time-label mv-create-lowercase mv-create-strong">Prep Time: </em>
+			<span class="mv-create-time-format mv-create-uppercase"><span class="mv-time-part mv-time-hours">2 hours</span> <span class="mv-time-part mv-time-minutes">10 minutes</span> </span>
+		</div>
+			<div class="mv-create-time mv-create-time-active">
+			<em class="mv-create-time-label mv-create-lowercase mv-create-strong">Cook Time: </em>
+			<span class="mv-create-time-format mv-create-uppercase"><span class="mv-time-part mv-time-minutes">10 minutes</span> </span>
+		</div>
+			<div class="mv-create-time mv-create-time-additional">
+			<em class="mv-create-time-label mv-create-lowercase mv-create-strong">Additional Time: </em>
+			<span class="mv-create-time-format mv-create-uppercase"><span class="mv-time-part mv-time-minutes">10 minutes</span> </span>
+		</div>
+			<div class="mv-create-time mv-create-time-total">
+			<em class="mv-create-time-label mv-create-lowercase mv-create-strong">Total Time: </em>
+			<span class="mv-create-time-format mv-create-uppercase"><span class="mv-time-part mv-time-hours">2 hours</span> <span class="mv-time-part mv-time-minutes">30 minutes</span> </span>
+		</div>
+	
+</div>
+		<div class="mv-create-description">
+			<p>Zucchini relish is a flavorful topping for summer grilling, and the perfect way to use up extra zucchini from the garden.</p>
+		</div>
+		<div class="mv-create-meta-flex">
+
+		<form class="mv-create-print-form">
+			<button class="mv-create-button mv-create-print-button mv-create-uppercase" data-mv-print="https://creativecanning.com/wp-json/mv-create/v1/creations/41/print?ajax=true">
+				Print			</button>
+		</form>
+
+					<div class="mv-create-reviews-flex">
+				<div id="mv-create-41" class="mv-create-reviews" data-mv-create-id="41" data-mv-create-rating="4.4" data-mv-create-total-ratings="11" data-mv-rest-url="https://creativecanning.com/wp-json/"></div>
+			</div>
+			</div>
+<div class="mv-create-target mv-create-primary-unit"><div class="mv_slot_target" data-slot="recipe"></div></div>	<div class="mv-create-ingredients">
+		<h3 class="mv-create-ingredients-title mv-create-title-secondary">Ingredients</h3>
+
+											<ul>
+									<li>
+						2 cups zucchini, diced (about 3 medium)					</li>
+									<li>
+						1 cup onion, diced (about 1 medium)					</li>
+									<li>
+						1 cup red bell pepper, diced (about 2 small or 1 large)					</li>
+									<li>
+						<a href="https://amzn.to/3xSdGkL" rel="nofollow" target="_blank">2 Tablespoons Salt (pickling and canning salt, or kosher salt)	</a>					</li>
+									<li>
+						1 3/4 cups sugar					</li>
+									<li>
+						2 teaspoons celery seed (whole)					</li>
+									<li>
+						1 teaspoon mustard seed (whole)					</li>
+									<li>
+						1 cup cider vinegar (5% acidity)					</li>
+									<li>
+						<a href="https://amzn.to/3jXnDbE" rel="nofollow" target="_blank">Pickle Crisp Granules (optional, helps veggies stay firm after canning)	</a>					</li>
+							</ul>
+			</div>
+		<div class="mv-create-hands-free"></div>
+		<div class="mv-create-instructions mv-create-instructions-slot-v2">
+		<h3 class="mv-create-instructions-title mv-create-title-secondary">Instructions</h3>
+		<ol><li id="mv_create_41_1">Wash vegetables.  </li><li id="mv_create_41_2">Remove stem and blossom ends from zucchini and dice into 1/4 to 1/2 inch pieces.  Measure 2 cups.</li><li id="mv_create_41_3">Peel and dice onion.  Measure 1 cup.</li><li id="mv_create_41_4">Stem and seed peppers, then dice.  Measure 1 cup.</li><li id="mv_create_41_5"><strong>Important, don't skip this step!</strong> Combine diced vegetables in a large bowl and sprinkle salt over the top.  Stir gently to distribute the salt, then add water until vegetables are completely submerged.  Allow the vegetables to soak in the saltwater for 2 hours, then drain completely.</li><li id="mv_create_41_6">Prepare a water bath canner (optional, only if canning).</li><li id="mv_create_41_7">In a separate saucepan or stockpot, bring vinegar, sugar, and spices to a gentle simmer (180 degrees F).  <em>Do not add salt, the salt is only used to soak veggies before draining.</em></li><li id="mv_create_41_8">Add drained vegetables to the simmering vinegar/spices and gently simmer for 10 minutes.</li><li id="mv_create_41_9">Pack hot relish into prepared half-pint or pint jars, leaving 1/2 inch headspace.</li><li id="mv_create_41_10">If not canning, just seal jars and allow them to cool on the counter before storing in the refrigerator.</li><li id="mv_create_41_11">If canning, de-bubble jars, wipe rims, and adjust headspace to ensure 1/2 inch.  Seal with 2 part canning lids.</li><li id="mv_create_41_12">Process in a water bath canner for 10 minutes, then turn off the heat.  Allow the jars to sit in the canner for another 5 minutes to cool slightly, then remove the jars to cool on a towel on the counter.</li><li id="mv_create_41_13">Leave the jars undisturbed for 24 hours, then check seals.  Store any unsealed jars in the refrigerator for immediate use.  Properly canned and sealed jars should maintain peak quality on the pantry shelf for <br>12-18 months.</li></ol>	</div>
+	<div class="mv-create-notes mv-create-notes-slot-v2">
+		<h3 class="mv-create-notes-title mv-create-title-secondary">Notes</h3>
+		<div class="mv-create-notes-content">
+			<p><p>Be sure to use pickling and canning salt, or kosher salt without additives.  Iodized table salt has anti-caking agents added and it doesn&#x27;t work well for canning.</p><p>If you&#x27;re not familiar with water bath canning, I&#x27;d strongly recommend reading this <a href="https://practicalselfreliance.com/water-bath-canning-beginners/">beginner&#x27;s guide to water bath canning</a> before beginning.</p></p>
+		</div>
+	</div>
+
+		</div>
+
+		<footer class="mv-create-footer">
+			
+<div class="mv-create-footer-flexbox">
+
+			<div class="mv-create-copy">&copy; Ashley Adamant</div>
+	
+	<div class="mv-create-categories">
+
+		
+		
+	</div>
+
+	<img decoding="async" src="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-735x490.jpg" alt="" data-pin-description="" class="mv-create-pinterest no_pin ggnoads" srcset="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-735x490.jpg 735w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-300x200.jpg 300w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-1024x683.jpg 1024w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61-768x512.jpg 768w, https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61.jpg 1200w" sizes="(max-width: 735px) 100vw, 735px" data-pin-media="https://creativecanning.com/wp-content/uploads/2021/02/Zucchini-Relish-61.jpg">
+</div>
+		</footer>
+
+		
+	</section>
+
+	
+<h2>Pickle Recipes for Canning</h2>
+<p>These easy water bath canning recipes make tasty homemade pickles (and relish too)!</p>
+<ul>
+<li><a href="https://practicalselfreliance.com/dill-pickle-recipe-home-canning/">Classic Dill Pickles</a></li>
+<li><a href="https://practicalselfreliance.com/bread-and-butter-pickles-canning-recipe/">Bread and Butter Pickles</a></li>
+<li><a href="https://practicalselfreliance.com/gherkin-recipe/">Gherkins (Baby Pickles)</a></li>
+<li><a href="https://practicalselfreliance.com/sweet-dill-pickle-relish-canning/">Dill Pickle Relish</a></li>
+<li><a href="https://practicalselfreliance.com/pickled-garlic/">Pickled Garlic</a></li>
+<li><a href="https://practicalselfreliance.com/pickled-carrots/">Pickled Carrots</a></li>
+<li><a href="https://practicalselfreliance.com/pickled-beets/">Pickled Beets</a></li>
+</ul>
+<h2>Summer Canning Recipes</h2>
+<p>Putting up more than pickles this season?</p>
+<ul>
+<li><a href="https://practicalselfreliance.com/canning-peaches/">Canning Peaches</a></li>
+<li><a href="https://practicalselfreliance.com/peach-jam/">Peach Jam</a></li>
+<li><a href="https://practicalselfreliance.com/grape-jam/">Grape Jam</a></li>
+<li><a href="https://practicalselfreliance.com/blackberry-jam-no-pectin/">Blackberry Jam</a></li>
+<li><a href="https://practicalselfreliance.com/canning-corn/">Canning Corn</a></li>
+<li><a href="https://practicalselfreliance.com/canning-tomatoes/">Canning Tomatoes</a></li>
+</ul>
+<p><img loading="lazy" decoding="async" class="size-full wp-image-22306 aligncenter" src="https://creativecanning.com/wp-content/uploads/2021/08/How-to-Make-Zucchini-Relish.jpg" alt="Zucchini Relish Recipe for Canning" width="600" height="1200" srcset="https://creativecanning.com/wp-content/uploads/2021/08/How-to-Make-Zucchini-Relish.jpg 600w, https://creativecanning.com/wp-content/uploads/2021/08/How-to-Make-Zucchini-Relish-150x300.jpg 150w, https://creativecanning.com/wp-content/uploads/2021/08/How-to-Make-Zucchini-Relish-512x1024.jpg 512w" sizes="(max-width: 600px) 100vw, 600px" /></p>
+<p>&nbsp;</p>
+<!--<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+			xmlns:dc="http://purl.org/dc/elements/1.1/"
+			xmlns:trackback="http://madskills.com/public/xml/rss/module/trackback/">
+		<rdf:Description rdf:about="https://creativecanning.com/zucchini-relish/"
+    dc:identifier="https://creativecanning.com/zucchini-relish/"
+    dc:title="Zucchini Relish Recipe for Canning"
+    trackback:ping="https://creativecanning.com/zucchini-relish/trackback/" />
+</rdf:RDF>-->
+</div><footer class="entry-footer"><p class="entry-meta"><span class="entry-categories">Filed Under: <a href="https://creativecanning.com/category/water-bath-canning/relish-canning-recipes/" rel="category tag">Relish Canning Recipes</a></span> </p></footer></article><div class="adjacent-entry-pagination pagination"><div class="pagination-previous alignleft"><a href="https://creativecanning.com/flower-jelly/" rel="prev">&#x000AB; How to Make Flower Jelly (with 20+ Recipes!)</a></div><div class="pagination-next alignright"><a href="https://creativecanning.com/pickled-jalapenos/" rel="next">Pickled Jalapeños &#x000BB;</a></div></div><h2 class="screen-reader-text">Reader Interactions</h2><div class="entry-comments" id="comments"><h3>Comments</h3><ol class="comment-list">
+	<li class="comment even thread-even depth-1" id="comment-3327">
+	<article itemprop="comment" itemscope itemtype="https://schema.org/Comment">
+
+		
+		<header class="comment-header">
+			<p class="comment-author" itemprop="author" itemscope itemtype="https://schema.org/Person">
+				<span itemprop="name">Aimee</span> 			</p>
+
+			<p class="comment-meta"><time class="comment-time" datetime="2022-04-26T18:22:33-04:00" itemprop="datePublished"><a href="https://creativecanning.com/zucchini-relish/#comment-3327" class="comment-time-link" itemprop="url">April 26, 2022 at 6:22 pm</a></time></p>		</header>
+
+		<div class="comment-content" itemprop="text">
+			
+			<p>Is it necessary to cook the relish in the brine? Or can I just put the relish in the jars and cover with hot brine like pickles?</p>
+		</div>
+
+		<div class="comment-reply"><a rel='nofollow' class='comment-reply-link' href='https://creativecanning.com/zucchini-relish/?replytocom=3327#respond' data-commentid="3327" data-postid="15600" data-belowelement="comment-3327" data-respondelement="respond" data-replyto="Reply to Aimee" aria-label='Reply to Aimee'>Reply</a></div>
+		
+	</article>
+	<ul class="children">
+
+	<li class="comment odd alt depth-2" id="comment-3328">
+	<article itemprop="comment" itemscope itemtype="https://schema.org/Comment">
+
+		
+		<header class="comment-header">
+			<p class="comment-author" itemprop="author" itemscope itemtype="https://schema.org/Person">
+				<span itemprop="name">Administrator</span> 			</p>
+
+			<p class="comment-meta"><time class="comment-time" datetime="2022-04-29T14:49:36-04:00" itemprop="datePublished"><a href="https://creativecanning.com/zucchini-relish/#comment-3328" class="comment-time-link" itemprop="url">April 29, 2022 at 2:49 pm</a></time></p>		</header>
+
+		<div class="comment-content" itemprop="text">
+			
+			<p>This recipe has been tested by first cooking the relish in the brine so I would recommend following those instructions.</p>
+		</div>
+
+		<div class="comment-reply"><a rel='nofollow' class='comment-reply-link' href='https://creativecanning.com/zucchini-relish/?replytocom=3328#respond' data-commentid="3328" data-postid="15600" data-belowelement="comment-3328" data-respondelement="respond" data-replyto="Reply to Administrator" aria-label='Reply to Administrator'>Reply</a></div>
+		
+	</article>
+	</li><!-- #comment-## -->
+</ul><!-- .children -->
+</li><!-- #comment-## -->
+
+	<li class="comment even thread-odd thread-alt depth-1" id="comment-3987">
+	<article itemprop="comment" itemscope itemtype="https://schema.org/Comment">
+
+		
+		<header class="comment-header">
+			<p class="comment-author" itemprop="author" itemscope itemtype="https://schema.org/Person">
+				<span itemprop="name">Clay</span> 			</p>
+
+			<p class="comment-meta"><time class="comment-time" datetime="2023-03-10T07:10:06-04:00" itemprop="datePublished"><a href="https://creativecanning.com/zucchini-relish/#comment-3987" class="comment-time-link" itemprop="url">March 10, 2023 at 7:10 am</a></time></p>		</header>
+
+		<div class="comment-content" itemprop="text">
+			
+			<p>This relish sounds pretty straight forward and tasty.<br />
+Could a grape leaf be used in each jar instead of Pickle Crisp to try and keep some crunchiness in the veggies?</p>
+		</div>
+
+		<div class="comment-reply"><a rel='nofollow' class='comment-reply-link' href='https://creativecanning.com/zucchini-relish/?replytocom=3987#respond' data-commentid="3987" data-postid="15600" data-belowelement="comment-3987" data-respondelement="respond" data-replyto="Reply to Clay" aria-label='Reply to Clay'>Reply</a></div>
+		
+	</article>
+	<ul class="children">
+
+	<li class="comment byuser comment-author-ashley bypostauthor odd alt depth-2" id="comment-3993">
+	<article itemprop="comment" itemscope itemtype="https://schema.org/Comment">
+
+		
+		<header class="comment-header">
+			<p class="comment-author" itemprop="author" itemscope itemtype="https://schema.org/Person">
+				<span itemprop="name"><a href="https://creativecanning.com/" class="comment-author-link" rel="external nofollow" itemprop="url">Ashley Adamant</a></span> 			</p>
+
+			<p class="comment-meta"><time class="comment-time" datetime="2023-03-12T16:49:41-04:00" itemprop="datePublished"><a href="https://creativecanning.com/zucchini-relish/#comment-3993" class="comment-time-link" itemprop="url">March 12, 2023 at 4:49 pm</a></time></p>		</header>
+
+		<div class="comment-content" itemprop="text">
+			
+			<p>Yup!</p>
+		</div>
+
+		<div class="comment-reply"><a rel='nofollow' class='comment-reply-link' href='https://creativecanning.com/zucchini-relish/?replytocom=3993#respond' data-commentid="3993" data-postid="15600" data-belowelement="comment-3993" data-respondelement="respond" data-replyto="Reply to Ashley Adamant" aria-label='Reply to Ashley Adamant'>Reply</a></div>
+		
+	</article>
+	</li><!-- #comment-## -->
+</ul><!-- .children -->
+</li><!-- #comment-## -->
+</ol></div>	<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Leave a Reply <small><a rel="nofollow" id="cancel-comment-reply-link" href="/zucchini-relish/#respond" style="display:none;">Cancel reply</a></small></h3><form action="https://creativecanning.com/wp-comments-post.php" method="post" id="commentform" class="comment-form" novalidate><p class="comment-notes"><span id="email-notes">Your email address will not be published.</span> <span class="required-field-message">Required fields are marked <span class="required">*</span></span></p><div class="comment-form-wprm-rating" style="display: none">
+	<label for="wprm-comment-rating-355563626">Recipe Rating</label>	<span class="wprm-rating-stars">
+		<fieldset class="wprm-comment-ratings-container" data-original-rating="0" data-current-rating="0">
+			<legend>Recipe Rating</legend>
+			<input aria-label="Don&#039;t rate this recipe" name="wprm-comment-rating" value="0" type="radio" onclick="WPRecipeMaker.rating.onClick(this)" style="margin-left: -21px !important; width: 24px !important; height: 24px !important;" checked="checked"><span aria-hidden="true" style="width: 120px !important; height: 24px !important;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="106.66666666667px" height="16px" viewBox="0 0 160 32">
+  <defs>
+    <polygon class="wprm-star-empty" id="wprm-star-empty-0" fill="none" stroke="#343434" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points="12,2.6 15,9 21.4,9 16.7,13.9 18.6,21.4 12,17.6 5.4,21.4 7.3,13.9 2.6,9 9,9" stroke-linejoin="miter"/>
+  </defs>
+	<use xlink:href="#wprm-star-empty-0" x="4" y="4" />
+	<use xlink:href="#wprm-star-empty-0" x="36" y="4" />
+	<use xlink:href="#wprm-star-empty-0" x="68" y="4" />
+	<use xlink:href="#wprm-star-empty-0" x="100" y="4" />
+	<use xlink:href="#wprm-star-empty-0" x="132" y="4" />
+</svg></span><br><input aria-label="Rate this recipe 1 out of 5 stars" name="wprm-comment-rating" value="1" type="radio" onclick="WPRecipeMaker.rating.onClick(this)" style="width: 24px !important; height: 24px !important;"><span aria-hidden="true" style="width: 120px !important; height: 24px !important;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="106.66666666667px" height="16px" viewBox="0 0 160 32">
+  <defs>
+	<polygon class="wprm-star-empty" id="wprm-star-empty-1" fill="none" stroke="#343434" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points="12,2.6 15,9 21.4,9 16.7,13.9 18.6,21.4 12,17.6 5.4,21.4 7.3,13.9 2.6,9 9,9" stroke-linejoin="miter"/>
+	<path class="wprm-star-full" id="wprm-star-full-1" fill="#343434" d="M12.712,1.942l2.969,6.015l6.638,0.965c0.651,0.095,0.911,0.895,0.44,1.354l-4.804,4.682l1.134,6.612c0.111,0.649-0.57,1.143-1.152,0.837L12,19.286l-5.938,3.122C5.48,22.714,4.799,22.219,4.91,21.57l1.134-6.612l-4.804-4.682c-0.471-0.459-0.211-1.26,0.44-1.354l6.638-0.965l2.969-6.015C11.579,1.352,12.421,1.352,12.712,1.942z"/>
+  </defs>
+	<use xlink:href="#wprm-star-full-1" x="4" y="4" />
+	<use xlink:href="#wprm-star-empty-1" x="36" y="4" />
+	<use xlink:href="#wprm-star-empty-1" x="68" y="4" />
+	<use xlink:href="#wprm-star-empty-1" x="100" y="4" />
+	<use xlink:href="#wprm-star-empty-1" x="132" y="4" />
+</svg></span><br><input aria-label="Rate this recipe 2 out of 5 stars" name="wprm-comment-rating" value="2" type="radio" onclick="WPRecipeMaker.rating.onClick(this)" style="width: 24px !important; height: 24px !important;"><span aria-hidden="true" style="width: 120px !important; height: 24px !important;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="106.66666666667px" height="16px" viewBox="0 0 160 32">
+  <defs>
+	<polygon class="wprm-star-empty" id="wprm-star-empty-2" fill="none" stroke="#343434" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points="12,2.6 15,9 21.4,9 16.7,13.9 18.6,21.4 12,17.6 5.4,21.4 7.3,13.9 2.6,9 9,9" stroke-linejoin="miter"/>
+	<path class="wprm-star-full" id="wprm-star-full-2" fill="#343434" d="M12.712,1.942l2.969,6.015l6.638,0.965c0.651,0.095,0.911,0.895,0.44,1.354l-4.804,4.682l1.134,6.612c0.111,0.649-0.57,1.143-1.152,0.837L12,19.286l-5.938,3.122C5.48,22.714,4.799,22.219,4.91,21.57l1.134-6.612l-4.804-4.682c-0.471-0.459-0.211-1.26,0.44-1.354l6.638-0.965l2.969-6.015C11.579,1.352,12.421,1.352,12.712,1.942z"/>
+  </defs>
+	<use xlink:href="#wprm-star-full-2" x="4" y="4" />
+	<use xlink:href="#wprm-star-full-2" x="36" y="4" />
+	<use xlink:href="#wprm-star-empty-2" x="68" y="4" />
+	<use xlink:href="#wprm-star-empty-2" x="100" y="4" />
+	<use xlink:href="#wprm-star-empty-2" x="132" y="4" />
+</svg></span><br><input aria-label="Rate this recipe 3 out of 5 stars" name="wprm-comment-rating" value="3" type="radio" onclick="WPRecipeMaker.rating.onClick(this)" style="width: 24px !important; height: 24px !important;"><span aria-hidden="true" style="width: 120px !important; height: 24px !important;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="106.66666666667px" height="16px" viewBox="0 0 160 32">
+  <defs>
+	<polygon class="wprm-star-empty" id="wprm-star-empty-3" fill="none" stroke="#343434" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points="12,2.6 15,9 21.4,9 16.7,13.9 18.6,21.4 12,17.6 5.4,21.4 7.3,13.9 2.6,9 9,9" stroke-linejoin="miter"/>
+	<path class="wprm-star-full" id="wprm-star-full-3" fill="#343434" d="M12.712,1.942l2.969,6.015l6.638,0.965c0.651,0.095,0.911,0.895,0.44,1.354l-4.804,4.682l1.134,6.612c0.111,0.649-0.57,1.143-1.152,0.837L12,19.286l-5.938,3.122C5.48,22.714,4.799,22.219,4.91,21.57l1.134-6.612l-4.804-4.682c-0.471-0.459-0.211-1.26,0.44-1.354l6.638-0.965l2.969-6.015C11.579,1.352,12.421,1.352,12.712,1.942z"/>
+  </defs>
+	<use xlink:href="#wprm-star-full-3" x="4" y="4" />
+	<use xlink:href="#wprm-star-full-3" x="36" y="4" />
+	<use xlink:href="#wprm-star-full-3" x="68" y="4" />
+	<use xlink:href="#wprm-star-empty-3" x="100" y="4" />
+	<use xlink:href="#wprm-star-empty-3" x="132" y="4" />
+</svg></span><br><input aria-label="Rate this recipe 4 out of 5 stars" name="wprm-comment-rating" value="4" type="radio" onclick="WPRecipeMaker.rating.onClick(this)" style="width: 24px !important; height: 24px !important;"><span aria-hidden="true" style="width: 120px !important; height: 24px !important;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="106.66666666667px" height="16px" viewBox="0 0 160 32">
+  <defs>
+	<polygon class="wprm-star-empty" id="wprm-star-empty-4" fill="none" stroke="#343434" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points="12,2.6 15,9 21.4,9 16.7,13.9 18.6,21.4 12,17.6 5.4,21.4 7.3,13.9 2.6,9 9,9" stroke-linejoin="miter"/>
+	<path class="wprm-star-full" id="wprm-star-full-4" fill="#343434" d="M12.712,1.942l2.969,6.015l6.638,0.965c0.651,0.095,0.911,0.895,0.44,1.354l-4.804,4.682l1.134,6.612c0.111,0.649-0.57,1.143-1.152,0.837L12,19.286l-5.938,3.122C5.48,22.714,4.799,22.219,4.91,21.57l1.134-6.612l-4.804-4.682c-0.471-0.459-0.211-1.26,0.44-1.354l6.638-0.965l2.969-6.015C11.579,1.352,12.421,1.352,12.712,1.942z"/>
+  </defs>
+	<use xlink:href="#wprm-star-full-4" x="4" y="4" />
+	<use xlink:href="#wprm-star-full-4" x="36" y="4" />
+	<use xlink:href="#wprm-star-full-4" x="68" y="4" />
+	<use xlink:href="#wprm-star-full-4" x="100" y="4" />
+	<use xlink:href="#wprm-star-empty-4" x="132" y="4" />
+</svg></span><br><input aria-label="Rate this recipe 5 out of 5 stars" name="wprm-comment-rating" value="5" type="radio" onclick="WPRecipeMaker.rating.onClick(this)" id="wprm-comment-rating-355563626" style="width: 24px !important; height: 24px !important;"><span aria-hidden="true" style="width: 120px !important; height: 24px !important;"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="106.66666666667px" height="16px" viewBox="0 0 160 32">
+  <defs>
+	<path class="wprm-star-full" id="wprm-star-full-5" fill="#343434" d="M12.712,1.942l2.969,6.015l6.638,0.965c0.651,0.095,0.911,0.895,0.44,1.354l-4.804,4.682l1.134,6.612c0.111,0.649-0.57,1.143-1.152,0.837L12,19.286l-5.938,3.122C5.48,22.714,4.799,22.219,4.91,21.57l1.134-6.612l-4.804-4.682c-0.471-0.459-0.211-1.26,0.44-1.354l6.638-0.965l2.969-6.015C11.579,1.352,12.421,1.352,12.712,1.942z"/>
+  </defs>
+	<use xlink:href="#wprm-star-full-5" x="4" y="4" />
+	<use xlink:href="#wprm-star-full-5" x="36" y="4" />
+	<use xlink:href="#wprm-star-full-5" x="68" y="4" />
+	<use xlink:href="#wprm-star-full-5" x="100" y="4" />
+	<use xlink:href="#wprm-star-full-5" x="132" y="4" />
+</svg></span>		</fieldset>
+	</span>
+</div>
+<p class="comment-form-comment"><label for="comment">Comment <span class="required">*</span></label> <textarea id="comment" name="comment" cols="45" rows="8" maxlength="65525" required></textarea></p><p class="comment-form-author"><label for="author">Name <span class="required">*</span></label> <input id="author" name="author" type="text" value="" size="30" maxlength="245" autocomplete="name" required /></p>
+<p class="comment-form-email"><label for="email">Email <span class="required">*</span></label> <input id="email" name="email" type="email" value="" size="30" maxlength="100" aria-describedby="email-notes" autocomplete="email" required /></p>
+<p class="comment-form-url"><label for="url">Website</label> <input id="url" name="url" type="url" value="" size="30" maxlength="200" autocomplete="url" /></p>
+<p class="comment-form-cookies-consent"><input id="wp-comment-cookies-consent" name="wp-comment-cookies-consent" type="checkbox" value="yes" /> <label for="wp-comment-cookies-consent">Save my name, email, and website in this browser for the next time I comment.</label></p>
+<p class="form-submit"><input name="submit" type="submit" id="submit" class="submit" value="Post Comment" /> <input type='hidden' name='comment_post_ID' value='15600' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="9e4df67d67" /></p><p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="21"/><script>document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );</script></p></form>	</div><!-- #respond -->
+	</main><aside class="sidebar sidebar-primary widget-area" role="complementary" aria-label="Primary Sidebar" itemscope itemtype="https://schema.org/WPSideBar" id="genesis-sidebar-primary"><h2 class="genesis-sidebar-title screen-reader-text">Primary Sidebar</h2><section id="search-3" class="widget widget_search"><div class="widget-wrap"><h3 class="widgettitle widget-title">Search</h3>
+<form class="search-form" itemprop="potentialAction" itemscope itemtype="https://schema.org/SearchAction" method="get" action="https://creativecanning.com/" role="search"><meta itemprop="target" content="https://creativecanning.com/?s={s}"/><label class="search-form-label screen-reader-text" for="searchform-663553110e59a3.34199429">Search</label><input itemprop="query-input" type="search" name="s" id="searchform-663553110e59a3.34199429" placeholder="Search" /><input type="submit" value="Search" /></form></div></section>
+<section id="text-3" class="widget widget_text"><div class="widget-wrap"><h3 class="widgettitle widget-title">About This Site</h3>
+			<div class="textwidget"><p>Welcome to Creative Canning!  Learn how to create your own home canning recipes.</p>
+</div>
+		</div></section>
+</aside></div></div><div class="footer-widgets" id="genesis-footer-widgets"><h2 class="genesis-sidebar-title screen-reader-text">Footer</h2><div class="wrap"><div class="widget-area footer-widgets-1 footer-widget-area"><section id="text-6" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><p>Creative Canning is a personal blog and a <strong>woman-owned small business</strong>.  I am a participant in the <strong>Amazon Services LLC Associates Program</strong>, an affiliate advertising program designed to provide a means for sites to earn advertising fees by advertising and linking to Amazon.com. For more details, visit my<a href="https://creativecanning.com/disclosures-privacy-policy/" data-type="URL" data-id="https://adamantgardening.com/disclosures-privacy-policy/"> disclosures page</a>.</p>
+</div>
+		</div></section>
+</div></div></div><footer class="site-footer" itemscope itemtype="https://schema.org/WPFooter"><div class="wrap"><p>Copyright &#x000A9;&nbsp;2024 &middot; <a href="http://feastdesignco.com/">Foodie Pro</a> & <a href="http://www.studiopress.com/">The Genesis Framework</a></p></div></footer></div><a href="#mv-creation-41" id="mv-create-screen-reader-text-in-footer" class="mv-create-screen-reader-text">Skip to Recipe</a><script>var screenReaderLink=document.getElementById("mv-create-screen-reader-text-in-footer");document.body.prepend(screenReaderLink)</script><style>.mv-create-screen-reader-text{overflow:hidden;clip:rect(1px,1px,1px,1px);position:absolute!important;width:1px;height:1px;margin:-1px;padding:0;border:0;clip-path:inset(50%)}.mv-create-screen-reader-text:focus{clip:auto!important;z-index:1000000;top:5px;left:5px;width:auto;height:auto;padding:15px 23px 14px;color:#444;background-color:#eee;font-size:1em;line-height:normal;text-decoration:none;clip-path:none}</style><div id="mv-grow-data" data-settings='{&quot;floatingSidebar&quot;:{&quot;stopSelector&quot;:false},&quot;general&quot;:{&quot;contentSelector&quot;:false,&quot;show_count&quot;:{&quot;content&quot;:false,&quot;sidebar&quot;:false},&quot;isTrellis&quot;:false},&quot;post&quot;:{&quot;ID&quot;:15600,&quot;categories&quot;:[{&quot;ID&quot;:68}]},&quot;shareCounts&quot;:{&quot;facebook&quot;:574,&quot;pinterest&quot;:167},&quot;shouldRun&quot;:true,&quot;buttonSVG&quot;:{&quot;share&quot;:{&quot;height&quot;:32,&quot;width&quot;:26,&quot;paths&quot;:[&quot;M20.8 20.8q1.984 0 3.392 1.376t1.408 3.424q0 1.984-1.408 3.392t-3.392 1.408-3.392-1.408-1.408-3.392q0-0.192 0.032-0.448t0.032-0.384l-8.32-4.992q-1.344 1.024-2.944 1.024-1.984 0-3.392-1.408t-1.408-3.392 1.408-3.392 3.392-1.408q1.728 0 2.944 0.96l8.32-4.992q0-0.128-0.032-0.384t-0.032-0.384q0-1.984 1.408-3.392t3.392-1.408 3.392 1.376 1.408 3.424q0 1.984-1.408 3.392t-3.392 1.408q-1.664 0-2.88-1.024l-8.384 4.992q0.064 0.256 0.064 0.832 0 0.512-0.064 0.768l8.384 4.992q1.152-0.96 2.88-0.96z&quot;]},&quot;facebook&quot;:{&quot;height&quot;:32,&quot;width&quot;:18,&quot;paths&quot;:[&quot;M17.12 0.224v4.704h-2.784q-1.536 0-2.080 0.64t-0.544 1.92v3.392h5.248l-0.704 5.28h-4.544v13.568h-5.472v-13.568h-4.544v-5.28h4.544v-3.904q0-3.328 1.856-5.152t4.96-1.824q2.624 0 4.064 0.224z&quot;]},&quot;twitter&quot;:{&quot;height&quot;:30,&quot;width&quot;:32,&quot;paths&quot;:[&quot;M30.3 29.7L18.5 12.4l0 0L29.2 0h-3.6l-8.7 10.1L10 0H0.6l11.1 16.1l0 0L0 29.7h3.6l9.7-11.2L21 29.7H30.3z M8.6 2.7 L25.2 27h-2.8L5.7 2.7H8.6z&quot;]},&quot;pinterest&quot;:{&quot;height&quot;:32,&quot;width&quot;:23,&quot;paths&quot;:[&quot;M0 10.656q0-1.92 0.672-3.616t1.856-2.976 2.72-2.208 3.296-1.408 3.616-0.448q2.816 0 5.248 1.184t3.936 3.456 1.504 5.12q0 1.728-0.32 3.36t-1.088 3.168-1.792 2.656-2.56 1.856-3.392 0.672q-1.216 0-2.4-0.576t-1.728-1.568q-0.16 0.704-0.48 2.016t-0.448 1.696-0.352 1.28-0.48 1.248-0.544 1.12-0.832 1.408-1.12 1.536l-0.224 0.096-0.16-0.192q-0.288-2.816-0.288-3.36 0-1.632 0.384-3.68t1.184-5.152 0.928-3.616q-0.576-1.152-0.576-3.008 0-1.504 0.928-2.784t2.368-1.312q1.088 0 1.696 0.736t0.608 1.824q0 1.184-0.768 3.392t-0.8 3.36q0 1.12 0.8 1.856t1.952 0.736q0.992 0 1.824-0.448t1.408-1.216 0.992-1.696 0.672-1.952 0.352-1.984 0.128-1.792q0-3.072-1.952-4.8t-5.12-1.728q-3.552 0-5.952 2.304t-2.4 5.856q0 0.8 0.224 1.536t0.48 1.152 0.48 0.832 0.224 0.544q0 0.48-0.256 1.28t-0.672 0.8q-0.032 0-0.288-0.032-0.928-0.288-1.632-0.992t-1.088-1.696-0.576-1.92-0.192-1.92z&quot;]}},&quot;inlineContentHook&quot;:[&quot;genesis_loop&quot;,&quot;loop_start&quot;]}'></div><aside id="dpsp-floating-sidebar" aria-label="social sharing sidebar" class="dpsp-shape-rectangular dpsp-size-medium   dpsp-hide-on-mobile dpsp-position-left dpsp-button-style-1 dpsp-no-animation" data-trigger-scroll="false">
+	</aside>
+<link rel='stylesheet' id='mv-create-card_big-image-css' href='https://creativecanning.com/wp-content/plugins/mediavine-create/client/build/card-big-image.1.9.5.css?ver=1.9.5' type='text/css' media='all' />
+<script type="text/javascript" async data-noptimize src="https://creativecanning.com/wp-content/plugins/social-pug/assets/dist/front-end-free.js?ver=1.33.2" id="dpsp-frontend-js-pro-js"></script>
+<script type="text/javascript" src="https://creativecanning.com/wp-includes/js/comment-reply.min.js?ver=6.4.4" id="comment-reply-js" async="async" data-wp-strategy="async"></script>
+<script type="text/javascript" src="https://creativecanning.com/wp-content/themes/genesis/lib/js/skip-links.js?ver=2.5.0" id="skip-links-js"></script>
+<script type="text/javascript" src="https://creativecanning.com/wp-content/themes/foodie-pro/assets/js/general.js?ver=3.0.0" id="foodie-pro-general-js"></script>
+<script type="text/javascript" src="https://stats.wp.com/e-202418.js" id="jetpack-stats-js" data-wp-strategy="defer"></script>
+<script type="text/javascript" id="jetpack-stats-js-after">
+/* <![CDATA[ */
+_stq = window._stq || [];
+_stq.push([ "view", JSON.parse("{\"v\":\"ext\",\"blog\":\"209227195\",\"post\":\"15600\",\"tz\":\"-4\",\"srv\":\"creativecanning.com\",\"j\":\"1:13.3.1\"}") ]);
+_stq.push([ "clickTrackerInit", "209227195", "15600" ]);
+/* ]]> */
+</script>
+<script type="text/javascript" id="mv_create/client.js-js-extra">
+/* <![CDATA[ */
+var MV_CREATE_SETTINGS = {"__API_ROOT__":"https:\/\/creativecanning.com\/wp-json\/","__REVIEWS_DIV__":null,"__PROMPT_THRESHOLD__":"5.5","__SUBMIT_THRESHOLD__":"5.5","__PX_BETWEEN_ADS__":null,"__OPTIONS__":{"reviews_ctas":false,"jtc_enabled":false,"asset_url":"https:\/\/creativecanning.com\/wp-content\/plugins\/mediavine-create\/","wakeLockEnabled":false}};
+var MV_CREATE_I18N = {"COMMENTS":"Comments","COMMENTS_AND_REVIEWS":"Comments & Reviews","RATING":"Rating","REVIEWS":"Reviews","RATING_SUBMITTED":"Your rating has been submitted. Write a review below (optional).","X_REVIEWS_FOR":"%1$s Reviews for %2$s","X_REVIEW_FOR":"%1$s Review for %2$s","LOADING":"Loading","VIEW_MORE":"View More","NUM_REVIEW":"%s Review","NUM_REVIEWS":"%s Reviews","REVIEW":"Review","NUM_STARS":"%s Stars","STARS":"Stars","STAR":"Star","TITLE":"Title","ANONYMOUS_USER":"Anonymous User","NO_TITLE":"No Title","CONTENT":"Content","NO_RATINGS":"No Ratings","NAME":"Name","EMAIL":"Email","REVIEW_TITLE":"Review Title","REVIEW_CONTENT":"Review","CONSENT":"To submit this review, I consent to the collection of this data.","SUBMIT_REVIEW":"Submit Review","SUBMITTING":"Submitting","UPDATE":"Update Review","THANKS_RATING":"Thanks for the rating!","DID_YOU_MAKE_THIS":"Did you make this? Tell us about it!","LEAVE_REVIEW":"Leave a review","THANKS_REVIEW":"Thanks for the review!","PRINT":"Print","YIELD":"Yield","SERVING_SIZE":"Serving Size","AMOUNT_PER_SERVING":"Amount Per Serving","CUISINE":"Cuisine","PROJECT_TYPE":"Project Type","TYPE":"Type","CATEGORY":"Category","RECOMMENDED_PRODUCTS":"Recommended Products","AFFILIATE_NOTICE":"As an Amazon Associate and member of other affiliate programs, I earn from qualifying purchases.","TOOLS":"Tools","MATERIALS":"Materials","INGREDIENTS":"Ingredients","INSTRUCTIONS":"Instructions","NOTES":"Notes","CALORIES":"Calories","TOTAL_FAT":"Total Fat","SATURATED_FAT":"Saturated Fat","TRANS_FAT":"Trans Fat","UNSATURATED_FAT":"Unsaturated Fat","CHOLESTEROL":"Cholesterol","SODIUM":"Sodium","CARBOHYDRATES":"Carbohydrates","NET_CARBOHYDRATES":"Net Carbohydrates","FIBER":"Fiber","SUGAR":"Sugar","SUGAR_ALCOHOLS":"Sugar Alcohols","PROTEIN":"Protein"};
+/* ]]> */
+</script>
+<script type="text/javascript" async data-noptimize src="https://creativecanning.com/wp-content/plugins/mediavine-create/client/build/bundle.1.9.5.js?ver=1.9.5" id="mv_create/client.js-js"></script>
+<script defer type="text/javascript" src="https://creativecanning.com/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1711306867" id="akismet-frontend-js"></script>
+</body></html>


### PR DESCRIPTION
The idea for this refactor originates from code-review of #1116.

There are two motivations:

  * Selection of a scraper should be possible based on the origin URL as input (this was already catered-for).
  * Domain names and brands can be merged/acquired over time, so if two sites appear distinct in the view of a typical consumer -- even if they are known to be owned by the same entity, and present the same content -- then we should retain different scraper classes for each of them.  Internally they may re-use implementation (as is the case here).