### PR TITLE
fix(deps): bump extruct and remove lxml pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version", "readme"]
 requires-python = ">= 3.8"
 dependencies = [
     "beautifulsoup4 >= 4.12.3",
-    "extruct >= 0.15.0",
+    "extruct >= 0.17.0",
     "isodate >= 0.6.1",
     "requests >= 2.31.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -e .
 coverage>=7.4.4
-lxml<5.1.1  # https://github.com/scrapinghub/extruct/issues/215
 responses>=0.25.0
 types-beautifulsoup4>=4.12.0
 types-requests>=2.31.0


### PR DESCRIPTION
A [new version of extruct](https://github.com/scrapinghub/extruct/releases/tag/v0.17.0) has been published which fixes https://github.com/hhursev/recipe-scrapers/issues/1045 which is the reason we pinned lxml. Bumping extruct allows us to use any lxml version again.

(fixes https://github.com/hhursev/recipe-scrapers/issues/1045)