### PR TITLE
Bakels: extend to add support for .co.uk domain.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,7 @@ Scrapers available for:
 - `https://www.atelierdeschefs.fr/ <https://www.atelierdeschefs.fr/>`_
 - `https://averiecooks.com/ <https://www.averiecooks.com/>`_
 - `https://www.bakels.com.au/ <https://www.bakels.com.au/>`_
+    - `.co.uk <https://bakels.co.uk/>`_
 - `https://baking-sense.com/ <https://baking-sense.com/>`_
 - `https://bakingmischief.com/ <https://bakingmischief.com/>`_
 - `https://barefeetinthekitchen.com/ <https://barefeetinthekitchen.com/>`_

--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -382,6 +382,7 @@ SCRAPERS = {
     BBCFood.host(domain="co.uk"): BBCFood,
     BBCGoodFood.host(): BBCGoodFood,
     Bakels.host(): Bakels,
+    Bakels.host(domain="co.uk"): Bakels,
     BakingSense.host(): BakingSense,
     BakingMischief.host(): BakingMischief,
     BareFootContessa.host(): BareFootContessa,

--- a/recipe_scrapers/bakels.py
+++ b/recipe_scrapers/bakels.py
@@ -6,11 +6,11 @@ from ._grouping_utils import group_ingredients
 
 class Bakels(AbstractScraper):
     @classmethod
-    def host(cls):
-        return "bakels.com.au"
+    def host(cls, domain="com.au"):
+        return f"bakels.{domain}"
 
     def author(self):
-        return "Australian Bakels"
+        return self.site_name()
 
     def title(self):
         return self.soup.find("h1").get_text()
@@ -56,7 +56,7 @@ class Bakels(AbstractScraper):
         if not tag:
             return None
 
-        instructions = tag.get_text(separator="\n", strip=True)
+        instructions = div.get_text(separator="\n", strip=True)
         instructions = "\n".join(
             step.split(". ", 1)[-1] for step in instructions.split("\n")
         )  # Removes the instruction number from each step

--- a/tests/test_data/bakels.co.uk/bakels.json
+++ b/tests/test_data/bakels.co.uk/bakels.json
@@ -1,0 +1,39 @@
+{
+  "author": "British Bakels",
+  "canonical_url": "https://www.britishbakels.co.uk/recipes/multiseed-rolls/",
+  "site_name": "British Bakels",
+  "host": "bakels.com.au",
+  "language": "en",
+  "title": "Multiseed Rolls",
+  "ingredients": [
+    "Wheat flour",
+    "Country Oven® Multiseed Bread Concentrate",
+    "Yeast",
+    "Water"
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "Wheat flour",
+        "Country Oven® Multiseed Bread Concentrate",
+        "Yeast",
+        "Water"
+      ],
+      "purpose": null
+    }
+  ],
+  "instructions": "Place all of the ingredients into a spiral mixing bowl.\nMix for 3 minutes on slow speed and 7 minutes on fast speed, until fully developed.\nDough temperature should be 24-26℃.\nScale at 90g for soft and crusty rolls.\nProve for 50 minutes.\nBake at 230℃ for 12 minutes (soft rolls: no steam, crusty rolls: with steam).\nYield\n: 169 rolls",
+  "instructions_list": [
+    "Place all of the ingredients into a spiral mixing bowl.",
+    "Mix for 3 minutes on slow speed and 7 minutes on fast speed, until fully developed.",
+    "Dough temperature should be 24-26℃.",
+    "Scale at 90g for soft and crusty rolls.",
+    "Prove for 50 minutes.",
+    "Bake at 230℃ for 12 minutes (soft rolls: no steam, crusty rolls: with steam).",
+    "Yield",
+    ": 169 rolls"
+  ],
+  "category": "Bakery",
+  "description": "Multiseed Rolls",
+  "image": "https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large.jpg"
+}

--- a/tests/test_data/bakels.co.uk/bakels.testhtml
+++ b/tests/test_data/bakels.co.uk/bakels.testhtml
@@ -1,0 +1,4285 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+        <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="https://www.britishbakels.co.uk/feed/" />
+    	<link rel="shortcut icon" href="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/images/favicon.ico" />
+        <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+
+<!-- Google Tag Manager for WordPress by gtm4wp.com -->
+<script data-cfasync="false" data-pagespeed-no-defer>
+	var gtm4wp_datalayer_name = "dataLayer";
+	var dataLayer = dataLayer || [];
+</script>
+<!-- End Google Tag Manager for WordPress by gtm4wp.com -->
+	<!-- This site is optimized with the Yoast SEO plugin v22.7 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Multiseed Rolls - British Bakels</title>
+<link rel="preload" as="font" href="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/fonts/5c8d59c2-9c85-4a22-88e3-bf3fba01dcd8.woff2" crossorigin>
+<link rel="preload" as="font" href="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/fonts/9fa24f1f-00d8-4d28-910f-78e925eaead6.woff2" crossorigin>
+<link rel="preload" as="font" href="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/fonts/452edecf-b228-4999-870a-a817fafba5bd.woff2" crossorigin>
+<link rel="preload" as="font" href="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/fonts/8a711a0d-3f17-4bfe-887b-6229858332b3.woff2" crossorigin>
+<link rel="preload" as="font" href="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/fonts/fontawesome-webfont.woff2?v=4.7.0" crossorigin>
+<link rel="preload" as="font" href="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/fonts/slick.woff" crossorigin>
+	<meta name="description" content="With a delicious bite and backed as a source of fibre and protein, your customers are sure to come back for more!" />
+	<link rel="canonical" href="https://www.britishbakels.co.uk/recipes/multiseed-rolls/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Multiseed Rolls" />
+	<meta property="og:description" content="With a delicious bite and backed as a source of fibre and protein, your customers are sure to come back for more!" />
+	<meta property="og:url" content="https://www.britishbakels.co.uk/recipes/multiseed-rolls/" />
+	<meta property="og:site_name" content="British Bakels" />
+	<meta property="article:modified_time" content="2023-08-28T16:11:19+00:00" />
+	<meta property="og:image" content="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large.jpg" />
+	<meta property="og:image:width" content="1619" />
+	<meta property="og:image:height" content="1080" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="Multiseed Rolls" />
+	<meta name="twitter:description" content="With a delicious bite and backed as a source of fibre and protein, your customers are sure to come back for more!" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://www.britishbakels.co.uk/recipes/multiseed-rolls/","url":"https://www.britishbakels.co.uk/recipes/multiseed-rolls/","name":"Multiseed Rolls - British Bakels","isPartOf":{"@id":"https://www.britishbakels.co.uk/#website"},"primaryImageOfPage":{"@id":"https://www.britishbakels.co.uk/recipes/multiseed-rolls/#primaryimage"},"image":{"@id":"https://www.britishbakels.co.uk/recipes/multiseed-rolls/#primaryimage"},"thumbnailUrl":"https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large.jpg","datePublished":"2018-10-16T10:42:24+00:00","dateModified":"2023-08-28T16:11:19+00:00","description":"With a delicious bite and backed as a source of fibre and protein, your customers are sure to come back for more!","breadcrumb":{"@id":"https://www.britishbakels.co.uk/recipes/multiseed-rolls/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://www.britishbakels.co.uk/recipes/multiseed-rolls/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.britishbakels.co.uk/recipes/multiseed-rolls/#primaryimage","url":"https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large.jpg","contentUrl":"https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large.jpg","width":1619,"height":1080},{"@type":"BreadcrumbList","@id":"https://www.britishbakels.co.uk/recipes/multiseed-rolls/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.britishbakels.co.uk/"},{"@type":"ListItem","position":2,"name":"Multiseed Rolls"}]},{"@type":"WebSite","@id":"https://www.britishbakels.co.uk/#website","url":"https://www.britishbakels.co.uk/","name":"British Bakels","description":"","potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.britishbakels.co.uk/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-US"}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//cc.cdn.civiccomputing.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel='dns-prefetch' href='//use.typekit.net' />
+<link rel='dns-prefetch' href='//britishbakels.b-cdn.net' />
+<link rel='dns-prefetch' href='//googletagmanager.com' />
+<link rel='dns-prefetch' href='//p.typekit.net' />
+<link rel='dns-prefetch' href='//google-analytics.com' />
+
+<link href='https://britishbakels.b-cdn.net' rel='preconnect' />
+<link rel="alternate" type="application/rss+xml" title="British Bakels &raquo; Multiseed Rolls Comments Feed" href="https://www.britishbakels.co.uk/recipes/multiseed-rolls/feed/" />
+		
+	<link rel='stylesheet' id='wpmf-bakery-style-css' href='https://www.britishbakels.co.uk/wp-content/plugins/wp-media-folder/assets/css/vc_style.css?ver=5.8.4' type='text/css' media='all' />
+<style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.britishbakels.co.uk/wp-includes/css/dist/block-library/style.min.css?ver=6.5.3' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='cookieconsent-style-css' href='https://www.britishbakels.co.uk/wp-content/plugins/insites-cookie-consent/assets/cookie-consent/cookieconsent.min.css?ver=3.1' type='text/css' media='all' />
+<link rel='stylesheet' id='tablepress-default-css' href='https://www.britishbakels.co.uk/wp-content/plugins/tablepress/css/build/default.css?ver=2.3.1' type='text/css' media='all' />
+<link rel='stylesheet' id='bakels-style-css' href='https://www.britishbakels.co.uk/wp-content/themes/bakels-local/style.css?ver=9.5.4' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-paginate-css' href='https://www.britishbakels.co.uk/wp-content/plugins/wp-paginate/css/wp-paginate.css?ver=2.2.2' type='text/css' media='screen' />
+<script type="text/javascript" src="https://www.britishbakels.co.uk/wp-content/plugins/insites-cookie-consent/assets/cookie-consent/cookieconsent.min.js?ver=3.1" id="cookieconsent-script-js"></script>
+<script type="text/javascript" src="https://www.britishbakels.co.uk/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://www.britishbakels.co.uk/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
+<script type="text/javascript" id="country-mobile-js-extra">
+/* <![CDATA[ */
+var ajax_bakels_country = {"ajaxurl":"https:\/\/www.britishbakels.co.uk\/wp-admin\/admin-ajax.php","redirecturl":"\/recipes\/multiseed-rolls\/","loadingmessage":"Loading..."};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/js/country-mobile.min.js?ver=1.0" id="country-mobile-js"></script>
+<script></script><link rel="https://api.w.org/" href="https://www.britishbakels.co.uk/wp-json/" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.britishbakels.co.uk/xmlrpc.php?rsd" />
+<link rel='shortlink' href='https://www.britishbakels.co.uk/?p=3128' />
+<link rel="alternate" type="application/json+oembed" href="https://www.britishbakels.co.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.britishbakels.co.uk%2Frecipes%2Fmultiseed-rolls%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.britishbakels.co.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.britishbakels.co.uk%2Frecipes%2Fmultiseed-rolls%2F&#038;format=xml" />
+<meta name="generator" content="WPML ver:4.6.11 stt:1;" />
+<!-- Stream WordPress user activity plugin v4.0.0 -->
+
+<!-- Google Tag Manager for WordPress by gtm4wp.com -->
+<!-- GTM Container placement set to manual -->
+<script data-cfasync="false" data-pagespeed-no-defer>
+	var dataLayer_content = {"pagePostType":"recipes","pagePostType2":"single-recipes","pagePostAuthor":"Mcoates"};
+	dataLayer.push( dataLayer_content );
+</script>
+<script data-cfasync="false">
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MJ6G7G');
+</script>
+<!-- End Google Tag Manager for WordPress by gtm4wp.com -->	<script>
+	// Search Market
+	function searchMarkets() {
+		// Declare variables
+		var input, filter, ul, li, a, i, txtValue;
+		input = document.getElementById('search-markets');
+		filter = input.value.toUpperCase();
+		ul = document.getElementById("markets");
+		li = ul.getElementsByTagName('li');
+
+		// Loop through all list items, and hide those who don't match the search query
+		for (i = 0; i < li.length; i++) {
+			a = li[i].getElementsByTagName("a")[0];
+			txtValue = a.textContent || a.innerText;
+			if (txtValue.toUpperCase().indexOf(filter) > -1) {
+			li[i].style.display = "";
+			} else {
+			li[i].style.display = "none";
+			}
+		}
+	}
+
+	function mobilsearcheMarkets() {
+		// Declare variables
+		var input, filter, ul, li, a, i, txtValue;
+		input = document.getElementById('mobile-search-markets');
+		filter = input.value.toUpperCase();
+		ul = document.getElementById("mobile-markets");
+		li = ul.getElementsByTagName('li');
+
+		// Loop through all list items, and hide those who don't match the search query
+		for (i = 0; i < li.length; i++) {
+			a = li[i].getElementsByTagName("a")[0];
+			txtValue = a.textContent || a.innerText;
+			if (txtValue.toUpperCase().indexOf(filter) > -1) {
+			li[i].style.display = "";
+			} else {
+			li[i].style.display = "none";
+			}
+		}
+	}
+
+	// Search Market
+	function searchStockist() {
+		// Declare variables
+		var containerArr = ['tab-stockists', 'stockists'];
+		containerArr.forEach(function(id) {
+			var container, input, filter, ul, li, i, company, companyValue, sku, skuValue, packsize, packsizeValue;
+			container = document.getElementById(id);
+			input = container.querySelector('#search-stockist');
+			filter = input.value.toUpperCase();
+			ul = container.querySelector('#stockist');
+			li = ul.querySelectorAll('.stockist-row');
+
+			// Loop through all list items, and hide those who don't match the search query
+			for (i = 0; i < li.length; i++) {
+				company = li[i].querySelector('.stockist-company');
+				companyValue = company.textContent || company.innerText;
+
+				sku = li[i].querySelector('.stockist-sku');
+				skuValue = sku.textContent || sku.innerText;
+
+				packsize = li[i].querySelector('.pack-size');
+				packsizeValue = packsize.textContent || packsize.innerText;
+
+				if ( companyValue.toUpperCase().indexOf(filter) > -1 || skuValue.toUpperCase().indexOf(filter) > -1 || packsizeValue.toUpperCase().indexOf(filter) > -1) {
+					li[i].style.display = "";
+				} else {
+					li[i].style.display = "none";
+				}
+			}
+		});
+	}
+	</script>
+		<script>
+	// Search Options
+	function searchFilter(input = null) {
+		// Declare variables
+		var filter, tax, parent, ul, li, label, i, txtValue, clearText;
+
+		var getArrayFromTag = function(element, tagname) {
+			//get the NodeList and transform it into an array
+			return Array.prototype.slice.call(element.getElementsByTagName(tagname));
+		}
+
+		filter = input.value.toUpperCase();
+		tax = input.dataset.tax;
+		parent = document.getElementById('field-option-'+tax);
+		clearText = parent.querySelector('.clear-text');
+		ul = parent.querySelector('.option-list');
+		li = getArrayFromTag(ul, 'li');
+
+		// Loop through all list items, and hide those who don't match the search query
+		for (i = 0; i < li.length; i++) {
+			label = li[i].getElementsByTagName('span')[0];
+			txtValue = label.textContent || label.innerText;
+
+			if (txtValue.toUpperCase().indexOf(filter) > -1) {
+				li[i].style.display = "";
+			} else {
+				// Declare child variables
+				var displayParent = 0, ulChild, liChild, j, labelChild, txtValueChild;
+
+				ulChild = li[i].querySelector('.suboption-list');
+
+				if( ulChild ) {
+					liChild = getArrayFromTag(ulChild, 'li');
+					for (j = 0; j < liChild.length; j++) {
+						labelChild = liChild[j].getElementsByTagName('span')[0];
+						txtValueChild = labelChild.textContent || labelChild.innerText;
+
+						if (txtValueChild.toUpperCase().indexOf(filter) > -1) {
+							liChild[j].style.display = "";
+
+							displayParent = 1;
+						} else {
+							liChild[j].style.display = "none";
+						}
+					}
+
+					if( displayParent == 0 ) {
+						li[i].style.display = "none";
+					} else {
+						li[i].style.display = "";
+					}
+				} else {
+					li[i].style.display = "none";
+				}
+			}
+		}
+
+
+		// Show button
+		if( input.value.length > 0 ) {
+			if( !clearText.classList.contains('clear-text-show') ) {
+				clearText.classList.add('clear-text-show');
+			}
+		} else {
+			clearText.classList.remove('clear-text-show');
+		}
+
+		// Clear text
+		clearText.addEventListener('click', function(e){
+			input.value = '';
+			e.target.classList.remove('clear-text-show');
+		}, false);
+	}
+	</script>
+	<link rel="alternate" href="https://www.sbakels.co.za" hreflang="en" /><link rel="alternate" href="https://www.maybakels.com" hreflang="en" /><link rel="alternate" href="https://www.bakelsph.com" hreflang="en" /><link rel="alternate" href="https://www.finnbakels.fi" hreflang="fi" /><link rel="alternate" href="https://www.irishbakels.ie" hreflang="en" /><link rel="alternate" href="https://www.bakelssweden.se" hreflang="sv" /><link rel="alternate" href="https://www.britishbakels.co.uk" hreflang="en" /><link rel="alternate" href="https://www.bakels.com.br" hreflang="pt" /><link rel="alternate" href="https://www.bakels.pe" hreflang="es" /><script type='text/javascript'>
+                    var imdmsTypeaheadJSON = 'typeaheadJSON_en';
+                    localStorage.setItem( 'typeaheadJSON_en', JSON.stringify( [{"id":15207,"title":"A story of COVID business pivoting: Beer Bread","url":"https:\/\/www.britishbakels.co.uk\/insights\/beer-bread-and-covid\/","post_type":"Insights","access_levels":null},{"id":3165,"title":"Aberdeen Softie Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/aberdeen-softies\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3070,"title":"Actiwhite\u00ae Meringue Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/actiwhite-meringue-mix\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Meringue Mixes","sku":"311010, 311050","access_levels":"public_access"},{"id":14927,"title":"Addressing Consumer Concern Around Healthy Bread Options","url":"https:\/\/www.britishbakels.co.uk\/insights\/consumer-concern-around-healthy-bread-options\/","post_type":"Insights","access_levels":null},{"id":19481,"title":"Addressing Sustainability Issues around Palm Oil","url":"https:\/\/www.britishbakels.co.uk\/insights\/sustainability-issues-around-palm-oil\/","post_type":"Insights","access_levels":null},{"id":3247,"title":"Almond Easter Basket","url":"https:\/\/www.britishbakels.co.uk\/recipes\/almond-easter-basket\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":5146,"title":"Almond Strudel Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-almond-strudel\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4511,"title":"Alpine Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/alpine-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4470,"title":"American Pancake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/american-pancake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4670,"title":"Apple & Vanilla Danish with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/apple-and-vanilla-danish-with-sourdough\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3206,"title":"Apple and Cider Banana Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/apple-and-cider-banana-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3168,"title":"Apple Filling","url":"https:\/\/www.britishbakels.co.uk\/recipes\/apple-filling\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24799,"title":"Aromatic Colours","url":"https:\/\/www.britishbakels.co.uk\/products\/aromatic-colours\/","post_type":"Products","tax_terms":"Colours, Flavours & Colours","sku":"N\/A","access_levels":"public_access"},{"id":24678,"title":"Aromatic Flavours","url":"https:\/\/www.britishbakels.co.uk\/products\/aromatic-flavours\/","post_type":"Products","tax_terms":"Flavours, Flavours & Colours","sku":"N\/A","access_levels":"public_access"},{"id":20954,"title":"Artisan Baguette: Fermdor\u00ae Active","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-baguette-fermdor-active\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3323,"title":"Artisan Boule Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-boule-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3329,"title":"Artisan Boule Straight Process","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-boule-straight-process-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":20958,"title":"Artisan Cheddar & Chive: Fermdor\u00ae Active Durum","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-cheddar-chive-fermdor-active-durum\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":13950,"title":"Artisan Ciabatta Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-ciabatta-roll-recipe\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3324,"title":"Artisan Mixed Olive Flute","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-mixed-olive-flute-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":20960,"title":"Artisan Mixed Olive: Fermdor\u00ae Active Durum","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-mixed-olive-fermdor-active-durum\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":7058,"title":"Artisan Rye Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-rye-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3328,"title":"Artisan Vienna Roll","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-vienna-roll\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":20963,"title":"Artisan: Fermdor\u00ae Active","url":"https:\/\/www.britishbakels.co.uk\/recipes\/artisan-fermdor-active\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":9600,"title":"Assorted Easter Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/assorted-easter-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3391,"title":"Australia","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/australia\/","post_type":"Baking Centres","access_levels":null},{"id":25815,"title":"Babka Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/babka-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":2981,"title":"Bacom","url":"https:\/\/www.britishbakels.co.uk\/products\/bacom\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crumb Softeners","sku":"218250","access_levels":"public_access"},{"id":3040,"title":"Bacom Cake Plus","url":"https:\/\/www.britishbakels.co.uk\/products\/bacom-cake-plus\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake Shelf Life Extenders","sku":"218135M, 218140M","access_levels":"public_access"},{"id":2982,"title":"Bacom Mellow","url":"https:\/\/www.britishbakels.co.uk\/products\/bacom-mellow\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crumb Softeners","sku":"218030","access_levels":"public_access"},{"id":3039,"title":"Bacom Soft","url":"https:\/\/www.britishbakels.co.uk\/products\/bacom-cake\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake Shelf Life Extenders","sku":"218160M","access_levels":"public_access"},{"id":5016,"title":"Bagel with Spelt Sourdough Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/bagel-with-spelt-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4544,"title":"Baguette with Smoked Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/smoked-sourdough-baguette\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":22190,"title":"Bake your way to success on TikTok","url":"https:\/\/www.britishbakels.co.uk\/insights\/bake-your-way-to-success-on-tiktok\/","post_type":"Insights","access_levels":"public_access"},{"id":7742,"title":"Bakels add bake-stable fillings to vegan range","url":"https:\/\/www.britishbakels.co.uk\/bakels-add-bake-stable-fillings-to-vegan-range\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":4930,"title":"Bakels add Fudgices to Vegan offering","url":"https:\/\/www.britishbakels.co.uk\/bakels-add-fudgices-to-vegan-offering\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":3383,"title":"Bakels expand True Caramel range","url":"https:\/\/www.britishbakels.co.uk\/bakels-expand-true-caramel-range\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":5262,"title":"Bakels host students from The Worshipful Company of Bakers","url":"https:\/\/www.britishbakels.co.uk\/bakels-host-students-from-the-worshipful-company-of-bakers\/","post_type":"Posts","tax_terms":"People","access_levels":null},{"id":19302,"title":"Bakels launch all new Premium Scone Mix","url":"https:\/\/www.britishbakels.co.uk\/bakels-launch-all-new-premium-scone-mix\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":19778,"title":"Bakels launch festive recipe lineup","url":"https:\/\/www.britishbakels.co.uk\/festive-recipe-series-2021\/","post_type":"Posts","tax_terms":"Recipes","access_levels":null},{"id":3385,"title":"Bakels launch new Instant Cream","url":"https:\/\/www.britishbakels.co.uk\/bakels-launch-instant-cream\/","post_type":"Posts","tax_terms":"Recipes, Products","access_levels":null},{"id":4296,"title":"Bakels launch New Multimix Vegan Cake Complete","url":"https:\/\/www.britishbakels.co.uk\/bakels-launch-new-multimix-vegan-cake-complete\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":17856,"title":"Bakels launch Summer Series of recipes","url":"https:\/\/www.britishbakels.co.uk\/summer-series-2021\/","post_type":"Posts","tax_terms":"Recipes","access_levels":null},{"id":18186,"title":"Bakels make chocolate addition to True Caramel range","url":"https:\/\/www.britishbakels.co.uk\/bakels-make-chocolate-addition-to-true-caramel-range\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":9725,"title":"Bakels make fruity addition to True Caramel range","url":"https:\/\/www.britishbakels.co.uk\/bakels-make-fruity-addition-to-true-caramel-range\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":26590,"title":"Bakels partner with Bicester foodbank to support local","url":"https:\/\/www.britishbakels.co.uk\/bakels-partner-with-bicester-foodbank-to-support-local\/","post_type":"Posts","tax_terms":"Sustainability","access_levels":null},{"id":14612,"title":"Bakels push health in Country Oven revamp","url":"https:\/\/www.britishbakels.co.uk\/bakels-push-health-in-country-oven-revamp\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":4032,"title":"Bakels raise capacity with New Distribution Centre","url":"https:\/\/www.britishbakels.co.uk\/bakels-raise-capacity-with-new-distribution-centre\/","post_type":"Posts","tax_terms":"Investments","access_levels":null},{"id":3382,"title":"Bakels relaunch Country Oven brand with new Rye Bread Concentrate","url":"https:\/\/www.britishbakels.co.uk\/bakels-relaunch-country-oven-brand-with-new-rye-bread-concentrate\/","post_type":"Posts","tax_terms":"Products, Recipes","access_levels":null},{"id":3006,"title":"Bakels Relax","url":"https:\/\/www.britishbakels.co.uk\/products\/bakels-relax\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Dough Relaxant, Pastry Relaxer","sku":"255055","access_levels":"public_access"},{"id":30344,"title":"Bakels Relax Clean Label","url":"https:\/\/www.britishbakels.co.uk\/products\/bakels-relax-clean-label\/","post_type":"Products","tax_terms":"Dough Relaxant","sku":"","access_levels":"public_access"},{"id":17433,"title":"Bakels Senior","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/bakels-senior\/","post_type":"Baking Centres","access_levels":null},{"id":4409,"title":"Bakels team up with Bako Wales to present Bakery Trends at Neath College","url":"https:\/\/www.britishbakels.co.uk\/bakels-team-up-with-bako-wales-to-present-bakery-trends-at-neath-college\/","post_type":"Posts","tax_terms":"Events","access_levels":null},{"id":25726,"title":"Bakels team up with the Worshipful Company of Bakers for 2022 Bursary Course","url":"https:\/\/www.britishbakels.co.uk\/bakels-team-up-with-the-worshipful-company-of-bakers-for-2022-bursary-course\/","post_type":"Posts","tax_terms":"Events","access_levels":null},{"id":23514,"title":"Bakels team up with The Worshipful Company of Bakers to support local","url":"https:\/\/www.britishbakels.co.uk\/bakels-team-up-with-worshipful-company-of-bakers-to-support-local\/","post_type":"Posts","tax_terms":"Events","access_levels":null},{"id":3386,"title":"Bakels turns up the heat with the next generation of caramels","url":"https:\/\/www.britishbakels.co.uk\/bakels-turns-up-the-heat-with-the-next-generation-of-caramels\/","post_type":"Posts","tax_terms":"Products, Recipes","access_levels":null},{"id":19610,"title":"Bakels welcome back students from The Worshipful Company of Bakers","url":"https:\/\/www.britishbakels.co.uk\/worshipful-company-of-bakers-2021\/","post_type":"Posts","tax_terms":"Events, People","access_levels":null},{"id":3657,"title":"Bakels welcome students in partnership with The Worshipful Company of Bakers","url":"https:\/\/www.britishbakels.co.uk\/bakels-welcome-students-in-partnership-with-the-worshipful-company-of-bakers\/","post_type":"Posts","tax_terms":"Events","access_levels":null},{"id":11946,"title":"Bakery Trends driven by Covid-19","url":"https:\/\/www.britishbakels.co.uk\/insights\/bakery-trends-driven-by-covid-19\/","post_type":"Insights","access_levels":null},{"id":12747,"title":"Baking for Millennials","url":"https:\/\/www.britishbakels.co.uk\/insights\/baking-for-millennials\/","post_type":"Insights","access_levels":null},{"id":2991,"title":"Baktem 10% Brioche Paste Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-10-brioche-paste-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Brioche Concentrates","sku":"378500","access_levels":"public_access"},{"id":7896,"title":"Baktem 10% Soft Bun Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-10-soft-bun-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bun Concentrates","sku":"392915","access_levels":"public_access"},{"id":2995,"title":"Baktem 10% Soft Roll Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-10-soft-roll-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Soft Roll Concentrates","sku":"392460","access_levels":"public_access"},{"id":2992,"title":"Baktem 5% Crusty Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-5-crusty-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crusty Concentrates","sku":"392955","access_levels":"public_access"},{"id":2996,"title":"Baktem 5% Soft Roll Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-5-soft-roll-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Soft Roll Concentrates","sku":"392967","access_levels":"public_access"},{"id":2993,"title":"Baktem 7% Soft Roll Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-7-soft-roll-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Soft Roll Concentrates","sku":"393160","access_levels":"public_access"},{"id":2998,"title":"Baktem Blue 20% Bun Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-blue-20-bun-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bun Concentrates","sku":"175220","access_levels":"public_access"},{"id":2989,"title":"Baktem Red 10% Soft Roll Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/baktem-red-10-soft-roll-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Soft Roll Concentrates","sku":"175020","access_levels":"public_access"},{"id":3202,"title":"Banana Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/banana-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":12526,"title":"Bangin' Brownies: Creative Ideas for your Bakery","url":"https:\/\/www.britishbakels.co.uk\/insights\/bangin-brownie-ideas\/","post_type":"Insights","access_levels":"public_access"},{"id":3274,"title":"Banoffee Tart Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/banoffee-tarts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4562,"title":"Beer Bread with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/beer-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":6843,"title":"Beetroot & Chilli Savoury Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/beetroot-chilli-savoury-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3393,"title":"Belgium","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/belgium\/","post_type":"Baking Centres","access_levels":null},{"id":29790,"title":"Biscuit Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/biscuit-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":22600,"title":"Black Forest Gateau Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/black-forest-gateau-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3224,"title":"Black Forest Stack","url":"https:\/\/www.britishbakels.co.uk\/recipes\/black-forest-stack\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":19482,"title":"Black Forest Wreath","url":"https:\/\/www.britishbakels.co.uk\/recipes\/black-forest-wreath\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25836,"title":"Black Forest Yule Log","url":"https:\/\/www.britishbakels.co.uk\/recipes\/black-forest-yule-log\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3205,"title":"Blueberry & Mango Banana Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/blueberry-and-mango-banana-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":22643,"title":"Blueberry Cheesecake Pot","url":"https:\/\/www.britishbakels.co.uk\/recipes\/blueberry-cheesecake-pot\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":22644,"title":"Blueberry Muffins","url":"https:\/\/www.britishbakels.co.uk\/recipes\/blueberry-muffins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4861,"title":"Blueberry Plait with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/blueberry-plait-with-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4857,"title":"B\u00f6rek Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/borek\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":19573,"title":"Brie & Cranberry Boule","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brie-and-cranberry-boule\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3115,"title":"Brie and Cranberry Rye Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brie-and-cranberry\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4744,"title":"Bright Tin Bread with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/bright-tin-bread-with-wheat-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3151,"title":"Brioche Buns","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brioche-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":5152,"title":"Brioche Panettone","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brioche-panettone\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":5121,"title":"Brioche Panettone Bite Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brio-ttone-bites\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3159,"title":"Brioche Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brioche\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5117,"title":"Brioche Stollen Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brioche-stollen\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":19575,"title":"Brioche Tear & Share","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brioche-tear-and-share\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30097,"title":"Britain\u2019s consumers want simple pleasures","url":"https:\/\/www.britishbakels.co.uk\/insights\/britains-consumers-want-simple-pleasures\/","post_type":"Insights","access_levels":"public_access"},{"id":3390,"title":"British Bakels","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/british-bakels\/","post_type":"Baking Centres","access_levels":null},{"id":25419,"title":"British Bakels add three New Cr\u00e8me Cake Mixes for Autumn 2022","url":"https:\/\/www.britishbakels.co.uk\/new-creme-cake-mixes-autumn-2022\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":4195,"title":"British Bakels appoint Hayley Calthorpe as Managing Director","url":"https:\/\/www.britishbakels.co.uk\/british-bakels-appoint-hayley-calthorpe-as-managing-director\/","post_type":"Posts","tax_terms":"People","access_levels":null},{"id":22370,"title":"British Bakels Celebrates 75 Years with Launch of New Report","url":"https:\/\/www.britishbakels.co.uk\/british-bakels-celebrates-75-years\/","post_type":"Posts","tax_terms":"Events","access_levels":null},{"id":30379,"title":"British Bakels is recognised for its pioneering adoption of Near Infrared Spectroscopy with IChemE Global Awards win","url":"https:\/\/www.britishbakels.co.uk\/bakels-ichem-2023\/","post_type":"Posts","tax_terms":"Awards","access_levels":null},{"id":28005,"title":"British Bakels launches first Direct to Consumer baking range with Ta-Da!\u00ae","url":"https:\/\/www.britishbakels.co.uk\/british-bakels-launches-first-direct-to-consumer-baking-range-with-ta-da\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":22880,"title":"British Bakels pass Sedex's Ethical Trade Audit","url":"https:\/\/www.britishbakels.co.uk\/british-bakels-pass-sedexs-ethical-trade-audit\/","post_type":"Posts","tax_terms":"Other","access_levels":null},{"id":14857,"title":"British Bakels release Product Brochure for 2021","url":"https:\/\/www.britishbakels.co.uk\/product-brochure-2021\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":21412,"title":"British Bakels release Product Brochure for 2022","url":"https:\/\/www.britishbakels.co.uk\/british-bakels-release-product-brochure-for-2022\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":30080,"title":"British Bakels win Oxfordshire Business Innovation Award for Near Infrared","url":"https:\/\/www.britishbakels.co.uk\/british-bakels-win-oxfordshire-business-innovation-award-for-near-infrared\/","post_type":"Posts","tax_terms":"Awards","access_levels":null},{"id":4066,"title":"Brown Oat & Barley Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brown-oat-barley-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5001,"title":"Brown Tin Bread with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brown-tin-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30322,"title":"Brownie Christmas Pudding","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brownie-christmas-pudding\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":25833,"title":"Brownie Reindeer","url":"https:\/\/www.britishbakels.co.uk\/recipes\/brownie-reindeer\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":19577,"title":"Bruschetta","url":"https:\/\/www.britishbakels.co.uk\/recipes\/bruschetta\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3019,"title":"Bun Glaze RTU","url":"https:\/\/www.britishbakels.co.uk\/products\/bun-glaze-rtu\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Bun Glazes","sku":"345805","access_levels":null},{"id":28923,"title":"Bunny Bum Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/bunny-bum-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4578,"title":"Burger Bun with Durum Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/durum-sourdough-burger-bun\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17427,"title":"Burger Buns","url":"https:\/\/www.britishbakels.co.uk\/recipes\/burger-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4435,"title":"B\u00fcrli Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/burli-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":9942,"title":"Burns the Bread crowned National Bakery of the Year 2020","url":"https:\/\/www.britishbakels.co.uk\/burns-the-bread-crowned-national-bakery-of-the-year-2020\/","post_type":"Posts","tax_terms":"Events","access_levels":null},{"id":4554,"title":"Butter Plait","url":"https:\/\/www.britishbakels.co.uk\/recipes\/butterplait\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3209,"title":"Cake Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cake-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":8000,"title":"Cake Doughnut Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/cake-doughnut-complete\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Doughnut Concentrates","sku":"378155","access_levels":"public_access"},{"id":3058,"title":"Cake Doughnut Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/cake-doughnut-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Doughnut Concentrates","sku":"378140","access_levels":null},{"id":28961,"title":"Cake Pops","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cake-pops\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":25111,"title":"Caramel & Raspberry Cake Cup","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-and-raspberry-cake-cup\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3292,"title":"Caramel and Pecan Ice Cream Sundae","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-and-pecan-ice-cream-sundae\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3295,"title":"Caramel Apple","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-apple\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":18237,"title":"Caramel Cereal Bar","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-cereal-bar\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15457,"title":"Caramel Cream Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-cream-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24042,"title":"Caramel Cr\u00e8me Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/caramel-creme-cake-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"373040","access_levels":"public_access"},{"id":30431,"title":"Caramel Crispy Gateau","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-crispy-gateau\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3076,"title":"Caramel Fudgice","url":"https:\/\/www.britishbakels.co.uk\/products\/caramel-fudgice\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471852","access_levels":"public_access"},{"id":18234,"title":"Caramel Popcorn Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-popcorn-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15509,"title":"Caramel Popcorn Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-popcorn-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3276,"title":"Caramel Ripple No Bake Tart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-ripple-no-bake-tart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3091,"title":"Caramel Ripple PF","url":"https:\/\/www.britishbakels.co.uk\/products\/caramel-ripple-pf\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings, Ice Cream Products","sku":"471806","access_levels":"public_access"},{"id":25224,"title":"Caramel Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3273,"title":"Caramel Tartlets","url":"https:\/\/www.britishbakels.co.uk\/recipes\/tartlets\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":24967,"title":"Caramel Truffle","url":"https:\/\/www.britishbakels.co.uk\/products\/caramel-truffle\/","post_type":"Products","tax_terms":"Truffles","sku":"537711","access_levels":"public_access"},{"id":15600,"title":"Caramel Yum Yum Bites - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-yum-yum-bites-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3114,"title":"Caraway and Cranberry Rye Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caraway-and-cranberry-rye-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":6856,"title":"Carrot & Coriander Savoury Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/carrot-coriander-savoury-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":21782,"title":"Carrot Cake Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/carrot-cake-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":23347,"title":"Changes in consumer behaviour towards baked goods in 2022","url":"https:\/\/www.britishbakels.co.uk\/insights\/changes-in-consumer-behaviour-towards-baked-goods-in-2022\/","post_type":"Insights","access_levels":"public_access"},{"id":3331,"title":"Cheese and Tomato Artisan Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cheese-and-tomato-artisan-muffin-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3217,"title":"Cheesecake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3064,"title":"Cheesecake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/cheesecake-mix\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Dessert Mixes","sku":"579200","access_levels":"public_access"},{"id":4661,"title":"Cherry and Vanilla Danish with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cherry-and-vanilla-sourdough-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30471,"title":"Cherry Bakewell Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cherry-bakewell-loaf-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3293,"title":"Cherry Bakewell Turnover","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cherry-bakewell-turnover\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3234,"title":"Cherry Meringue Nests Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cherry-meringue-nests\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":29543,"title":"Chile","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/chile\/","post_type":"Baking Centres","access_levels":null},{"id":4519,"title":"Chimney Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chimney-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24635,"title":"Chockex - Dark","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-dark\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"521410","access_levels":"public_access"},{"id":24636,"title":"Chockex - Light","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-light\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"521440","access_levels":"public_access"},{"id":24634,"title":"Chockex - White","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-white\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"521470","access_levels":"public_access"},{"id":24650,"title":"Chockex Premium - Blond","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-blond\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"523710","access_levels":"public_access"},{"id":24546,"title":"Chockex Premium - Dark","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-dark\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"521710, 520811","access_levels":"public_access"},{"id":24571,"title":"Chockex Premium - Dark Soft Coating","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-dark-soft-coating\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"520410","access_levels":"public_access"},{"id":24460,"title":"Chockex Premium - Dark Vegan PF","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-dark-vegan-pf\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"521511","access_levels":"public_access"},{"id":24621,"title":"Chockex Premium - Light","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-light\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"520711, 520713","access_levels":"public_access"},{"id":24485,"title":"Chockex Premium - Ruby","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-ruby\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"521710","access_levels":"public_access"},{"id":24651,"title":"Chockex Premium - White","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-white\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"520611, 520615","access_levels":"public_access"},{"id":24637,"title":"Chockex Premium - White Natural Flavour","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-white-natural-flavour\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"520911","access_levels":"public_access"},{"id":24596,"title":"Chockex Premium Dark No Added Sugar","url":"https:\/\/www.britishbakels.co.uk\/products\/chockex-premium-dark-no-added-sugar\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"521210","access_levels":"public_access"},{"id":25161,"title":"Chocolate & Dark Cherry Stack","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-dark-cherry-stack\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":19579,"title":"Chocolate & Ginger Multiseed","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-ginger-multiseed\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":19567,"title":"Chocolate & Hazelnut Choux Bun","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-hazelnut-choux-bun\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15522,"title":"Chocolate & Pistachio Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-pistachio-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4589,"title":"Chocolate and Apricot Loaf with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-apricot-loaf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3309,"title":"Chocolate and Caramel Nut Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-caramel-nut-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3184,"title":"Chocolate and Hazelnut Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hazel-chocolate-bar-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3305,"title":"Chocolate and Hazelnut Christmas Star","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-hazelnut-christmas-star\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3154,"title":"Chocolate and Orange Tear and Share Brioche","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-orange-tear-and-share-brioche\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4907,"title":"Chocolate and Pecan Plait with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-and-pecan-plait-with-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30329,"title":"Chocolate Bouche Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-bouche-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":15614,"title":"Chocolate Brownie Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-brownie-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":19486,"title":"Chocolate Brownie Stack","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-brownie-stack\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4905,"title":"Chocolate Cake with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-cake-with-sourdough\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17330,"title":"Chocolate Cake-away Jar","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-cake-away-jar\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3279,"title":"Chocolate Caramel Hearts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-caramel-hearts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3231,"title":"Chocolate Caramel Mini Tarts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-caramel-mini-tarts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25261,"title":"Chocolate Caramel Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-caramel-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3275,"title":"Chocolate Caramel Slice Recipe - Low Sugar","url":"https:\/\/www.britishbakels.co.uk\/recipes\/low-sugar-caramel-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3178,"title":"Chocolate Cherry Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-cherry-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":19484,"title":"Chocolate Christmas Baubles","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-christmas-baubles\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15561,"title":"Chocolate Coconut Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-coconut-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15535,"title":"Chocolate Cream Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-cream-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3228,"title":"Chocolate Cream Flan Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-cream-flan\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":21546,"title":"Chocolate Cr\u00e8me Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/chocolate-creme-cake-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"373020","access_levels":"public_access"},{"id":3201,"title":"Chocolate Creme Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-cr%c2%8fme-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":9649,"title":"Chocolate Easter Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-easter-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3245,"title":"Chocolate Easter Carrot Muffins","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-easter-carrot-muffins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3248,"title":"Chocolate Easter Nests","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-easter-nests\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":8139,"title":"Chocolate Eggless Sponge Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/chocolate-eggless-sponge-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"371520","access_levels":"public_access"},{"id":25816,"title":"Chocolate Hazelnut Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-hazelnut-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":18061,"title":"Chocolate Millionaires Caramel PF","url":"https:\/\/www.britishbakels.co.uk\/products\/chocolate-millionaires-caramel-pf\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"471827","access_levels":"public_access"},{"id":18242,"title":"Chocolate Millionaires Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-millionaires-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":18239,"title":"Chocolate Millionaires Flapjack","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-millionaires-flapjack\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":18243,"title":"Chocolate Millionaires Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-millionaires-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3218,"title":"Chocolate Mousse Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-mousse\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5364,"title":"Chocolate Mud Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/chocolate-mud-cake-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382860","access_levels":null},{"id":17338,"title":"Chocolate Muffins - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-muffins-vegan\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":29791,"title":"Chocolate Orange Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-orange-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":8940,"title":"Chocolate Orange Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-orange-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17322,"title":"Chocolate Orange Shooter - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-orange-shooter-vegan\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":8852,"title":"Chocolate Orange Vegan Traybake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-vegan-traybake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3211,"title":"Chocolate Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3049,"title":"Chocolate Sponge Mix Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/chocolate-sponge-mix-complete\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382616","access_levels":null},{"id":5327,"title":"Chocolate Strawberries Heart Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-strawberries-heart-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":8903,"title":"Chocolate Toffee Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolate-toffee-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5324,"title":"Chocolates Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chocolates-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5157,"title":"Choux Bun Wreath","url":"https:\/\/www.britishbakels.co.uk\/recipes\/choux-bun-wreath\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3059,"title":"Choux Paste Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/choux-paste-mix\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Confectionery Mixes","sku":"329105","access_levels":"public_access"},{"id":12537,"title":"Christmas 2020 Bakery Trends","url":"https:\/\/www.britishbakels.co.uk\/insights\/christmas-2020-bakery-trends\/","post_type":"Insights","access_levels":null},{"id":3239,"title":"Christmas Bundt Cake Recipe - Chocolate and Caramel","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-chocolate-and-caramel-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30320,"title":"Christmas Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":25814,"title":"Christmas Caramel Bundt Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-caramel-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30295,"title":"Christmas Character Doughnut Selection","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-character-doughnut-selection\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":19569,"title":"Christmas Danish Pastry","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-danish-pastry\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30314,"title":"Christmas Doughnuts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-doughnuts\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3189,"title":"Christmas Fruit Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rich-christmas-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5144,"title":"Christmas Koko Treats","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-koko-treats\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3313,"title":"Christmas Mincemeat Crumble Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-mince-crumble\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3307,"title":"Christmas Puddings","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-puddings\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5109,"title":"Christmas Seeded Wreath","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-seeded-wreath\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30315,"title":"Christmas Stocking Doughnuts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-stocking-doughnuts\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3253,"title":"Christmas Tear and Share Monkey Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-tear-and-share-monkey-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3251,"title":"Christmas Tree Cupcake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-tree-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":26306,"title":"Christmas Tree Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-tree-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":5163,"title":"Christmas Tree Danish Pastry Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/danish-christmas-tree\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25835,"title":"Christmas Tree Meringues","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmas-tree-meringues\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":28936,"title":"Churros","url":"https:\/\/www.britishbakels.co.uk\/recipes\/churros\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4061,"title":"Churros Hearts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/churros-hearts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":20956,"title":"Ciabatta: Fermdor\u00ae Active Durum","url":"https:\/\/www.britishbakels.co.uk\/recipes\/ciabatta-fermdor-active-durum\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3153,"title":"Cinnamon and Pecan Brioche Loaf","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cinnamon-and-pecan-brioche-loaf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":26322,"title":"Cinnamon Bun Loaf","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cinnamon-bun-loaf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":28747,"title":"Cinnamon Buns","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cinnamon-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3083,"title":"Cinnamon Filling","url":"https:\/\/www.britishbakels.co.uk\/products\/cinnamon-filling\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"470089","access_levels":null},{"id":3304,"title":"Cinnamon Palmiers","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cinnamon-palmiers\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":27373,"title":"Cinnamon Remonce","url":"https:\/\/www.britishbakels.co.uk\/products\/cinnamon-remonce\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"572010","access_levels":"public_access"},{"id":3157,"title":"Cinnamon Swirls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cinnamon-swirls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15587,"title":"Cinnamon Yum Yum","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cinnamon-yum-yum\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3193,"title":"Classic Carrot Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/classic-carrot-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4735,"title":"Classic Farmer Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/classic-farmer-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3020,"title":"Clean Label Bun Glaze RTU","url":"https:\/\/www.britishbakels.co.uk\/products\/clean-label-bun-glaze-rtu\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Bun Glazes","sku":"345820","access_levels":"public_access"},{"id":2983,"title":"Clean Label Crumb Softener","url":"https:\/\/www.britishbakels.co.uk\/products\/clean-label-crumb-softener\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crumb Softeners","sku":"218900","access_levels":"public_access"},{"id":4652,"title":"Clean Label Danish Improver","url":"https:\/\/www.britishbakels.co.uk\/products\/clean-label-danish-improver\/","post_type":"Products","tax_terms":"Savoury & Pastry Ingredients, Pastry Improver","sku":"192336","access_levels":null},{"id":3022,"title":"Clean Label Savoury Glaze","url":"https:\/\/www.britishbakels.co.uk\/products\/clean-label-savoury-glaze\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Savoury Glaze, Savoury & Pastry Ingredients, Savoury Ingredients","sku":"345880","access_levels":null},{"id":2971,"title":"Clean Label Super Improver","url":"https:\/\/www.britishbakels.co.uk\/products\/clean-label-super-improver\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"194245","access_levels":"public_access"},{"id":16973,"title":"Clear Glaze","url":"https:\/\/www.britishbakels.co.uk\/products\/clear-glaze\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Confectionery Glazes","sku":"472290","access_levels":"public_access"},{"id":3297,"title":"Coconut Pumpkin Treat Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/koko-pumpkins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":19488,"title":"Coconut Snowman Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/coconut-snowman-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":23464,"title":"Coffee Caramel Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/coffee-caramel-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3271,"title":"Coffee, Pecan and Salted Caramel Poke Cake Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/coffee-pecan-and-salted-caramel-poke-cake-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3029,"title":"Colco","url":"https:\/\/www.britishbakels.co.uk\/products\/colco\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Emulsifiers","sku":"215205A","access_levels":"public_access"},{"id":17324,"title":"Coloured Meringues","url":"https:\/\/www.britishbakels.co.uk\/recipes\/coloured-meringues\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":16126,"title":"Consumers care about your Packaging","url":"https:\/\/www.britishbakels.co.uk\/insights\/consumers-care-about-your-packaging\/","post_type":"Insights","access_levels":null},{"id":3017,"title":"Cook up Starch","url":"https:\/\/www.britishbakels.co.uk\/products\/bakels-cook-up-starch\/","post_type":"Products","tax_terms":"Savoury & Pastry Ingredients, Pie Filling Thickener","sku":"355160","access_levels":"public_access"},{"id":2956,"title":"Country Oven\u00ae Artisan","url":"https:\/\/www.britishbakels.co.uk\/products\/country-oven-artisan\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Speciality Bread Mixes","sku":"394190","access_levels":"public_access"},{"id":14226,"title":"Country Oven\u00ae Fibre Plus","url":"https:\/\/www.britishbakels.co.uk\/products\/country-oven-fibre-plus\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Speciality Bread Mixes","sku":"394505","access_levels":"public_access"},{"id":14277,"title":"Country Oven\u00ae Golden Grains","url":"https:\/\/www.britishbakels.co.uk\/products\/country-oven-golden-grains\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Speciality Bread Mixes","sku":"394787","access_levels":"public_access"},{"id":2960,"title":"Country Oven\u00ae Multiseed","url":"https:\/\/www.britishbakels.co.uk\/products\/country-oven-multiseed\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Speciality Bread Mixes","sku":"394720","stockist_sku":"60559, 60559, 60559, 270203, 830005, 23368, FLR20, BAK-MUL01","access_levels":"public_access"},{"id":2962,"title":"Country Oven\u00ae Oat & Barley","url":"https:\/\/www.britishbakels.co.uk\/products\/country-oven-oat-barley\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Speciality Bread Mixes","sku":"394477","access_levels":"public_access"},{"id":2958,"title":"Country Oven\u00ae Rye","url":"https:\/\/www.britishbakels.co.uk\/products\/country-oven-rye\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Speciality Bread Mixes","sku":"394350","access_levels":"public_access"},{"id":14328,"title":"Country Oven\u00ae Seeded Artisan","url":"https:\/\/www.britishbakels.co.uk\/products\/country-oven-seeded-artisan\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Speciality Bread Mixes","sku":"394185","access_levels":"public_access"},{"id":4750,"title":"Cracker with Spelt Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/spelt-sourdough-cracker\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5158,"title":"Cranberry and Orange Bundt Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cranberry-and-orange-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3197,"title":"Cranberry and Pecan Bake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cranberry-and-pecan-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3327,"title":"Cranberry and Stilton Boule","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cranberry-and-stilton-boule-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5170,"title":"Cranberry Farmhouse Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cranberry-farmhouse-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4666,"title":"Cream Cheese and Blueberry Danish with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cream-cheese-and-blueberry-sourdough-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3082,"title":"Cream Cheese Flavoured Icing","url":"https:\/\/www.britishbakels.co.uk\/products\/cream-cheese-flavoured-icing\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"423035","access_levels":"public_access"},{"id":4908,"title":"Cream Cheese Plait with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cream-cheese-plait-with-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3071,"title":"Cream Stabiliser","url":"https:\/\/www.britishbakels.co.uk\/products\/cream-stabiliser\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Cream Stabiliser","sku":"244110","access_levels":null},{"id":28686,"title":"Cream-Filled Tsoureki","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cream-filled-tsoureki\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3200,"title":"Cr\u00e9me Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cr%c2%8fme-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3093,"title":"Cremodan\u00ae SIM VEG","url":"https:\/\/www.britishbakels.co.uk\/products\/cremodan-sim-veg\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Ice Cream Products","sku":"226050","access_levels":"public_access"},{"id":4993,"title":"Crispy Sourdough Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/crispy-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30010,"title":"Croissant Cube","url":"https:\/\/www.britishbakels.co.uk\/recipes\/croissant-cube\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30009,"title":"Croissant Cubes: Made famous in London and taking over Tik Tok","url":"https:\/\/www.britishbakels.co.uk\/insights\/croissant-cubes\/","post_type":"Insights","access_levels":"public_access"},{"id":3150,"title":"Croissant Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/croissants\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4662,"title":"Croissant with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sourdough-croissant\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30347,"title":"Crossing Mix SG","url":"https:\/\/www.britishbakels.co.uk\/products\/crossing-mix-sg\/","post_type":"Products","tax_terms":"Crossing Mix","sku":"","access_levels":"public_access"},{"id":5020,"title":"Crumpet with Rye Sourdough Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/crumpet-with-rye-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3142,"title":"Crunchy French Baguette Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/crusty-rolls-and-baguette\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3143,"title":"Crusty Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/crusty-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3362,"title":"Crusty Roll","url":"https:\/\/www.britishbakels.co.uk\/recipes\/crusty-roll-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3282,"title":"Cupcake Bouquet","url":"https:\/\/www.britishbakels.co.uk\/recipes\/cupcake-bouquet\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3374,"title":"Custard","url":"https:\/\/www.britishbakels.co.uk\/recipes\/custard\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3220,"title":"Custard Vol-Au-Vent","url":"https:\/\/www.britishbakels.co.uk\/recipes\/custard-vol-au-vent\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4682,"title":"Danish Feta, Spinach and Walnut Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/spinach-walnut-and-feta-sourdough-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3167,"title":"Danish Pastry","url":"https:\/\/www.britishbakels.co.uk\/recipes\/danish-pastry\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":22573,"title":"Dark Cherry Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/dark-cherry-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":7021,"title":"Dark Fruited Rye Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/dark-fruited-rye-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":7008,"title":"Dark Rye Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/dark-rye-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24966,"title":"Dark Truffle","url":"https:\/\/www.britishbakels.co.uk\/products\/dark-truffle\/","post_type":"Products","tax_terms":"Truffles","sku":"538101","access_levels":"public_access"},{"id":24965,"title":"Dark Truffle - Soft","url":"https:\/\/www.britishbakels.co.uk\/products\/dark-truffle-soft\/","post_type":"Products","tax_terms":"Truffles","sku":"538101","access_levels":"public_access"},{"id":24924,"title":"Dark Truffle Vegan PF","url":"https:\/\/www.britishbakels.co.uk\/products\/dark-truffle-vegan-pf\/","post_type":"Products","tax_terms":"Truffles","sku":"538101","access_levels":"public_access"},{"id":4976,"title":"Dark Twisted Bread with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/dark-twisted-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3191,"title":"Date and Walnut Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/date-and-walnut-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4692,"title":"Delight consumers with Fermdor Signature Sourdoughs","url":"https:\/\/www.britishbakels.co.uk\/delight-consumers-with-fermdor-signature-sourdoughs\/","post_type":"Posts","tax_terms":"Recipes, Products","access_levels":null},{"id":3062,"title":"Digestive Biscuit Crumb","url":"https:\/\/www.britishbakels.co.uk\/products\/digestive-biscuit-crumb\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Confectionery Mixes","sku":"562020A","access_levels":"public_access"},{"id":24973,"title":"Double Caramel Popcorn Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/double-caramel-popcorn-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21405,"title":"Doughnut Hearts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/doughnut-hearts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3057,"title":"Doughnut Paste Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/doughnut-paste-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Doughnut Concentrates","sku":"378212","access_levels":"public_access"},{"id":3008,"title":"Dovidol\u00ae","url":"https:\/\/www.britishbakels.co.uk\/products\/dovidol\/","post_type":"Products","tax_terms":"Release Solutions, Bread","sku":"136100A, 13160","access_levels":"public_access"},{"id":3179,"title":"Drunken Chocolate Cherry Muffins","url":"https:\/\/www.britishbakels.co.uk\/recipes\/drunken-chocolate-cherry-muffins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5009,"title":"Durum Bread with Durum Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/durum-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4532,"title":"Durum Wheat Sourdough Bread Pizza Base Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sourdough-pizza\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30428,"title":"Easter Brownie Nests","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-brownie-nests\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":21817,"title":"Easter Bunny Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-bunny-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21786,"title":"Easter Caramel Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-caramel-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":9549,"title":"Easter Chocolate Lemon Cheesecake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-chocolate-lemon-cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":9536,"title":"Easter Crown","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-crown\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30404,"title":"Easter Egg Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-egg-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":9562,"title":"Easter Fruit Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-fruit-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30423,"title":"Easter Loaded Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-loaded-brownie\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30418,"title":"Easter Nest Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/easter-nest-cup-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3394,"title":"Ecuador","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/ecuador\/","post_type":"Baking Centres","access_levels":null},{"id":30325,"title":"Eggnog Cheesecake Trees","url":"https:\/\/www.britishbakels.co.uk\/recipes\/eggnog-cheesecake-trees\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3042,"title":"Emilka Bake","url":"https:\/\/www.britishbakels.co.uk\/products\/emilka-bake\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Milk Powder & Egg Extenders","sku":"365120","access_levels":"public_access"},{"id":3003,"title":"Eminex Liquid","url":"https:\/\/www.britishbakels.co.uk\/products\/eminex-liquid\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Fats for Fermented Goods","sku":"112750","access_levels":"public_access"},{"id":3072,"title":"Enbellet Cold Custard Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/enbellet-cold-custard-mix\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Custard Mixes","sku":"336250","access_levels":"public_access"},{"id":30048,"title":"Eton Mess Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/eton-mess-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":15640,"title":"Eton Mess Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/eton-mess-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30133,"title":"Eton Mess Swirl Cheesecake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/eton-mess-swirl-cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":18060,"title":"Exploring the nation\u2019s love affair with caramel","url":"https:\/\/www.britishbakels.co.uk\/insights\/love-affair-with-caramel\/","post_type":"Insights","access_levels":null},{"id":4513,"title":"Farmer Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/farmer-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15113,"title":"Fedima launch campaign educating consumers on Sourdough","url":"https:\/\/www.britishbakels.co.uk\/fedima-launch-campaign-educating-consumers-on-sourdough\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":20795,"title":"Fermdor\u00ae Active - Durum","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-active-durum\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260600","access_levels":"public_access"},{"id":4104,"title":"Fermdor\u00ae Durum","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-durum\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260110","access_levels":null},{"id":4110,"title":"Fermdor\u00ae R Classic","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-r-classic\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260080A","access_levels":null},{"id":4116,"title":"Fermdor\u00ae R Plus","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-r-plus\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260310","access_levels":null},{"id":3007,"title":"Fermdor\u00ae Relax","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-relax\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Dough Relaxant","sku":"255540A","access_levels":"public_access"},{"id":4119,"title":"Fermdor\u00ae Rustic","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-rustic\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","access_levels":null},{"id":4122,"title":"Fermdor\u00ae S Classic","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-s-classic\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260070A","access_levels":null},{"id":4125,"title":"Fermdor\u00ae S Germ","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-s-germ\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260250","access_levels":null},{"id":4134,"title":"Fermdor\u00ae W Bright","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-w-bright\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260450","access_levels":null},{"id":4100,"title":"Fermdor\u00ae W Classic","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-w-classic\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260200","access_levels":"public_access"},{"id":4140,"title":"Fermdor\u00ae W Germ","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-w-germ\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260050A","access_levels":"public_access"},{"id":4137,"title":"Fermdor\u00ae W Germ Liquid","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-w-germ-liquid\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","access_levels":null},{"id":4143,"title":"Fermdor\u00ae W Mild","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-w-mild\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","access_levels":null},{"id":4149,"title":"Fermdor\u00ae W Plus","url":"https:\/\/www.britishbakels.co.uk\/products\/fermdor-w-plus\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Sourdough Products","sku":"260270","access_levels":null},{"id":9523,"title":"Filled Brioche","url":"https:\/\/www.britishbakels.co.uk\/recipes\/filled-brioche\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4613,"title":"Flower Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/flower-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30429,"title":"Flower Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/flower-cupcakes\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":28773,"title":"Flower Wreath Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/flower-wreath-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4523,"title":"Fondue Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fondue-bread-bright\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":16336,"title":"Food-to-go ready to bounce back with help from healthier bakes","url":"https:\/\/www.britishbakels.co.uk\/insights\/food-to-go-ready-to-bounce-back-2021\/","post_type":"Insights","access_levels":null},{"id":22641,"title":"Forest Fruit Crumble Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/forest-fruit-crumble-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":22642,"title":"Forest Fruit Strudel","url":"https:\/\/www.britishbakels.co.uk\/recipes\/forest-fruit-strudel\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3299,"title":"Frankenstein Pop Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/frankenstein-pops\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":2972,"title":"French Improver","url":"https:\/\/www.britishbakels.co.uk\/products\/french-improver\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"195750A","access_levels":"public_access"},{"id":29792,"title":"Fresh Fruit Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fresh-fruit-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3235,"title":"Fresh Fruit Meringue","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fresh-fruit-meringue\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3230,"title":"Fresh Fruit Mille-Feuille","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fresh-fruit-mille-feuille\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3237,"title":"Fresh Fruit Paris-Brest","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fresh-fruit-paris-brest\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":22645,"title":"Fruit Filled \u00c9clair","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fruit-filled-eclair\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21342,"title":"Fruit Filling - Blueberry 50%","url":"https:\/\/www.britishbakels.co.uk\/products\/fruit-filling-blueberry-50\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"581030","access_levels":"public_access"},{"id":21340,"title":"Fruit Filling - Dark Cherry 70%","url":"https:\/\/www.britishbakels.co.uk\/products\/fruit-filling-dark-cherry-70\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580220","access_levels":"public_access"},{"id":21341,"title":"Fruit Filling - Fruits of the Forest 70%","url":"https:\/\/www.britishbakels.co.uk\/products\/fruit-filling-fruits-of-the-forest-70\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580300","access_levels":"public_access"},{"id":21343,"title":"Fruit Filling - Raspberry 50%","url":"https:\/\/www.britishbakels.co.uk\/products\/fruit-filling-raspberry-50\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580205","access_levels":"public_access"},{"id":21175,"title":"Fruit Filling - Strawberry 70%","url":"https:\/\/www.britishbakels.co.uk\/products\/fruit-filling-strawberry-70\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580160","access_levels":"public_access"},{"id":3288,"title":"Fruit Tart Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/summer-fruit-tarts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4091,"title":"Fruited Teacake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fruited-teacake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":29618,"title":"Fudgy Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fudgy-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":29820,"title":"Fudgy Brownie Hearts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/fudgy-brownie-hearts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3055,"title":"Fudgy Brownie Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/fudgy-brownie-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"384120","access_levels":"public_access"},{"id":24998,"title":"Funfetti Birthday Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/funfetti-birthday-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30333,"title":"Future of JF Renshaw Ltd secured following sale to Bakels","url":"https:\/\/www.britishbakels.co.uk\/future-of-jf-renshaw-ltd-secured-following-sale-to-bakels\/","post_type":"Posts","tax_terms":"Announcements","access_levels":null},{"id":4630,"title":"Garlic and Herb Ciabatta Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/garlic-and-herb-ciabatta\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":25817,"title":"Garlic Bread Christmas Tree","url":"https:\/\/www.britishbakels.co.uk\/recipes\/garlic-bread-christmas-tree\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3180,"title":"Genoa Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/genoa-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":29884,"title":"Genoese Cake Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/genoese-cake-complete\/","post_type":"Products","tax_terms":"Cake & Sponge Mixes","sku":"382695","access_levels":"public_access"},{"id":4809,"title":"German Pretzel","url":"https:\/\/www.britishbakels.co.uk\/recipes\/german-pretzel\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24134,"title":"Germany","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/germany\/","post_type":"Baking Centres","access_levels":null},{"id":3190,"title":"Ginger and Marmalade Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/ginger-and-marmalade-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25813,"title":"Ginger Caramel Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/ginger-caramel-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":19490,"title":"Gingerbread & Amaretto Chocolate Tart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/gingerbread-and-amaretto-chocolate-tart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":19565,"title":"Gingerbread Doughnut Men","url":"https:\/\/www.britishbakels.co.uk\/recipes\/gingerbread-doughnut-men\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17436,"title":"Global flavours for your local bakery","url":"https:\/\/www.britishbakels.co.uk\/insights\/global-flavours\/","post_type":"Insights","access_levels":null},{"id":26876,"title":"Global Trends in Bakery 2023","url":"https:\/\/www.britishbakels.co.uk\/insights\/global-trends-in-bakery-2023\/","post_type":"Insights","access_levels":"public_access"},{"id":8141,"title":"Gluten Free Muffin Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/gluten-free-muffin-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"383150","access_levels":"public_access"},{"id":14326,"title":"Golden Grains Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/golden-grains-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14327,"title":"Golden Grains Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/golden-grains-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":19581,"title":"Gruyere & Garlic Ciabatta","url":"https:\/\/www.britishbakels.co.uk\/recipes\/gruyere-and-garlic-ciabatta\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3301,"title":"Halloween Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/halloween-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3296,"title":"Halloween Meringue Ghost Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/ghostly-meringues\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3298,"title":"Halloween Mummy Sweet Bites Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mummy-bites\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3163,"title":"Hamburger Roll Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hamburger-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":29789,"title":"Hazelnut Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hazelnut-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4868,"title":"Hazelnut Ice Cream Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hazelnut-ice-cream-with-sourdough\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3034,"title":"Hercules\u00ae Double","url":"https:\/\/www.britishbakels.co.uk\/products\/hercules-double\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Baking Powders","sku":"297330A","access_levels":"public_access"},{"id":3037,"title":"Hercules\u00ae Low Sodium 40","url":"https:\/\/www.britishbakels.co.uk\/products\/hercules-low-sodium-40\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Baking Powders","sku":"297600A","access_levels":null},{"id":3035,"title":"Hercules\u00ae Regular","url":"https:\/\/www.britishbakels.co.uk\/products\/hercules-regular\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Baking Powders","sku":"297020","access_levels":"public_access"},{"id":3036,"title":"Hercules\u00ae Slow","url":"https:\/\/www.britishbakels.co.uk\/products\/hercules-slow\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Baking Powders","sku":"297300A","access_levels":"public_access"},{"id":17431,"title":"High Fibre BBQ Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/high-fibre-bbq-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14275,"title":"High Fibre Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/high-fibre-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14276,"title":"High Fibre Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/high-fibre-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3196,"title":"Honey and Almond Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/honey-and-almond-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3138,"title":"Honey and Sunflower Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/honey-and-sunflower-bread-recipe-for-bakeries-british-bakels\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":21781,"title":"Honey Glazed Fruit Danish Pastry","url":"https:\/\/www.britishbakels.co.uk\/recipes\/honey-glazed-fruit-danish-pastry-2\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":17261,"title":"Hong Kong","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/hong-kong\/","post_type":"Baking Centres","access_levels":null},{"id":3294,"title":"Horror Style Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/horror-style-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":28798,"title":"Hot Cross Bread & Lemon Pudding","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hot-cross-bread-lemon-pudding\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":21889,"title":"Hot Cross Buns","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hot-cross-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30430,"title":"Hot Cross Choux Buns","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hot-cross-choux-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":21887,"title":"Hot Cross Doughnut Bites","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hot-cross-doughnut-bites\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3246,"title":"Hot Cross Muffins","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hot-cross-muffins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30425,"title":"Hot Cross Pancakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hot-cross-pancakes\/","post_type":"Recipes","tax_terms":"Cooking","access_levels":"public_access"},{"id":21888,"title":"Hot Cross S'mores","url":"https:\/\/www.britishbakels.co.uk\/recipes\/hot-cross-smores\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":10614,"title":"Hot off the press! Bakels Worldwide Review 170","url":"https:\/\/www.britishbakels.co.uk\/hot-off-the-press-bakels-worldwide-review-170\/","post_type":"Posts","tax_terms":"Products, People, Bakels Worldwide","access_levels":null},{"id":16460,"title":"How Bakeries Can Support Climatarian Customers","url":"https:\/\/www.britishbakels.co.uk\/insights\/how-bakeries-can-support-climatarian-customers\/","post_type":"Insights","access_levels":null},{"id":12528,"title":"How London Bakeries are using Instagram to Boost Engagement and win over Customers","url":"https:\/\/www.britishbakels.co.uk\/insights\/how-london-bakeries-use-instagram-to-win-customers\/","post_type":"Insights","access_levels":null},{"id":18908,"title":"How to give your bakery a competitive advantage","url":"https:\/\/www.britishbakels.co.uk\/insights\/make-your-bakery-stand-out-from-competitors\/","post_type":"Insights","access_levels":null},{"id":23513,"title":"How to reduce costs in your bakery & become more sustainable","url":"https:\/\/www.britishbakels.co.uk\/insights\/how-to-reduce-costs-in-your-bakery-become-more-sustainable\/","post_type":"Insights","access_levels":"public_access"},{"id":11748,"title":"How to use Social Channels to Boost your Sales","url":"https:\/\/www.britishbakels.co.uk\/insights\/how-to-use-social-channels-to-boost-your-sales\/","post_type":"Insights","access_levels":null},{"id":17851,"title":"How you can start taking better photos of your baked goods","url":"https:\/\/www.britishbakels.co.uk\/insights\/photography-tips\/","post_type":"Insights","access_levels":null},{"id":29845,"title":"Ice Cream Brownie Sandwich","url":"https:\/\/www.britishbakels.co.uk\/recipes\/ice-cream-brownie-sandwich\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3160,"title":"Iced Buns","url":"https:\/\/www.britishbakels.co.uk\/recipes\/iced-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":17257,"title":"India","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/india\/","post_type":"Baking Centres","access_levels":null},{"id":3067,"title":"Instant Cream","url":"https:\/\/www.britishbakels.co.uk\/products\/instant-cream\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Dessert Mixes","sku":"325160","access_levels":"public_access"},{"id":3068,"title":"Instant Cream - Chocolate","url":"https:\/\/www.britishbakels.co.uk\/products\/instant-cream-chocolate\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Dessert Mixes","sku":"325170","access_levels":null},{"id":3069,"title":"Instant Lemon Supreme","url":"https:\/\/www.britishbakels.co.uk\/products\/instant-lemon-supreme\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Dessert Mixes","sku":"571140","access_levels":"public_access"},{"id":3092,"title":"Instant Starch","url":"https:\/\/www.britishbakels.co.uk\/products\/instant-starch\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Fruit Pie Thickener, Savoury & Pastry Ingredients, Pie Filling Thickener","sku":"355150","access_levels":null},{"id":3023,"title":"Instant Superglaze - Apricot","url":"https:\/\/www.britishbakels.co.uk\/products\/instant-superglaze-apricot\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Confectionery Glazes","sku":"347250","access_levels":null},{"id":3024,"title":"Instant Superglaze - Neutral","url":"https:\/\/www.britishbakels.co.uk\/products\/instant-superglaze-neutral\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Confectionery Glazes","sku":"347310","access_levels":null},{"id":3219,"title":"Instant Whipped Cream Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/instant-cream\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30051,"title":"Introducing New RTU Tiger Paste","url":"https:\/\/www.britishbakels.co.uk\/introducing-new-tiger-paste\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":30486,"title":"Introducing the Bakels and Renshaw Product Guide 2024","url":"https:\/\/www.britishbakels.co.uk\/bakels-renshaw-product-guide-2024\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":16461,"title":"It's here: Vegan Caramel","url":"https:\/\/www.britishbakels.co.uk\/vegan-caramel\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":21780,"title":"Italian Easter Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/italian-easter-bread-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3041,"title":"K3000 Lemon","url":"https:\/\/www.britishbakels.co.uk\/products\/k3000-lemon\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake Shelf Life Extenders","sku":"441090, 441030","access_levels":"public_access"},{"id":3289,"title":"Key Lime Pie Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/key-lime-pie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3286,"title":"Kiwi and Passion Fruit Fruit Pavlova Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/kiwi-and-passion-fruit-pavlova\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3312,"title":"Koko Christmas Wreath","url":"https:\/\/www.britishbakels.co.uk\/recipes\/koko-christmas-wreath\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17027,"title":"Koko Cream Bites","url":"https:\/\/www.britishbakels.co.uk\/recipes\/koko-cream-bites\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3306,"title":"Koko Snowmen","url":"https:\/\/www.britishbakels.co.uk\/recipes\/koko-snowmen\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3377,"title":"Koko Valentine's Heart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/koko-valentines-heart-2\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3278,"title":"Koko Valentine's Heart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/koko-valentines-heart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3061,"title":"Kokomix","url":"https:\/\/www.britishbakels.co.uk\/products\/kokomix\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Confectionery Mixes","sku":"385040","access_levels":"public_access"},{"id":3310,"title":"Kokotop Mince Pie Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/kokotop-mince-pie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":2973,"title":"Lecitem\u00ae 1000","url":"https:\/\/www.britishbakels.co.uk\/products\/lecitem-1000\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"197350A","access_levels":"public_access"},{"id":2974,"title":"Lecitem\u00ae 2000","url":"https:\/\/www.britishbakels.co.uk\/products\/lecitem-2000\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"197460","access_levels":"public_access"},{"id":2975,"title":"Lecitem\u00ae 5000 Plus","url":"https:\/\/www.britishbakels.co.uk\/products\/lecitem-5000-plus\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"199850","access_levels":"public_access"},{"id":2976,"title":"Lecitem\u00ae Premium Paste Improver","url":"https:\/\/www.britishbakels.co.uk\/products\/lecitem-premium-paste-improver\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"197590R","access_levels":"public_access"},{"id":25060,"title":"Lemon & Blueberry Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-and-blueberry-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":17326,"title":"Lemon & Blueberry Cake-away Jar","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-and-blueberry-cakeaway-jar\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":19587,"title":"Lemon & Meringue Sheet Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-and-meringue-sheet-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25086,"title":"Lemon & Poppy Seed Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-and-poppy-seed-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":17354,"title":"Lemon & Poppy Seed Muffin - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-and-poppy-seed-muffin-vegan\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":8965,"title":"Lemon & Raspberry Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-raspberry-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3183,"title":"Lemon and Blueberry Slice Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-and-blueberry-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4092,"title":"Lemon Bundt Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3192,"title":"Lemon Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15470,"title":"Lemon Cream Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-cream-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24016,"title":"Lemon Cr\u00e8me Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/lemon-creme-cake-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"373030","access_levels":"public_access"},{"id":3244,"title":"Lemon Flower Cupcake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-flower-cakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21785,"title":"Lemon Flower Stacks","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-flower-stacks-2\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30424,"title":"Lemon Layered Pavlova","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-layered-pavlova\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":18218,"title":"Lemon Meringue & Poppy Seed Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-poppy-seed-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17397,"title":"Lemon Meringue Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3175,"title":"Lemon Meringue Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15627,"title":"Lemon Meringue Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":28848,"title":"Lemon Meringue Finger Doughnuts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-finger-doughnuts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":28835,"title":"Lemon Meringue Pie Bites","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-pie-bites\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3291,"title":"Lemon Meringue Pie Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-pie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17318,"title":"Lemon Meringue Shooter","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-meringue-shooter\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":21902,"title":"Lemon Swirl","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-swirl\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":8827,"title":"Lemon Vegan Traybake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lemon-vegan-traybake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":6971,"title":"Light Rye Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/light-rye-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24813,"title":"Light Truffle","url":"https:\/\/www.britishbakels.co.uk\/products\/light-truffle\/","post_type":"Products","tax_terms":"Truffles","sku":"536611","access_levels":"public_access"},{"id":3009,"title":"Liquid Tinwax","url":"https:\/\/www.britishbakels.co.uk\/products\/liquid-tinwax\/","post_type":"Products","tax_terms":"Release Solutions, Bread, Cake\/Confectionery","sku":"132100","access_levels":"public_access"},{"id":21408,"title":"Love Letter Danish Pastry","url":"https:\/\/www.britishbakels.co.uk\/recipes\/love-letter-danish-pastry\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3090,"title":"Low Sugar Caramel","url":"https:\/\/www.britishbakels.co.uk\/products\/low-sugar-caramel\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471846","access_levels":"public_access"},{"id":18749,"title":"Low Sugar Vegan Caramel PF","url":"https:\/\/www.britishbakels.co.uk\/products\/low-sugar-vegan-caramel-pf\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"471844","access_levels":"public_access"},{"id":3088,"title":"Low Water (AW) Caramel","url":"https:\/\/www.britishbakels.co.uk\/products\/low-aw-caramel\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471828","access_levels":"public_access"},{"id":4374,"title":"Lucerne Bread Intense Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lucerne-bread-intense\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4723,"title":"Lucerne Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/lucerne-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3080,"title":"Luxury Caramel","url":"https:\/\/www.britishbakels.co.uk\/products\/luxury-caramel\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"473000","access_levels":"public_access"},{"id":11692,"title":"Mainland China","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/mainland-china\/","post_type":"Baking Centres","access_levels":null},{"id":12874,"title":"Maintaining a robust Supply Chain through COVID-19","url":"https:\/\/www.britishbakels.co.uk\/maintaining-a-robust-supply-chain-through-covid-19\/","post_type":"Posts","tax_terms":"Other","access_levels":null},{"id":17253,"title":"Malaysia","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/malaysia\/","post_type":"Baking Centres","access_levels":null},{"id":19583,"title":"Malty Beer Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/malty-beer-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4674,"title":"Mango Chutney, Goats Cheese and Paprika Danish with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mango-chutney-goats-cheese-and-paprika-sourdough-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4678,"title":"Maple and Pecan Danish with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/maple-and-pecan-sourdough-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3238,"title":"Meringue Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/meringue\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":29818,"title":"Millionaires Brownie Sandwich","url":"https:\/\/www.britishbakels.co.uk\/recipes\/millionaires-brownie-sandwich\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3084,"title":"Millionaires Caramel","url":"https:\/\/www.britishbakels.co.uk\/products\/millionaires-caramel\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471808","access_levels":"public_access"},{"id":23469,"title":"Millionaires Caramel Cheesecake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/millionaire-caramel-cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":5328,"title":"Millionaires Caramel Hearts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/millionaires-caramel-hearts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3085,"title":"Millionaires Caramel PF","url":"https:\/\/www.britishbakels.co.uk\/products\/millionaires-caramel-pf\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471822","access_levels":"public_access"},{"id":3214,"title":"Millionaires Caramel Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/millionaires-caramel-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15548,"title":"Millionaires Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/millionaires-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3285,"title":"Millionaires Easter Egg Pop","url":"https:\/\/www.britishbakels.co.uk\/recipes\/millionaires-easter-egg-pop\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":18231,"title":"Millionaires Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/millionaires-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":19479,"title":"Mincemeat & Cherry Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mincemeat-and-cherry-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5130,"title":"Mincemeat and Walnut Pastry Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mincemeat-and-walnut-tear-and-share\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3232,"title":"Mini Caramel Tart Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/caramel-mini-tarts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3233,"title":"Mini Chocolate Bundt Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mini-chocolate-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30324,"title":"Mini Panettone","url":"https:\/\/www.britishbakels.co.uk\/recipes\/panettone\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3281,"title":"Mini Victoria Sponge Cakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mini-victoria-sponge-cakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":18235,"title":"Miniature Caramel Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/miniature-caramel-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3290,"title":"Miniature Strawberry Trifles","url":"https:\/\/www.britishbakels.co.uk\/recipes\/miniature-strawberry-trifles\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3256,"title":"Mixed Nut Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mixed-nut-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4965,"title":"Mixed Olive Artisan Bread Sticks","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mixed-olive-artisan-bread-sticks-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3330,"title":"Mixed Olive Fougasse","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mixed-olive-fougasse-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":28661,"title":"Mojito Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mojito-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":2984,"title":"Monofresh\u00ae Super","url":"https:\/\/www.britishbakels.co.uk\/products\/monofresh-super\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crumb Softeners","sku":"218650","access_levels":"public_access"},{"id":15145,"title":"Mood, Food and Surviving 2021","url":"https:\/\/www.britishbakels.co.uk\/insights\/mood-food-surviving-2021\/","post_type":"Insights","access_levels":null},{"id":3322,"title":"Muesli Loaf with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/muesli-loaf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4075,"title":"Muesli Style Oat & Barley Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/muesli-style-oat-barley-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3052,"title":"Muffin & Cr\u00e8me Cake Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/muffin-and-creme-cake-complete\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"373110","access_levels":"public_access"},{"id":30327,"title":"Mulled Wine Crown Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mulled-wine-crown-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3119,"title":"Multi-rye","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multi-rye\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3050,"title":"Multimix Cake Base","url":"https:\/\/www.britishbakels.co.uk\/products\/multimix-cake-base\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382730","access_levels":"public_access"},{"id":4313,"title":"Multimix Cake Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/multimix-cake-complete\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382755","access_levels":"public_access"},{"id":3051,"title":"Multimix Cake Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/multimix-cake-concentrate\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382777","access_levels":"public_access"},{"id":8253,"title":"Multimix Eggless Cake Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/multimix-eggless-cake-complete\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382717","access_levels":null},{"id":4243,"title":"Multimix Vegan Cake Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/multimix-vegan-cake-complete\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382702","access_levels":null},{"id":3127,"title":"Multiseed Baguette","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-baguette\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3124,"title":"Multiseed Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3126,"title":"Multiseed Ciabatta","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-ciabatta\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3136,"title":"Multiseed Cookies","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-cookies\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30181,"title":"Multiseed Crackers","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-crackers\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30180,"title":"Multiseed Date & Walnut Loaf","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-date-walnut-loaf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30163,"title":"Multiseed Focaccia","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-focaccia\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3133,"title":"Multiseed Hot Cross Buns Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-hot-cross-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3134,"title":"Multiseed Panettone Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-panettone\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30205,"title":"Multiseed Pitta","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-pitta\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":6637,"title":"Multiseed Pizza Base","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-pizza-base\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3129,"title":"Multiseed Raisin & Cranberry Loaf","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-raisin-cranberry-loaf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3128,"title":"Multiseed Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3135,"title":"Multiseed Scones","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-scones\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30165,"title":"Multiseed Thins","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-thins\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":14224,"title":"Multiseed Vitality Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-vitality-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14225,"title":"Multiseed Vitality Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-vitality-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3125,"title":"Multiseed with wholemeal","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-with-wholemeal\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4373,"title":"Mustard Onion Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mustard-onion-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5005,"title":"Mutschli Bread Roll Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mutschli\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":23247,"title":"New Fermdor\u00ae Active: The foundation of your bread production","url":"https:\/\/www.britishbakels.co.uk\/new-fermdor-active-the-foundation-of-your-bread-production\/","post_type":"Posts","tax_terms":"Products","access_levels":null},{"id":17435,"title":"New prospects for bakeries","url":"https:\/\/www.britishbakels.co.uk\/insights\/new-prospects-for-bakeries-post-covid\/","post_type":"Insights","access_levels":null},{"id":14751,"title":"News from around the Group - Bakels Worldwide Review 171","url":"https:\/\/www.britishbakels.co.uk\/news-from-around-the-group-bakels-worldwide-review-171\/","post_type":"Posts","tax_terms":"Products, People, Bakels Worldwide","access_levels":null},{"id":18246,"title":"News from around the Group - Bakels Worldwide Review 172","url":"https:\/\/www.britishbakels.co.uk\/news-from-around-the-group-bakels-worldwide-review-172\/","post_type":"Posts","tax_terms":"Products, People, Bakels Worldwide","access_levels":null},{"id":3260,"title":"No Bake Bars","url":"https:\/\/www.britishbakels.co.uk\/recipes\/no-bake-bars\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3060,"title":"No Bake Chocolate Slice","url":"https:\/\/www.britishbakels.co.uk\/products\/no-bake-chocolate-slice\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Confectionery Mixes","sku":"386650","access_levels":"public_access"},{"id":16631,"title":"No kitchen? No worries.","url":"https:\/\/www.britishbakels.co.uk\/insights\/how-bakeries-can-make-use-of-ghost-kitchens\/","post_type":"Insights","access_levels":null},{"id":4499,"title":"Nordic Loaf","url":"https:\/\/www.britishbakels.co.uk\/recipes\/nordic-loaf\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4079,"title":"Oat & Barley Artisan Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/oat-barley-artisan-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4081,"title":"Oat & Barley Cookies","url":"https:\/\/www.britishbakels.co.uk\/recipes\/oat-barley-cookies\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":6756,"title":"Oat & Barley Pizza Base","url":"https:\/\/www.britishbakels.co.uk\/recipes\/oat-and-barley-pizza-base\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4077,"title":"Oat and Barley Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/oat-and-barley-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4084,"title":"Oat and Barley Cracker Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/oat-barley-crackers\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14161,"title":"Oat and Barley Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/oat-and-barley-roll-recipe\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4986,"title":"Olive Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/olive-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":25186,"title":"Ombr\u00e8 Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/ombre-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3272,"title":"On-the-go Bar","url":"https:\/\/www.britishbakels.co.uk\/recipes\/on-the-go-bar\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3384,"title":"One Product, Endless Possibilities - Bakels launch new Multimix Cake Base Recipes","url":"https:\/\/www.britishbakels.co.uk\/one-product-endless-possibilities-bakels-launch-new-multimix-cake-base-recipes\/","post_type":"Posts","tax_terms":"Recipes","access_levels":null},{"id":3187,"title":"Orange and Lime Brazilian Bun Cakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/orange-and-lime-brazilian-bun-cakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15444,"title":"Orange Cream Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/orange-cream-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24969,"title":"Orange Truffle","url":"https:\/\/www.britishbakels.co.uk\/products\/orange-truffle\/","post_type":"Products","tax_terms":"Truffles","sku":"537111","access_levels":"public_access"},{"id":15717,"title":"Original Glazed Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/original-glazed-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3027,"title":"Ovalett\u00ae","url":"https:\/\/www.britishbakels.co.uk\/products\/ovalett\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Emulsifiers","sku":"211150","access_levels":"public_access"},{"id":3028,"title":"Ovalett\u00ae NNC","url":"https:\/\/www.britishbakels.co.uk\/products\/ovalett-nnc\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Emulsifiers","sku":"211100","access_levels":"public_access"},{"id":3325,"title":"Overnight Artisan Boule","url":"https:\/\/www.britishbakels.co.uk\/recipes\/overnight-artisan-boule-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":8013,"title":"Palm Free Crossing Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/palm-free-crossing-mix\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crossing Mix","sku":"413025","access_levels":"public_access"},{"id":8552,"title":"Palm Free Digestive Biscuit Crumb","url":"https:\/\/www.britishbakels.co.uk\/products\/palm-free-digestive-biscuit-crumb\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Confectionery Mixes","sku":"562030","access_levels":null},{"id":2985,"title":"Palm Free Duo","url":"https:\/\/www.britishbakels.co.uk\/products\/palm-free-duo-shortening\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Fats for Fermented Goods","sku":"112479, 112475","access_levels":"public_access"},{"id":3195,"title":"Parkin Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/parkin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17076,"title":"Party Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/party-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":28748,"title":"Paska Easter Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/paska-easter-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3229,"title":"Passion Fruit Cheesecake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/passion-fruit-cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":23467,"title":"Peach & Caramel Upside-Down Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/peach-and-caramel-upside-down-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":23462,"title":"Peach & Cinnamon Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/peach-and-cinnamon-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":29655,"title":"Pecan Millionaires Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/pecan-millionaires-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3257,"title":"Pecan Pie Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/pecan-pie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3303,"title":"Peppermint Pretzel Bites","url":"https:\/\/www.britishbakels.co.uk\/recipes\/peppermint-pretzel-bites\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17392,"title":"Picnic Muffins - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/picnic-muffins-vegan\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4473,"title":"Pikelet Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/pikelet\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3194,"title":"Pineapple and Coconut Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/pineapple-and-coconut-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4736,"title":"Pizza Base with Smoked Sourdough Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/smoked-sourdough-pizza\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":22268,"title":"Pizza Trends: These factors driving category NPD","url":"https:\/\/www.britishbakels.co.uk\/insights\/pizza-trends-these-factors-driving-category-npd\/","post_type":"Insights","access_levels":"public_access"},{"id":3174,"title":"Plain Cake Base","url":"https:\/\/www.britishbakels.co.uk\/recipes\/plain-cake-base\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":21344,"title":"Plain Cr\u00e8me Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/plain-creme-cake-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"373010","access_levels":"public_access"},{"id":8140,"title":"Plain Eggless Sponge Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/plain-eggless-sponge-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"371510","access_levels":"public_access"},{"id":3199,"title":"Plain Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/plain-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25831,"title":"Polar Bear Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/polar-bear-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3216,"title":"Popcorn Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/popcorn-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4464,"title":"Premium Pancake Mix Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/premium-pancake-mix-complete\/","post_type":"Products","tax_terms":"Confectionery Mixes","sku":"391020","access_levels":"public_access"},{"id":3372,"title":"Profiterole Shells Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/choux-paste-2\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3373,"title":"Profiterole Shells Recipe (With Oil)","url":"https:\/\/www.britishbakels.co.uk\/recipes\/choux-paste-3\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3266,"title":"Profiteroles","url":"https:\/\/www.britishbakels.co.uk\/recipes\/profiteroles\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":29909,"title":"Protect","url":"https:\/\/www.britishbakels.co.uk\/products\/protect\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Shelf Life Control","sku":"255075","access_levels":"public_access"},{"id":2977,"title":"Quantum Clean Label Improver","url":"https:\/\/www.britishbakels.co.uk\/products\/quantum-clean-label-improver\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"194230A","access_levels":"public_access"},{"id":2978,"title":"Quantum Premium Bread Improver","url":"https:\/\/www.britishbakels.co.uk\/products\/quantum-premium-bread-improver\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"194300","access_levels":"public_access"},{"id":4982,"title":"Quark Bread with Spelt Sourdough Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/quark-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3176,"title":"Raspberry Almond Tart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-almond-tart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17320,"title":"Raspberry and Chocolate Shooter","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-and-chocolate-shooter\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3287,"title":"Raspberry and Mint Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-and-mint-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3204,"title":"Raspberry and White Chocolate Banana Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-and-white-chocolate-banana-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":30115,"title":"Raspberry Bomboloni","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-bomboloni\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":23478,"title":"Raspberry Brioche Crown","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-brioche-crown\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":15005,"title":"Raspberry Caramel Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-caramel-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15031,"title":"Raspberry Caramel Danish","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-caramel-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15496,"title":"Raspberry Caramel Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-caramel-doughnut\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15018,"title":"Raspberry Caramel Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-caramel-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25298,"title":"Raspberry Caramel Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-caramel-slice-2\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":15069,"title":"Raspberry Caramel Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-caramel-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15574,"title":"Raspberry Caramel Yum Yum","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-caramel-yum-yum\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":15056,"title":"Raspberry Cereal Bites","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-cereal-bites\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":25035,"title":"Raspberry Chocolate Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-chocolate-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3185,"title":"Raspberry Coconut Slice Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-coconut-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3181,"title":"Raspberry Coffee Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/coffee-raspberry-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30129,"title":"Raspberry Cream Cheese Danish","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-cream-cheese-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":15483,"title":"Raspberry Cream Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-cream-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3182,"title":"Raspberry Granola Slice Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-granola-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":29819,"title":"Raspberry Millionaires Brownie Sandwich","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-millionaires-brownie-sandwich\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":8826,"title":"Raspberry Millionaires Caramel PF","url":"https:\/\/www.britishbakels.co.uk\/products\/raspberry-millionaires-caramel-pf\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471824","access_levels":"public_access"},{"id":30136,"title":"Raspberry Millionaires Caramel Tart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-millionaires-caramel-tart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3227,"title":"Raspberry Mini Tart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-mini-tart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30113,"title":"Raspberry Muffins","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-muffins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30050,"title":"Raspberry Swirl Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-swirl-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":23471,"title":"Raspberry Swiss Roll","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-swiss-roll\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3236,"title":"Raspberry Swiss Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-swiss-rolls\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":22640,"title":"Raspberry Tart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-tart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30117,"title":"Raspberry White Chocolate Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/raspberry-white-chocolate-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3089,"title":"Ready to use Caramel Sauce","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-caramel-sauce\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471180","access_levels":"public_access"},{"id":3002,"title":"Ready to use Crossing Paste","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-crossing-paste\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crossing Mix","sku":"413077","access_levels":"public_access"},{"id":3026,"title":"Ready to use Neutral Glaze","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-neutral-glaze\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Confectionery Glazes","sku":"346420, 346440","access_levels":null},{"id":3021,"title":"Ready to use Spiced Bun Glaze","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-spiced-bun-glaze\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Bun Glazes","sku":"345812","access_levels":null},{"id":3025,"title":"Ready to use Strawberry Glaze","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-strawberry-glaze\/","post_type":"Products","tax_terms":"Sweet & Savoury Glazes, Confectionery Glazes","sku":"346490, 346480","access_levels":"public_access"},{"id":3078,"title":"Ready-to-use Confectionery Filling - Lemon","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-confectionery-filling-lemon\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471550","access_levels":"public_access"},{"id":21662,"title":"Ready-to-use Confectionery Filling - Salted Caramel","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-confectionery-filling-salted-caramel\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"470175","access_levels":"public_access"},{"id":3079,"title":"Ready-to-use Confectionery Filling - Toffee","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-confectionery-filling-toffee\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471600","access_levels":"public_access"},{"id":21663,"title":"Ready-to-use Confectionery Filling - Vanilla","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-confectionery-filling-vanilla\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471322","access_levels":"public_access"},{"id":4557,"title":"Red Pepper Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/red-pepper-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":19592,"title":"Red Velvet Bundt Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/red-velvet-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3270,"title":"Red Velvet Caramel Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/red-velvet-caramel-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3250,"title":"Red Velvet Cobweb Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/red-velvet-cobweb-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5322,"title":"Red Velvet Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/red-velvet-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":21391,"title":"Red Velvet Stack","url":"https:\/\/www.britishbakels.co.uk\/recipes\/red-velvet-stack\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30318,"title":"Reindeer Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/reindeer-cupcake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3047,"title":"Release No 65","url":"https:\/\/www.britishbakels.co.uk\/products\/release-no-65\/","post_type":"Products","tax_terms":"Release Solutions, Cake\/Confectionery","sku":"132550","access_levels":"public_access"},{"id":19202,"title":"Removing Titanium Dioxide (TiO2) with Bakels","url":"https:\/\/www.britishbakels.co.uk\/insights\/removing-titanium-dioxide-with-bakels\/","post_type":"Insights","access_levels":null},{"id":3302,"title":"Rice Pop Christmas Trees","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rice-pop-christmas-trees\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3186,"title":"Rich Caramel Layer Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rich-caramel-layer-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3212,"title":"Rich Chocolate Crunchies","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rich-chocolate-crunchies\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3075,"title":"Rich Chocolate Fudgice","url":"https:\/\/www.britishbakels.co.uk\/products\/rich-chocolate-fudgice\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471800","access_levels":"public_access"},{"id":4595,"title":"Ring Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/ring-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3016,"title":"Rollex\u00ae Gold","url":"https:\/\/www.britishbakels.co.uk\/products\/rollex-gold\/","post_type":"Products","tax_terms":"Savoury & Pastry Ingredients, Pastry Fat","sku":"166050, 166060","access_levels":"public_access"},{"id":3332,"title":"Rosemary and Rock Salt Focaccia","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rosemary-and-rock-salt-focaccia-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4601,"title":"Rosemary and Rock Salt Focaccia with Spelt Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rosemary-and-rock-salt-sourdough-focaccia\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3333,"title":"Rosemary and Sweet Potato Tear and Share","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rosemary-and-sweet-potato-tear-and-share-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5403,"title":"RTU Cream Filling - Caramel","url":"https:\/\/www.britishbakels.co.uk\/products\/caramel-filling\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580257","access_levels":"public_access"},{"id":5429,"title":"RTU Cream Filling - Chocolate","url":"https:\/\/www.britishbakels.co.uk\/products\/chocolate-filling\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580250","access_levels":null},{"id":3081,"title":"RTU Cream Filling - Lemon","url":"https:\/\/www.britishbakels.co.uk\/products\/lemon-filling\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"584102","access_levels":"public_access"},{"id":5378,"title":"RTU Cream Filling - Orange","url":"https:\/\/www.britishbakels.co.uk\/products\/orange-filling\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580262","access_levels":"public_access"},{"id":14817,"title":"RTU Cream Filling - Raspberry","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-cream-filling-raspberry\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"584110","access_levels":null},{"id":14780,"title":"RTU Cream Filling - Vanilla","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-cream-filling-vanilla\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580247","access_levels":"public_access"},{"id":30353,"title":"RTU Salt & Pepper Tiger Paste","url":"https:\/\/www.britishbakels.co.uk\/products\/salt-pepper-tiger-paste\/","post_type":"Products","tax_terms":"Tiger Paste","sku":"","access_levels":"public_access"},{"id":27335,"title":"RTU Tiger Paste","url":"https:\/\/www.britishbakels.co.uk\/products\/rtu-tiger-paste\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Tiger Paste","sku":"413042","access_levels":"public_access"},{"id":24961,"title":"Ruby Truffle","url":"https:\/\/www.britishbakels.co.uk\/products\/ruby-truffle\/","post_type":"Products","tax_terms":"Truffles","sku":"537910","access_levels":"public_access"},{"id":3308,"title":"Rustic Pear Spiced Christmas Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rustic-pear-spiced-christmas-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4745,"title":"Rustic Seeded B\u00e2tard","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rustic-seeded-batard\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":6622,"title":"Rye Artisan Focaccia","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-artisan-focaccia\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3117,"title":"Rye Baguette Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/chia-baguette\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":7358,"title":"Rye Cheese Twist","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-cheese-twist\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3120,"title":"Rye Crackers","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-crackers\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":6869,"title":"Rye Danish","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":7247,"title":"Rye Mille Feuille","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-mille-feuille\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4069,"title":"Rye Oat and Barley Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-oat-barley-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":6793,"title":"Rye Pizza Base","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-pizza-base\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14026,"title":"Rye Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-roll\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":6907,"title":"Rye Soft Roll","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-soft-roll\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4617,"title":"Rye Wheat Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/rye-wheat-bread-60-40\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5113,"title":"Sage and Onion Stuffing and Cranberry Brioche","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sage-and-onion-stuffing-and-cranberry-brioche\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3269,"title":"Salted Caramel Biscuit Bars","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-caramel-biscuit-bars\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":19477,"title":"Salted Caramel Bundt Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-caramel-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17336,"title":"Salted Caramel Cheesecake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-caramel-cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3268,"title":"Salted Caramel Choux Ring Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-caramel-choux-rings\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30323,"title":"Salted Millionaire's Caramel Pudding","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-millionaires-caramel-pudding\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30326,"title":"Salted Millionaire's Caramel Stars","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-millionaires-caramel-stars\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":30328,"title":"Salted Millionaire's Caramel Yule Log","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-millionaires-caramel-yule-log\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3087,"title":"Salted Millionaires Caramel","url":"https:\/\/www.britishbakels.co.uk\/products\/salted-millionaires-caramel\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471956","access_levels":"public_access"},{"id":29805,"title":"Salted Millionaires Caramel Brownie Stacks","url":"https:\/\/www.britishbakels.co.uk\/recipes\/salted-millionaires-caramel-brownie-stacks\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4582,"title":"San Francisco Style Sourdough Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/san-francisco-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":25837,"title":"Santa Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/santa-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3169,"title":"Sausage Roll - Mincemeat","url":"https:\/\/www.britishbakels.co.uk\/recipes\/mincemeat\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3018,"title":"Sausage Roll Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/sausage-roll-concentrate\/","post_type":"Products","tax_terms":"Savoury & Pastry Ingredients, Savoury Ingredients","sku":"811050","access_levels":null},{"id":30350,"title":"Scotch Pancake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/scotch-pancake-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Mixes","sku":"","access_levels":"public_access"},{"id":4472,"title":"Scotch Pancake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/scotch-pancake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3164,"title":"Scotch Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/scotch-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14413,"title":"Seeded Artisan Bloomer","url":"https:\/\/www.britishbakels.co.uk\/recipes\/seeded-artisan-bloomer\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4607,"title":"Seeded B\u00e2tard with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/seeded-batard\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5207,"title":"Seeded Christmas Holly Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/seeded-christmas-holly\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":5159,"title":"Seeded Christmas Tree","url":"https:\/\/www.britishbakels.co.uk\/recipes\/seeded-christmas-tree\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":14414,"title":"Seeded Ciabatta Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/seeded-ciabatta-rolls\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3116,"title":"Seeded Rye Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/seed-soaker\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":28648,"title":"Sheep Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sheep-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":28873,"title":"Simnel Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/simnel-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":30422,"title":"Simnel Cake Bites","url":"https:\/\/www.britishbakels.co.uk\/recipes\/simnel-cake-bites\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":26308,"title":"Six ways to upgrade Festive Bakery at Christmas","url":"https:\/\/www.britishbakels.co.uk\/insights\/six-ways-to-upgrade-festive-bakery-at-christmas\/","post_type":"Insights","access_levels":"public_access"},{"id":4548,"title":"Smoked Meat Marinade","url":"https:\/\/www.britishbakels.co.uk\/recipes\/smoked-meat-marinade\/","post_type":"Recipes","tax_terms":"Cooking","access_levels":null},{"id":4867,"title":"Smoked Roulade Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/smoked-roulade\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4738,"title":"Smoked Rye-Wheat Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/smoked-rye-wheat-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4506,"title":"Smoked Sourdough Hamburger Buns Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/smoked-sourdough-burger-bun\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4622,"title":"Snack Roll with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sourdough-snack-roll\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":13297,"title":"Snap-worthy Designer Doughnut Ideas for your Bakery","url":"https:\/\/www.britishbakels.co.uk\/insights\/doughnut-toppings-fillings\/","post_type":"Insights","access_levels":null},{"id":30293,"title":"Snowflake Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/snowflake-cupcakes\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3343,"title":"Soft Rolls","url":"https:\/\/www.britishbakels.co.uk\/recipes\/soft-rolls-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3038,"title":"Sorbex","url":"https:\/\/www.britishbakels.co.uk\/products\/sorbex\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake Shelf Life Extenders","sku":"271150A, 271020","access_levels":"public_access"},{"id":4730,"title":"Sourdough Burger Buns Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/spelt-sourdough-burger-bun\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4628,"title":"Sourdough Cracker Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sourdough-cracker\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4550,"title":"Sourdough Pasta Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/smoked-sourdough-pasta\/","post_type":"Recipes","tax_terms":"Cooking","access_levels":null},{"id":28635,"title":"Speculoos 'Carrot' Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/speculoos-carrot-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":29788,"title":"Speculoos Brownie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/speculoos-brownie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":25818,"title":"Speculoos Cheesecake Tart","url":"https:\/\/www.britishbakels.co.uk\/recipes\/speculoos-cheesecake-tart\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":24041,"title":"Speculoos Cr\u00e8me Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/speculoos-creme-cake-mix\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"373045","access_levels":"public_access"},{"id":22820,"title":"Speculoos Crumbles","url":"https:\/\/www.britishbakels.co.uk\/products\/speculoos-crumbles\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Confectionery Mixes","sku":"562050","access_levels":"public_access"},{"id":22683,"title":"Speculoos Doughnut","url":"https:\/\/www.britishbakels.co.uk\/recipes\/speculoos-doughnut\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":25136,"title":"Speculoos Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/speculoos-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21348,"title":"Speculoos Spread","url":"https:\/\/www.britishbakels.co.uk\/products\/speculoos-spread\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"580295","access_levels":"public_access"},{"id":23062,"title":"Speculoos: Are you keeping up with the trend?","url":"https:\/\/www.britishbakels.co.uk\/insights\/speculoos-are-you-keeping-up-with-the-trend\/","post_type":"Insights","access_levels":"public_access"},{"id":4911,"title":"Spelt Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/spelt-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3249,"title":"Spicy Easter Bundt Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/spicy-easter-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4909,"title":"Spinach and Feta Plait with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/spinach-and-feta-plait-with-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3170,"title":"Sponge","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sponge\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3048,"title":"Sponge Mix Complete","url":"https:\/\/www.britishbakels.co.uk\/products\/sponge-mix-complete\/","post_type":"Products","tax_terms":"Cake & Sponge Ingredients, Cake & Sponge Mixes","sku":"382611","access_levels":"public_access"},{"id":3300,"title":"Spooky Cake Pops Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/spooky-cake-pops\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3010,"title":"Sprink","url":"https:\/\/www.britishbakels.co.uk\/products\/sprink\/","post_type":"Products","tax_terms":"Release Solutions, Bread, Cake\/Confectionery","sku":"132040","access_levels":"public_access"},{"id":6830,"title":"Stilton & Walnut Savoury Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/stilton-walnut-savoury-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":21386,"title":"Stock Syrup","url":"https:\/\/www.britishbakels.co.uk\/products\/stock-syrup\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Meringue Mixes","sku":"345870","access_levels":"public_access"},{"id":19585,"title":"Stollen","url":"https:\/\/www.britishbakels.co.uk\/recipes\/stollen-2\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":9587,"title":"Stollen Bites","url":"https:\/\/www.britishbakels.co.uk\/recipes\/stollen-bites\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":17334,"title":"Strawberry & Lemon Cheesecake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-and-lemon-cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30119,"title":"Strawberry Buns","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-buns\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3222,"title":"Strawberry Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":30126,"title":"Strawberry Focaccia","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-focaccia\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":22637,"title":"Strawberry Gateau","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-gateau\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":22639,"title":"Strawberry Pie","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-pie\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4906,"title":"Strawberry Plait with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-plait-with-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3226,"title":"Strawberry Scone","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-scone\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17328,"title":"Strawberry Trifle Cake-away Jar","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-trifle-cake-away-jar\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5326,"title":"Strawberry Valentine's Gateau","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-valentines-gateau\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4686,"title":"Strawberry, Lime and Vanilla Danish with Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/strawberry-lime-and-vanilla-sourdough-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":2986,"title":"Super Bacom","url":"https:\/\/www.britishbakels.co.uk\/products\/super-bacom\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crumb Softeners","sku":"218222","access_levels":"public_access"},{"id":2979,"title":"Super Lecitem\u00ae 3000","url":"https:\/\/www.britishbakels.co.uk\/products\/super-lecitem-3000\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Bread & Roll Improvers","sku":"198850A","access_levels":"public_access"},{"id":2987,"title":"Super Monobac","url":"https:\/\/www.britishbakels.co.uk\/products\/super-monobac\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crumb Softeners","sku":"218505","access_levels":"public_access"},{"id":2988,"title":"Supersoft B","url":"https:\/\/www.britishbakels.co.uk\/products\/supersoft-b\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Crumb Softeners","sku":"218050","access_levels":"public_access"},{"id":11607,"title":"Sweden","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/sweden\/","post_type":"Baking Centres","access_levels":null},{"id":3188,"title":"Swedish Almond Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/swedish-almond-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3166,"title":"Sweet Puff Pastry Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/puff-pastry\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3171,"title":"Swiss Roll Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/swiss-roll\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3389,"title":"Switzerland","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/switzerland\/","post_type":"Baking Centres","access_levels":null},{"id":27654,"title":"Ta-Da!\u00ae Chocolate Brownie Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/ta-da-chocolate-brownie-mix\/","post_type":"Products","tax_terms":"Home Baking","sku":"384200","access_levels":"public_access"},{"id":27775,"title":"Ta-Da!\u00ae Chocolate Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/ta-da-chocolate-cake-mix\/","post_type":"Products","tax_terms":"Home Baking","sku":"384190","access_levels":"public_access"},{"id":27533,"title":"Ta-Da!\u00ae Pizza Base Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/ta-da-pizza-base-mix\/","post_type":"Products","tax_terms":"Home Baking","sku":"392360","access_levels":"public_access"},{"id":27058,"title":"Ta-Da!\u00ae Triple Seed Bread Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/ta-da-triple-seed-bread-mix\/","post_type":"Products","tax_terms":"Home Baking","sku":"397280","access_levels":"public_access"},{"id":27920,"title":"Ta-Da!\u00ae Vanilla Cake Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/ta-da-vanilla-cake-mix\/","post_type":"Products","tax_terms":"Home Baking","sku":"384180","access_levels":"public_access"},{"id":27400,"title":"Ta-Da!\u00ae White Bread Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/ta-da-white-bread-mix\/","post_type":"Products","tax_terms":"Home Baking","sku":"397285","access_levels":"public_access"},{"id":3392,"title":"Thailand","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/thailand\/","post_type":"Baking Centres","access_levels":null},{"id":13016,"title":"The Bounce-Back Bakery: Tips to Entice your Customers","url":"https:\/\/www.britishbakels.co.uk\/insights\/the-bounce-back-bakery-tips-to-entice-your-customers\/","post_type":"Insights","access_levels":null},{"id":11974,"title":"The only way is up for Caramel","url":"https:\/\/www.britishbakels.co.uk\/insights\/the-only-way-is-up-for-caramel\/","post_type":"Insights","access_levels":null},{"id":14928,"title":"The rise and rise of Vegan Baked Goods","url":"https:\/\/www.britishbakels.co.uk\/insights\/the-rise-of-vegan-baked-goods\/","post_type":"Insights","access_levels":null},{"id":12750,"title":"The Rise of the \u201cSide-Hustle\u201d Baker","url":"https:\/\/www.britishbakels.co.uk\/insights\/the-rise-of-the-side-hustle-baker\/","post_type":"Insights","access_levels":null},{"id":11746,"title":"The Takeaway Baker\u2014How UK bakeries have survived and thrived during COVID-19","url":"https:\/\/www.britishbakels.co.uk\/insights\/how-uk-bakeries-have-survived-and-thrived-during-covid-19\/","post_type":"Insights","access_levels":null},{"id":2980,"title":"Tiger Paste Mix","url":"https:\/\/www.britishbakels.co.uk\/products\/tiger-paste-mix\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Tiger Paste","sku":"412980","access_levels":null},{"id":4541,"title":"Tin Bread with Spelt Sourdough Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/white-tin-bread-3\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4743,"title":"Tin Bread with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/classic-sourdough-tin-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3011,"title":"Tincol\u00ae","url":"https:\/\/www.britishbakels.co.uk\/products\/tincol\/","post_type":"Products","tax_terms":"Release Solutions, Bread","sku":"133030, 133050","access_levels":"public_access"},{"id":3044,"title":"Tinglide\u00ae","url":"https:\/\/www.britishbakels.co.uk\/products\/tinglide\/","post_type":"Products","tax_terms":"Release Solutions, Cake\/Confectionery","sku":"135610","access_levels":"public_access"},{"id":3045,"title":"Tinglide\u00ae No 2","url":"https:\/\/www.britishbakels.co.uk\/products\/tinglide-no-2\/","post_type":"Products","tax_terms":"Release Solutions, Cake\/Confectionery","sku":"135025","access_levels":"public_access"},{"id":3046,"title":"Tinglide\u00ae Super","url":"https:\/\/www.britishbakels.co.uk\/products\/tinglide-super\/","post_type":"Products","tax_terms":"Release Solutions, Cake\/Confectionery","sku":"135800","access_levels":"public_access"},{"id":3370,"title":"Toffee Apple Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/toffee-apple-cake-2\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3177,"title":"Toffee Apple Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/toffee-apple-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3203,"title":"Toffee Banana Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/toffee-banana-cake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3240,"title":"Toffee Cupcake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/toffee-cupcake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17428,"title":"Tomato, Garlic & Rosemary Focaccia","url":"https:\/\/www.britishbakels.co.uk\/recipes\/tomato-garlic-and-rosemary-focaccia\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":11749,"title":"Top Tips for Top Bakery Sales","url":"https:\/\/www.britishbakels.co.uk\/insights\/top-tips-for-top-bakery-sales\/","post_type":"Insights","access_levels":null},{"id":3118,"title":"Treacle and Millet Rye Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/treacle-and-millet-rye-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":25211,"title":"Triple Speculoos Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/triple-speculoos-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3267,"title":"Truffle Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/truffles\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4567,"title":"Twisted Bread with Durum Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/twisted-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4724,"title":"Twisted Bread with Spelt Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/twisted-classic-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4577,"title":"Twisted Bread with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/twisted-intense-sourdough-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":21035,"title":"UK Dessert Trends to look out for in 2022","url":"https:\/\/www.britishbakels.co.uk\/insights\/uk-dessert-trends-2022\/","post_type":"Insights","access_levels":null},{"id":3243,"title":"Valentine Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/luxury-chocolate-valentines-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4057,"title":"Valentine Push Pop Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/heart-push-pops\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4059,"title":"Valentine's Meringue","url":"https:\/\/www.britishbakels.co.uk\/recipes\/valentines-meringue\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":21409,"title":"Valentine's Raspberry Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/valentines-raspberry-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21407,"title":"Valentine's Strawberry Cheesecake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/valentines-strawberry-cheesecake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21410,"title":"Valentine's Strawberry Cheesecake Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/valentines-strawberry-cheesecake-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":21389,"title":"Valentine's Strawberry Cupcakes","url":"https:\/\/www.britishbakels.co.uk\/recipes\/valentines-strawberry-cupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":5323,"title":"Valentine's Tarts","url":"https:\/\/www.britishbakels.co.uk\/recipes\/valentines-tarts\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":15431,"title":"Vanilla Cream Doughnut - Vegan","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vanilla-cream-doughnut-vegan\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":23476,"title":"Vegan Baked Alaska","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-baked-alaska\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4289,"title":"Vegan Beetroot Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-beetroot-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":14779,"title":"Vegan Caramel PF","url":"https:\/\/www.britishbakels.co.uk\/products\/vegan-caramel-pf\/","post_type":"Products","tax_terms":"Icings, Coverings & Fillings","sku":"471814","access_levels":"public_access"},{"id":4288,"title":"Vegan Cherry and Almond Traybake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-cherry-and-almond-tray-bake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4261,"title":"Vegan Chocolate and Pistachio Muffin Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-chocolate-and-pistachio-muffins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":8878,"title":"Vegan Chocolate Chip Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-chocolate-chip-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":5175,"title":"Vegan Christmas Cupcakes Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/christmasvegancupcakes\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":17423,"title":"Vegan Danish","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-danish\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":19571,"title":"Vegan Date & Walnut Brioche","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-date-and-walnut-brioche\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":4263,"title":"Vegan Ginger and Lemon Muffin Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-ginger-and-lemon-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4269,"title":"Vegan Ginger Tea Masala Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-ginger-tea-masala-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4273,"title":"Vegan Lime Loaf Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-lime-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4259,"title":"Vegan Luxury Victoria Sponge","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-luxury-victoria-sponge\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4291,"title":"Vegan Matcha and Chocolate Marble Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-matcha-and-chocolate-marble-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4290,"title":"Vegan Matcha, Lemon and Poppy Seed Bundt Cake Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-matcha-lemon-and-poppy-seed-bundt-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4287,"title":"Vegan Miniature Spiced Carrot Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-miniature-spiced-carrot-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4267,"title":"Vegan Orange and Chocolate Chip Muffin Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-orange-and-chocolate-chip-muffin\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4255,"title":"Vegan Peanut Butter Muffin","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-peanut-butter-muffins\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4271,"title":"Vegan Pecan and Banana Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-pecan-and-banana-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4283,"title":"Vegan Pistachio Miniature Loaf Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-pistachio-miniature-loaf-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":4265,"title":"Vegan Rich Fruit Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-rich-fruit-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":6870,"title":"Vegan Seeded Rye Twist","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-seeded-rye-twist\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":23473,"title":"Vegan Strawberry & Vanilla Cake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/vegan-strawberry-and-vanilla-cake\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":"public_access"},{"id":3198,"title":"Victoria Sponge Slice","url":"https:\/\/www.britishbakels.co.uk\/recipes\/victoria-sponge-slice\/","post_type":"Recipes","tax_terms":"Patisserie","access_levels":null},{"id":3004,"title":"Voltem\u00ae","url":"https:\/\/www.britishbakels.co.uk\/products\/voltem\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Fats for Fermented Goods","sku":"171400","access_levels":"public_access"},{"id":17332,"title":"Waffles","url":"https:\/\/www.britishbakels.co.uk\/recipes\/waffles\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":4972,"title":"Walnut Sourdough Bread Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/walnut-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":22685,"title":"Welcome to the Team: Meet tomorrow's Industry Professionals","url":"https:\/\/www.britishbakels.co.uk\/insights\/welcome-to-the-team-meet-tomorrows-industry-professionals\/","post_type":"Insights","access_levels":"public_access"},{"id":21791,"title":"What's sweet for 2022? Flavour trends to watch","url":"https:\/\/www.britishbakels.co.uk\/insights\/whats-sweet-for-2022-flavour-trends-to-watch\/","post_type":"Insights","access_levels":"public_access"},{"id":3077,"title":"White Fudgice","url":"https:\/\/www.britishbakels.co.uk\/products\/white-fudgice\/","post_type":"Products","tax_terms":"Confectionery Ingredients, Icings, Coverings & Fillings","sku":"471935","access_levels":"public_access"},{"id":3147,"title":"White Tin Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/white-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":24962,"title":"White Truffle","url":"https:\/\/www.britishbakels.co.uk\/products\/white-truffle\/","post_type":"Products","tax_terms":"Truffles","sku":"536611","access_levels":"public_access"},{"id":24963,"title":"White Truffle - Soft","url":"https:\/\/www.britishbakels.co.uk\/products\/white-truffle-soft\/","post_type":"Products","tax_terms":"Truffles","sku":"537511","access_levels":"public_access"},{"id":4647,"title":"White Truffle Ciabatta Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/white-truffle-ciabatta\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":4737,"title":"Whole Wheat Sourdough Baguette Recipe","url":"https:\/\/www.britishbakels.co.uk\/recipes\/sourdough-baguette\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":3146,"title":"Wholemeal Bread","url":"https:\/\/www.britishbakels.co.uk\/recipes\/wholemeal-bread\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":11747,"title":"Why would you use Bread Improver?","url":"https:\/\/www.britishbakels.co.uk\/insights\/why-would-you-use-bread-improver\/","post_type":"Insights","access_levels":null},{"id":4869,"title":"Wrap with Wheat Sourdough","url":"https:\/\/www.britishbakels.co.uk\/recipes\/wrap-with-wheat-sourdough\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":null},{"id":13717,"title":"Wrapped Goods Solutions","url":"https:\/\/www.britishbakels.co.uk\/insights\/wrapped-goods-solutions\/","post_type":"Insights","access_levels":null},{"id":30321,"title":"Wreath Cupcake","url":"https:\/\/www.britishbakels.co.uk\/recipes\/wreath-cupcake\/","post_type":"Recipes","tax_terms":"Bakery","access_levels":"public_access"},{"id":3056,"title":"Yeast Doughnut Concentrate","url":"https:\/\/www.britishbakels.co.uk\/products\/yeast-doughnut-concentrate\/","post_type":"Products","tax_terms":"Bread, Roll & Morning Goods, Doughnut Concentrates","sku":"378160, 378185","access_levels":"public_access"}] ) );
+                </script><script type='text/javascript'>
+                    var imdmsTypeaheadPageTaxonomyJSON = 'typeaheadPageTaxonomyJSON_en';
+                    localStorage.setItem( 'typeaheadPageTaxonomyJSON_en', JSON.stringify( [{"id":85,"title":"About","url":"https:\/\/www.britishbakels.co.uk\/about\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":3654,"title":"Artisan Bakery","url":"https:\/\/www.britishbakels.co.uk\/artisanbakery\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":103,"title":"Baking Centres","url":"https:\/\/www.britishbakels.co.uk\/services\/baking-centres\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":3556,"title":"British Bakels","url":"https:\/\/www.britishbakels.co.uk\/britishbakels\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":10035,"title":"British Bakels Covid-19 Statement","url":"https:\/\/www.britishbakels.co.uk\/british-bakels-covid-19-statement\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":null},{"id":93,"title":"Centres of Competence","url":"https:\/\/www.britishbakels.co.uk\/centres-of-competence\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":79,"title":"Core Values","url":"https:\/\/www.britishbakels.co.uk\/core-values\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":81,"title":"Facts & Figures","url":"https:\/\/www.britishbakels.co.uk\/facts-figures\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":80,"title":"History","url":"https:\/\/www.britishbakels.co.uk\/history\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":3649,"title":"Instant Cream","url":"https:\/\/www.britishbakels.co.uk\/cakeshop\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":76,"title":"Jobs","url":"https:\/\/www.britishbakels.co.uk\/jobs\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":78,"title":"Mission Statement","url":"https:\/\/www.britishbakels.co.uk\/mission-statement\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":87,"title":"Our Customers","url":"https:\/\/www.britishbakels.co.uk\/our-customers\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":92,"title":"Research & Development","url":"https:\/\/www.britishbakels.co.uk\/research-development\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":89,"title":"Services","url":"https:\/\/www.britishbakels.co.uk\/services\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":23909,"title":"Sustainability Commitment","url":"https:\/\/www.britishbakels.co.uk\/sustainability-commitment\/","post_type":"Pages","tax_terms":"","sku":"","access_levels":"public_access"},{"id":1757,"title":"Bread, Roll & Morning Goods","url":"https:\/\/www.britishbakels.co.uk\/product-category\/bread-roll-morning-goods\/","post_type":"Product Categories"},{"id":1759,"title":"Speciality Bread Mixes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/speciality-bread-mixes-bread-roll-morning-goods\/","post_type":"Product Categories"},{"id":1758,"title":"Bread & Roll Improvers","url":"https:\/\/www.britishbakels.co.uk\/product-category\/bread-roll-improvers\/","post_type":"Product Categories"},{"id":1763,"title":"Soft Roll Concentrates","url":"https:\/\/www.britishbakels.co.uk\/product-category\/roll-concentrates\/","post_type":"Product Categories"},{"id":1764,"title":"Bun Concentrates","url":"https:\/\/www.britishbakels.co.uk\/product-category\/bun-concentrates\/","post_type":"Product Categories"},{"id":2994,"title":"Crusty Concentrates","url":"https:\/\/www.britishbakels.co.uk\/product-category\/crusty-concentrates\/","post_type":"Product Categories"},{"id":2995,"title":"Brioche Concentrates","url":"https:\/\/www.britishbakels.co.uk\/product-category\/brioche-concentrates\/","post_type":"Product Categories"},{"id":1765,"title":"Crossing Mix","url":"https:\/\/www.britishbakels.co.uk\/product-category\/crossing-mix\/","post_type":"Product Categories"},{"id":2992,"title":"Doughnut Concentrates","url":"https:\/\/www.britishbakels.co.uk\/product-category\/doughnut-concentrates\/","post_type":"Product Categories"},{"id":1761,"title":"Tiger Paste","url":"https:\/\/www.britishbakels.co.uk\/product-category\/tiger-paste\/","post_type":"Product Categories"},{"id":1762,"title":"Crumb Softeners","url":"https:\/\/www.britishbakels.co.uk\/product-category\/crumb-softeners\/","post_type":"Product Categories"},{"id":1766,"title":"Fats for Fermented Goods","url":"https:\/\/www.britishbakels.co.uk\/product-category\/fats-for-fermented-goods\/","post_type":"Product Categories"},{"id":1768,"title":"Dough Relaxant","url":"https:\/\/www.britishbakels.co.uk\/product-category\/dough-relaxant\/","post_type":"Product Categories"},{"id":1770,"title":"Sourdough Products","url":"https:\/\/www.britishbakels.co.uk\/product-category\/sourdough-powders\/","post_type":"Product Categories"},{"id":1779,"title":"Cake & Sponge Ingredients","url":"https:\/\/www.britishbakels.co.uk\/product-category\/cake-sponge-products\/","post_type":"Product Categories"},{"id":1780,"title":"Cake & Sponge Emulsifiers","url":"https:\/\/www.britishbakels.co.uk\/product-category\/cake-sponge-emulsifiers\/","post_type":"Product Categories"},{"id":1781,"title":"Baking Powders","url":"https:\/\/www.britishbakels.co.uk\/product-category\/baking-powders\/","post_type":"Product Categories"},{"id":1782,"title":"Cake Shelf Life Extenders","url":"https:\/\/www.britishbakels.co.uk\/product-category\/shelf-life-extenders\/","post_type":"Product Categories"},{"id":1783,"title":"Milk Powder & Egg Extenders","url":"https:\/\/www.britishbakels.co.uk\/product-category\/milk-powder-egg-extenders\/","post_type":"Product Categories"},{"id":1785,"title":"Cake & Sponge Mixes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/cake-sponge-mixes\/","post_type":"Product Categories"},{"id":3385,"title":"Release Solutions","url":"https:\/\/www.britishbakels.co.uk\/product-category\/release-solutions\/","post_type":"Product Categories"},{"id":1786,"title":"Confectionery Ingredients","url":"https:\/\/www.britishbakels.co.uk\/product-category\/confectionery-mixes\/","post_type":"Product Categories"},{"id":1788,"title":"Confectionery Mixes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/confectionery-mixes-confectionery-mixes\/","post_type":"Product Categories"},{"id":1792,"title":"Icings, Coverings & Fillings","url":"https:\/\/www.britishbakels.co.uk\/product-category\/icings-coverings-fillings\/","post_type":"Product Categories"},{"id":2993,"title":"Dessert Mixes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/dessert-mixes\/","post_type":"Product Categories"},{"id":1789,"title":"Meringue Mixes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/meringue-mixes\/","post_type":"Product Categories"},{"id":1790,"title":"Cream Stabiliser","url":"https:\/\/www.britishbakels.co.uk\/product-category\/cream-stabiliser\/","post_type":"Product Categories"},{"id":1791,"title":"Custard Mixes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/custard-mixes\/","post_type":"Product Categories"},{"id":1795,"title":"Fruit Pie Thickener","url":"https:\/\/www.britishbakels.co.uk\/product-category\/fruit-pie-thickener\/","post_type":"Product Categories"},{"id":1793,"title":"Ice Cream Products","url":"https:\/\/www.britishbakels.co.uk\/product-category\/ice-cream-products\/","post_type":"Product Categories"},{"id":1775,"title":"Sweet & Savoury Glazes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/glazes-sweet-savoury\/","post_type":"Product Categories"},{"id":1776,"title":"Bun Glazes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/bun-glazes\/","post_type":"Product Categories"},{"id":3288,"title":"Savoury Glaze","url":"https:\/\/www.britishbakels.co.uk\/product-category\/savoury-glaze\/","post_type":"Product Categories"},{"id":1778,"title":"Confectionery Glazes","url":"https:\/\/www.britishbakels.co.uk\/product-category\/confectionery-glazes\/","post_type":"Product Categories"},{"id":1771,"title":"Savoury & Pastry Ingredients","url":"https:\/\/www.britishbakels.co.uk\/product-category\/savoury-pastry-products\/","post_type":"Product Categories"},{"id":1774,"title":"Savoury Ingredients","url":"https:\/\/www.britishbakels.co.uk\/product-category\/sausage-roll-concentrate\/","post_type":"Product Categories"},{"id":1772,"title":"Pastry Fat","url":"https:\/\/www.britishbakels.co.uk\/product-category\/pastry-fat\/","post_type":"Product Categories"},{"id":1794,"title":"Pastry Relaxer","url":"https:\/\/www.britishbakels.co.uk\/product-category\/pastry-relaxer\/","post_type":"Product Categories"},{"id":3129,"title":"Pastry Improver","url":"https:\/\/www.britishbakels.co.uk\/product-category\/viennoiserie\/","post_type":"Product Categories"},{"id":1773,"title":"Pie Filling Thickener","url":"https:\/\/www.britishbakels.co.uk\/product-category\/pie-filling-thickener\/","post_type":"Product Categories"},{"id":3386,"title":"Bread","url":"https:\/\/www.britishbakels.co.uk\/product-category\/bread\/","post_type":"Product Categories"},{"id":3387,"title":"Cake\/Confectionery","url":"https:\/\/www.britishbakels.co.uk\/product-category\/cake-confectionery\/","post_type":"Product Categories"},{"id":3689,"title":"Colours","url":"https:\/\/www.britishbakels.co.uk\/product-category\/colours\/","post_type":"Product Categories"},{"id":3688,"title":"Flavours","url":"https:\/\/www.britishbakels.co.uk\/product-category\/flavours\/","post_type":"Product Categories"},{"id":3687,"title":"Flavours & Colours","url":"https:\/\/www.britishbakels.co.uk\/product-category\/flavours-colours\/","post_type":"Product Categories"},{"id":3695,"title":"Truffles","url":"https:\/\/www.britishbakels.co.uk\/product-category\/truffles\/","post_type":"Product Categories"},{"id":3745,"title":"Home Baking","url":"https:\/\/www.britishbakels.co.uk\/product-category\/home-baking\/","post_type":"Product Categories"},{"id":3851,"title":"Shelf Life Control","url":"https:\/\/www.britishbakels.co.uk\/product-category\/shelf-life-control\/","post_type":"Product Categories"},{"id":1796,"title":"Bakery","url":"https:\/\/www.britishbakels.co.uk\/recipe-category\/bakery\/","post_type":"Recipe Categories"},{"id":3113,"title":"Cooking","url":"https:\/\/www.britishbakels.co.uk\/recipe-category\/cooking\/","post_type":"Recipe Categories"},{"id":1797,"title":"Patisserie","url":"https:\/\/www.britishbakels.co.uk\/recipe-category\/patisserie\/","post_type":"Recipe Categories"}] ) );
+                </script><script type='text/javascript'>
+        var ualType = 0, ualRestrictedLevels = ["subscriber_access","staff_access"];
+    </script>	<script>
+	function copyClipboard() {
+		let copyTextarea = document.getElementById('clipboard');
+
+		copyTextarea.select();
+		document.execCommand('copy');
+		this.focus();
+	}
+
+	function copyClipboardMobile() {
+		let copyTextarea = document.getElementById('clipboard-mobile');
+
+		copyTextarea.select();
+		document.execCommand('copy');
+		this.focus();
+	}
+	</script>
+    	<script>
+   		var countrySelected = "GB";
+	</script>
+    <script></script><meta name="generator" content="Powered by WPBakery Page Builder - drag and drop page builder for WordPress."/>
+			<script type='text/javascript'>
+		        /* <![CDATA[ */
+		        var stockist_lang =  'en';
+		        /* ]]> */
+	     	</script>
+
+		<noscript><style> .wpb_animate_when_almost_visible { opacity: 1; }</style></noscript>        <link rel="stylesheet" href="https://use.typekit.net/tnw7zdv.css">
+
+                <!--[if lte IE 11]>
+        <script type="text/javascript">window.location = "/browser-upgrade/";</script>
+        <![endif]-->
+            </head>
+
+    <body class="recipes-template-default single single-recipes postid-3128 full-width-content bakels-en site-2 wpb-js-composer js-comp-ver-7.6 vc_responsive">
+
+        
+    	<!-- BEGIN CONTAINER -->
+      	<div class="wrapper">
+        
+<div class="header-top ">
+	<div class="container">
+		<div class="row">
+						<div class="col-xl-7 col-lg-6 d-lg-flex d-none justify-content-end header-center offset-lg-3 offset-xl-2">
+				<nav class="navbar top-nav navbar-expand" id="top-nav">
+					<div class="top-navbar navbar-collapse">
+						<ul id="menu-primary-menu" class="navbar-nav"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-211" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-211 nav-item"><a title="Jobs" href="https://www.britishbakels.co.uk/jobs/" class="nav-link">Jobs</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-212" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent menu-item-212 nav-item"><a title="News" href="https://www.britishbakels.co.uk/news/" class="nav-link">News</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-12090" class="menu-item menu-item-type-post_type_archive menu-item-object-insight menu-item-12090 nav-item"><a title="Insights" href="https://www.britishbakels.co.uk/insights/" class="nav-link">Insights</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-299" class="menu-item menu-item-type-post_type_archive menu-item-object-stockist menu-item-299 nav-item"><a title="Where to buy" href="https://www.britishbakels.co.uk/stockist/" class="nav-link">Where to buy</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-210" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-210 nav-item"><a title="Contact" href="https://www.britishbakels.co.uk/contact/" class="nav-link">Contact</a></li>
+</ul>
+						<div id="account-nav" class="navbar account-nav navbar-expand-sm d-inline-block">
+							<ul class="navbar-nav">
+								<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" class="menu-item menu-item-type-post_type menu-item-object-page nav-item">
+									<a title="My Bakels" href="https://www.britishbakels.co.uk/my-bakels/" class="dropdown-toggle nav-link" data-toggle="dropdown" role="button">My Bakels</a>
+									<ul id="menu-logged-out-menu" class="dropdown-menu loggedout-nav"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-218" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-218 nav-item"><a title="Login" href="https://www.britishbakels.co.uk/my-bakels/login/" class="nav-link">Login</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-217" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-217 nav-item"><a title="Register" href="https://www.britishbakels.co.uk/my-bakels/register/" class="nav-link">Register</a></li>
+</ul>								</li>
+							</ul>
+						</div>
+					</div>
+				</nav>
+			</div>
+			<div class="col-lg-3 d-lg-block d-none header-right">
+						<form role="search" method="get" id="headertop-searchform" class="searchform search-form typeahead__form" action="https://www.britishbakels.co.uk">
+			<div class="typeahead__container">
+				<div class="typeahead__field">
+					<div class="typeahead__query">
+						<label class="screen-reader-text" for="headertop-s" style="display: none;">Search:</label>
+						<input name="s" type="search" value="" class="search-typeahead" id="headertop-s" placeholder="Search..." autocomplete="off">
+					</div>
+					<div class="typeahead__button">
+						<button type="submit" id="headertop-searchsubmit" class="btn btn-search">Search</button>
+					</div>
+				</div>
+			</div>
+		</form>
+
+				</div>
+		</div>
+	</div>
+</div>
+
+<header class="site-header" itemscope="" itemtype="https://schema.org/WPHeader">
+	<div class="container">
+		<div class="row">
+			<div class="col-2 d-lg-none d-flex mobile-btn">
+				<button class="menu-btn" id="responsive-menu">
+					<img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/hamburger-icon.svg" alt="Menu">
+					<!-- <span>Menu</span> -->
+				</button>
+			</div>
+
+			<div class="col-lg-3 col-8 site-logo text-xs-center">
+				<a href="https://www.britishbakels.co.uk" title="British Bakels" class="site-title">
+					<img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/logo-blue-new.svg" alt="British Bakels" class="dnp d-lg-inline-block d-none">
+					<img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/logo-responsive-blue.svg" alt="British Bakels" class="dnp d-lg-none d-inline-block">
+					<img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/logo-blue-new.svg" alt="British Bakels" class="print-logo">
+				</a>
+
+				<div class="mobile-search">
+							<form role="search" method="get" id="logo-searchform" class="searchform search-form typeahead__form" action="https://www.britishbakels.co.uk">
+			<div class="typeahead__container">
+				<div class="typeahead__field">
+					<div class="typeahead__query">
+						<label class="screen-reader-text" for="logo-s" style="display: none;">Search:</label>
+						<input name="s" type="search" value="" class="search-typeahead" id="logo-s" placeholder="Search..." autocomplete="off">
+					</div>
+					<div class="typeahead__button">
+						<button type="submit" id="logo-searchsubmit" class="btn btn-search">Search</button>
+					</div>
+				</div>
+			</div>
+		</form>
+
+					</div>
+			</div>
+
+			<div class="col-lg-9 col-2 header-right text-xs-right">
+				<button class="d-lg-none d-inline-block search-btn" id="search-toggle">Search</button>
+
+				<nav class="primary-nav navbar-mega navbar-expand-lg d-lg-block d-none navbar-special" id="nav-primary" itemscope="" itemtype="https://schema.org/SiteNavigationElement" aria-label="Main navigation">
+					<div class="navbar-collapse">
+						<ul id="menu-main-menu" class="navbar-nav navbar-nav-mega"><li id="menu-item-219" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-219 nav-item dropdown dropdown-mega product-category"><a title="Products" href="https://www.britishbakels.co.uk/products/" data-toggle="dropdown" id="219" aria-haspopup="true" role="button" class="nav-link">Products <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-219" aria-labelledby="menu-item-219"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>Products</h4><p>Bakels develop, manufacture and distribute innovative ingredients and solutions for bakers and patissiers across all five continents.</p><a href="https://www.britishbakels.co.uk/products/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">View all products</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-11" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-11 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-1757"><a title="Bread, Roll &amp; Morning Goods" href="https://www.britishbakels.co.uk/product-category/bread-roll-morning-goods/" class="nav-link"><span class="align-middle">Bread, Roll &amp; Morning Goods</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1759"><a href="https://www.britishbakels.co.uk/product-category/speciality-bread-mixes-bread-roll-morning-goods/">Speciality Bread Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1758"><a href="https://www.britishbakels.co.uk/product-category/bread-roll-improvers/">Bread &amp; Roll Improvers</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1763"><a href="https://www.britishbakels.co.uk/product-category/roll-concentrates/">Soft Roll Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1764"><a href="https://www.britishbakels.co.uk/product-category/bun-concentrates/">Bun Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2994"><a href="https://www.britishbakels.co.uk/product-category/crusty-concentrates/">Crusty Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2995"><a href="https://www.britishbakels.co.uk/product-category/brioche-concentrates/">Brioche Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1765"><a href="https://www.britishbakels.co.uk/product-category/crossing-mix/">Crossing Mix</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2992"><a href="https://www.britishbakels.co.uk/product-category/doughnut-concentrates/">Doughnut Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1761"><a href="https://www.britishbakels.co.uk/product-category/tiger-paste/">Tiger Paste</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1762"><a href="https://www.britishbakels.co.uk/product-category/crumb-softeners/">Crumb Softeners</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1766"><a href="https://www.britishbakels.co.uk/product-category/fats-for-fermented-goods/">Fats for Fermented Goods</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1768"><a href="https://www.britishbakels.co.uk/product-category/dough-relaxant/">Dough Relaxant</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1770"><a href="https://www.britishbakels.co.uk/product-category/sourdough-powders/">Sourdough Products</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3851"><a href="https://www.britishbakels.co.uk/product-category/shelf-life-control/">Shelf Life Control</a></li></ul></li>
+	<li id="menu-item-12" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-12 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-1779"><a title="Cake &amp; Sponge Ingredients" href="https://www.britishbakels.co.uk/product-category/cake-sponge-products/" class="nav-link"><span class="align-middle">Cake &amp; Sponge Ingredients</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1780"><a href="https://www.britishbakels.co.uk/product-category/cake-sponge-emulsifiers/">Cake &amp; Sponge Emulsifiers</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1781"><a href="https://www.britishbakels.co.uk/product-category/baking-powders/">Baking Powders</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1782"><a href="https://www.britishbakels.co.uk/product-category/shelf-life-extenders/">Cake Shelf Life Extenders</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1783"><a href="https://www.britishbakels.co.uk/product-category/milk-powder-egg-extenders/">Milk Powder &amp; Egg Extenders</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1785"><a href="https://www.britishbakels.co.uk/product-category/cake-sponge-mixes/">Cake &amp; Sponge Mixes</a></li></ul></li>
+	<li id="menu-item-13" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-13 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-3385"><a title="Release Solutions" href="https://www.britishbakels.co.uk/product-category/release-solutions/" class="nav-link"><span class="align-middle">Release Solutions</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3386"><a href="https://www.britishbakels.co.uk/product-category/bread/">Bread</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3387"><a href="https://www.britishbakels.co.uk/product-category/cake-confectionery/">Cake/Confectionery</a></li></ul></li>
+	<li id="menu-item-14" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-14 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-1786"><a title="Confectionery Ingredients" href="https://www.britishbakels.co.uk/product-category/confectionery-mixes/" class="nav-link"><span class="align-middle">Confectionery Ingredients</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1788"><a href="https://www.britishbakels.co.uk/product-category/confectionery-mixes-confectionery-mixes/">Confectionery Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1792"><a href="https://www.britishbakels.co.uk/product-category/icings-coverings-fillings/">Icings, Coverings &amp; Fillings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2993"><a href="https://www.britishbakels.co.uk/product-category/dessert-mixes/">Dessert Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1789"><a href="https://www.britishbakels.co.uk/product-category/meringue-mixes/">Meringue Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1790"><a href="https://www.britishbakels.co.uk/product-category/cream-stabiliser/">Cream Stabiliser</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1791"><a href="https://www.britishbakels.co.uk/product-category/custard-mixes/">Custard Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1795"><a href="https://www.britishbakels.co.uk/product-category/fruit-pie-thickener/">Fruit Pie Thickener</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1793"><a href="https://www.britishbakels.co.uk/product-category/ice-cream-products/">Ice Cream Products</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3695"><a href="https://www.britishbakels.co.uk/product-category/truffles/">Truffles</a></li></ul></li>
+	<li id="menu-item-15" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-15 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-1775"><a title="Sweet &amp; Savoury Glazes" href="https://www.britishbakels.co.uk/product-category/glazes-sweet-savoury/" class="nav-link"><span class="align-middle">Sweet &amp; Savoury Glazes</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1776"><a href="https://www.britishbakels.co.uk/product-category/bun-glazes/">Bun Glazes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3288"><a href="https://www.britishbakels.co.uk/product-category/savoury-glaze/">Savoury Glaze</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1778"><a href="https://www.britishbakels.co.uk/product-category/confectionery-glazes/">Confectionery Glazes</a></li></ul></li>
+	<li id="menu-item-16" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-16 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-1771"><a title="Savoury &amp; Pastry Ingredients" href="https://www.britishbakels.co.uk/product-category/savoury-pastry-products/" class="nav-link"><span class="align-middle">Savoury &amp; Pastry Ingredients</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1774"><a href="https://www.britishbakels.co.uk/product-category/sausage-roll-concentrate/">Savoury Ingredients</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1772"><a href="https://www.britishbakels.co.uk/product-category/pastry-fat/">Pastry Fat</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1794"><a href="https://www.britishbakels.co.uk/product-category/pastry-relaxer/">Pastry Relaxer</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3129"><a href="https://www.britishbakels.co.uk/product-category/viennoiserie/">Pastry Improver</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1773"><a href="https://www.britishbakels.co.uk/product-category/pie-filling-thickener/">Pie Filling Thickener</a></li></ul></li>
+	<li id="menu-item-17" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-17 nav-item nav-item-col-1 menu-item-has-children menu-item-parent-3687"><a title="Flavours &amp; Colours" href="https://www.britishbakels.co.uk/product-category/flavours-colours/" class="nav-link"><span class="align-middle">Flavours &amp; Colours</span></a><ul class="second-level-terms"><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3689"><a href="https://www.britishbakels.co.uk/product-category/colours/">Colours</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3688"><a href="https://www.britishbakels.co.uk/product-category/flavours/">Flavours</a></li></ul></li>
+	<li id="menu-item-18" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-18 nav-item nav-item-col-1"><a title="Home Baking" href="https://www.britishbakels.co.uk/product-category/home-baking/" class="nav-link"><span class="align-middle">Home Baking</span></a></li>
+</ul>
+</div></div></div></div></li>
+<li id="menu-item-220" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-220 nav-item dropdown dropdown-mega recipe-category"><a title="Recipes" href="https://www.britishbakels.co.uk/recipes/" data-toggle="dropdown" id="220" aria-haspopup="true" role="button" class="nav-link">Recipes <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-220" aria-labelledby="menu-item-220"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>Recipes</h4><p>Our team of applications specialists have developed a wide range of recipes to showcase our versatile products.</p><a href="https://www.britishbakels.co.uk/recipes/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">View all recipes</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-19" class="menu-item menu-item-type-taxonomy menu-item-object-term current-menu-parent current-recipes-parent menu-item-19 nav-item nav-item-col-1"><a title="Bakery" href="https://www.britishbakels.co.uk/recipe-category/bakery/" class="nav-link"><span class="align-middle">Bakery</span></a></li>
+	<li id="menu-item-20" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-20 nav-item nav-item-col-1"><a title="Cooking" href="https://www.britishbakels.co.uk/recipe-category/cooking/" class="nav-link"><span class="align-middle">Cooking</span></a></li>
+	<li id="menu-item-21" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-21 nav-item nav-item-col-1"><a title="Patisserie" href="https://www.britishbakels.co.uk/recipe-category/patisserie/" class="nav-link"><span class="align-middle">Patisserie</span></a></li>
+</ul>
+</div></div></div></div></li>
+<li id="menu-item-221" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-221 nav-item dropdown dropdown-mega service-pages"><a title="Services" href="https://www.britishbakels.co.uk/services/" data-toggle="dropdown" id="221" aria-haspopup="true" role="button" class="nav-link">Services <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-221" aria-labelledby="menu-item-221"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>Services</h4><p>Developing market-leading ingredients with industry-leading facilities, in partnership with customers across the world.</p><a href="https://www.britishbakels.co.uk/services/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">Find out more</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-223" class="remove-link services-menu-1 menu-item menu-item-type-custom menu-item-object-custom menu-item-223 nav-item"><div id="custom_html-2" class="widget_text widget-area widget widget_custom_html"><div class="textwidget custom-html-widget"><h4><a href="/services/centres-of-competence/">Centres of Competence</a></h4></div></div><div id="nav_menu-2" class="widget-area widget widget_nav_menu"><div class="menu-services-menu-1-container"><ul id="menu-services-menu-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-229" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-229 nav-item"><a title="Sours" href="/services/centres-of-competence/#sours" class="nav-link">Sours</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-230" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-230 nav-item"><a title="Bread" href="/services/centres-of-competence/#bread" class="nav-link">Bread</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-231" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-231 nav-item"><a title="Sponge Emulsifiers" href="/services/centres-of-competence/#sponge-emulsifiers" class="nav-link">Sponge Emulsifiers</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-232" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-232 nav-item"><a title="Oils &amp; Fats" href="/services/centres-of-competence/#oils-fats" class="nav-link">Oils &#038; Fats</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-233" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-233 nav-item"><a title="Pettinice and Icings" href="/services/centres-of-competence/#pettinice-icings" class="nav-link">Pettinice and Icings</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-234" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-234 nav-item"><a title="Fruit Fillings &amp; Glazes" href="/services/centres-of-competence/#fruit-fillings-glazes" class="nav-link">Fruit Fillings &#038; Glazes</a></li>
+</ul></div></div></li>
+	<li id="menu-item-224" class="remove-link services-menu-2 menu-item menu-item-type-custom menu-item-object-custom menu-item-224 nav-item"><div id="custom_html-3" class="widget_text widget-area widget widget_custom_html"><div class="textwidget custom-html-widget"><h4><a href="/services/baking-centres/switzerland/">Baking Centres</a></h4></div></div><div id="nav_menu-3" class="widget-area widget widget_nav_menu"><div class="menu-services-menu-2-container"><ul id="menu-services-menu-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3400" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3400 nav-item"><a title="Switzerland" href="https://www.britishbakels.co.uk/services/baking-centres/switzerland/" class="nav-link">Switzerland</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3399" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3399 nav-item"><a title="British Bakels" href="https://www.britishbakels.co.uk/services/baking-centres/british-bakels/" class="nav-link">British Bakels</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3398" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3398 nav-item"><a title="Australia" href="https://www.britishbakels.co.uk/services/baking-centres/australia/" class="nav-link">Australia</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3397" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3397 nav-item"><a title="Thailand" href="https://www.britishbakels.co.uk/services/baking-centres/thailand/" class="nav-link">Thailand</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3396" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3396 nav-item"><a title="Belgium" href="https://www.britishbakels.co.uk/services/baking-centres/belgium/" class="nav-link">Belgium</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3395" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-3395 nav-item"><a title="Ecuador" href="https://www.britishbakels.co.uk/services/baking-centres/ecuador/" class="nav-link">Ecuador</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-11742" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11742 nav-item"><a title="Mainland China" href="https://www.britishbakels.co.uk/services/baking-centres/mainland-china/" class="nav-link">Mainland China</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-11743" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11743 nav-item"><a title="Sweden" href="https://www.britishbakels.co.uk/services/baking-centres/sweden/" class="nav-link">Sweden</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-17639" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17639 nav-item"><a title="Malaysia" href="https://www.britishbakels.co.uk/services/baking-centres/malaysia/" class="nav-link">Malaysia</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-17640" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17640 nav-item"><a title="Hong Kong" href="https://www.britishbakels.co.uk/services/baking-centres/hong-kong/" class="nav-link">Hong Kong</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-17641" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17641 nav-item"><a title="India" href="https://www.britishbakels.co.uk/services/baking-centres/india/" class="nav-link">India</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-19594" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-19594 nav-item"><a title="The Netherlands" href="https://www.britishbakels.co.uk/services/baking-centres/bakels-senior/" class="nav-link">The Netherlands</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-24184" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-24184 nav-item"><a title="Germany" href="https://www.britishbakels.co.uk/services/baking-centres/germany/" class="nav-link">Germany</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-29604" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-29604 nav-item"><a title="Chile" href="https://www.britishbakels.co.uk/services/baking-centres/chile/" class="nav-link">Chile</a></li>
+</ul></div></div></li>
+	<li id="menu-item-225" class="remove-link services-menu-3 menu-item menu-item-type-custom menu-item-object-custom menu-item-225 nav-item"><div id="custom_html-5" class="widget_text widget-area widget widget_custom_html"><div class="textwidget custom-html-widget"><h4><a href="/research-development/">Research &amp; Development</a></h4></div></div><div id="nav_menu-4" class="widget-area widget widget_nav_menu"><div class="menu-services-menu-3-container"><ul id="menu-services-menu-3" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-235" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-235 nav-item"><a title="Foundation To Innovation" href="https://www.britishbakels.co.uk/research-development/" class="nav-link">Foundation To Innovation</a></li>
+</ul></div></div></li>
+</ul>
+</div></div></div></div></li>
+<li id="menu-item-222" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-222 nav-item dropdown dropdown-mega about-pages"><a title="About" href="https://www.britishbakels.co.uk/about/" data-toggle="dropdown" id="222" aria-haspopup="true" role="button" class="nav-link">About <span class="caret hidden-xs"></span></a>
+<div  class="dropdown-menu "  id="drop-222" aria-labelledby="menu-item-222"><div class="container"><div class="row"><div class="col-3 dropdown-excerpt"><h4>About</h4><p>Our commitment goes beyond the ingredients we produce - Our rich history of research and development and innovation breeds our continuous investment in people and customer partnerships.</p><a href="https://www.britishbakels.co.uk/about/" class="btn btn-opaque btn-opaque-orange btn-icon-right btn-fa-angle-right">Find out more</a></div><div class="col-9 dropdown-content"><ul>
+	<li id="menu-item-226" class="remove-link about-menu-1 menu-item menu-item-type-custom menu-item-object-custom menu-item-226 nav-item"><div id="nav_menu-5" class="widget-area widget widget_nav_menu"><h4 class="widget-title">About Bakels</h4><div class="menu-about-menu-1-container"><ul id="menu-about-menu-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-258" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-258 nav-item"><a title="Our Customers" href="https://www.britishbakels.co.uk/our-customers/" class="nav-link">Our Customers</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-257" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-257 nav-item"><a title="Mission Statement" href="https://www.britishbakels.co.uk/mission-statement/" class="nav-link">Mission Statement</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-256" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-256 nav-item"><a title="Core Values" href="https://www.britishbakels.co.uk/core-values/" class="nav-link">Core Values</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3598" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3598 nav-item"><a title="British Bakels" href="https://www.britishbakels.co.uk/britishbakels/" class="nav-link">British Bakels</a></li>
+</ul></div></div></li>
+	<li id="menu-item-227" class="remove-link about-menu-2 menu-item menu-item-type-custom menu-item-object-custom menu-item-227 nav-item"><div id="nav_menu-6" class="widget-area widget widget_nav_menu"><h4 class="widget-title">&nbsp;</h4><div class="menu-about-menu-2-container"><ul id="menu-about-menu-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-261" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-261 nav-item"><a title="History" href="https://www.britishbakels.co.uk/history/" class="nav-link">History</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-260" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-260 nav-item"><a title="Facts &amp; Figures" href="https://www.britishbakels.co.uk/facts-figures/" class="nav-link">Facts &#038; Figures</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-262" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-262 nav-item"><a title="Jobs" href="https://www.britishbakels.co.uk/jobs/" class="nav-link">Jobs</a></li>
+</ul></div></div></li>
+	<li id="menu-item-228" class="remove-link about-menu-3 menu-item menu-item-type-custom menu-item-object-custom menu-item-228 nav-item"></li>
+</ul>
+</div></div></div></div></li>
+</ul>					</div>
+				</nav>
+			</div>
+		</div>
+	</div>
+</header>
+
+<div class="site-breadcrumb breadcrumbs" typeof="BreadcrumbList" vocab="https://schema.org/">
+  <div class="container">
+    <div class="row">
+      <div class="col-12">
+      	<ul>
+        	<!-- Breadcrumb NavXT 7.3.0 -->
+<li><a property="item" typeof="WebPage" title="Go to British Bakels." href="https://www.britishbakels.co.uk" class="home"><span property="name">Home</span></a><meta property="position" content="1"></li><li><i class="fa fa-angle-right"></i></li><li><a property="item" typeof="WebPage" title="Go to Recipes." href="https://www.britishbakels.co.uk/recipes/" class="recipes-root post post-recipes"><span property="name">Recipes</span></a></li><li><i class="fa fa-angle-right"></i></li><li><a property="item" typeof="WebPage" title="Go to the Bakery Category archives." href="https://www.britishbakels.co.uk/recipe-category/bakery/" class="taxonomy recipe-category"><span property="name">Bakery</span></a></li><li><i class="fa fa-angle-right"></i></li><li><span property="name">Multiseed Rolls</span></li>    	</ul>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="site-inner">
+
+    
+        	<div class="content-header curve-section">
+	    <div class="container">
+	        <div class="row">
+	            <div class="col-12 text-xs-center">
+	
+        <div class="content-sidebar-wrap">
+
+            <main class="content">
+    <article class="post-3128 recipes type-recipes status-publish hentry recipe-category-bakery display-condition-ambient finished-product-crusty-roll finished-product-multiseed finished-product-soft-roll" itemscope="" itemtype="https://schema.org/CreativeWork">
+
+        <h1>Multiseed Rolls</h1>
+        
+    </article>
+</main>
+
+        </div>
+
+        		        </div>
+	        </div>
+	    </div>
+	</div>
+	                <div class="social-section" id="next-section">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-4 col-md-4 col-sm-12 col-12 text-xs-left">
+                                                <a href="https://www.britishbakels.co.uk/recipes/" class="btn btn-blank btn-icon-left btn-fa-angle-left">Back to recipes</a>
+                    </div>
+                    <div class="col-lg-8 col-md-8 col-sm-12 col-12 text-md-right text-xs-center d-md-block d-none">
+                        <div class="d-md-inline-block d-none"><div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3128"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div></div>
+                                                <div class="d-inline-block social-btn social-inline">
+
+                                                            <a class="social-share btn-fa-facebook-f" href="javascript:void(0);" id="fb-share" rel="nofollow"><span class="social-tooltip">Share on Facebook</span></a>
+                            
+                            <a class="social-share btn-fa-twitter-x" href="javascript:void(0);" id="tweet" rel="nofollow"><i class=""><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc.--><path fill="currentColor" stroke="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9L389.2 48zm-24.8 373.8h39.1L151.1 88h-42l255.3 333.8z"/></svg></i><span class="social-tooltip">Tweet this Page</span></a>
+                            <a class="social-share btn-fa-linkedin-in" href="javascript:void(0);" id="linkedin" rel="nofollow"><span class="social-tooltip">Share on Linkedin</span></a>
+                            <a class="social-share btn-fa-whatsapp d-md-none d-inline-block" href="javascript:void(0);" id="whatsapp" rel="nofollow"><span class="social-tooltip">Share on WhatsApp</span></a>
+                        </div>
+                                                                            <div class="d-inline-block social-btn social-inline social-btn-download">
+                            <a href="https://www.britishbakels.co.uk/recipes/multiseed-rolls/pdf/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-download" download><span class="social-tooltip">Download PDF</span></a>
+                        </div>
+                                                <div class="d-inline-block social-btn social-inline social-btn-preview">
+                            <input type="text" value="https://www.britishbakels.co.uk/recipes/multiseed-rolls/" readonly id="clipboard" class="sr-only" tabindex='-1' aria-hidden='true'>
+                            <button onclick="copyClipboard()" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-preview" title="Copy to clipboard"><span class="social-tooltip">Copy to clipboard</span></button>
+                        </div>
+                                                <div class="d-inline-block social-btn">
+                            <a href="mailto:?subject=Check out Multiseed Rolls on Bakels.com&body=https://www.britishbakels.co.uk/recipes/multiseed-rolls/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-envelop"><span class="social-tooltip">Email this page</span></a>                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                <div class="recipe-content">
+            <div class="container">
+                <div class="row">
+
+                    <div class="col-lg-12">
+                            <div class="recipe-details-section">
+        <div class="row">
+            <div class="col-12 recipe-details-accordion">
+                                                                                <div class="row recipe-tab-accordion-row">
+                            <div class="col-lg-6 col-md-12 col-sm-12 col-12 mb-order-2">
+                                <div class="accordion card-filter single-recipe" id="">
+                                                                                                                    <div class="card">
+                                            <div class="card-header" id="card-ingredients_1">
+                                                                                                <a href="javascript:void(0);" data-toggle="collapse" data-target="#tab-ingredients_1" aria-expanded="false" aria-controls="collapseOne">
+                                                    Ingredients                                                </a>
+                                            </div>
+
+                                            <div id="tab-ingredients_1" class="collapse show" aria-labelledby="card-ingredients_1" data-parent="">
+                                                <div class="card-body">
+                                                                            <div class="row row-group">
+                <div class="col-12 text-xs-left"><span class="group-label">Group 1</span></div>
+                <div class="col-lg-6 col-md-6 col-sm-6 col-6 text-xs-left">
+                    <span class="sr-only ingredient-label">Ingredient</span>
+                </div>
+
+                                    <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">
+                        <span class="ingredient-label">KG</span>
+                    </div>
+                
+                                    <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">
+                        <span class="ingredient-label">%</span>
+                    </div>
+                                        <div class="col-lg-6 col-md-6 col-sm-6 col-6 text-xs-left">Wheat flour</div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">5.000</div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">50.00</div>
+                                            <div class="col-lg-6 col-md-6 col-sm-6 col-6 text-xs-left"><a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/">Country Oven® Multiseed Bread Concentrate</a></div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">5.000</div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">50.00</div>
+                                            <div class="col-lg-6 col-md-6 col-sm-6 col-6 text-xs-left">Yeast</div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">0.250</div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">2.50</div>
+                                            <div class="col-lg-6 col-md-6 col-sm-6 col-6 text-xs-left">Water</div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">5.000</div>
+                    
+                                            <div class="col-lg-3 col-md-3 col-sm-3 col-3 text-xs-right">50.00</div>
+                                </div>
+            <div class="row row-group">
+                                    <div class="col-9 text-xs-right">
+                        <strong>Total Weight</strong>: 15.250                    </div>
+                
+                <div class="col-3"></div>            </div>
+                                                                        </div>
+                                            </div>
+                                        </div>
+                                    
+                                                                                                                    <div class="card">
+                                            <div class="card-header" id="card-method_1">
+                                                <a href="javascript:void(0);" data-toggle="collapse" data-target="#tab-method_1" aria-expanded="false" aria-controls="collapseOne">
+                                                    Method                                                </a>
+                                            </div>
+
+                                            <div id="tab-method_1" class="collapse " aria-labelledby="card-method_1" data-parent="">
+                                                <div class="card-body">
+                                                    <ol>
+<li>Place all of the ingredients into a spiral mixing bowl.</li>
+<li>Mix for 3 minutes on slow speed and 7 minutes on fast speed, until fully developed.</li>
+<li>Dough temperature should be 24-26℃.</li>
+<li>Scale at 90g for soft and crusty rolls.</li>
+<li>Prove for 50 minutes.</li>
+<li>Bake at 230℃ for 12 minutes (soft rolls: no steam, crusty rolls: with steam).</li>
+</ol>
+<p><strong>Yield</strong>: 169 rolls</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    
+                                                                                                                    <div class="card">
+                                            <div class="card-header" id="card-information_1">
+                                                <a href="javascript:void(0);" data-toggle="collapse" data-target="#tab-information_1" aria-expanded="false" aria-controls="collapseOne">
+                                                    Additional Information                                                </a>
+                                            </div>
+
+                                            <div id="tab-information_1" class="collapse " aria-labelledby="card-information_1" data-parent="">
+                                                <div class="card-body">
+                                                    <p>Full nutrients and claims:</p>
+<p>Source of Fibre</p>
+<p>Source of Protein</p>
+<p>High In Thiamin<br />
+Thiamin contributes to normal energy-yielding metabolism.<br />
+Thiamin contributes to normal functioning of the nervous system.<br />
+Thiamin contributes to normal psychological function.<br />
+Thiamin contributes to the normal function of the heart.</p>
+<p>High in Chloride<br />
+Chloride contributes to normal digestion by production of hydrochloric acid in the stomach.</p>
+<p>High in Copper<br />
+Copper contributes to maintenance of normal connective tissues.<br />
+Copper contributes to normal energy-yielding metabolism.<br />
+Copper contributes to normal functioning of the nervous system.<br />
+Copper contributes to normal hair pigmentation.<br />
+Copper contributes to normal iron transport in the body.<br />
+Copper contributes to normal skin pigmentation.<br />
+Copper contributes to the normal function of the immune system.<br />
+Copper contributes to the protection of cells from oxidative stress.</p>
+<p>High in Manganese<br />
+Manganese contributes to normal energy-yielding metabolism.<br />
+Manganese contributes to the maintenance of normal bones.<br />
+Manganese contributes to the normal formation of connective tissue.<br />
+Manganese contributes to the protection of cells from oxidative stress.</p>
+<p>High in Phosphorus<br />
+Phosphorus contributes to normal energy-yielding metabolism.<br />
+Phosphorus contributes to normal function of cell membranes.<br />
+Phosphorus contributes to the maintenance of normal bones.<br />
+Phosphorus contributes to the maintenance of normal teeth.</p>
+<p>Source of Folate<br />
+Folate contributes to maternal tissue growth during pregnancy.<br />
+Folate contributes to normal amino acid synthesis.<br />
+Folate contributes to normal blood formation.<br />
+Folate contributes to normal homocysteine metabolism.<br />
+Folate contributes to normal psychological function.<br />
+Folate contributes to the normal function of the immune system.<br />
+Folate contributes to the reduction of tiredness and fatigue.<br />
+Folate has a role in the process of cell division.</p>
+<p>Source of Iron<br />
+Iron contributes to normal cognitive development of children.<br />
+Iron contributes to normal cognitive function.<br />
+Iron contributes to normal energy-yielding metabolism.<br />
+Iron contributes to normal formation of red blood cells and haemoglobin.<br />
+Iron contributes to normal oxygen transport in the body.<br />
+Iron contributes to the normal function of the immune system.<br />
+Iron contributes to the reduction of tiredness and fatigue.<br />
+Iron has a role in the process of cell division.</p>
+<p>Source of Magnesium<br />
+Magnesium contributes to a reduction of tiredness and fatigue.<br />
+Magnesium contributes to electrolyte balance.<br />
+Magnesium contributes to normal energy-yielding metabolism.<br />
+Magnesium contributes to normal functioning of the nervous system.<br />
+Magnesium contributes to normal muscle function.<br />
+Magnesium contributes to normal protein synthesis.<br />
+Magnesium contributes to normal psychological function.<br />
+Magnesium contributes to the maintenance of normal bones.<br />
+Magnesium contributes to the maintenance of normal teeth.<br />
+Magnesium has a role in the process of cell division.</p>
+<p>Source of Zinc<br />
+Zinc contributes to normal DNA synthesis.<br />
+Zinc contributes to normal acid-base metabolism.<br />
+Zinc contributes to normal carbohydrate metabolism.<br />
+Zinc contributes to normal cognitive function.<br />
+Zinc contributes to normal fertility and reproduction.<br />
+Zinc contributes to normal macronutrient metabolism.<br />
+Zinc contributes to normal metabolism of fatty acids.<br />
+Zinc contributes to normal metabolism of vitamin A.<br />
+Zinc contributes to normal protein synthesis.<br />
+Zinc contributes to the maintenance of normal bones.<br />
+Zinc contributes to the maintenance of normal hair.<br />
+Zinc contributes to the maintenance of normal nails.<br />
+Zinc contributes to the maintenance of normal skin.<br />
+Zinc contributes to the maintenance of normal testosterone levels in the blood.<br />
+Zinc contributes to the maintenance of normal vision.<br />
+Zinc contributes to the normal function of the immune system.<br />
+Zinc contributes to the protection of cells from oxidative stress.<br />
+Zinc has a role in the process of cell division.</p>
+<p>Source of Selenium<br />
+Selenium contributes to normal spermatogenesis.<br />
+Selenium contributes to the maintenance of normal hair.<br />
+Selenium contributes to the maintenance of normal nails.<br />
+Selenium contributes to the normal function of the immune system.<br />
+Selenium contributes to the normal thyroid function.<br />
+Selenium contributes to the protection of cells from oxidative stress.</p>
+<p>Source of Vitamin E<br />
+Vitamin E contributes to the protection of cells from oxidative stress</p>
+<p>All nutrients need to be eaten regularly, as part of a healthy lifestyle and balanced diet.</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    
+                                                                                                                    <div class="card">
+                                            <div class="card-header" id="card-related_1">
+                                                <a href="javascript:void(0);" data-toggle="collapse" data-target="#tab-related_1" aria-expanded="false" aria-controls="collapseOne">
+                                                    Product Used                                                </a>
+                                            </div>
+
+                                            <div id="tab-related_1" class="collapse " aria-labelledby="card-related_1" data-parent="">
+                                                <div class="card-body">
+                                                            <ul class="related-list">
+                    <li>
+            	<a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/">Country Oven® Multiseed</a>
+            </li>
+                    </ul>
+                                                    </div>
+                                            </div>
+                                        </div>
+                                                                    </div>
+                            </div>
+                                                            <div class="col-lg-6 col-md-12 col-sm-12 col-12 mb-order-1">
+                                        <div class="image-slider" id="gallery-slider">
+                    <div>
+                <div class="overview-item">
+                    <img width="560" height="370" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large-560x370.jpg" class="attachment-content-carousel-thumb-3 size-content-carousel-thumb-3 wp-post-image" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large-560x370.jpg 560w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_040-Large-160x107.jpg 160w" sizes="(max-width: 560px) 100vw, 560px" />                                        <div class="overview-pagination">
+                        <button class="slick-arrow slick-prev" tabindex="0">Previous</button>
+                        <button class="slick-arrow slick-next" tabindex="0">Next</button>
+                    </div>
+                                    </div>
+            </div>
+        
+                    <div>
+                <div class="overview-item">
+                    <img width="560" height="370" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_259-Large-560x370.jpg" class="attachment-content-carousel-thumb-3 size-content-carousel-thumb-3" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_259-Large-560x370.jpg 560w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_259-Large-160x107.jpg 160w" sizes="(max-width: 560px) 100vw, 560px" />                                        <div class="overview-pagination">
+                        <button class="slick-arrow slick-prev" tabindex="0">Previous</button>
+                        <button class="slick-arrow slick-next" tabindex="0">Next</button>
+                    </div>
+                                    </div>
+            </div>
+                    <div>
+                <div class="overview-item">
+                    <img width="560" height="370" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_324-Large-1-560x370.jpg" class="attachment-content-carousel-thumb-3 size-content-carousel-thumb-3" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_324-Large-1-560x370.jpg 560w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_324-Large-1-160x107.jpg 160w" sizes="(max-width: 560px) 100vw, 560px" />                                        <div class="overview-pagination">
+                        <button class="slick-arrow slick-prev" tabindex="0">Previous</button>
+                        <button class="slick-arrow slick-next" tabindex="0">Next</button>
+                    </div>
+                                    </div>
+            </div>
+                    <div>
+                <div class="overview-item">
+                    <img width="560" height="370" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_321-Large-560x370.jpg" class="attachment-content-carousel-thumb-3 size-content-carousel-thumb-3" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_321-Large-560x370.jpg 560w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_321-Large-160x107.jpg 160w" sizes="(max-width: 560px) 100vw, 560px" />                                        <div class="overview-pagination">
+                        <button class="slick-arrow slick-prev" tabindex="0">Previous</button>
+                        <button class="slick-arrow slick-next" tabindex="0">Next</button>
+                    </div>
+                                    </div>
+            </div>
+                    <div>
+                <div class="overview-item">
+                    <img width="560" height="370" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_244-Large-560x370.jpg" class="attachment-content-carousel-thumb-3 size-content-carousel-thumb-3" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_244-Large-560x370.jpg 560w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_244-Large-160x107.jpg 160w" sizes="(max-width: 560px) 100vw, 560px" />                                        <div class="overview-pagination">
+                        <button class="slick-arrow slick-prev" tabindex="0">Previous</button>
+                        <button class="slick-arrow slick-next" tabindex="0">Next</button>
+                    </div>
+                                    </div>
+            </div>
+                    <div>
+                <div class="overview-item">
+                    <img width="560" height="370" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_249-Large-560x370.jpg" class="attachment-content-carousel-thumb-3 size-content-carousel-thumb-3" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_249-Large-560x370.jpg 560w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_249-Large-160x107.jpg 160w" sizes="(max-width: 560px) 100vw, 560px" />                                        <div class="overview-pagination">
+                        <button class="slick-arrow slick-prev" tabindex="0">Previous</button>
+                        <button class="slick-arrow slick-next" tabindex="0">Next</button>
+                    </div>
+                                    </div>
+            </div>
+            </div>
+    
+                                    </div>
+                                                    </div>
+                                                </div>
+        </div>
+    </div>
+                    </div>
+
+                                        <div class="col-lg-6 col-md-12 col-sm-12 col-12 d-lg-none d-block">
+                                            </div>
+                    
+                    <div class="col-lg-6 col-md-12 col-sm-12 col-12 print-display">
+                                            </div>
+
+                                        <div class="col-lg-6 col-md-12 col-sm-12 col-12 d-lg-block d-none">
+                                            </div>
+                    
+                </div>
+            </div>
+        </div>
+            <div class="social-section d-md-none d-block">
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-8 col-md-8 col-sm-12 col-12 text-md-right text-xs-center">
+                        <div class="d-inline-block"><div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3128"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div></div>
+                                                <div class="d-inline-block social-btn social-inline social-inline">
+                            <a class="social-share btn-fa-facebook-f" href="javascript:void(0);" id="fb-share" rel="nofollow" title="Share on Facebook">Facebook</a>
+                            <a class="social-share btn-fa-twitter" href="javascript:void(0);" id="tweet" rel="nofollow" title="Tweet this Page">Twitter</a>
+                            <a class="social-share btn-fa-linkedin-in" href="javascript:void(0);" id="linkedin" rel="nofollow" title="Share on Linkedin">LinkedIn</a>
+                            <a class="social-share btn-fa-whatsapp d-md-none d-inline-block" href="javascript:void(0);" id="whatsapp" rel="nofollow"><span class="social-tooltip" title="Share on WhatsApp">WhatsApp</a>
+                        </div>
+                                                                            <div class="d-inline-block social-btn social-inline social-btn-download">
+                            <a href="https://www.britishbakels.co.uk/recipes/multiseed-rolls/pdf/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-download" download title="Download PDF">Download PDF</a>
+                        </div>
+                        <div class="d-inline-block social-btn social-inline social-btn-preview">
+                            <input type="text" value="https://www.britishbakels.co.uk/recipes/multiseed-rolls/" readonly id="clipboard-mobile" class="sr-only" tabindex='-1' aria-hidden='true'>
+                            <button onclick="copyClipboardMobile()" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-preview" title="Copy to clipboard"><span class="social-tooltip">Copy to clipboard</span></button>
+                        </div>
+                                                                        <div class="d-inline-block social-btn">
+                            <a href="mailto:?subject=Check out Multiseed Rolls on Bakels.com&body=https://www.britishbakels.co.uk/recipes/multiseed-rolls/" class="btn btn-opaque btn-opaque-blue btn-icon-right btn-envelop">Email</a>                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="recipe-term-section">
+            <div class="container">
+                <div class="row">
+                                        <div class="col-lg-3 col-md-3 col-sm-6 col-6 text-xs-center term-item">
+                        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/icon-display-conditions-new.svg" alt="Display Conditions">
+                        <h4>Display Conditions</h4>
+                        <p><a href="https://www.britishbakels.co.uk/recipes/?display-condition%5B%5D=1801">Ambient</a></p>
+                    </div>
+                    
+                                        <div class="col-lg-3 col-md-3 col-sm-6 col-6 text-xs-center term-item">
+                        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/icon-category-new.svg" alt="Category">
+                        <h4>Category</h4>
+                        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>
+                    </div>
+                    
+                    
+                                        <div class="col-lg-3 col-md-3 col-sm-6 col-6 text-xs-center term-item">
+                        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/icon-finished-product-new.svg"alt="Finished Product">
+                        <h4>Finished Product</h4>
+                        <p><a href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1806">Crusty Roll</a>, <a href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1811">Multiseed</a>, <a href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1814">Soft Roll</a></p>
+                    </div>
+                                    </div>
+            </div>
+        </div>
+            <div class="related-category-section" id="related-recipe">
+            <div class="container">
+                <div class="row">
+                    <div class="col-12 text-xs-center">
+                        <h2>Related recipes</h2>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-12">
+                        <div class="related-category-slider" id="related-recipe-slider">
+                        <div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3165"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/aberdeen-softies/" title="Aberdeen Softie Recipe">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2768-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Aberdeen Softie Recipe" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2768-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2768-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2768-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2768-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2768-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/aberdeen-softies/">Aberdeen Softie Recipe</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/aberdeen-softies/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/voltem/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Voltem®</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-13950"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/artisan-ciabatta-roll-recipe/" title="Artisan Ciabatta Rolls">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Artisan Ciabatta Rolls" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_230-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/artisan-ciabatta-roll-recipe/">Artisan Ciabatta Rolls</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/artisan-ciabatta-roll-recipe/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-artisan/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Artisan</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3328"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/artisan-vienna-roll/" title="Artisan Vienna Roll">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSC01156-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Artisan Vienna Roll" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSC01156-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSC01156-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSC01156-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSC01156-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSC01156-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/artisan-vienna-roll/">Artisan Vienna Roll</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/artisan-vienna-roll/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-artisan/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Artisan</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3151"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/brioche-buns/" title="Brioche Buns">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Brioche Buns" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/BSWE_hamburger_bun_potatobread_lecisoft-NG_lecimax_3-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/brioche-buns/">Brioche Buns</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/brioche-buns/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/baktem-10-brioche-paste-concentrate/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Baktem 10% Brioche Paste Concentrate</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17427"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/burger-buns/" title="Burger Buns">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Burger Buns" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_brioche_potatobread_lecisoft-NG-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/burger-buns/">Burger Buns</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/burger-buns/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/baktem-red-10-soft-roll-concentrate/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Baktem Red 10% Soft Roll Concentrate</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-19579"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/chocolate-and-ginger-multiseed/" title="Chocolate &amp; Ginger Multiseed">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Chocolate &amp; Ginger Multiseed" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large-1536x1025.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/09/Bakels_053-Large.jpg 1619w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/chocolate-and-ginger-multiseed/">Chocolate &amp; Ginger Multiseed</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/chocolate-and-ginger-multiseed/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Multiseed</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3142"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/crusty-rolls-and-baguette/" title="Crunchy French Baguette Recipe">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A3035-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Crunchy French Baguette Recipe" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A3035-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A3035-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A3035-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A3035-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A3035-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/crusty-rolls-and-baguette/">Crunchy French Baguette Recipe</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/crusty-rolls-and-baguette/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/french-improver/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">French Improver</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3362"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/crusty-roll-2/" title="Crusty Roll">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2695-Large-1-360x240.jpg" class="aligncenter wp-post-image" alt="Crusty Roll" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2695-Large-1-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2695-Large-1-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2695-Large-1-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2695-Large-1-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2695-Large-1.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/crusty-roll-2/">Crusty Roll</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/crusty-roll-2/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/baktem-5-crusty-concentrate/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Baktem 5% Crusty Concentrate</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-14327"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/golden-grains-rolls/" title="Golden Grains Rolls">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Golden Grains Rolls" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_387-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/golden-grains-rolls/">Golden Grains Rolls</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/golden-grains-rolls/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-golden-grains/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Golden Grains</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3163"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/hamburger-rolls/" title="Hamburger Roll Recipe">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2748-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Hamburger Roll Recipe" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2748-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2748-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2748-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2748-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/7I6A2748-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/hamburger-rolls/">Hamburger Roll Recipe</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/hamburger-rolls/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">2 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/eminex-liquid/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Eminex Liquid</a>
+										</li>
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/lecitem-2000/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Lecitem® 2000</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-17431"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/high-fibre-bbq-rolls/" title="High Fibre BBQ Rolls">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large-360x240.jpg" class="aligncenter wp-post-image" alt="High Fibre BBQ Rolls" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2021/06/BSWE_hamburger_bun_wholegrain_Basta-bas_Lecisoft-NG_2-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/high-fibre-bbq-rolls/">High Fibre BBQ Rolls</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/high-fibre-bbq-rolls/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-fibre-plus/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Fibre Plus</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-14276"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/high-fibre-rolls/" title="High Fibre Rolls">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large-360x240.jpg" class="aligncenter wp-post-image" alt="High Fibre Rolls" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2020/11/Bakels_113-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/high-fibre-rolls/">High Fibre Rolls</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/high-fibre-rolls/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-fibre-plus/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Fibre Plus</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3119"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/multi-rye/" title="Multi-rye">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSF9479edit-Large-1-360x240.jpg" class="aligncenter wp-post-image" alt="Multi-rye" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSF9479edit-Large-1-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSF9479edit-Large-1-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSF9479edit-Large-1-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSF9479edit-Large-1-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/DSF9479edit-Large-1.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/multi-rye/">Multi-rye</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/multi-rye/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3127"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/multiseed-baguette/" title="Multiseed Baguette">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1-360x240.jpg" class="aligncenter wp-post-image" alt="Multiseed Baguette" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1-1536x1025.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_334-Large-1.jpg 1619w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/multiseed-baguette/">Multiseed Baguette</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/multiseed-baguette/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Multiseed</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+<div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-3124"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/recipes/multiseed-bread/" title="Multiseed Bread">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Multiseed Bread" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_301-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/recipes/multiseed-bread/">Multiseed Bread</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/recipe-category/bakery/">Bakery</a></p>        
+        <div class="row align-items-center products-used-row">
+            <div class="col col-auto text-xs-left pr-xl-2">
+                <a href="https://www.britishbakels.co.uk/recipes/multiseed-bread/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View recipe</a>
+            </div>
+            <div class="col col-auto flex-fill text-xl-right text-lg-left pl-xl-2 product-used-link" onclick="">
+            Products Used						<div class="d-inline-block products-used">
+								<span class="products-used-icon">i</span>
+						</div>
+						<div class="products-used-box">
+                                <span class="d-flex d-md-none products-used-close">x</span>
+								<span class="d-block products-used-label">1 Product Used</span>
+								<ul class="related-list">
+																		<li>
+												<a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">Country Oven® Multiseed</a>
+										</li>
+																</ul>
+						</div>
+                        </div>
+        </div>
+  	</div>
+</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                <div class="related-category-section" id="related-product">
+            <div class="container">
+                <div class="row">
+                    <div class="col-12 text-xs-center">
+                        <h2>Related products</h2>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-12">
+                        <div class="related-category-slider" id="related-product-slider">
+                        <div>
+	<div class="related-item text-xs-left">
+		<div class="favourites"><a href="https://www.britishbakels.co.uk/my-bakels/login/" class="fav-btn fav-add" id="fav-btn-2960"><span class="sr-only"></span><svg class="fav-icon-active fav-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m8 15.429-1.16-1.07C2.72 10.58 0 8.086 0 5.026 0 2.53 1.936.57 4.4.57c1.392 0 2.728.656 3.6 1.693C8.872 1.227 10.208.57 11.6.57c2.464 0 4.4 1.96 4.4 4.454 0 3.06-2.72 5.554-6.84 9.343L8 15.428Z" fill="#FFF" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-blue" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6 0C10.208 0 8.872.656 8 1.692 7.128.656 5.792 0 4.4 0 1.936 0 0 1.96 0 4.453c0 3.06 2.72 5.554 6.84 9.343L8 14.857l1.16-1.069C13.28 10.008 16 7.514 16 4.453 16 1.96 14.064 0 11.6 0ZM8.08 12.59l-.08.081-.08-.08C4.112 9.1 1.6 6.792 1.6 4.452c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.802 2.856 1.911h1.496c.416-1.11 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.833 0 2.34-2.512 4.648-6.32 8.137Z" fill="#003976" fill-rule="nonzero"/></svg><svg class="fav-icon fav-opaque-white" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M11.6.571c-1.392 0-2.728.656-3.6 1.693C7.128 1.227 5.792.57 4.4.57 1.936.571 0 2.531 0 5.025c0 3.06 2.72 5.554 6.84 9.343L8 15.428l1.16-1.068C13.28 10.579 16 8.085 16 5.025 16 2.53 14.064.57 11.6.57Zm-3.52 12.59-.08.082-.08-.081C4.112 9.672 1.6 7.364 1.6 5.025c0-1.62 1.2-2.834 2.8-2.834 1.232 0 2.432.801 2.856 1.91h1.496c.416-1.109 1.616-1.91 2.848-1.91 1.6 0 2.8 1.214 2.8 2.834 0 2.34-2.512 4.647-6.32 8.137Z" fill="#FFF" fill-rule="nonzero"/></svg></a></div>                            <a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/" title="Country Oven® Multiseed">
+                <img width="360" height="240" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large-360x240.jpg" class="aligncenter wp-post-image" alt="Country Oven® Multiseed" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large-360x240.jpg 360w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large-300x200.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large-1024x683.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large-768x512.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large-1536x1024.jpg 1536w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large-160x107.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2018/10/Bakels_309-Large.jpg 1620w" sizes="(max-width: 360px) 100vw, 360px" />            </a>
+                <h4>
+        	<a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/">Country Oven® Multiseed</a>
+        </h4>
+        <p><a href="https://www.britishbakels.co.uk/product-category/bread-roll-morning-goods/">Bread, Roll &amp; Morning Goods</a>, <a href="https://www.britishbakels.co.uk/product-category/speciality-bread-mixes-bread-roll-morning-goods/">Speciality Bread Mixes</a></p>        <p>The Original and Still the Best - versatile 50% concentrate containing pumpkin, sunflower and linseed for bread with a coarse, ...</p>
+        <a href="https://www.britishbakels.co.uk/products/country-oven-multiseed/" class="btn btn-blank-orange btn-icon-right btn-fa-angle-right">View product</a>
+  	</div>
+</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+    
+    </div>
+
+
+    	          
+  <div class="footer-curve"></div>
+
+  <div class="footer-area">
+    <div class="footer-search">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-8 col-md-7 col-sm-10 col-10 text-xs-center">
+
+            
+            
+              <div class="footer-social">
+                <ul>
+                                                            <li>
+                        <a href="https://www.facebook.com/BritishBakels/" title="Facebook" target="_blank" class="fa fa-facebook"><span>Facebook</span></a>
+                      </li>
+                                      
+                                      <li>
+                      <a href="https://twitter.com/britishbakels" title="Twitter" target="_blank" class="fa fa-twitter-x">
+                      <i class=""><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc.--><path fill="currentColor" stroke="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9L389.2 48zm-24.8 373.8h39.1L151.1 88h-42l255.3 333.8z"/></svg></i>                      <span>Twitter</span></a>
+                    </li>
+                  
+                  
+                                      <li>
+                      <a href="https://www.instagram.com/british.bakels/" title="Instagram" target="_blank" class="fa fa-instagram"><span>Instagram</span></a>
+                    </li>
+                  
+                                      <li>
+                      <a href="https://www.linkedin.com/company/british-bakels/" title="Linkedin" target="_blank" class="fa fa-linkedin"><span>Linkedin</span></a>
+                    </li>
+                  
+                  
+                                      <li>
+                      <a href="https://www.youtube.com/channel/UCqst5glkRB9MHX5_i5jvy8g" title="YouTube" target="_blank" class="fa fa-youtube"><span>YouTube</span></a>
+                    </li>
+                  
+                  
+                                      <li>
+                                            <a href="https://www.britishbakels.co.uk/email-newsletter/" title="Newsletter" target="_blank" class="fa fa-envelope"><span>Newsletter</span></a>
+                    </li>
+                                  </ul>
+              </div>
+            
+          </div>
+          <div class="col-lg-4 col-md-5 col-sm-2 col-2 text-sm-right text-xs-center">
+            <div class="scroll-to-top">
+              <span class="d-md-inline-block d-none scroll-text">Back to top</span>
+              <button class="btn btn-scroll">Back to top</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer-widgets">
+      <div class="container">
+        <div class="row">
+                        <div class="col-lg-2 col-md-4 col-12 footer-widget footer-widget-1">
+                <div id="nav_menu-7" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Navigation</h4><div class="menu-footer-1-container"><ul id="menu-footer-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-239" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-home menu-item-239 nav-item"><a title="Home" href="https://www.britishbakels.co.uk/" class="nav-link">Home</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-242" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-242 nav-item"><a title="Jobs at Bakels" href="https://www.britishbakels.co.uk/jobs/" class="nav-link">Jobs at Bakels</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-241" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-241 nav-item"><a title="Contact" href="https://www.britishbakels.co.uk/contact/" class="nav-link">Contact</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-2 col-md-4 col-12 footer-widget footer-widget-2">
+                <div id="nav_menu-8" class="widget-area widget widget_nav_menu"><h4 class="widget-title">About</h4><div class="menu-footer-2-container"><ul id="menu-footer-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-247" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-247 nav-item"><a title="Our Customers" href="https://www.britishbakels.co.uk/our-customers/" class="nav-link">Our Customers</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-246" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-246 nav-item"><a title="Mission Statement" href="https://www.britishbakels.co.uk/mission-statement/" class="nav-link">Mission Statement</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-243" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-243 nav-item"><a title="Core Values" href="https://www.britishbakels.co.uk/core-values/" class="nav-link">Core Values</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-245" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-245 nav-item"><a title="History" href="https://www.britishbakels.co.uk/history/" class="nav-link">History</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-244" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-244 nav-item"><a title="Facts &amp; Figures" href="https://www.britishbakels.co.uk/facts-figures/" class="nav-link">Facts &#038; Figures</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-3 col-md-4 col-12 footer-widget footer-widget-3">
+                <div id="nav_menu-9" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Products</h4><div class="menu-footer-3-1-container"><ul id="menu-footer-3-1" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-248" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-248 nav-item"><a title="Products" href="https://www.britishbakels.co.uk/products/" class="nav-link">Products</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-249" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-249 nav-item"><a title="Recipes" href="https://www.britishbakels.co.uk/recipes/" class="nav-link">Recipes</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-301" class="menu-item menu-item-type-post_type_archive menu-item-object-stockist menu-item-301 nav-item"><a title="Where to buy" href="https://www.britishbakels.co.uk/stockist/" class="nav-link">Where to buy</a></li>
+</ul></div></div><div id="nav_menu-10" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Services</h4><div class="menu-footer-3-2-container"><ul id="menu-footer-3-2" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-251" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-251 nav-item"><a title="Centres of Competence" href="https://www.britishbakels.co.uk/centres-of-competence/" class="nav-link">Centres of Competence</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-4387" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4387 nav-item"><a title="Baking Centres" href="https://www.britishbakels.co.uk/services/baking-centres/" class="nav-link">Baking Centres</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-252" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-252 nav-item"><a title="Research &amp; Development" href="https://www.britishbakels.co.uk/research-development/" class="nav-link">Research &#038; Development</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-2 col-md-4 col-12 footer-widget footer-widget-4">
+                <div id="nav_menu-11" class="widget-area widget widget_nav_menu"><h4 class="widget-title">Other</h4><div class="menu-footer-4-container"><ul id="menu-footer-4" class="menu"><li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-254" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-254 nav-item"><a title="Privacy Policy" href="https://www.britishbakels.co.uk/privacy-policy/" class="nav-link">Privacy Policy</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-253" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-253 nav-item"><a title="Cookie Policy" href="https://www.britishbakels.co.uk/cookie-policy/" class="nav-link">Cookie Policy</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-3890" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3890 nav-item"><a title="Modern Slavery Statement" href="https://www.britishbakels.co.uk/modern-slavery-statement/" class="nav-link">Modern Slavery Statement</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-21719" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-21719 nav-item"><a title="Ethical Trading Statement" href="https://www.britishbakels.co.uk/ethical-trading-statement/" class="nav-link">Ethical Trading Statement</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-23458" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-23458 nav-item"><a title="Human Rights Policy Statement" href="https://www.britishbakels.co.uk/human-rights-policy-statement/" class="nav-link">Human Rights Policy Statement</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-4050" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4050 nav-item"><a title="Terms and Conditions of Sale" href="https://www.britishbakels.co.uk/terms-and-conditions-of-sale/" class="nav-link">Terms and Conditions of Sale</a></li>
+<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement" id="menu-item-255" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-255 nav-item"><a title="Sitemap" href="https://www.britishbakels.co.uk/sitemap/" class="nav-link">Sitemap</a></li>
+</ul></div></div>            </div>
+            
+                        <div class="col-lg-3 col-md-8 col-12 footer-widget footer-widget-5">
+                <div id="custom_html-4" class="widget_text widget-area widget widget_custom_html"><h4 class="widget-title">Head Office</h4><div class="textwidget custom-html-widget"><div class="row">
+	<div class="col-lg-12 col-md-6 col-12">
+		<p>
+			<span class="d-lg-block d-inline">Granville Way, Bicester, </span>
+			<span class="d-lg-block d-inline">Oxon, OX26 4JT, </span> 
+			United Kingdom
+		</p>
+	</div>
+	<div class="col-lg-12 col-md-6 col-12">
+		<div class="widget-nav nav">
+			<ul class="navbar-nav">
+				<li class="nav-item phone-link">
+					<a href="tel:4401869247098">+44(0) 1869 247098</a>
+				</li>
+				<li class="nav-item email-link">
+					<a href="mailto:bakels@bakels.com" class="nav-link">bakels@bakels.com</a>
+				</li>
+			</ul>
+		</div>
+	</div>
+</div></div></div>
+                <div class="mt-4">
+                  <button type="button" class="btn btn-country d-lg-inline-block d-none" data-toggle="modal" data-target="#select-country">Select a market</button>
+                  <button class="btn btn-country select-country d-lg-none d-inline-block">Select a market</button>
+                </div>
+            </div>
+                    </div>
+
+      </div>
+    </div>
+
+    </div>
+  <div class="site-accreditation">
+    <div class="container">
+      <div class="row">
+        <div class="col-12 text-center">
+          <div class="slider-accreditation"><a href="https://www.britishbakels.co.uk/british-bakels-pass-sedexs-ethical-trade-audit/" target="_blank" title="Sedex (SMETA)"><img width="160" height="120" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2022/04/BB-website-accreditations-1-160x120.jpg" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2022/04/BB-website-accreditations-1-160x120.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2022/04/BB-website-accreditations-1-300x225.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2022/04/BB-website-accreditations-1.jpg 320w" sizes="(max-width: 160px) 100vw, 160px" /></a><a href="https://www.britishbakels.co.uk/wp-content/uploads/sites/2/2023/07/BRC.pdf" target="_blank" title="BRC Certified"><img width="160" height="120" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/10/www.brcgs_.com_-160x120.jpg" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/10/www.brcgs_.com_-160x120.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/10/www.brcgs_.com_-300x225.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/10/www.brcgs_.com_.jpg 320w" sizes="(max-width: 160px) 100vw, 160px" /></a><a href="https://www.britishbakels.co.uk/wp-content/uploads/sites/2/2023/07/RSPO.pdf" target="_blank" title="RSPO"><img width="160" height="120" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.rspo_.org_-160x120.jpg" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.rspo_.org_-160x120.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.rspo_.org_-300x225.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.rspo_.org_-768x576.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.rspo_.org_-1024x768.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.rspo_.org_.jpg 1334w" sizes="(max-width: 160px) 100vw, 160px" /></a><a href="https://www.britishbakels.co.uk/wp-content/uploads/sites/2/2023/07/RA.pdf" target="_blank" title="Rainforest Alliance"><img width="160" height="120" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/Rainsforest-Alliance-1-160x120.jpg" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/Rainsforest-Alliance-1-160x120.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/Rainsforest-Alliance-1-300x225.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/Rainsforest-Alliance-1.jpg 320w" sizes="(max-width: 160px) 100vw, 160px" /></a><a href="https://www.britishbakels.co.uk/wp-content/uploads/sites/2/2023/07/Soil-Association.pdf" target="_blank" title="Soil Association"><img width="160" height="120" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.soilassociation.org_-160x120.jpg" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.soilassociation.org_-160x120.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.soilassociation.org_-300x225.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.soilassociation.org_-768x576.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.soilassociation.org_-1024x768.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.soilassociation.org_.jpg 1334w" sizes="(max-width: 160px) 100vw, 160px" /></a><a href="https://www.britishbakels.co.uk/wp-content/uploads/sites/2/2023/07/Halal.pdf" target="_blank" title="Halal Certified"><img width="160" height="120" src="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.tmfb_.net_-160x120.jpg" class="attachment-accreditation-logo size-accreditation-logo" alt="" decoding="async" srcset="https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.tmfb_.net_-160x120.jpg 160w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.tmfb_.net_-300x225.jpg 300w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.tmfb_.net_-768x576.jpg 768w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.tmfb_.net_-1024x768.jpg 1024w, https://britishbakels.b-cdn.net/wp-content/uploads/sites/2/2019/09/www.tmfb_.net_.jpg 1334w" sizes="(max-width: 160px) 100vw, 160px" /></a></div>        </div>
+      </div>
+    </div>
+  </div>
+  
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-4 col-md-4 col-12 text-md-left text-xs-center footer-left">
+          <div class="widget-area">
+            <div class="widget-text">
+              <p>&copy; 2024 British Bakels</p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-4 col-12 text-xs-center footer-center">
+          <div class="widget-area">
+            <div class="widget-text">
+              <a href="https://www.britishbakels.co.uk" title="British Bakels">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/logo-footer.svg" alt="British Bakels">
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-4 col-12 footer-right text-md-right text-xs-center">
+          <div class="widget-area">
+            <div class="widget-text">
+              <p class="dnp">
+                                Website by <a href="https://www.impactmedia.co.uk/" target="_blank" rel="nofollow">Impact Media</a>&reg; <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/logo-im.svg" alt="Impact Media" class="ml-2 dnp">
+              </p>
+
+              <p>
+               <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/logo-blue.svg" alt="British Bakels" class="print-logo-footer">
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+</div>
+<!-- END CONTAINER -->
+
+<div class="sidr-bg"></div>
+
+<div id="mobile-nav" class="sidr left">
+  <ul class="sidr-class-menu sidr-class-menu-top"><li class="sidr-class-item sidr-depth-1 sidr-level-header"><span class="sidr-label">Navigation</span><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li id="menu-item-270" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-270 sidr-class-item sidr-class-menuparent sidr-depth-1 product-category"><a title="Products" href="https://www.britishbakels.co.uk/products/" class="sidr-class-link sidr-class-menuparent">Products</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.britishbakels.co.uk/products/" class="sidr-class-link">Products</a></li>
+	<li id="menu-item-34" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-34 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-1757 sidr-depth-2"><a title="Bread, Roll &amp; Morning Goods" href="https://www.britishbakels.co.uk/product-category/bread-roll-morning-goods/" class="sidr-class-link sidr-class-menuparent">Bread, Roll &amp; Morning Goods</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/bread-roll-morning-goods/" class="sidr-class-link">Bread, Roll &amp; Morning Goods</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1759 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/speciality-bread-mixes-bread-roll-morning-goods/" class="sidr-class-link">Speciality Bread Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1758 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/bread-roll-improvers/" class="sidr-class-link">Bread &amp; Roll Improvers</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1763 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/roll-concentrates/" class="sidr-class-link">Soft Roll Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1764 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/bun-concentrates/" class="sidr-class-link">Bun Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2994 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/crusty-concentrates/" class="sidr-class-link">Crusty Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2995 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/brioche-concentrates/" class="sidr-class-link">Brioche Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1765 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/crossing-mix/" class="sidr-class-link">Crossing Mix</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2992 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/doughnut-concentrates/" class="sidr-class-link">Doughnut Concentrates</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1761 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/tiger-paste/" class="sidr-class-link">Tiger Paste</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1762 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/crumb-softeners/" class="sidr-class-link">Crumb Softeners</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1766 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/fats-for-fermented-goods/" class="sidr-class-link">Fats for Fermented Goods</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1768 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/dough-relaxant/" class="sidr-class-link">Dough Relaxant</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1770 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/sourdough-powders/" class="sidr-class-link">Sourdough Products</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3851 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/shelf-life-control/" class="sidr-class-link">Shelf Life Control</a></li></ul></li>
+	<li id="menu-item-35" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-35 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-1779 sidr-depth-2"><a title="Cake &amp; Sponge Ingredients" href="https://www.britishbakels.co.uk/product-category/cake-sponge-products/" class="sidr-class-link sidr-class-menuparent">Cake &amp; Sponge Ingredients</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/cake-sponge-products/" class="sidr-class-link">Cake &amp; Sponge Ingredients</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1780 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/cake-sponge-emulsifiers/" class="sidr-class-link">Cake &amp; Sponge Emulsifiers</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1781 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/baking-powders/" class="sidr-class-link">Baking Powders</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1782 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/shelf-life-extenders/" class="sidr-class-link">Cake Shelf Life Extenders</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1783 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/milk-powder-egg-extenders/" class="sidr-class-link">Milk Powder &amp; Egg Extenders</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1785 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/cake-sponge-mixes/" class="sidr-class-link">Cake &amp; Sponge Mixes</a></li></ul></li>
+	<li id="menu-item-36" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-36 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-3385 sidr-depth-2"><a title="Release Solutions" href="https://www.britishbakels.co.uk/product-category/release-solutions/" class="sidr-class-link sidr-class-menuparent">Release Solutions</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/release-solutions/" class="sidr-class-link">Release Solutions</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3386 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/bread/" class="sidr-class-link">Bread</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3387 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/cake-confectionery/" class="sidr-class-link">Cake/Confectionery</a></li></ul></li>
+	<li id="menu-item-37" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-37 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-1786 sidr-depth-2"><a title="Confectionery Ingredients" href="https://www.britishbakels.co.uk/product-category/confectionery-mixes/" class="sidr-class-link sidr-class-menuparent">Confectionery Ingredients</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/confectionery-mixes/" class="sidr-class-link">Confectionery Ingredients</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1788 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/confectionery-mixes-confectionery-mixes/" class="sidr-class-link">Confectionery Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1792 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/icings-coverings-fillings/" class="sidr-class-link">Icings, Coverings &amp; Fillings</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-2993 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/dessert-mixes/" class="sidr-class-link">Dessert Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1789 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/meringue-mixes/" class="sidr-class-link">Meringue Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1790 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/cream-stabiliser/" class="sidr-class-link">Cream Stabiliser</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1791 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/custard-mixes/" class="sidr-class-link">Custard Mixes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1795 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/fruit-pie-thickener/" class="sidr-class-link">Fruit Pie Thickener</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1793 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/ice-cream-products/" class="sidr-class-link">Ice Cream Products</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3695 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/truffles/" class="sidr-class-link">Truffles</a></li></ul></li>
+	<li id="menu-item-38" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-38 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-1775 sidr-depth-2"><a title="Sweet &amp; Savoury Glazes" href="https://www.britishbakels.co.uk/product-category/glazes-sweet-savoury/" class="sidr-class-link sidr-class-menuparent">Sweet &amp; Savoury Glazes</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/glazes-sweet-savoury/" class="sidr-class-link">Sweet &amp; Savoury Glazes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1776 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/bun-glazes/" class="sidr-class-link">Bun Glazes</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3288 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/savoury-glaze/" class="sidr-class-link">Savoury Glaze</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1778 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/confectionery-glazes/" class="sidr-class-link">Confectionery Glazes</a></li></ul></li>
+	<li id="menu-item-39" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-39 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-1771 sidr-depth-2"><a title="Savoury &amp; Pastry Ingredients" href="https://www.britishbakels.co.uk/product-category/savoury-pastry-products/" class="sidr-class-link sidr-class-menuparent">Savoury &amp; Pastry Ingredients</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/savoury-pastry-products/" class="sidr-class-link">Savoury &amp; Pastry Ingredients</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1774 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/sausage-roll-concentrate/" class="sidr-class-link">Savoury Ingredients</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1772 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/pastry-fat/" class="sidr-class-link">Pastry Fat</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1794 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/pastry-relaxer/" class="sidr-class-link">Pastry Relaxer</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3129 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/viennoiserie/" class="sidr-class-link">Pastry Improver</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-1773 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/pie-filling-thickener/" class="sidr-class-link">Pie Filling Thickener</a></li></ul></li>
+	<li id="menu-item-40" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-40 sidr-class-item nav-item-col-1 menu-item-has-children menu-item-parent-3687 sidr-depth-2"><a title="Flavours &amp; Colours" href="https://www.britishbakels.co.uk/product-category/flavours-colours/" class="sidr-class-link sidr-class-menuparent">Flavours &amp; Colours</a><ul class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/flavours-colours/" class="sidr-class-link">Flavours &amp; Colours</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3689 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/colours/" class="sidr-class-link">Colours</a></li><li class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-3688 sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/product-category/flavours/" class="sidr-class-link">Flavours</a></li></ul></li>
+	<li id="menu-item-41" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-41 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Home Baking" href="https://www.britishbakels.co.uk/product-category/home-baking/" class="sidr-class-link">Home Baking</a></li>
+</ul>
+</li>
+<li id="menu-item-271" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-271 sidr-class-item sidr-class-menuparent sidr-depth-1 recipe-category"><a title="Recipes" href="https://www.britishbakels.co.uk/recipes/" class="sidr-class-link sidr-class-menuparent">Recipes</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.britishbakels.co.uk/recipes/" class="sidr-class-link">Recipes</a></li>
+	<li id="menu-item-42" class="menu-item menu-item-type-taxonomy menu-item-object-term current-menu-parent current-recipes-parent menu-item-42 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Bakery" href="https://www.britishbakels.co.uk/recipe-category/bakery/" class="sidr-class-link">Bakery</a></li>
+	<li id="menu-item-43" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-43 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Cooking" href="https://www.britishbakels.co.uk/recipe-category/cooking/" class="sidr-class-link">Cooking</a></li>
+	<li id="menu-item-44" class="menu-item menu-item-type-taxonomy menu-item-object-term menu-item-44 sidr-class-item nav-item-col-1 sidr-depth-2"><a title="Patisserie" href="https://www.britishbakels.co.uk/recipe-category/patisserie/" class="sidr-class-link">Patisserie</a></li>
+</ul>
+</li>
+<li id="menu-item-269" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-269 sidr-class-item sidr-class-menuparent sidr-depth-1"><a title="About" href="https://www.britishbakels.co.uk/about/" class="sidr-class-link sidr-class-menuparent">About</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.britishbakels.co.uk/about/" class="sidr-class-link">About</a></li>
+	<li id="menu-item-275" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-275 sidr-class-item sidr-depth-2"><a title="Core Values" href="https://www.britishbakels.co.uk/core-values/" class="sidr-class-link">Core Values</a></li>
+	<li id="menu-item-276" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-276 sidr-class-item sidr-depth-2"><a title="Facts &amp; Figures" href="https://www.britishbakels.co.uk/facts-figures/" class="sidr-class-link">Facts &amp; Figures</a></li>
+	<li id="menu-item-277" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-277 sidr-class-item sidr-depth-2"><a title="History" href="https://www.britishbakels.co.uk/history/" class="sidr-class-link">History</a></li>
+	<li id="menu-item-278" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-278 sidr-class-item sidr-depth-2"><a title="Jobs" href="https://www.britishbakels.co.uk/jobs/" class="sidr-class-link">Jobs</a></li>
+	<li id="menu-item-279" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-279 sidr-class-item sidr-depth-2"><a title="Mission Statement" href="https://www.britishbakels.co.uk/mission-statement/" class="sidr-class-link">Mission Statement</a></li>
+	<li id="menu-item-280" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-280 sidr-class-item sidr-depth-2"><a title="Our Customers" href="https://www.britishbakels.co.uk/our-customers/" class="sidr-class-link">Our Customers</a></li>
+	<li id="menu-item-3597" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3597 sidr-class-item sidr-depth-2"><a title="British Bakels" href="https://www.britishbakels.co.uk/britishbakels/" class="sidr-class-link">British Bakels</a></li>
+</ul>
+</li>
+<li id="menu-item-272" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-272 sidr-class-item sidr-class-menuparent sidr-depth-1"><a title="Services" href="https://www.britishbakels.co.uk/services/" class="sidr-class-link sidr-class-menuparent">Services</a>
+<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-2"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-2"><a href="https://www.britishbakels.co.uk/services/" class="sidr-class-link">Services</a></li>
+	<li id="menu-item-281" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-281 sidr-class-item sidr-depth-2"><a title="Centres of Competence" href="https://www.britishbakels.co.uk/centres-of-competence/" class="sidr-class-link">Centres of Competence</a></li>
+	<li id="menu-item-4386" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-4386 sidr-class-item sidr-class-menuparent sidr-depth-2"><a title="Baking Centres" href="https://www.britishbakels.co.uk/services/baking-centres/" class="sidr-class-link sidr-class-menuparent">Baking Centres</a>
+	<ul  class="sidr-class-submenu"><li class="sidr-class-item sidr-level-header sidr-depth-3"><a class="sidr-level-back">Back</a><a class="menu-btn"><img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu"></a></li><li class="sidr-class-item sidr-depth-3"><a href="https://www.britishbakels.co.uk/services/baking-centres/" class="sidr-class-link">Baking Centres</a></li>
+		<li id="menu-item-11944" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11944 sidr-class-item sidr-depth-3"><a title="Switzerland" href="https://www.britishbakels.co.uk/services/baking-centres/switzerland/" class="sidr-class-link">Switzerland</a></li>
+		<li id="menu-item-11943" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11943 sidr-class-item sidr-depth-3"><a title="British Bakels" href="https://www.britishbakels.co.uk/services/baking-centres/british-bakels/" class="sidr-class-link">British Bakels</a></li>
+		<li id="menu-item-11942" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11942 sidr-class-item sidr-depth-3"><a title="Australia" href="https://www.britishbakels.co.uk/services/baking-centres/australia/" class="sidr-class-link">Australia</a></li>
+		<li id="menu-item-11941" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11941 sidr-class-item sidr-depth-3"><a title="Thailand" href="https://www.britishbakels.co.uk/services/baking-centres/thailand/" class="sidr-class-link">Thailand</a></li>
+		<li id="menu-item-11940" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11940 sidr-class-item sidr-depth-3"><a title="Belgium" href="https://www.britishbakels.co.uk/services/baking-centres/belgium/" class="sidr-class-link">Belgium</a></li>
+		<li id="menu-item-11939" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11939 sidr-class-item sidr-depth-3"><a title="Ecuador" href="https://www.britishbakels.co.uk/services/baking-centres/ecuador/" class="sidr-class-link">Ecuador</a></li>
+		<li id="menu-item-11937" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11937 sidr-class-item sidr-depth-3"><a title="Mainland China" href="https://www.britishbakels.co.uk/services/baking-centres/mainland-china/" class="sidr-class-link">Mainland China</a></li>
+		<li id="menu-item-11938" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-11938 sidr-class-item sidr-depth-3"><a title="Sweden" href="https://www.britishbakels.co.uk/services/baking-centres/sweden/" class="sidr-class-link">Sweden</a></li>
+		<li id="menu-item-17642" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17642 sidr-class-item sidr-depth-3"><a title="Malaysia" href="https://www.britishbakels.co.uk/services/baking-centres/malaysia/" class="sidr-class-link">Malaysia</a></li>
+		<li id="menu-item-17643" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17643 sidr-class-item sidr-depth-3"><a title="Hong Kong" href="https://www.britishbakels.co.uk/services/baking-centres/hong-kong/" class="sidr-class-link">Hong Kong</a></li>
+		<li id="menu-item-17644" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-17644 sidr-class-item sidr-depth-3"><a title="India" href="https://www.britishbakels.co.uk/services/baking-centres/india/" class="sidr-class-link">India</a></li>
+		<li id="menu-item-19595" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-19595 sidr-class-item sidr-depth-3"><a title="The Netherlands" href="https://www.britishbakels.co.uk/services/baking-centres/bakels-senior/" class="sidr-class-link">The Netherlands</a></li>
+		<li id="menu-item-24183" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-24183 sidr-class-item sidr-depth-3"><a title="Germany" href="https://www.britishbakels.co.uk/services/baking-centres/germany/" class="sidr-class-link">Germany</a></li>
+		<li id="menu-item-29605" class="menu-item menu-item-type-post_type menu-item-object-baking-centres menu-item-29605 sidr-class-item sidr-depth-3"><a title="Chile" href="https://www.britishbakels.co.uk/services/baking-centres/chile/" class="sidr-class-link">Chile</a></li>
+	</ul>
+</li>
+	<li id="menu-item-282" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-282 sidr-class-item sidr-depth-2"><a title="Research &amp; Development" href="https://www.britishbakels.co.uk/research-development/" class="sidr-class-link">Research &amp; Development</a></li>
+</ul>
+</li>
+<li id="menu-item-3781" class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent menu-item-3781 sidr-class-item sidr-depth-1"><a title="News" href="https://www.britishbakels.co.uk/news/" class="sidr-class-link">News</a></li>
+<li id="menu-item-12091" class="menu-item menu-item-type-post_type_archive menu-item-object-insight menu-item-12091 sidr-class-item sidr-depth-1"><a title="Insights" href="https://www.britishbakels.co.uk/insights/" class="sidr-class-link">Insights</a></li>
+<li id="menu-item-300" class="menu-item menu-item-type-post_type_archive menu-item-object-stockist menu-item-300 sidr-class-item sidr-depth-1"><a title="Where to buy" href="https://www.britishbakels.co.uk/stockist/" class="sidr-class-link">Where to buy</a></li>
+<li id="menu-item-273" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-273 sidr-class-item sidr-depth-1"><a title="Contact" href="https://www.britishbakels.co.uk/contact/" class="sidr-class-link">Contact</a></li>
+<li id="menu-item-3432" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3432 sidr-class-item sidr-depth-1"><a title="My Bakels" href="https://www.britishbakels.co.uk/my-bakels/" class="sidr-class-link">My Bakels</a></li>
+</ul><ul class="sidr-class-menu sidr-class-menu-top"><li id="menu-item-3473" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3473 sidr-class-item sidr-depth-1"><a title="Login" href="https://www.britishbakels.co.uk/my-bakels/login/" class="sidr-class-link">Login</a></li>
+<li id="menu-item-3474" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-3474 sidr-class-item sidr-depth-1"><a title="Register" href="https://www.britishbakels.co.uk/my-bakels/register/" class="sidr-class-link">Register</a></li>
+</ul></div><div id="country-nav" class="sidr left">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Select a Market</span>
+      <a class="menu-btn">
+        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-africa">
+      <a class="sidr-class-link sidr-class-menuparent">Africa</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://bakelseastafrica.com" class="sidr-class-link">East Africa</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.sbakels.co.za" class="sidr-class-link">South Africa</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-antarctica">
+      <a class="sidr-class-link sidr-class-menuparent">Antarctica</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+                  </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-asia">
+      <a class="sidr-class-link sidr-class-menuparent">Asia</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.hkbakels.com.hk" class="sidr-class-link">Hong Kong</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.in" class="sidr-class-link">India</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.com.cn" class="sidr-class-link">Mainland China</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.maybakels.com" class="sidr-class-link">Malaysia</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsph.com" class="sidr-class-link">Philippines</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsingapore.com.sg" class="sidr-class-link">Singapore</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.co.th" class="sidr-class-link">Thailand</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-europe">
+      <a class="sidr-class-link sidr-class-menuparent">Europe</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakbel.com" class="sidr-class-link">Belgium</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.finnbakels.fi" class="sidr-class-link">Finland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsdeutschland.de" class="sidr-class-link">Germany</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.hu" class="sidr-class-link">Hungary</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.irishbakels.ie" class="sidr-class-link">Ireland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels-senior.nl" class="sidr-class-link">Netherlands</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.pl" class="sidr-class-link">Poland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelssweden.se" class="sidr-class-link">Sweden</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.ch" class="sidr-class-link">Switzerland</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.britishbakels.co.uk" class="sidr-class-link">United Kingdom</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-oceania">
+      <a class="sidr-class-link sidr-class-menuparent">Oceania</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.com.au" class="sidr-class-link">Australia</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsfiji.com.fj" class="sidr-class-link">Fiji</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.nzbakels.co.nz" class="sidr-class-link">New Zealand</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.beobakels.co.nz" class="sidr-class-link">New Zealand - Edible Oils</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-north-america">
+      <a class="sidr-class-link sidr-class-menuparent">North America</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelsusa.com" class="sidr-class-link">United States</a></li>        </ul>
+          </li>
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent" id="sidr-list-south-america">
+      <a class="sidr-class-link sidr-class-menuparent">South America</a>
+              <ul class="sidr-class-submenu">
+          <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+            <a class="sidr-level-back">Back</a>
+            <a class="menu-btn">
+              <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+            </a>
+          </li>
+
+          <li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.com.br" class="sidr-class-link">Brazil</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakelschile.cl" class="sidr-class-link">Chile</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.com.ec" class="sidr-class-link">Ecuador</a></li><li class="sidr-class-item sidr-depth-2"><a href="http://www.bakels.pe" class="sidr-class-link">Peru</a></li>        </ul>
+          </li>
+    
+    <li class="sidr-class-item sidr-depth-1" id="sidr-list-group">
+      <a href="https://www.bakels.com/" target="_blank" class="sidr-class-link">Visit Bakels Group</a>
+    </li>
+
+  </ul>
+</div>
+<div id="product-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter Products</span>
+      <a class="menu-btn">
+        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Categories</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Bread, Roll &amp; Morning Goods</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1757">Bread, Roll &amp; Morning Goods</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1759" class="sidr-class-link">Speciality Bread Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1758" class="sidr-class-link">Bread &amp; Roll Improvers</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1763" class="sidr-class-link">Soft Roll Concentrates</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1764" class="sidr-class-link">Bun Concentrates</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=2994" class="sidr-class-link">Crusty Concentrates</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=2995" class="sidr-class-link">Brioche Concentrates</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1765" class="sidr-class-link">Crossing Mix</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=2992" class="sidr-class-link">Doughnut Concentrates</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1761" class="sidr-class-link">Tiger Paste</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1762" class="sidr-class-link">Crumb Softeners</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1766" class="sidr-class-link">Fats for Fermented Goods</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1768" class="sidr-class-link">Dough Relaxant</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1770" class="sidr-class-link">Sourdough Products</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3851" class="sidr-class-link">Shelf Life Control</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Cake &amp; Sponge Ingredients</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1779">Cake &amp; Sponge Ingredients</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1780" class="sidr-class-link">Cake &amp; Sponge Emulsifiers</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1781" class="sidr-class-link">Baking Powders</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1782" class="sidr-class-link">Cake Shelf Life Extenders</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1783" class="sidr-class-link">Milk Powder &amp; Egg Extenders</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1785" class="sidr-class-link">Cake &amp; Sponge Mixes</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Release Solutions</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3385">Release Solutions</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3386" class="sidr-class-link">Bread</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3387" class="sidr-class-link">Cake/Confectionery</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Confectionery Ingredients</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1786">Confectionery Ingredients</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1788" class="sidr-class-link">Confectionery Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1792" class="sidr-class-link">Icings, Coverings &amp; Fillings</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=2993" class="sidr-class-link">Dessert Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1789" class="sidr-class-link">Meringue Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1790" class="sidr-class-link">Cream Stabiliser</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1791" class="sidr-class-link">Custard Mixes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1795" class="sidr-class-link">Fruit Pie Thickener</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1793" class="sidr-class-link">Ice Cream Products</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3695" class="sidr-class-link">Truffles</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Sweet &amp; Savoury Glazes</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1775">Sweet &amp; Savoury Glazes</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1776" class="sidr-class-link">Bun Glazes</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3288" class="sidr-class-link">Savoury Glaze</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1778" class="sidr-class-link">Confectionery Glazes</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Savoury &amp; Pastry Ingredients</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1771">Savoury &amp; Pastry Ingredients</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1774" class="sidr-class-link">Savoury Ingredients</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1772" class="sidr-class-link">Pastry Fat</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1794" class="sidr-class-link">Pastry Relaxer</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3129" class="sidr-class-link">Pastry Improver</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=1773" class="sidr-class-link">Pie Filling Thickener</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Flavours &amp; Colours</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3687">Flavours &amp; Colours</a>
+            </li>
+
+                            <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3689" class="sidr-class-link">Colours</a>
+                </li>
+                                <li class="sidr-class-item sidr-depth-3">
+                  <a href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3688" class="sidr-class-link">Flavours</a>
+                </li>
+                          </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?product-category%5B%5D=3745" >Home Baking</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Finished product</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3022" >Bagel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1860" >Baguette</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1899" >Batter Coating</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1884" >Biscuit</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1876" >Brioche</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1905" >Brownie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1882" >Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1890" >Cheesecake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1896" >Chilled Dough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1906" >Choux</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1854" >Ciabatta</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1885" >Confectionery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1861" >Cookies</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1859" >Cracker</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=2937" >Crème Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1875" >Croissant</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1893" >Crumpet</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1868" >Crusty Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1857" >Crusty Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1912" >Cupcake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1910" >Custard</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1874" >Danish</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1907" >Dessert</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1878" >Doughnut</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3651" >Éclair</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1873" >Flat Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1897" >Frozen Dough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1889" >Fruit Tart</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1891" >Gateau</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1894" >Genoese</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1866" >Gluten Free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1870" >Hamburger Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1871" >Hot Cross Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1911" >Ice Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1895" >Madeira</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3020" >Meat</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1902" >Meringue</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1903" >Muffin</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1898" >Naan</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1855" >Occasion Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1880" >Organic</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1892" >Pancake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1865" >Panettone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3021" >Pasta</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3019" >Pie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1881" >Pizza</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3664" >Profiteroles</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1858" >Rye Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1888" >Sausage Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1887" >Savoury Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1862" >Scone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1877" >Scotch Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1864" >Seeded Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1900" >Self Raising Flour</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3801" >Sheet Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1908" >Sliced Line</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3652" >Snack cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=3746" >Snack roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1863" >Soft Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1856" >Sourdough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1869" >Speciality Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1883" >Sponge</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1879" >Stollen</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1872" >Sweet Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1886" >Swiss Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1853" >Tin Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1909" >Traybake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1901" >Wafer</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?finished-products%5B%5D=1867" >Wholemeal</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Brand</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1714" >Actiwhite®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=3692" >Aromatic®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1708" >Aroplus</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1694" >Bacom</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1697" >Baktem</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=3653" >Chockex</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1707" >Colco</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1691" >Country Oven®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1717" >Cremodan®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1701" >Dovidol®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1698" >Eminex</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1715" >Enbellet</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1700" >Fermdor®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1709" >Hercules®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1713" >Kokomix</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1692" >Lecitem®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1696" >Monobac</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1695" >Monofresh®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1712" >Multimix</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1706" >Ovalett®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1693" >Quantum</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1705" >Rollex®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1710" >Sorbex</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1703" >Sprink</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=3747" >Ta-Da!®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1704" >Tincol®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1711" >Tinglide®</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1702" >Tinwax</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1716" >True Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?brands%5B%5D=1699" >Voltem®</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Ingredient Features</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3406" >Aerosol application</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3405" >Automatic equipment</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3403" >Brush application</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3337" >Clean Label</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3339" >Egg free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=1800" >Gluten free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3649" >Halal</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3401" >Just-add-water</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3650" >Kosher</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3662" >Natural</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3686" >Natural flavour</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3400" >Palm free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3333" >Produce products with claims</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3332" >Ready-To-Use</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3663" >RSPO</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3656" >Soya free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3404" >Spray application</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=1798" >Vegan suitable</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=1799" >Vegetarian</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3407" >Versatile application</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/products/?dietary%5B%5D=3680" >Without added sugar</a>
+
+                  </li>
+            </ul>
+    </li>
+      </ul>
+</div>
+
+<div id="recipe-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter Recipes</span>
+      <a class="menu-btn">
+        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Categories</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?recipe-category%5B%5D=1796" >Bakery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?recipe-category%5B%5D=3113" >Cooking</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?recipe-category%5B%5D=1797" >Patisserie</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Bakels products</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3070">Actiwhite® Meringue Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24799">Aromatic Colours</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2982">Bacom Mellow</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3039">Bacom Soft</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3006">Bakels Relax</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2991">Baktem 10% Brioche Paste Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2992">Baktem 5% Crusty Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2996">Baktem 5% Soft Roll Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2998">Baktem Blue 20% Bun Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2989">Baktem Red 10% Soft Roll Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3019">Bun Glaze RTU</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3058">Cake Doughnut Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24042">Caramel Crème Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3076">Caramel Fudgice</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3091">Caramel Ripple PF</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24967">Caramel Truffle</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3064">Cheesecake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24635">Chockex - Dark</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24634">Chockex - White</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24546">Chockex Premium - Dark</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24485">Chockex Premium - Ruby</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24651">Chockex Premium - White</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21546">Chocolate Crème Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=18061">Chocolate Millionaires Caramel PF</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=5364">Chocolate Mud Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3049">Chocolate Sponge Mix Complete</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3059">Choux Paste Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3083">Cinnamon Filling</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=27373">Cinnamon Remonce</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3020">Clean Label Bun Glaze RTU</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2983">Clean Label Crumb Softener</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4652">Clean Label Danish Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=16973">Clear Glaze</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2956">Country Oven® Artisan</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=14226">Country Oven® Fibre Plus</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=14277">Country Oven® Golden Grains</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2960">Country Oven® Multiseed</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2962">Country Oven® Oat &amp; Barley</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2958">Country Oven® Rye</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=14328">Country Oven® Seeded Artisan</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3082">Cream Cheese Flavoured Icing</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3062">Digestive Biscuit Crumb</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3057">Doughnut Paste Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3003">Eminex Liquid</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3072">Enbellet Cold Custard Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=20795">Fermdor® Active - Durum</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4104">Fermdor® Durum</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4110">Fermdor® R Classic</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4116">Fermdor® R Plus</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3007">Fermdor® Relax</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4119">Fermdor® Rustic</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4122">Fermdor® S Classic</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4125">Fermdor® S Germ</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4134">Fermdor® W Bright</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4100">Fermdor® W Classic</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4140">Fermdor® W Germ</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4137">Fermdor® W Germ Liquid</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4143">Fermdor® W Mild</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4149">Fermdor® W Plus</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2972">French Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21342">Fruit Filling - Blueberry 50%</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21340">Fruit Filling - Dark Cherry 70%</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21341">Fruit Filling - Fruits of the Forest 70%</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21343">Fruit Filling - Raspberry 50%</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21175">Fruit Filling - Strawberry 70%</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3055">Fudgy Brownie Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3034">Hercules® Double</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3035">Hercules® Regular</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3067">Instant Cream</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3068">Instant Cream - Chocolate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3069">Instant Lemon Supreme</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3092">Instant Starch</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3023">Instant Superglaze - Apricot</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3024">Instant Superglaze - Neutral</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3061">Kokomix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2973">Lecitem® 1000</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2974">Lecitem® 2000</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2976">Lecitem® Premium Paste Improver</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24016">Lemon Crème Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3090">Low Sugar Caramel</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3088">Low Water (AW) Caramel</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3084">Millionaires Caramel</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3085">Millionaires Caramel PF</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3052">Muffin &amp; Crème Cake Complete</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3050">Multimix Cake Base</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4313">Multimix Cake Complete</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3051">Multimix Cake Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4243">Multimix Vegan Cake Complete</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3060">No Bake Chocolate Slice</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3027">Ovalett®</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=8552">Palm Free Digestive Biscuit Crumb</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21344">Plain Crème Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=4464">Premium Pancake Mix Complete</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=8826">Raspberry Millionaires Caramel PF</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3089">Ready to use Caramel Sauce</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3002">Ready to use Crossing Paste</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3026">Ready to use Neutral Glaze</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3025">Ready to use Strawberry Glaze</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3075">Rich Chocolate Fudgice</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3016">Rollex® Gold</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=5403">RTU Cream Filling - Caramel</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=5429">RTU Cream Filling - Chocolate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3081">RTU Cream Filling - Lemon</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=5378">RTU Cream Filling - Orange</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=14817">RTU Cream Filling - Raspberry</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=14780">RTU Cream Filling - Vanilla</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24961">Ruby Truffle</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3087">Salted Millionaires Caramel</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3018">Sausage Roll Concentrate</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=30350">Scotch Pancake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24041">Speculoos Crème Cake Mix</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=22820">Speculoos Crumbles</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=21348">Speculoos Spread</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3048">Sponge Mix Complete</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3010">Sprink</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=2979">Super Lecitem® 3000</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=14779">Vegan Caramel PF</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3004">Voltem®</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3077">White Fudgice</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=24962">White Truffle</a>
+          </li>
+
+        
+          <li class="sidr-class-item sidr-depth-2">
+            <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?product-used%5B%5D=3056">Yeast Doughnut Concentrate</a>
+          </li>
+
+        
+      </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Finished products</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1805" >Baguette</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1844" >Biscuit</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1825" >Brioche</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1840" >Brownie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1835" >Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1845" >Cheesecake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1849" >Chilled Dough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1841" >Choux</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3831" >Ciabatta</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1838" >Confectionery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1820" >Cookie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1812" >Cracker</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1823" >Croissant</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3168" >Crumpet</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1804" >Crusty Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1806" >Crusty Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1837" >Cupcake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1839" >Custard</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1824" >Danish</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1830" >Dessert</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1826" >Doughnut</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3601" >Eclair</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1807" >Flat Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3829" >Focaccia</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1831" >Fruit Tart</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1846" >Gateau</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1852" >Gluten Free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1828" >Hamburger Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1816" >Hot Cross Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1847" >Ice Cream</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3114" >Meat</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3897" >Meringue</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1808" >Muffin</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1811" >Multiseed</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1809" >Occasion Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1848" >Pancake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1818" >Panettone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3115" >Pasta</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3834" >Pitta</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3108" >Pizza</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3135" >Pretzel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1810" >Rye Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1832" >Sausage Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1833" >Savoury Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1819" >Scone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1829" >Scotch Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1842" >Sliced Line</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1814" >Soft Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3068" >Speciality Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1817" >Speciality Bun</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1834" >Sponge</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1850" >Stollen</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3171" >Strudel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link sidr-class-menuparent" >Sweet Food</a>
+
+                    <ul class="sidr-class-submenu">
+            <li class="sidr-class-item sidr-depth-3 sidr-level-header">
+              <a class="sidr-level-back">Back</a>
+              <a class="menu-btn">
+                <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+              </a>
+            </li>
+            <li class="sidr-class-item sidr-depth-3">
+              <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1851">Sweet Food</a>
+            </li>
+
+                          <li class="sidr-class-item sidr-depth-3">
+                <a href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3898" class="sidr-class-link">Meringue</a>
+              </li>
+                      </ul>
+                </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1827" >Sweet Good</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1836" >Swiss Roll</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3830" >Thin</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1813" >Tin Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1843" >Traybake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3453" >Waffle</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=1822" >Wholemeal</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3103" >World Bakery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?finished-product%5B%5D=3139" >Wrap</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Display conditions</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?display-condition%5B%5D=1801" >Ambient</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?display-condition%5B%5D=1802" >Chilled</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Occasion</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2855" >Afternoon Tea</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2856" >BBQ</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2979" >Breakfast</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2854" >Christmas</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2857" >Easter</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2859" >Halloween</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2861" >Mother's Day</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2860" >Summer</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/recipes/?occasion%5B%5D=2858" >Valentine's Day</a>
+
+                  </li>
+            </ul>
+    </li>
+      </ul>
+</div>
+
+<div id="news-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter News</span>
+      <a class="menu-btn">
+        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Categories</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/announcements/" >Announcements</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/awards/" >Awards</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/bakels-worldwide/" >Bakels Worldwide</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/events/" >Events</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/investments/" >Investments</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/other/" >Other</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/people/" >People</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/products/" >Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/recipes/" >Recipes</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/category/sustainability/" >Sustainability</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Archives</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+        	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2024/06/'>June 2024</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2023/12/'>December 2023</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2023/06/'>June 2023</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2023/05/'>May 2023</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2022/12/'>December 2022</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2022/10/'>October 2022</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2022/09/'>September 2022</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2022/07/'>July 2022</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2022/06/'>June 2022</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2022/04/'>April 2022</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2022/02/'>February 2022</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2021/12/'>December 2021</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2021/10/'>October 2021</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2021/09/'>September 2021</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2021/06/'>June 2021</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2021/04/'>April 2021</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2021/01/'>January 2021</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2020/12/'>December 2020</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2020/10/'>October 2020</a></li>
+	<li class="sidr-class-item sidr-depth-2 sidr-item-archive"><a href='https://www.britishbakels.co.uk/2020/06/'>June 2020</a></li>
+      </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Tags</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/artisan-bread/" >Artisan Bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/audit/" >audit</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/bake-stable/" >bake stable</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/bakels-magazine/" >Bakels Magazine</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/bread/" >bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/bread-concentrate/" >Bread Concentrate</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/cake/" >Cake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/cake-mix/" >cake mix</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/caramel/" >caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/caramel-ripple/" >Caramel Ripple</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/charity/" >Charity</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/college/" >College</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/country-oven/" >country oven</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/covid-19/" >COVID-19</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/distribution-centre/" >Distribution Centre</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/fermdor/" >Fermdor</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/fudgice/" >Fudgice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/home-baking/" >home baking</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/local/" >local</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/low-aw-caramel/" >Low AW Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/low-sugar-caramel/" >Low Sugar Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/managing-director/" >Managing Director</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/millionaires-caramel/" >Millionaires Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/millionaires-caramel-extra/" >Millionaires Caramel Extra</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/multimix-cake-base/" >Multimix Cake Base</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/national-bakery-awards/" >national bakery awards</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/new-productcs/" >New productcs</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/new-products/" >new products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/palm-free/" >Palm Free</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/people/" >People</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/product-guide/" >product guide</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/products/" >Products</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/promotion/" >Promotion</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/ready-to-use/" >ready to use</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/recipes/" >recipes</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/rtu-caramel-sauce/" >RTU Caramel Sauce</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/rye/" >Rye</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/salted-caramel/" >Salted Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/scone/" >scone</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/seasonal/" >seasonal</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/slice/" >Slice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/sourdough/" >Sourdough</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/students/" >Students</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/summer/" >summer</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/technology/" >technology</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/tiger/" >tiger</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/topping/" >Topping</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/training/" >Training</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/traybake/" >Traybake</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/trends/" >Trends</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/true-caramel/" >True Caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/vegan/" >Vegan</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/tag/wcb/" >WCB</a>
+
+                  </li>
+            </ul>
+    </li>
+      </ul>
+</div>
+
+<div id="insight-nav" class="sidr right">
+  <ul class="sidr-class-menu sidr-class-menu-top">
+    <li class="sidr-class-item sidr-depth-1 sidr-level-header">
+      <span class="sidr-label">Filter Insights</span>
+      <a class="menu-btn">
+        <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+      </a>
+    </li>
+
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Categories</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-category/business-advice/" >Business Advice</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-category/inspiration/" >Inspiration</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-category/market-trends/" >Market Trends</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-category/products/" >Products</a>
+
+                  </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Archives</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2023/07/">July 2023</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2023/04/">April 2023</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/11/">November 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/10/">October 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/09/">September 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/07/">July 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/06/">June 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/03/">March 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/02/">February 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2022/01/">January 2022</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/12/">December 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/11/">November 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/09/">September 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/07/">July 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/06/">June 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/04/">April 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/03/">March 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/02/">February 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2021/01/">January 2021</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2020/12/">December 2020</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2020/11/">November 2020</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2020/10/">October 2020</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2020/09/">September 2020</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2020/08/">August 2020</a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insights/2020/07/">July 2020</a>
+        </li>
+            </ul>
+    </li>
+    
+        <li class="sidr-class-item sidr-depth-1 sidr-class-menuparent">
+      <a class="sidr-class-link sidr-class-menuparent">Tags</a>
+      <ul class="sidr-class-submenu">
+        <li class="sidr-class-item sidr-depth-2 sidr-level-header">
+          <a class="sidr-level-back">Back</a>
+          <a class="menu-btn">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Menu">
+          </a>
+        </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/asian/" >Asian</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/bakery-delivery/" >Bakery delivery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/baking/" >baking</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/beer-bread/" >beer bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/behaviour-trends/" >behaviour trends</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/bread/" >bread</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/brown-flavours/" >brown flavours</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/brownie/" >brownie</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/caramel/" >caramel</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/carbon-footprint/" >carbon footprint</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/christmas/" >christmas</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/claims/" >claims</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/climatarian/" >climatarian</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/consumer/" >consumer</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/consumer-behaviour/" >consumer behaviour</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/convenience/" >convenience</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/cube-croissant/" >cube croissant</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/dessert/" >dessert</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/doughnuts/" >doughnuts</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/environment/" >environment</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/flavour-trends/" >flavour trends</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/flavours/" >flavours</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/food-waste/" >food waste</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/food-to-go/" >food-to-go</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/ghost-kitchen/" >ghost kitchen</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/health-wellbeing/" >health &amp; wellbeing</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/innova/" >innova</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/innovation/" >innovation</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/international-bakery/" >international bakery</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/lifeatbakels/" >lifeatbakels</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/macro-trends/" >macro trends</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/online/" >Online</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/packaging/" >packaging</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/palm-oil/" >palm oil</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/pastry/" >pastry</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/photography/" >photography</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/pizza/" >pizza</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/plant-based/" >plant-based</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/seasonal/" >seasonal</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/social-media/" >social media</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/sustainability/" >sustainability</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/titanium-dioxide/" >titanium dioxide</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/trends/" >trends</a>
+
+                  </li>
+              <li class="sidr-class-item sidr-depth-2">
+          <a class="sidr-class-link" href="https://www.britishbakels.co.uk/insight-tag/vegan/" >vegan</a>
+
+                  </li>
+            </ul>
+    </li>
+      </ul>
+</div>
+<!-- Modal -->
+<div class="modal fade" id="select-country" tabindex="-1" role="dialog" aria-labelledby="select-country" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h3 class="modal-title">Bakels Worldwide</h3>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">
+            <img src="https://britishbakels.b-cdn.net/wp-content/themes/bakels-local/assets/images/close-icon.svg" alt="Close">
+          </span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6" id="list-africa"><h3>Africa</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://bakelseastafrica.com" target="_blank">East Africa</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.sbakels.co.za" target="_blank">South Africa</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-antarctica"><h3>Antarctica</h3><ul class="row list-group-trans"></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-asia"><h3>Asia</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.hkbakels.com.hk" target="_blank">Hong Kong</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.in" target="_blank">India</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.com.cn" target="_blank">Mainland China</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.maybakels.com" target="_blank">Malaysia</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsph.com" target="_blank">Philippines</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsingapore.com.sg" target="_blank">Singapore</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.co.th" target="_blank">Thailand</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-europe"><h3>Europe</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakbel.com" target="_blank">Belgium</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.finnbakels.fi" target="_blank">Finland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsdeutschland.de" target="_blank">Germany</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.hu" target="_blank">Hungary</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.irishbakels.ie" target="_blank">Ireland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels-senior.nl" target="_blank">Netherlands</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.pl" target="_blank">Poland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelssweden.se" target="_blank">Sweden</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.ch" target="_blank">Switzerland</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.britishbakels.co.uk" target="_blank">United Kingdom</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-oceania"><h3>Oceania</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.com.au" target="_blank">Australia</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsfiji.com.fj" target="_blank">Fiji</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.nzbakels.co.nz" target="_blank">New Zealand</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.beobakels.co.nz" target="_blank">New Zealand - Edible Oils</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-north-america"><h3>North America</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelsusa.com" target="_blank">United States</a></li></ul></li><li class="list-group-item list-group-item-trans col-6" id="list-south-america"><h3>South America</h3><ul class="row list-group-trans"><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.com.br" target="_blank">Brazil</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakelschile.cl" target="_blank">Chile</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.com.ec" target="_blank">Ecuador</a></li><li class="list-group-item list-group-item-trans col-6"><a href="http://www.bakels.pe" target="_blank">Peru</a></li></ul></li></ul>      </div>
+      <div class="modal-footer" style="margin: 0 40px;">
+        <a href="https://www.bakels.com/" target="_blank" class="btn btn-orange btn-icon-right btn-fa-angle-right">Visit Bakels Group</a>
+      </div>
+    </div>
+  </div>
+</div>	        <script type="text/javascript">
+			var imdmsHomePageURL = "https://www.britishbakels.co.uk/";
+		</script>
+<script type="text/javascript">
+	var viewallTranslation = 'View all';
+	var productsTranslation = 'Products';
+	var recipesTranslation = 'Recipes';
+	var allTranslation = 'All';
+	var noResult = 'No result for';
+	var moreButton = 'More';
+</script>
+		<div class="imdms-social-media d-none d-lg-block">
+			<ul>
+								<li>
+					<a href="https://www.facebook.com/BritishBakels/" title="Facebook" target="_blank" class="fa fa-facebook"><span>Facebook</span></a>
+				</li>
+				
+								<li>
+					<a href="https://twitter.com/britishbakels" title="Twitter" target="_blank" class="fa fa-twitter-x">
+					<i class=""><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc.--><path fill="currentColor" stroke="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9L389.2 48zm-24.8 373.8h39.1L151.1 88h-42l255.3 333.8z"/></svg></i>					<span>Twitter</span></a>
+				</li>
+				
+				
+								<li>
+					<a href="https://www.instagram.com/british.bakels/" title="Instagram" target="_blank" class="fa fa-instagram"><span>Instagram</span></a>
+				</li>
+				
+								<li>
+					<a href="https://www.linkedin.com/company/british-bakels/" title="Linkedin" target="_blank" class="fa fa-linkedin"><span>Linkedin</span></a>
+				</li>
+				
+				
+								<li>
+					<a href="https://www.youtube.com/channel/UCqst5glkRB9MHX5_i5jvy8g" title="YouTube" target="_blank" class="fa fa-youtube"><span>YouTube</span></a>
+				</li>
+				
+				
+								<li>
+										<a href="https://www.britishbakels.co.uk/email-newsletter/" title="Newsletter" target="_blank" class="fa fa-envelope"><span>Newsletter</span></a>
+				</li>
+							</ul>
+		</div>
+    <script type="text/javascript" src="//cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js?ver=6.5.3" id="ccc-cookie-control-js"></script>
+<script type="text/javascript" src="https://www.britishbakels.co.uk/wp-content/plugins/duracelltomi-google-tag-manager/dist/js/gtm4wp-form-move-tracker.js?ver=1.20.2" id="gtm4wp-form-move-tracker-js"></script>
+<script type="text/javascript" id="rocket-browser-checker-js-after">
+/* <![CDATA[ */
+"use strict";var _createClass=function(){function defineProperties(target,props){for(var i=0;i<props.length;i++){var descriptor=props[i];descriptor.enumerable=descriptor.enumerable||!1,descriptor.configurable=!0,"value"in descriptor&&(descriptor.writable=!0),Object.defineProperty(target,descriptor.key,descriptor)}}return function(Constructor,protoProps,staticProps){return protoProps&&defineProperties(Constructor.prototype,protoProps),staticProps&&defineProperties(Constructor,staticProps),Constructor}}();function _classCallCheck(instance,Constructor){if(!(instance instanceof Constructor))throw new TypeError("Cannot call a class as a function")}var RocketBrowserCompatibilityChecker=function(){function RocketBrowserCompatibilityChecker(options){_classCallCheck(this,RocketBrowserCompatibilityChecker),this.passiveSupported=!1,this._checkPassiveOption(this),this.options=!!this.passiveSupported&&options}return _createClass(RocketBrowserCompatibilityChecker,[{key:"_checkPassiveOption",value:function(self){try{var options={get passive(){return!(self.passiveSupported=!0)}};window.addEventListener("test",null,options),window.removeEventListener("test",null,options)}catch(err){self.passiveSupported=!1}}},{key:"initRequestIdleCallback",value:function(){!1 in window&&(window.requestIdleCallback=function(cb){var start=Date.now();return setTimeout(function(){cb({didTimeout:!1,timeRemaining:function(){return Math.max(0,50-(Date.now()-start))}})},1)}),!1 in window&&(window.cancelIdleCallback=function(id){return clearTimeout(id)})}},{key:"isDataSaverModeOn",value:function(){return"connection"in navigator&&!0===navigator.connection.saveData}},{key:"supportsLinkPrefetch",value:function(){var elem=document.createElement("link");return elem.relList&&elem.relList.supports&&elem.relList.supports("prefetch")&&window.IntersectionObserver&&"isIntersecting"in IntersectionObserverEntry.prototype}},{key:"isSlowConnection",value:function(){return"connection"in navigator&&"effectiveType"in navigator.connection&&("2g"===navigator.connection.effectiveType||"slow-2g"===navigator.connection.effectiveType)}}]),RocketBrowserCompatibilityChecker}();
+/* ]]> */
+</script>
+<script type="text/javascript" id="rocket-preload-links-js-extra">
+/* <![CDATA[ */
+var RocketPreloadLinksConfig = {"excludeUris":"\/recipes\/(.*)\/pdf\/|\/products\/(.*)\/pdf\/|\/wp-content\/themes\/bakels-local\/functions\/data\/(.*).json|\/(?:.+\/)?feed(?:\/(?:.+\/?)?)?$|\/(?:.+\/)?embed\/|\/(index.php\/)?(.*)wp-json(\/.*|$)|\/refer\/|\/go\/|\/recommend\/|\/recommends\/","usesTrailingSlash":"1","imageExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php","fileExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php|html|htm","siteUrl":"https:\/\/www.britishbakels.co.uk","onHoverDelay":"100","rateThrottle":"3"};
+/* ]]> */
+</script>
+<script type="text/javascript" id="rocket-preload-links-js-after">
+/* <![CDATA[ */
+(function() {
+"use strict";var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},e=function(){function i(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}return function(e,t,n){return t&&i(e.prototype,t),n&&i(e,n),e}}();function i(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var t=function(){function n(e,t){i(this,n),this.browser=e,this.config=t,this.options=this.browser.options,this.prefetched=new Set,this.eventTime=null,this.threshold=1111,this.numOnHover=0}return e(n,[{key:"init",value:function(){!this.browser.supportsLinkPrefetch()||this.browser.isDataSaverModeOn()||this.browser.isSlowConnection()||(this.regex={excludeUris:RegExp(this.config.excludeUris,"i"),images:RegExp(".("+this.config.imageExt+")$","i"),fileExt:RegExp(".("+this.config.fileExt+")$","i")},this._initListeners(this))}},{key:"_initListeners",value:function(e){-1<this.config.onHoverDelay&&document.addEventListener("mouseover",e.listener.bind(e),e.listenerOptions),document.addEventListener("mousedown",e.listener.bind(e),e.listenerOptions),document.addEventListener("touchstart",e.listener.bind(e),e.listenerOptions)}},{key:"listener",value:function(e){var t=e.target.closest("a"),n=this._prepareUrl(t);if(null!==n)switch(e.type){case"mousedown":case"touchstart":this._addPrefetchLink(n);break;case"mouseover":this._earlyPrefetch(t,n,"mouseout")}}},{key:"_earlyPrefetch",value:function(t,e,n){var i=this,r=setTimeout(function(){if(r=null,0===i.numOnHover)setTimeout(function(){return i.numOnHover=0},1e3);else if(i.numOnHover>i.config.rateThrottle)return;i.numOnHover++,i._addPrefetchLink(e)},this.config.onHoverDelay);t.addEventListener(n,function e(){t.removeEventListener(n,e,{passive:!0}),null!==r&&(clearTimeout(r),r=null)},{passive:!0})}},{key:"_addPrefetchLink",value:function(i){return this.prefetched.add(i.href),new Promise(function(e,t){var n=document.createElement("link");n.rel="prefetch",n.href=i.href,n.onload=e,n.onerror=t,document.head.appendChild(n)}).catch(function(){})}},{key:"_prepareUrl",value:function(e){if(null===e||"object"!==(void 0===e?"undefined":r(e))||!1 in e||-1===["http:","https:"].indexOf(e.protocol))return null;var t=e.href.substring(0,this.config.siteUrl.length),n=this._getPathname(e.href,t),i={original:e.href,protocol:e.protocol,origin:t,pathname:n,href:t+n};return this._isLinkOk(i)?i:null}},{key:"_getPathname",value:function(e,t){var n=t?e.substring(this.config.siteUrl.length):e;return n.startsWith("/")||(n="/"+n),this._shouldAddTrailingSlash(n)?n+"/":n}},{key:"_shouldAddTrailingSlash",value:function(e){return this.config.usesTrailingSlash&&!e.endsWith("/")&&!this.regex.fileExt.test(e)}},{key:"_isLinkOk",value:function(e){return null!==e&&"object"===(void 0===e?"undefined":r(e))&&(!this.prefetched.has(e.href)&&e.origin===this.config.siteUrl&&-1===e.href.indexOf("?")&&-1===e.href.indexOf("#")&&!this.regex.excludeUris.test(e.href)&&!this.regex.images.test(e.href))}}],[{key:"run",value:function(){"undefined"!=typeof RocketPreloadLinksConfig&&new n(new RocketBrowserCompatibilityChecker({capture:!0,passive:!0}),RocketPreloadLinksConfig).init()}}]),n}();t.run();
+}());
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/js/vendor.min.js?ver=9.5.4" id="imdms-js-vendor-js"></script>
+<script type="text/javascript" src="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/js/app.min.js?ver=9.5.4" id="imdms-js-js"></script>
+<script type="text/javascript" id="imdms-js-ajax-js-extra">
+/* <![CDATA[ */
+var imdms_ajax = {"ajaxnonce":"4a584c803a","query":{"page":"","recipes":"multiseed-rolls","post_type":"recipes","name":"multiseed-rolls"},"ajaxurl":"https:\/\/www.britishbakels.co.uk\/wp-admin\/admin-ajax.php?wpml_lang=en"};
+/* ]]> */
+</script>
+<script type="text/javascript" async="async" src="https://www.britishbakels.co.uk/wp-content/themes/bakels-local/assets/js/ajax-script.min.js?ver=9.5.4" id="imdms-js-ajax-js"></script>
+<script></script>            <script type="text/javascript">
+
+                var config = {
+                    apiKey: 'd80d368542e1554ea2b89ac15890cc3d4cbe2e72',
+                    product: 'PRO_MULTISITE',
+                    logConsent: false,
+                    notifyOnce: false,
+                    initialState: 'NOTIFY',
+                    position: 'RIGHT',
+                    theme: 'DARK',
+                    layout: 'POPUP',
+                    toggleType: 'slider',
+                    acceptBehaviour :  'recommended',
+                    closeOnGlobalChange : true,
+                    iabCMP: false,
+                                        closeStyle: 'button',
+                    consentCookieExpiry: 90,
+                    subDomains :  true,
+                    mode :  'gdpr',
+                    rejectButton: false,
+                    settingsStyle : 'link',
+                    encodeCookie : false,
+                    setInnerHTML: true,
+                    wrapInnerHTML : false,
+                    accessibility: {
+                        accessKey: 'C',
+                        highlightFocus: false,
+                        outline: false,
+                        overlay: true,
+                        disableSiteScrolling: false,                       
+                    },
+                                        text: {
+                        title: 'This site uses cookies',
+                        intro: 'Some of these cookies are essential, while others help us to improve your experience by providing insights into how the site is being used.<br /><br />For more detailed information on the cookies we use, please check our <a href="https://www.britishbakels.co.uk/privacy-policy/" target="_blank">Privacy Policy</a>',
+                        necessaryTitle: 'Necessary Cookies',
+                        necessaryDescription: 'Necessary cookies enable core functionality. The website cannot function properly without these cookies, and can only be disabled by changing your browser preferences.',
+                        thirdPartyTitle: 'Warning: Some cookies require your attention',
+                        thirdPartyDescription: 'Consent for the following cookies could not be automatically revoked. Please follow the link(s) below to opt out manually.',
+                        on: 'On',
+                        off: 'Off',
+                        accept: 'Accept Recommended Settings',
+                        settings: 'Cookie Preferences',
+                        acceptRecommended: 'Accept Recommended Settings',
+                        acceptSettings: 'Accept Recommended Settings',
+                        notifyTitle: 'Your choice regarding cookies on this site',
+                        notifyDescription: 'We use cookies to optimise site functionality and give you the best possible experience.',
+                        closeLabel: 'Close',
+                        cornerButton :  'Set cookie preferences.',
+                        landmark :  'Cookie preferences.',
+                        showVendors : 'Show vendors within this category',
+                        thirdPartyCookies : 'This vendor may set third party cookies.',
+                        readMore : 'Read more',
+                        accessibilityAlert: 'This site uses cookies to store information. Press accesskey C to learn more about your options.',
+                        rejectSettings: 'I Do Not Accept',
+                        reject: 'I Do Not Accept',
+                                            },
+                    
+                    branding: {
+                        fontColor: '#fff',
+                        fontFamily: '\&quot;Univers LT W01_59 Ult Cond\&quot;,Arial,serif',
+                        fontSizeTitle: '2em',
+                        fontSizeHeaders: '1.5em',
+                        fontSize: '0.94em',
+                        backgroundColor: '#003976',
+                        toggleText: '#fff',
+                        toggleColor: '#ea5f40',
+                        toggleBackground: '#111125',
+                        alertText: '#fff',
+                        alertBackground: '#003976',
+                        acceptText: '#ffffff',
+                        acceptBackground: '#ea5f40',
+                        rejectText: '#ffffff',
+                        rejectBackground: '#111125',
+                        closeText : '#111125',
+                        closeBackground : '#FFF',
+                        notifyFontColor : '#FFF',
+                        notifyBackgroundColor: '#003976',
+                                                buttonIcon: 'https://www.britishbakels.co.uk/wp-content/uploads/sites/2/2022/01/icon-cookie-control.svg',
+                                                buttonIconWidth: '64px',
+                        buttonIconHeight: '64px',
+                        removeIcon: false,
+                        removeAbout: true                    },
+                                        
+                                                            
+                  
+                                                                                
+                                        necessaryCookies: [ 'wordpress_*','wordpress_logged_in_*','CookieControl','lang','tr','bakels_geo_funnel' ],
+                    
+                                        optionalCookies: [
+                                                                        {
+                            name: 'analytics',
+                            label: 'Analytical Cookies',
+                            description: 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
+                                                        cookies: [ '_ga', '_gat', '_gid', 'Collect' ],
+                            onAccept: function () {
+                                dataLayer.push({
+    'civic_cookies_analytics': 'consent_given',
+    'event': 'analytics_consent_given',
+});                            },
+                            onRevoke: function () {
+                                dataLayer.push({
+    'civic_cookies_analytics': 'consent_revoked',
+});                            },
+                                                        recommendedState: 'on',
+                            lawfulBasis: 'consent',
+                        
+                            
+                        },
+                                                                                                {
+                            name: 'targeting-advertising',
+                            label: 'Targeting / Advertising',
+                            description: 'We use marketing cookies to help us improve the relevancy of advertising campaigns you receive.',
+                                                        cookies: [ 'Fr', 'i/jot', 'i/jot/syndication', 'impression.php/#' ],
+                            onAccept: function () {
+                                                            },
+                            onRevoke: function () {
+                                                            },
+                                                        recommendedState: 'on',
+                            lawfulBasis: 'consent',
+                        
+                            
+                        },
+                                                                    ],
+                                                            sameSiteCookie : true,
+                    sameSiteValue : 'Strict',
+                    notifyDismissButton: false
+                };
+                CookieControl.load(config);
+            </script>
+
+            <script>var rocket_lcp_data = {"ajax_url":"https:\/\/www.britishbakels.co.uk\/wp-admin\/admin-ajax.php","nonce":"3bcda31c9f","url":"https:\/\/www.britishbakels.co.uk\/recipes\/multiseed-rolls","is_mobile":false,"elements":"img, video, picture, p, main, div, li, svg","width_threshold":1600,"height_threshold":700,"debug":null}</script><script data-name="wpr-lcp-beacon" src='https://www.britishbakels.co.uk/wp-content/plugins/wp-rocket/assets/js/lcp-beacon.min.js' async></script></body>
+</html>
+<!-- This website is like a Rocket, isn't it? Performance optimized by WP Rocket. Learn more: https://wp-rocket.me - Debug: cached@1717417222 -->

--- a/tests/test_data/bakels.com.au/bakels_2.json
+++ b/tests/test_data/bakels.com.au/bakels_2.json
@@ -29,12 +29,18 @@
       "purpose": "Group 2"
     }
   ],
-  "instructions": "Dry blend Group 1 in mixing bowl.\nAdd Group 2 into mixing bowl.\nBlend together on low speed for 5 minutes. Scrape down in between mixing.\nLet the mix stand for 5-10 minutes for full hydration.",
+  "instructions": "Dry blend Group 1 in mixing bowl.\nAdd Group 2 into mixing bowl.\nBlend together on low speed for 5 minutes. Scrape down in between mixing.\nLet the mix stand for 5-10 minutes for full hydration.\nCooking Procedure:\nDivide the filling into desired portions and place on oiled surface to prevent sticking.\nPatty should be thinner in the middle to prevent edges from breaking during frying/grilling\nFry/grill at low flame as the patties are prone to over-browning.\nCooking time for each side is approximately 4-5 minute for 160g patty with 10cm diameter.\nLet cooked patties cool down to rest and serve warm.",
   "instructions_list": [
     "Dry blend Group 1 in mixing bowl.",
     "Add Group 2 into mixing bowl.",
     "Blend together on low speed for 5 minutes. Scrape down in between mixing.",
-    "Let the mix stand for 5-10 minutes for full hydration."
+    "Let the mix stand for 5-10 minutes for full hydration.",
+    "Cooking Procedure:",
+    "Divide the filling into desired portions and place on oiled surface to prevent sticking.",
+    "Patty should be thinner in the middle to prevent edges from breaking during frying/grilling",
+    "Fry/grill at low flame as the patties are prone to over-browning.",
+    "Cooking time for each side is approximately 4-5 minute for 160g patty with 10cm diameter.",
+    "Let cooked patties cool down to rest and serve warm."
   ],
   "description": "Plant-Based Burger Patty Recipe - Australian Bakels | Sponge Cake Mix",
   "image": "https://www.bakels.com.au/wp-content/uploads/sites/21/2020/08/Vegan-Burger-Patty-scaled.jpg"


### PR DESCRIPTION
These recipes looked well-structured and useful to me while reviewing #1096 so I wanted to extend their support to their `.co.uk` domain.

Doing that seems to have uncovered a couple of other issues:

  * Our `host` field might not be easily testable for non-default domains?
  * The existing Bakels scraper may have some fragile `instructions` handling logic.

Resolves #1099.

cc @heathrampazis 