### PR TITLE
fix: AllRecipes Missing Ingredients

### DIFF
--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -23,7 +23,7 @@ class AllRecipesCurated(AbstractScraper):
         def get_ingredient_text(item, key):
             span = item.find("span", {"data-ingredient-" + key: True})
             return normalize_string(span.text) if span else ""
-        
+
         def match_ingredient_class(tag):
             return tag.has_attr('class') and any(cls.endswith('structured-ingredients__list-item') for cls in tag['class'])
 

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -25,7 +25,10 @@ class AllRecipesCurated(AbstractScraper):
             return normalize_string(span.text) if span else ""
 
         def match_ingredient_class(tag):
-            return tag.has_attr('class') and any(cls.endswith('structured-ingredients__list-item') for cls in tag['class'])
+            return tag.has_attr("class") and any(
+                cls.endswith("structured-ingredients__list-item")
+                for cls in tag["class"]
+            )
 
         ingredients_list = []
         keys = ["quantity", "unit", "name"]

--- a/recipe_scrapers/allrecipes.py
+++ b/recipe_scrapers/allrecipes.py
@@ -23,10 +23,13 @@ class AllRecipesCurated(AbstractScraper):
         def get_ingredient_text(item, key):
             span = item.find("span", {"data-ingredient-" + key: True})
             return normalize_string(span.text) if span else ""
+        
+        def match_ingredient_class(tag):
+            return tag.has_attr('class') and any(cls.endswith('structured-ingredients__list-item') for cls in tag['class'])
 
         ingredients_list = []
         keys = ["quantity", "unit", "name"]
-        for item in self.soup.select(".mntl-structured-ingredients__list-item"):
+        for item in self.soup.find_all(match_ingredient_class):
             ingredient_parts = [get_ingredient_text(item, key) for key in keys]
             ingredients_list.append(" ".join(filter(None, ingredient_parts)))
 

--- a/tests/test_data/allrecipes.com/allrecipescurated.json
+++ b/tests/test_data/allrecipes.com/allrecipescurated.json
@@ -48,7 +48,7 @@
   "prep_time": 15.0,
   "cuisine": "Italian Inspired",
   "ratings": 4.8,
-  "ratings_count": 487,
+  "ratings_count": 489,
   "nutrients": {
     "calories": "551 kcal",
     "carbohydrateContent": "54 g",

--- a/tests/test_data/allrecipes.com/allrecipescurated.testhtml
+++ b/tests/test_data/allrecipes.com/allrecipescurated.testhtml
@@ -1,28 +1,20 @@
-<!DOCTYPE html>
-<html id="recipeScTemplate_1-0" class="comp no-js taxlevel-4   recipeScTemplate html mntl-html" data-ab="99,99,99,82,99,54,99,99,75,99,99,71,72,58,99,65,63" data-resource-version="1.130.0" lang="en" data-lazy-offset="200" data-mantle-resource-version="3.14.359" data-allrecipes-resource-version="1.130.0" data-tracking-container="true">				
-<!--
-<globe-environment environment="k8s-prod" application="allrecipes" dataCenter="us-east-1"/>
--->
-<head class="loc head">				
-					
-					<script type="text/javascript">var Mntl = window.Mntl || {};</script>
-					
-					    <link rel="preconnect" href="//js-sec.indexww.com">
-    <link rel="preconnect" href="//c.amazon-adsystem.com">
-    <link rel="preconnect" href="//securepubads.g.doubleclick.net">
-    <link rel="preconnect" href="//allrecipes.groceryserver.com">
-    <link rel="preconnect" href="//products.polaris.me">
-    <link rel="preconnect" href="//calvera.allrecipes.com">
 
-					
-					
+<!DOCTYPE html>
+<html id="recipeScTemplate_1-0" class="comp recipeScTemplate html mntl-html no-js taxlevel-4 " data-mm-ads-resource-version="1.2.78" data-mm-video-resource-version="1.4.0" data-mm-myrecipes-resource-version="1.3.0" data-mantle-resource-version="4.0.432" data-allrecipes-resource-version="2.56.0" data-lazy-offset="200.0" data-ab="99,50,99,99,99,99,99,99,99,55,99,99,63,99,99,99,77,99,99,99,99,58,78,99,64" data-mm-transactional-resource-version="1.11.6" data-mm-digital-issues-resource-version="1.18.4" lang="en" data-tracking-container="true" data-resource-version="2.56.0" data-mm-recipes-resource-version="1.1.0"><!--
+<globe-environment environment="k8s-prod" application="allrecipes" dataCenter="us-west-1"/>
+-->
+<head class="loc head">
+<link rel="preconnect" href="//js-sec.indexww.com">
+<link rel="preconnect" href="//c.amazon-adsystem.com">
+<link rel="preconnect" href="//securepubads.g.doubleclick.net">
+<link rel="preconnect" href="//allrecipes.groceryserver.com">
+<link rel="preconnect" href="//products.polaris.me">
+<link rel="preconnect" href="//calvera-telemetry.polaris.me">
+<link rel="preconnect" href="//live.polaris.me">
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
 <meta name="robots" content="max-image-preview:large, NOODP, NOYDIR" />
-
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
 <link rel="canonical" href="https://www.allrecipes.com/recipe/133948/four-cheese-margherita-pizza/" />
 <title>Four Cheese Margherita Pizza Recipe</title>
 <meta name="description" content="These delicious four cheese pizzas are bursting with flavor, and ready in under one hour." itemprop="description">
@@ -32,7 +24,6 @@
 <meta itemprop="name" content="Four Cheese Margherita Pizza" />
 <meta property="article:section" content="Allrecipes" />
 <!-- Facebook Open Graph Tags -->
-<meta property="fb:app_id" content="66102450266" />
 <meta property="og:type" content="article" />
 <meta property="og:site_name" content="Allrecipes" />
 <meta property="og:url" content="https://www.allrecipes.com/recipe/133948/four-cheese-margherita-pizza/" />
@@ -47,13 +38,10 @@
 <meta name="twitter:title" content="Four Cheese Margherita Pizza" />
 <meta name="twitter:description" content="These delicious four cheese pizzas are bursting with flavor, and ready in under one hour." />
 <meta name="twitter:image" content="https://www.allrecipes.com/thmb/QAkG8tNHkvVMe-otLmfdqM7Cc2o=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():focal(619x989:621x991)/5225433-four-cheese-margherita-pizza-Christina-4x3-1-29b0fe4316b74017a5ae437e9ebb319d.jpg" />
-					
-					<link type="text/css" rel="stylesheet" data-glb-css href="/static/1.130.0/cache/eNq1V2u2oyAM3tBwXMT8nU0gppq5CB7A9nb3Ex7WR1Gs98wPhYR8gYSQQGUddyiqnisnoRLWVp4Dv6r3Aex5C2yQXECnZQPmJeRHe47qDaX7QStQzla8sUHsjg3oGbgWoC83dAfVaFMNo-3kMzUHUz2waYHaDrDt3O-Oqxb-oHWgwGSZR8s2xE_2p3528UmMS2lA4ACWnZGOLeuAkzdf5GDAc1C1GVZOn-J3bImpVVUbEhNm7Gu77B9YuAP2Bp9TMLk77KwPjyfZ4uF_H4litdG8OeMJoRXtiIu6VhqjDvb38aOVHICtM6Nwo4HmtYoQ8PF_AIxSfpoWbzkje2iQJ7HBUGuebK10R_iGLa2HCT747fnEfzEIU7PhTmRO3xrXgOMo7Ya8vo6CvlN7EjKUYMtM8Y5L06JyRsd_ITMpGrvHTexpnEW6PIM0ltGhpAViYG_osoKFhUs9efZnnupcL8OvvIq0IYYSP6UanENl5lzf9VNa35dWj85pZec9CQAW2WWT1OgM-mPDblz4NLemmR17fxB_rkjyGuQF7_wvvQYkuZfCgP6tplRjgRvR7fFzM9y06Smb-dLI5YRfk_uwOM5q_b3o5sSnbN2Dtf5iUXPlC_Sa_EHYbe11vLWHgxdK9bZOb4t08cTBHeFBtpp3Tjk_Z2T3iyIdOlpZPE-xf8FeO9Zbk2fWBX09lYAVcZQQnhIVpJtJ7B_NOIl_IMpH12nDnNbS4XBUMhydVcpEOCWoBYOhg_50AFgt0B-qjpss73r8n9acKSacaqH_5WZf5mUvU87IdKGRuk3NJwa9r2M_vFfmvmrGSYOnx4nxbwMqTygLwjVKWWtuEs6S5NeTzdzP4BncCe9Ier0wGx9fqV94HFB8SnRPut3cl_0CauAtqm03hxk67TRLu70kTnj-JuEba7KOF50X7A1pJPhs7y1ZELEg4vH1R8OI1BxMLUgR836eezm9Iu7qgXBedfjtK5yu7l5y0Y8JdMvIqWmlrrms7BcOlODmI7amD5Apc8emLDdlnHgF2EctAi0KheicuwXMbZTSCgOgAm5Nnnv1phzh4eEsv8jC1AvcMSY55qa1I8fEpmRWEIomvbrnMFTKvuyKOOeGRruG246Nil4-xi48kh0pG3oFquBhJTi_9JRH3jj_AAVUMS8.min.css"/>
-					
-					<style type="text/css">#onetrust-banner-sdk{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}#onetrust-banner-sdk .onetrust-vendors-list-handler{cursor:pointer;color:#1f96db;font-size:inherit;font-weight:bold;text-decoration:none;margin-left:5px}#onetrust-banner-sdk .onetrust-vendors-list-handler:hover{color:#1f96db}#onetrust-banner-sdk:focus{outline:2px solid #000;outline-offset:-2px}#onetrust-banner-sdk a:focus{outline:2px solid #000}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{outline-offset:1px}#onetrust-banner-sdk .ot-close-icon,#onetrust-pc-sdk .ot-close-icon,#ot-sync-ntfy .ot-close-icon{background-image:url("data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB3aWR0aD0iMzQ4LjMzM3B4IiBoZWlnaHQ9IjM0OC4zMzNweCIgdmlld0JveD0iMCAwIDM0OC4zMzMgMzQ4LjMzNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzQ4LjMzMyAzNDguMzM0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PGc+PHBhdGggZmlsbD0iIzU2NTY1NiIgZD0iTTMzNi41NTksNjguNjExTDIzMS4wMTYsMTc0LjE2NWwxMDUuNTQzLDEwNS41NDljMTUuNjk5LDE1LjcwNSwxNS42OTksNDEuMTQ1LDAsNTYuODVjLTcuODQ0LDcuODQ0LTE4LjEyOCwxMS43NjktMjguNDA3LDExLjc2OWMtMTAuMjk2LDAtMjAuNTgxLTMuOTE5LTI4LjQxOS0xMS43NjlMMTc0LjE2NywyMzEuMDAzTDY4LjYwOSwzMzYuNTYzYy03Ljg0Myw3Ljg0NC0xOC4xMjgsMTEuNzY5LTI4LjQxNiwxMS43NjljLTEwLjI4NSwwLTIwLjU2My0zLjkxOS0yOC40MTMtMTEuNzY5Yy0xNS42OTktMTUuNjk4LTE1LjY5OS00MS4xMzksMC01Ni44NWwxMDUuNTQtMTA1LjU0OUwxMS43NzQsNjguNjExYy0xNS42OTktMTUuNjk5LTE1LjY5OS00MS4xNDUsMC01Ni44NDRjMTUuNjk2LTE1LjY4Nyw0MS4xMjctMTUuNjg3LDU2LjgyOSwwbDEwNS41NjMsMTA1LjU1NEwyNzkuNzIxLDExLjc2N2MxNS43MDUtMTUuNjg3LDQxLjEzOS0xNS42ODcsNTYuODMyLDBDMzUyLjI1OCwyNy40NjYsMzUyLjI1OCw1Mi45MTIsMzM2LjU1OSw2OC42MTF6Ii8+PC9nPjwvc3ZnPg==");background-size:contain;background-repeat:no-repeat;background-position:center;height:12px;width:12px}#onetrust-banner-sdk .powered-by-logo,#onetrust-banner-sdk .ot-pc-footer-logo a,#onetrust-pc-sdk .powered-by-logo,#onetrust-pc-sdk .ot-pc-footer-logo a,#ot-sync-ntfy .powered-by-logo,#ot-sync-ntfy .ot-pc-footer-logo a{background-size:contain;background-repeat:no-repeat;background-position:center;height:25px;width:152px;display:block}#onetrust-banner-sdk h3 *,#onetrust-banner-sdk h4 *,#onetrust-banner-sdk h6 *,#onetrust-banner-sdk button *,#onetrust-banner-sdk a[data-parent-id] *,#onetrust-pc-sdk h3 *,#onetrust-pc-sdk h4 *,#onetrust-pc-sdk h6 *,#onetrust-pc-sdk button *,#onetrust-pc-sdk a[data-parent-id] *,#ot-sync-ntfy h3 *,#ot-sync-ntfy h4 *,#ot-sync-ntfy h6 *,#ot-sync-ntfy button *,#ot-sync-ntfy a[data-parent-id] *{font-size:inherit;font-weight:inherit;color:inherit}#onetrust-banner-sdk .ot-hide,#onetrust-pc-sdk .ot-hide,#ot-sync-ntfy .ot-hide{display:none !important}#onetrust-pc-sdk .ot-sdk-row .ot-sdk-column{padding:0}#onetrust-pc-sdk .ot-sdk-container{padding-right:0}#onetrust-pc-sdk .ot-sdk-row{flex-direction:initial;width:100%}#onetrust-pc-sdk [type="checkbox"]:checked,#onetrust-pc-sdk [type="checkbox"]:not(:checked){pointer-events:initial}#onetrust-pc-sdk [type="checkbox"]:disabled+label::before,#onetrust-pc-sdk [type="checkbox"]:disabled+label:after,#onetrust-pc-sdk [type="checkbox"]:disabled+label{pointer-events:none;opacity:0.7}#onetrust-pc-sdk #vendor-list-content{transform:translate3d(0, 0, 0)}#onetrust-pc-sdk li input[type="checkbox"]{z-index:1}#onetrust-pc-sdk li .ot-checkbox label{z-index:2}#onetrust-pc-sdk li .ot-checkbox input[type="checkbox"]{height:auto;width:auto}#onetrust-pc-sdk li .host-title a,#onetrust-pc-sdk li .ot-host-name a,#onetrust-pc-sdk li .accordion-text,#onetrust-pc-sdk li .ot-acc-txt{z-index:2;position:relative}#onetrust-pc-sdk input{margin:3px 0.1ex}#onetrust-pc-sdk .pc-logo,#onetrust-pc-sdk .ot-pc-logo{height:60px;width:180px;background-position:center;background-size:contain;background-repeat:no-repeat}#onetrust-pc-sdk .screen-reader-only,#onetrust-pc-sdk .ot-scrn-rdr,.ot-sdk-cookie-policy .screen-reader-only,.ot-sdk-cookie-policy .ot-scrn-rdr{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}#onetrust-pc-sdk.ot-fade-in,.onetrust-pc-dark-filter.ot-fade-in,#onetrust-banner-sdk.ot-fade-in{animation-name:onetrust-fade-in;animation-duration:400ms;animation-timing-function:ease-in-out}#onetrust-pc-sdk.ot-hide{display:none !important}.onetrust-pc-dark-filter.ot-hide{display:none !important}#ot-sdk-btn.ot-sdk-show-settings,#ot-sdk-btn.optanon-show-settings{color:#68b631;border:1px solid #68b631;height:auto;white-space:normal;word-wrap:break-word;padding:0.8em 2em;font-size:0.8em;line-height:1.2;cursor:pointer;-moz-transition:0.1s ease;-o-transition:0.1s ease;-webkit-transition:1s ease;transition:0.1s ease}#ot-sdk-btn.ot-sdk-show-settings:hover,#ot-sdk-btn.optanon-show-settings:hover{color:#fff;background-color:#68b631}.onetrust-pc-dark-filter{background:rgba(0,0,0,0.5);z-index:2147483646;width:100%;height:100%;overflow:hidden;position:fixed;top:0;bottom:0;left:0}@keyframes onetrust-fade-in{0%{opacity:0}100%{opacity:1}}.ot-cookie-label{text-decoration:underline}@media only screen and (min-width: 426px) and (max-width: 896px) and (orientation: landscape){#onetrust-pc-sdk p{font-size:0.75em}}#onetrust-banner-sdk .banner-option-input:focus+label{outline:1px solid #000;outline-style:auto}.category-vendors-list-handler+a:focus,.category-vendors-list-handler+a:focus-visible{outline:2px solid #000}#onetrust-pc-sdk .ot-userid-title{margin-top:10px}#onetrust-pc-sdk .ot-userid-title>span,#onetrust-pc-sdk .ot-userid-timestamp>span{font-weight:700}#onetrust-pc-sdk .ot-userid-desc{font-style:italic}#onetrust-pc-sdk .ot-host-desc a{pointer-events:initial}#onetrust-pc-sdk .ot-ven-hdr>p a{position:relative;z-index:2;pointer-events:initial}
-#onetrust-banner-sdk,#onetrust-pc-sdk,#ot-sdk-cookie-policy,#ot-sync-ntfy{font-size:16px}#onetrust-banner-sdk *,#onetrust-banner-sdk ::after,#onetrust-banner-sdk ::before,#onetrust-pc-sdk *,#onetrust-pc-sdk ::after,#onetrust-pc-sdk ::before,#ot-sdk-cookie-policy *,#ot-sdk-cookie-policy ::after,#ot-sdk-cookie-policy ::before,#ot-sync-ntfy *,#ot-sync-ntfy ::after,#ot-sync-ntfy ::before{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}#onetrust-banner-sdk div,#onetrust-banner-sdk span,#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-banner-sdk p,#onetrust-banner-sdk img,#onetrust-banner-sdk svg,#onetrust-banner-sdk button,#onetrust-banner-sdk section,#onetrust-banner-sdk a,#onetrust-banner-sdk label,#onetrust-banner-sdk input,#onetrust-banner-sdk ul,#onetrust-banner-sdk li,#onetrust-banner-sdk nav,#onetrust-banner-sdk table,#onetrust-banner-sdk thead,#onetrust-banner-sdk tr,#onetrust-banner-sdk td,#onetrust-banner-sdk tbody,#onetrust-banner-sdk .ot-main-content,#onetrust-banner-sdk .ot-toggle,#onetrust-banner-sdk #ot-content,#onetrust-banner-sdk #ot-pc-content,#onetrust-banner-sdk .checkbox,#onetrust-pc-sdk div,#onetrust-pc-sdk span,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#onetrust-pc-sdk p,#onetrust-pc-sdk img,#onetrust-pc-sdk svg,#onetrust-pc-sdk button,#onetrust-pc-sdk section,#onetrust-pc-sdk a,#onetrust-pc-sdk label,#onetrust-pc-sdk input,#onetrust-pc-sdk ul,#onetrust-pc-sdk li,#onetrust-pc-sdk nav,#onetrust-pc-sdk table,#onetrust-pc-sdk thead,#onetrust-pc-sdk tr,#onetrust-pc-sdk td,#onetrust-pc-sdk tbody,#onetrust-pc-sdk .ot-main-content,#onetrust-pc-sdk .ot-toggle,#onetrust-pc-sdk #ot-content,#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk .checkbox,#ot-sdk-cookie-policy div,#ot-sdk-cookie-policy span,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy p,#ot-sdk-cookie-policy img,#ot-sdk-cookie-policy svg,#ot-sdk-cookie-policy button,#ot-sdk-cookie-policy section,#ot-sdk-cookie-policy a,#ot-sdk-cookie-policy label,#ot-sdk-cookie-policy input,#ot-sdk-cookie-policy ul,#ot-sdk-cookie-policy li,#ot-sdk-cookie-policy nav,#ot-sdk-cookie-policy table,#ot-sdk-cookie-policy thead,#ot-sdk-cookie-policy tr,#ot-sdk-cookie-policy td,#ot-sdk-cookie-policy tbody,#ot-sdk-cookie-policy .ot-main-content,#ot-sdk-cookie-policy .ot-toggle,#ot-sdk-cookie-policy #ot-content,#ot-sdk-cookie-policy #ot-pc-content,#ot-sdk-cookie-policy .checkbox,#ot-sync-ntfy div,#ot-sync-ntfy span,#ot-sync-ntfy h1,#ot-sync-ntfy h2,#ot-sync-ntfy h3,#ot-sync-ntfy h4,#ot-sync-ntfy h5,#ot-sync-ntfy h6,#ot-sync-ntfy p,#ot-sync-ntfy img,#ot-sync-ntfy svg,#ot-sync-ntfy button,#ot-sync-ntfy section,#ot-sync-ntfy a,#ot-sync-ntfy label,#ot-sync-ntfy input,#ot-sync-ntfy ul,#ot-sync-ntfy li,#ot-sync-ntfy nav,#ot-sync-ntfy table,#ot-sync-ntfy thead,#ot-sync-ntfy tr,#ot-sync-ntfy td,#ot-sync-ntfy tbody,#ot-sync-ntfy .ot-main-content,#ot-sync-ntfy .ot-toggle,#ot-sync-ntfy #ot-content,#ot-sync-ntfy #ot-pc-content,#ot-sync-ntfy .checkbox{font-family:inherit;font-weight:normal;-webkit-font-smoothing:auto;letter-spacing:normal;line-height:normal;padding:0;margin:0;height:auto;min-height:0;max-height:none;width:auto;min-width:0;max-width:none;border-radius:0;border:none;clear:none;float:none;position:static;bottom:auto;left:auto;right:auto;top:auto;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;white-space:normal;background:none;overflow:visible;vertical-align:baseline;visibility:visible;z-index:auto;box-shadow:none}#onetrust-banner-sdk label:before,#onetrust-banner-sdk label:after,#onetrust-banner-sdk .checkbox:after,#onetrust-banner-sdk .checkbox:before,#onetrust-pc-sdk label:before,#onetrust-pc-sdk label:after,#onetrust-pc-sdk .checkbox:after,#onetrust-pc-sdk .checkbox:before,#ot-sdk-cookie-policy label:before,#ot-sdk-cookie-policy label:after,#ot-sdk-cookie-policy .checkbox:after,#ot-sdk-cookie-policy .checkbox:before,#ot-sync-ntfy label:before,#ot-sync-ntfy label:after,#ot-sync-ntfy .checkbox:after,#ot-sync-ntfy .checkbox:before{content:"";content:none}
-#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{position:relative;width:100%;max-width:100%;margin:0 auto;padding:0 20px;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{width:100%;float:left;box-sizing:border-box;padding:0;display:initial}@media (min-width: 400px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:90%;padding:0}}@media (min-width: 550px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:100%}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{margin-left:4%}#onetrust-banner-sdk .ot-sdk-column:first-child,#onetrust-banner-sdk .ot-sdk-columns:first-child,#onetrust-pc-sdk .ot-sdk-column:first-child,#onetrust-pc-sdk .ot-sdk-columns:first-child,#ot-sdk-cookie-policy .ot-sdk-column:first-child,#ot-sdk-cookie-policy .ot-sdk-columns:first-child{margin-left:0}#onetrust-banner-sdk .ot-sdk-two.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-two.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-two.ot-sdk-columns{width:13.3333333333%}#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-three.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-three.ot-sdk-columns{width:22%}#onetrust-banner-sdk .ot-sdk-four.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-four.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-four.ot-sdk-columns{width:30.6666666667%}#onetrust-banner-sdk .ot-sdk-eight.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eight.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eight.ot-sdk-columns{width:65.3333333333%}#onetrust-banner-sdk .ot-sdk-nine.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-nine.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-nine.ot-sdk-columns{width:74%}#onetrust-banner-sdk .ot-sdk-ten.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-ten.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-ten.ot-sdk-columns{width:82.6666666667%}#onetrust-banner-sdk .ot-sdk-eleven.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eleven.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eleven.ot-sdk-columns{width:91.3333333333%}#onetrust-banner-sdk .ot-sdk-twelve.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-twelve.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-twelve.ot-sdk-columns{width:100%;margin-left:0}}#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6{margin-top:0;font-weight:600;font-family:inherit}#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem;line-height:1.2}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem;line-height:1.25}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem;line-height:1.3}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem;line-height:1.35}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem;line-height:1.5}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem;line-height:1.6}@media (min-width: 550px){#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem}}#onetrust-banner-sdk p,#onetrust-pc-sdk p,#ot-sdk-cookie-policy p{margin:0 0 1em 0;font-family:inherit;line-height:normal}#onetrust-banner-sdk a,#onetrust-pc-sdk a,#ot-sdk-cookie-policy a{color:#565656;text-decoration:underline}#onetrust-banner-sdk a:hover,#onetrust-pc-sdk a:hover,#ot-sdk-cookie-policy a:hover{color:#565656;text-decoration:none}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{display:inline-block;height:38px;padding:0 30px;color:#555;text-align:center;font-size:0.9em;font-weight:400;line-height:38px;letter-spacing:0.01em;text-decoration:none;white-space:nowrap;background-color:transparent;border-radius:2px;border:1px solid #bbb;cursor:pointer;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{color:#333;border-color:#888;opacity:0.7}#onetrust-banner-sdk .ot-sdk-button:focus,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:focus,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:focus,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{outline:2px solid #000}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-banner-sdk button.ot-sdk-button-primary,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-pc-sdk button.ot-sdk-button-primary,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary,#ot-sdk-cookie-policy button.ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary{color:#fff;background-color:#33c3f0;border-color:#33c3f0}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-banner-sdk button.ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:hover,#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-banner-sdk button.ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="submit"].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="reset"].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type="button"].ot-sdk-button-primary:focus,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-pc-sdk button.ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:hover,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-pc-sdk button.ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="submit"].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="reset"].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type="button"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="submit"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="reset"].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type="button"].ot-sdk-button-primary:focus{color:#fff;background-color:#1eaedb;border-color:#1eaedb}#onetrust-banner-sdk input[type="text"],#onetrust-pc-sdk input[type="text"],#ot-sdk-cookie-policy input[type="text"]{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #d1d1d1;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-banner-sdk input[type="text"],#onetrust-pc-sdk input[type="text"],#ot-sdk-cookie-policy input[type="text"]{-webkit-appearance:none;-moz-appearance:none;appearance:none}#onetrust-banner-sdk input[type="text"]:focus,#onetrust-pc-sdk input[type="text"]:focus,#ot-sdk-cookie-policy input[type="text"]:focus{border:1px solid #000;outline:0}#onetrust-banner-sdk label,#onetrust-pc-sdk label,#ot-sdk-cookie-policy label{display:block;margin-bottom:0.5rem;font-weight:600}#onetrust-banner-sdk input[type="checkbox"],#onetrust-pc-sdk input[type="checkbox"],#ot-sdk-cookie-policy input[type="checkbox"]{display:inline}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{list-style:circle inside}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{padding-left:0;margin-top:0}#onetrust-banner-sdk ul ul,#onetrust-pc-sdk ul ul,#ot-sdk-cookie-policy ul ul{margin:1.5rem 0 1.5rem 3rem;font-size:90%}#onetrust-banner-sdk li,#onetrust-pc-sdk li,#ot-sdk-cookie-policy li{margin-bottom:1rem}#onetrust-banner-sdk th,#onetrust-banner-sdk td,#onetrust-pc-sdk th,#onetrust-pc-sdk td,#ot-sdk-cookie-policy th,#ot-sdk-cookie-policy td{padding:12px 15px;text-align:left;border-bottom:1px solid #e1e1e1}#onetrust-banner-sdk button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-container:after,#onetrust-banner-sdk .ot-sdk-row:after,#onetrust-pc-sdk .ot-sdk-container:after,#onetrust-pc-sdk .ot-sdk-row:after,#ot-sdk-cookie-policy .ot-sdk-container:after,#ot-sdk-cookie-policy .ot-sdk-row:after{content:"";display:table;clear:both}#onetrust-banner-sdk .ot-sdk-row,#onetrust-pc-sdk .ot-sdk-row,#ot-sdk-cookie-policy .ot-sdk-row{margin:0;max-width:none;display:block}
-#onetrust-banner-sdk{box-shadow:0 0 18px rgba(0,0,0,.2)}#onetrust-banner-sdk.otFlat{position:fixed;z-index:2147483645;bottom:0;right:0;left:0;background-color:#fff;max-height:90%;overflow-x:hidden;overflow-y:auto}#onetrust-banner-sdk.otFlat.top{top:0px;bottom:auto}#onetrust-banner-sdk.otRelFont{font-size:1rem}#onetrust-banner-sdk>.ot-sdk-container{overflow:hidden}#onetrust-banner-sdk::-webkit-scrollbar{width:11px}#onetrust-banner-sdk::-webkit-scrollbar-thumb{border-radius:10px;background:#c1c1c1}#onetrust-banner-sdk{scrollbar-arrow-color:#c1c1c1;scrollbar-darkshadow-color:#c1c1c1;scrollbar-face-color:#c1c1c1;scrollbar-shadow-color:#c1c1c1}#onetrust-banner-sdk #onetrust-policy{margin:1.25em 0 .625em 2em;overflow:hidden}#onetrust-banner-sdk #onetrust-policy .ot-gv-list-handler{float:left;font-size:.82em;padding:0;margin-bottom:0;border:0;line-height:normal;height:auto;width:auto}#onetrust-banner-sdk #onetrust-policy-title{font-size:1.2em;line-height:1.3;margin-bottom:10px}#onetrust-banner-sdk #onetrust-policy-text{clear:both;text-align:left;font-size:.88em;line-height:1.4}#onetrust-banner-sdk #onetrust-policy-text *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk #onetrust-policy-text a{font-weight:bold;margin-left:5px}#onetrust-banner-sdk #onetrust-policy-title,#onetrust-banner-sdk #onetrust-policy-text{color:dimgray;float:left}#onetrust-banner-sdk #onetrust-button-group-parent{min-height:1px;text-align:center}#onetrust-banner-sdk #onetrust-button-group{display:inline-block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{background-color:#68b631;color:#fff;border-color:#68b631;margin-right:1em;min-width:125px;height:auto;white-space:normal;word-break:break-word;word-wrap:break-word;padding:12px 10px;line-height:1.2;font-size:.813em;font-weight:600}#onetrust-banner-sdk #onetrust-pc-btn-handler.cookie-setting-link{background-color:#fff;border:none;color:#68b631;text-decoration:underline;padding-left:0;padding-right:0}#onetrust-banner-sdk .onetrust-close-btn-ui{width:44px;height:44px;background-size:12px;border:none;position:relative;margin:auto;padding:0}#onetrust-banner-sdk .banner_logo{display:none}#onetrust-banner-sdk .ot-b-addl-desc{clear:both;float:left;display:block}#onetrust-banner-sdk #banner-options{float:left;display:table;margin-right:0;margin-left:1em;width:calc(100% - 1em)}#onetrust-banner-sdk .banner-option-input{cursor:pointer;width:auto;height:auto;border:none;padding:0;padding-right:3px;margin:0 0 10px;font-size:.82em;line-height:1.4}#onetrust-banner-sdk .banner-option-input *{pointer-events:none;font-size:inherit;line-height:inherit}#onetrust-banner-sdk .banner-option-input[aria-expanded=true]~.banner-option-details{display:block;height:auto}#onetrust-banner-sdk .banner-option-input[aria-expanded=true] .ot-arrow-container{transform:rotate(90deg)}#onetrust-banner-sdk .banner-option{margin-bottom:12px;margin-left:0;border:none;float:left;padding:0}#onetrust-banner-sdk .banner-option:first-child{padding-left:2px}#onetrust-banner-sdk .banner-option:not(:first-child){padding:0;border:none}#onetrust-banner-sdk .banner-option-header{cursor:pointer;display:inline-block}#onetrust-banner-sdk .banner-option-header :first-child{color:dimgray;font-weight:bold;float:left}#onetrust-banner-sdk .banner-option-header .ot-arrow-container{display:inline-block;border-top:6px solid transparent;border-bottom:6px solid transparent;border-left:6px solid dimgray;margin-left:10px;vertical-align:middle}#onetrust-banner-sdk .banner-option-details{display:none;font-size:.83em;line-height:1.5;padding:10px 0px 5px 10px;margin-right:10px;height:0px}#onetrust-banner-sdk .banner-option-details *{font-size:inherit;line-height:inherit;color:dimgray}#onetrust-banner-sdk .ot-arrow-container,#onetrust-banner-sdk .banner-option-details{transition:all 300ms ease-in 0s;-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s}#onetrust-banner-sdk .ot-dpd-container{float:left}#onetrust-banner-sdk .ot-dpd-title{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-title,#onetrust-banner-sdk .ot-dpd-desc{font-size:.88em;line-height:1.4;color:dimgray}#onetrust-banner-sdk .ot-dpd-title *,#onetrust-banner-sdk .ot-dpd-desc *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text *{margin-bottom:0}#onetrust-banner-sdk.ot-iab-2 .onetrust-vendors-list-handler{display:block;margin-left:0;margin-top:5px;clear:both;margin-bottom:0;padding:0;border:0;height:auto;width:auto}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk.ot-close-btn-link{padding-top:25px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container{top:15px;transform:none;right:15px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container button{padding:0;white-space:pre-wrap;border:none;height:auto;line-height:1.5;text-decoration:underline;font-size:.69em}#onetrust-banner-sdk #onetrust-policy-text,#onetrust-banner-sdk .ot-dpd-desc,#onetrust-banner-sdk .ot-b-addl-desc{font-size:.813em;line-height:1.5}#onetrust-banner-sdk .ot-dpd-desc{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-desc>.ot-b-addl-desc{margin-top:10px;margin-bottom:10px;font-size:1em}@media only screen and (max-width: 425px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:6px;right:2px}#onetrust-banner-sdk #onetrust-policy{margin-left:0;margin-top:3em}#onetrust-banner-sdk #onetrust-button-group{display:block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk .onetrust-close-btn-ui{top:auto;transform:none}#onetrust-banner-sdk #onetrust-policy-title{display:inline;float:none}#onetrust-banner-sdk #banner-options{margin:0;padding:0;width:100%}}@media only screen and (min-width: 426px)and (max-width: 896px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:0;right:0}#onetrust-banner-sdk #onetrust-policy{margin-left:1em;margin-right:1em}#onetrust-banner-sdk .onetrust-close-btn-ui{top:10px;right:10px}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:95%}#onetrust-banner-sdk.ot-iab-2 #onetrust-group-container{width:100%}#onetrust-banner-sdk #onetrust-button-group-parent{width:100%;position:relative;margin-left:0}#onetrust-banner-sdk #onetrust-button-group button{display:inline-block}#onetrust-banner-sdk #onetrust-button-group{margin-right:0;text-align:center}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler{float:left}#onetrust-banner-sdk .has-reject-all-button #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-accept-btn-handler{float:right}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group{width:calc(100% - 2em);margin-right:0}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler.cookie-setting-link{padding-left:0px;text-align:left}#onetrust-banner-sdk.ot-buttons-fw .ot-sdk-three button{width:100%;text-align:center}#onetrust-banner-sdk.ot-buttons-fw #onetrust-button-group-parent button{float:none}#onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link{text-align:center}}@media only screen and (min-width: 550px){#onetrust-banner-sdk .banner-option:not(:first-child){border-left:1px solid #d8d8d8;padding-left:25px}}@media only screen and (min-width: 425px)and (max-width: 550px){#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group,#onetrust-banner-sdk.ot-iab-2 #onetrust-policy,#onetrust-banner-sdk.ot-iab-2 .banner-option{width:100%}}@media only screen and (min-width: 769px){#onetrust-banner-sdk #onetrust-button-group{margin-right:30%}#onetrust-banner-sdk #banner-options{margin-left:2em;margin-right:5em;margin-bottom:1.25em;width:calc(100% - 7em)}}@media only screen and (min-width: 897px)and (max-width: 1023px){#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:75%;transform:translateY(-50%)}#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;padding:0;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{position:relative;margin:0;right:-22px;top:2px}}@media only screen and (min-width: 1024px){#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{right:-12px}#onetrust-banner-sdk #onetrust-policy{margin-left:2em}#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:60%;transform:translateY(-50%)}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-title{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text,#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:1em;width:50%;border-right:1px solid #d8d8d8;padding-right:1rem}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-container{width:45%;padding-left:1rem;display:inline-block;float:none}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-title{line-height:1.7}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent{left:auto;right:4%;margin-left:0}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{margin:auto;width:30%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:60%}#onetrust-banner-sdk #onetrust-button-group{margin-right:auto}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{margin-top:1em}}@media only screen and (min-width: 890px){#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group-parent{padding-left:3%;padding-right:4%;margin-left:0}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group{margin-right:0;margin-top:1.25em;width:100%}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button{width:100%;margin-bottom:5px;margin-top:5px}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button:last-of-type{margin-bottom:20px}}@media only screen and (min-width: 1280px){#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:55%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{width:44%;padding-left:2%;padding-right:2%}#onetrust-banner-sdk:not(.ot-iab-2).vertical-align-content #onetrust-button-group-parent{position:absolute;left:55%}}
+<link rel="alternate" type="application/rss+xml" href="https://feeds.distribution.dotdashmeredith.com/v3/rss/51ac80cf-247d-468b-ac72-58f647950059">
+<link type="text/css" rel="stylesheet" data-glb-css="top" href="/static/2.56.0/cache/eNqtWOvamyAMvqHxeBH7u5tAiMrGwQXst979AtoqLaXY7Y-QkDfkAATsfOBBic5wGzR0wvsucuBb9zygDB-BzZoLmJyWgHehOGq4sjvKyUWD74Qzs7Ngg--QK80uSoJL4qlXk--53-wRjEu_z7WLELt7MXQBKx128-Infd2aJ5928S8lR6B2AjVO4fvE7Qg_lA9gAYvMiq5Ru55rQnGZwDyLVKPcs1rLL2qkMWe7JSitwpUR69ivgAeHhiIJHMXEInHsV3AGvI9J77mNkcjJNmNXx5Kte7cNOixae4EANsFzsk2Fd0JxneBpLd3JUkbKuDomrkGd_OodR1mxqkduSdhcsQuO-7B-GeMaSer9ghqcC5SDtaksqLJcPdBJdg3yvXsKqpX95TOiDS5dkNxPbLHqAui3kBe5FYWSEuTGrWlLAZeSIQg1w6HrG7Jx0DHwi0MVgAmnNYg1Hs-8BqUWvryGEIO3-fLEqWT8DLrqkHB2UGhSam6qCrwGhzgSf6sbW7-4ezYxrvUtA4_ShdKQagf7-UWl6Eoe9ui47HKyHX4HVrzxARcRFgRJabVUAMJaDNdvBbhKxSCMaigFwACFdBObkVq8slzpC-FBjWQPE3yOiXlzmvVIJ5TAxfT-2G_boufB96yuLdtKXE7WMnROweczn7XcQOAZUdtWVzoGo1v-3q9ZfBM_IcqXMDlkwTkd1FzzKgRU_RKzmRGMzilTvbNte3IrgX7iCEVmSy5uO2c7ddempLqsuekk3o_f90fU7c6XWZBusiT5wobXIUK4KPiimxEWWKXw5GEoyL6cjJEAMiQhOxZYLdbmubjTn6cx5_67PkmbS2n_QLa4liP9GaiyAV1nDMsYNaSlgcu6atZuyzQao-aRqomq8Zs25l6YShrLw-cK3RSMTp-mXUBPR0Z17LC0dtbnq-FJbUlrxSy70JmXTryBi9d85hcTK_D_VKl5D_oDzx_11_WWDI2PVhZf3Wl57mQN5H8vt1PQk8ivK1s5rZhcuMFbTe9p5tc_CFu_BJ8nF9ztRnokTtTyxykfp6v9gxg0_FE9KanfLA8PwdWjpoeh354OMfMoWJms4AWpZ9GbvfdGOn0aCk3Sly49j4y_cc4FWw.min.css"></link>
+<style type="text/css">
+#onetrust-banner-sdk{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}#onetrust-banner-sdk .onetrust-vendors-list-handler{cursor:pointer;color:#1f96db;font-size:inherit;font-weight:bold;text-decoration:none;margin-left:5px}#onetrust-banner-sdk .onetrust-vendors-list-handler:hover{color:#1f96db}#onetrust-banner-sdk:focus{outline:2px solid #000;outline-offset:-2px}#onetrust-banner-sdk a:focus{outline:2px solid #000}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{outline-offset:1px}#onetrust-banner-sdk.ot-bnr-w-logo .ot-bnr-logo{height:64px;width:64px}#onetrust-banner-sdk .ot-tcf2-vendor-count.ot-text-bold{font-weight:bold}#onetrust-banner-sdk .ot-close-icon,#onetrust-pc-sdk .ot-close-icon,#ot-sync-ntfy .ot-close-icon{background-size:contain;background-repeat:no-repeat;background-position:center;height:12px;width:12px}#onetrust-banner-sdk .powered-by-logo,#onetrust-banner-sdk .ot-pc-footer-logo a,#onetrust-pc-sdk .powered-by-logo,#onetrust-pc-sdk .ot-pc-footer-logo a,#ot-sync-ntfy .powered-by-logo,#ot-sync-ntfy .ot-pc-footer-logo a{background-size:contain;background-repeat:no-repeat;background-position:center;height:25px;width:152px;display:block;text-decoration:none;font-size:.75em}#onetrust-banner-sdk .powered-by-logo:hover,#onetrust-banner-sdk .ot-pc-footer-logo a:hover,#onetrust-pc-sdk .powered-by-logo:hover,#onetrust-pc-sdk .ot-pc-footer-logo a:hover,#ot-sync-ntfy .powered-by-logo:hover,#ot-sync-ntfy .ot-pc-footer-logo a:hover{color:#565656}#onetrust-banner-sdk h3 *,#onetrust-banner-sdk h4 *,#onetrust-banner-sdk h6 *,#onetrust-banner-sdk button *,#onetrust-banner-sdk a[data-parent-id] *,#onetrust-pc-sdk h3 *,#onetrust-pc-sdk h4 *,#onetrust-pc-sdk h6 *,#onetrust-pc-sdk button *,#onetrust-pc-sdk a[data-parent-id] *,#ot-sync-ntfy h3 *,#ot-sync-ntfy h4 *,#ot-sync-ntfy h6 *,#ot-sync-ntfy button *,#ot-sync-ntfy a[data-parent-id] *{font-size:inherit;font-weight:inherit;color:inherit}#onetrust-banner-sdk .ot-hide,#onetrust-pc-sdk .ot-hide,#ot-sync-ntfy .ot-hide{display:none !important}#onetrust-banner-sdk button.ot-link-btn:hover,#onetrust-pc-sdk button.ot-link-btn:hover,#ot-sync-ntfy button.ot-link-btn:hover{text-decoration:underline;opacity:1}#onetrust-pc-sdk .ot-sdk-row .ot-sdk-column{padding:0}#onetrust-pc-sdk .ot-sdk-container{padding-right:0}#onetrust-pc-sdk .ot-sdk-row{flex-direction:initial;width:100%}#onetrust-pc-sdk [type=checkbox]:checked,#onetrust-pc-sdk [type=checkbox]:not(:checked){pointer-events:initial}#onetrust-pc-sdk [type=checkbox]:disabled+label::before,#onetrust-pc-sdk [type=checkbox]:disabled+label:after,#onetrust-pc-sdk [type=checkbox]:disabled+label{pointer-events:none;opacity:.7}#onetrust-pc-sdk #vendor-list-content{transform:translate3d(0, 0, 0)}#onetrust-pc-sdk li input[type=checkbox]{z-index:1}#onetrust-pc-sdk li .ot-checkbox label{z-index:2}#onetrust-pc-sdk li .ot-checkbox input[type=checkbox]{height:auto;width:auto}#onetrust-pc-sdk li .host-title a,#onetrust-pc-sdk li .ot-host-name a,#onetrust-pc-sdk li .accordion-text,#onetrust-pc-sdk li .ot-acc-txt{z-index:2;position:relative}#onetrust-pc-sdk input{margin:3px .1ex}#onetrust-pc-sdk .pc-logo,#onetrust-pc-sdk .ot-pc-logo{height:60px;width:180px;background-position:center;background-size:contain;background-repeat:no-repeat;display:inline-flex;justify-content:center;align-items:center}#onetrust-pc-sdk .pc-logo img,#onetrust-pc-sdk .ot-pc-logo img{max-height:100%;max-width:100%}#onetrust-pc-sdk .screen-reader-only,#onetrust-pc-sdk .ot-scrn-rdr,.ot-sdk-cookie-policy .screen-reader-only,.ot-sdk-cookie-policy .ot-scrn-rdr{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}#onetrust-pc-sdk.ot-fade-in,.onetrust-pc-dark-filter.ot-fade-in,#onetrust-banner-sdk.ot-fade-in{animation-name:onetrust-fade-in;animation-duration:400ms;animation-timing-function:ease-in-out}#onetrust-pc-sdk.ot-hide{display:none !important}.onetrust-pc-dark-filter.ot-hide{display:none !important}#ot-sdk-btn.ot-sdk-show-settings,#ot-sdk-btn.optanon-show-settings{color:#68b631;border:1px solid #68b631;height:auto;white-space:normal;word-wrap:break-word;padding:.8em 2em;font-size:.8em;line-height:1.2;cursor:pointer;-moz-transition:.1s ease;-o-transition:.1s ease;-webkit-transition:1s ease;transition:.1s ease}#ot-sdk-btn.ot-sdk-show-settings:hover,#ot-sdk-btn.optanon-show-settings:hover{color:#fff;background-color:#68b631}.onetrust-pc-dark-filter{background:rgba(0,0,0,.5);z-index:2147483646;width:100%;height:100%;overflow:hidden;position:fixed;top:0;bottom:0;left:0}@keyframes onetrust-fade-in{0%{opacity:0}100%{opacity:1}}.ot-cookie-label{text-decoration:underline}@media only screen and (min-width: 426px)and (max-width: 896px)and (orientation: landscape){#onetrust-pc-sdk p{font-size:.75em}}#onetrust-banner-sdk .banner-option-input:focus+label{outline:1px solid #000;outline-style:auto}.category-vendors-list-handler+a:focus,.category-vendors-list-handler+a:focus-visible{outline:2px solid #000}#onetrust-pc-sdk .ot-userid-title{margin-top:10px}#onetrust-pc-sdk .ot-userid-title>span,#onetrust-pc-sdk .ot-userid-timestamp>span{font-weight:700}#onetrust-pc-sdk .ot-userid-desc{font-style:italic}#onetrust-pc-sdk .ot-host-desc a{pointer-events:initial}#onetrust-pc-sdk .ot-ven-hdr>p a{position:relative;z-index:2;pointer-events:initial}#onetrust-pc-sdk .ot-vnd-serv .ot-vnd-item .ot-vnd-info a,#onetrust-pc-sdk .ot-vs-list .ot-vnd-item .ot-vnd-info a{margin-right:auto}#onetrust-pc-sdk .ot-pc-footer-logo img{width:136px;height:16px}#onetrust-pc-sdk .ot-pur-vdr-count{font-weight:400;font-size:.7rem;padding-top:3px;display:block}#onetrust-banner-sdk .ot-optout-signal,#onetrust-pc-sdk .ot-optout-signal{border:1px solid #32ae88;border-radius:3px;padding:5px;margin-bottom:10px;background-color:#f9fffa;font-size:.85rem;line-height:2}#onetrust-banner-sdk .ot-optout-signal .ot-optout-icon,#onetrust-pc-sdk .ot-optout-signal .ot-optout-icon{display:inline;margin-right:5px}#onetrust-banner-sdk .ot-optout-signal svg,#onetrust-pc-sdk .ot-optout-signal svg{height:20px;width:30px;transform:scale(0.5)}#onetrust-banner-sdk .ot-optout-signal svg path,#onetrust-pc-sdk .ot-optout-signal svg path{fill:#32ae88}#onetrust-banner-sdk,#onetrust-pc-sdk,#ot-sdk-cookie-policy,#ot-sync-ntfy{font-size:16px}#onetrust-banner-sdk *,#onetrust-banner-sdk ::after,#onetrust-banner-sdk ::before,#onetrust-pc-sdk *,#onetrust-pc-sdk ::after,#onetrust-pc-sdk ::before,#ot-sdk-cookie-policy *,#ot-sdk-cookie-policy ::after,#ot-sdk-cookie-policy ::before,#ot-sync-ntfy *,#ot-sync-ntfy ::after,#ot-sync-ntfy ::before{-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box}#onetrust-banner-sdk div,#onetrust-banner-sdk span,#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-banner-sdk p,#onetrust-banner-sdk img,#onetrust-banner-sdk svg,#onetrust-banner-sdk button,#onetrust-banner-sdk section,#onetrust-banner-sdk a,#onetrust-banner-sdk label,#onetrust-banner-sdk input,#onetrust-banner-sdk ul,#onetrust-banner-sdk li,#onetrust-banner-sdk nav,#onetrust-banner-sdk table,#onetrust-banner-sdk thead,#onetrust-banner-sdk tr,#onetrust-banner-sdk td,#onetrust-banner-sdk tbody,#onetrust-banner-sdk .ot-main-content,#onetrust-banner-sdk .ot-toggle,#onetrust-banner-sdk #ot-content,#onetrust-banner-sdk #ot-pc-content,#onetrust-banner-sdk .checkbox,#onetrust-pc-sdk div,#onetrust-pc-sdk span,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#onetrust-pc-sdk p,#onetrust-pc-sdk img,#onetrust-pc-sdk svg,#onetrust-pc-sdk button,#onetrust-pc-sdk section,#onetrust-pc-sdk a,#onetrust-pc-sdk label,#onetrust-pc-sdk input,#onetrust-pc-sdk ul,#onetrust-pc-sdk li,#onetrust-pc-sdk nav,#onetrust-pc-sdk table,#onetrust-pc-sdk thead,#onetrust-pc-sdk tr,#onetrust-pc-sdk td,#onetrust-pc-sdk tbody,#onetrust-pc-sdk .ot-main-content,#onetrust-pc-sdk .ot-toggle,#onetrust-pc-sdk #ot-content,#onetrust-pc-sdk #ot-pc-content,#onetrust-pc-sdk .checkbox,#ot-sdk-cookie-policy div,#ot-sdk-cookie-policy span,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6,#ot-sdk-cookie-policy p,#ot-sdk-cookie-policy img,#ot-sdk-cookie-policy svg,#ot-sdk-cookie-policy button,#ot-sdk-cookie-policy section,#ot-sdk-cookie-policy a,#ot-sdk-cookie-policy label,#ot-sdk-cookie-policy input,#ot-sdk-cookie-policy ul,#ot-sdk-cookie-policy li,#ot-sdk-cookie-policy nav,#ot-sdk-cookie-policy table,#ot-sdk-cookie-policy thead,#ot-sdk-cookie-policy tr,#ot-sdk-cookie-policy td,#ot-sdk-cookie-policy tbody,#ot-sdk-cookie-policy .ot-main-content,#ot-sdk-cookie-policy .ot-toggle,#ot-sdk-cookie-policy #ot-content,#ot-sdk-cookie-policy #ot-pc-content,#ot-sdk-cookie-policy .checkbox,#ot-sync-ntfy div,#ot-sync-ntfy span,#ot-sync-ntfy h1,#ot-sync-ntfy h2,#ot-sync-ntfy h3,#ot-sync-ntfy h4,#ot-sync-ntfy h5,#ot-sync-ntfy h6,#ot-sync-ntfy p,#ot-sync-ntfy img,#ot-sync-ntfy svg,#ot-sync-ntfy button,#ot-sync-ntfy section,#ot-sync-ntfy a,#ot-sync-ntfy label,#ot-sync-ntfy input,#ot-sync-ntfy ul,#ot-sync-ntfy li,#ot-sync-ntfy nav,#ot-sync-ntfy table,#ot-sync-ntfy thead,#ot-sync-ntfy tr,#ot-sync-ntfy td,#ot-sync-ntfy tbody,#ot-sync-ntfy .ot-main-content,#ot-sync-ntfy .ot-toggle,#ot-sync-ntfy #ot-content,#ot-sync-ntfy #ot-pc-content,#ot-sync-ntfy .checkbox{font-family:inherit;font-weight:normal;-webkit-font-smoothing:auto;letter-spacing:normal;line-height:normal;padding:0;margin:0;height:auto;min-height:0;max-height:none;width:auto;min-width:0;max-width:none;border-radius:0;border:none;clear:none;float:none;position:static;bottom:auto;left:auto;right:auto;top:auto;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;white-space:normal;background:none;overflow:visible;vertical-align:baseline;visibility:visible;z-index:auto;box-shadow:none}#onetrust-banner-sdk label:before,#onetrust-banner-sdk label:after,#onetrust-banner-sdk .checkbox:after,#onetrust-banner-sdk .checkbox:before,#onetrust-pc-sdk label:before,#onetrust-pc-sdk label:after,#onetrust-pc-sdk .checkbox:after,#onetrust-pc-sdk .checkbox:before,#ot-sdk-cookie-policy label:before,#ot-sdk-cookie-policy label:after,#ot-sdk-cookie-policy .checkbox:after,#ot-sdk-cookie-policy .checkbox:before,#ot-sync-ntfy label:before,#ot-sync-ntfy label:after,#ot-sync-ntfy .checkbox:after,#ot-sync-ntfy .checkbox:before{content:"";content:none}#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{position:relative;width:100%;max-width:100%;margin:0 auto;padding:0 20px;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{width:100%;float:left;box-sizing:border-box;padding:0;display:initial}@media(min-width: 400px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:90%;padding:0}}@media(min-width: 550px){#onetrust-banner-sdk .ot-sdk-container,#onetrust-pc-sdk .ot-sdk-container,#ot-sdk-cookie-policy .ot-sdk-container{width:100%}#onetrust-banner-sdk .ot-sdk-column,#onetrust-banner-sdk .ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-column,#onetrust-pc-sdk .ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-column,#ot-sdk-cookie-policy .ot-sdk-columns{margin-left:4%}#onetrust-banner-sdk .ot-sdk-column:first-child,#onetrust-banner-sdk .ot-sdk-columns:first-child,#onetrust-pc-sdk .ot-sdk-column:first-child,#onetrust-pc-sdk .ot-sdk-columns:first-child,#ot-sdk-cookie-policy .ot-sdk-column:first-child,#ot-sdk-cookie-policy .ot-sdk-columns:first-child{margin-left:0}#onetrust-banner-sdk .ot-sdk-two.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-two.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-two.ot-sdk-columns{width:13.3333333333%}#onetrust-banner-sdk .ot-sdk-three.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-three.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-three.ot-sdk-columns{width:22%}#onetrust-banner-sdk .ot-sdk-four.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-four.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-four.ot-sdk-columns{width:30.6666666667%}#onetrust-banner-sdk .ot-sdk-eight.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eight.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eight.ot-sdk-columns{width:65.3333333333%}#onetrust-banner-sdk .ot-sdk-nine.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-nine.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-nine.ot-sdk-columns{width:74%}#onetrust-banner-sdk .ot-sdk-ten.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-ten.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-ten.ot-sdk-columns{width:82.6666666667%}#onetrust-banner-sdk .ot-sdk-eleven.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-eleven.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-eleven.ot-sdk-columns{width:91.3333333333%}#onetrust-banner-sdk .ot-sdk-twelve.ot-sdk-columns,#onetrust-pc-sdk .ot-sdk-twelve.ot-sdk-columns,#ot-sdk-cookie-policy .ot-sdk-twelve.ot-sdk-columns{width:100%;margin-left:0}}#onetrust-banner-sdk h1,#onetrust-banner-sdk h2,#onetrust-banner-sdk h3,#onetrust-banner-sdk h4,#onetrust-banner-sdk h5,#onetrust-banner-sdk h6,#onetrust-pc-sdk h1,#onetrust-pc-sdk h2,#onetrust-pc-sdk h3,#onetrust-pc-sdk h4,#onetrust-pc-sdk h5,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h1,#ot-sdk-cookie-policy h2,#ot-sdk-cookie-policy h3,#ot-sdk-cookie-policy h4,#ot-sdk-cookie-policy h5,#ot-sdk-cookie-policy h6{margin-top:0;font-weight:600;font-family:inherit}#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem;line-height:1.2}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem;line-height:1.25}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem;line-height:1.3}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem;line-height:1.35}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem;line-height:1.5}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem;line-height:1.6}@media(min-width: 550px){#onetrust-banner-sdk h1,#onetrust-pc-sdk h1,#ot-sdk-cookie-policy h1{font-size:1.5rem}#onetrust-banner-sdk h2,#onetrust-pc-sdk h2,#ot-sdk-cookie-policy h2{font-size:1.5rem}#onetrust-banner-sdk h3,#onetrust-pc-sdk h3,#ot-sdk-cookie-policy h3{font-size:1.5rem}#onetrust-banner-sdk h4,#onetrust-pc-sdk h4,#ot-sdk-cookie-policy h4{font-size:1.5rem}#onetrust-banner-sdk h5,#onetrust-pc-sdk h5,#ot-sdk-cookie-policy h5{font-size:1.5rem}#onetrust-banner-sdk h6,#onetrust-pc-sdk h6,#ot-sdk-cookie-policy h6{font-size:1.5rem}}#onetrust-banner-sdk p,#onetrust-pc-sdk p,#ot-sdk-cookie-policy p{margin:0 0 1em 0;font-family:inherit;line-height:normal}#onetrust-banner-sdk a,#onetrust-pc-sdk a,#ot-sdk-cookie-policy a{color:#565656;text-decoration:underline}#onetrust-banner-sdk a:hover,#onetrust-pc-sdk a:hover,#ot-sdk-cookie-policy a:hover{color:#565656;text-decoration:none}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-button,#onetrust-banner-sdk button,#onetrust-pc-sdk .ot-sdk-button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy .ot-sdk-button,#ot-sdk-cookie-policy button{display:inline-block;height:38px;padding:0 30px;color:#555;text-align:center;font-size:.9em;font-weight:400;line-height:38px;letter-spacing:.01em;text-decoration:none;white-space:nowrap;background-color:rgba(0,0,0,0);border-radius:2px;border:1px solid #bbb;cursor:pointer;box-sizing:border-box}#onetrust-banner-sdk .ot-sdk-button:hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):hover,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):focus,#onetrust-pc-sdk .ot-sdk-button:hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):hover,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:not(.ot-link-btn):focus,#ot-sdk-cookie-policy .ot-sdk-button:hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:not(.ot-link-btn):hover,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:not(.ot-link-btn):focus{color:#333;border-color:#888;opacity:.7}#onetrust-banner-sdk .ot-sdk-button:focus,#onetrust-banner-sdk :not(.ot-leg-btn-container)>button:focus,#onetrust-pc-sdk .ot-sdk-button:focus,#onetrust-pc-sdk :not(.ot-leg-btn-container)>button:focus,#ot-sdk-cookie-policy .ot-sdk-button:focus,#ot-sdk-cookie-policy :not(.ot-leg-btn-container)>button:focus{outline:2px solid #000}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-banner-sdk button.ot-sdk-button-primary,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary,#onetrust-pc-sdk button.ot-sdk-button-primary,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary,#ot-sdk-cookie-policy button.ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary{color:#fff;background-color:#33c3f0;border-color:#33c3f0}#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-banner-sdk button.ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary:hover,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary:hover,#onetrust-banner-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-banner-sdk button.ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=submit].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=reset].ot-sdk-button-primary:focus,#onetrust-banner-sdk input[type=button].ot-sdk-button-primary:focus,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:hover,#onetrust-pc-sdk button.ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary:hover,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary:hover,#onetrust-pc-sdk .ot-sdk-button.ot-sdk-button-primary:focus,#onetrust-pc-sdk button.ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=submit].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=reset].ot-sdk-button-primary:focus,#onetrust-pc-sdk input[type=button].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy button.ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary:hover,#ot-sdk-cookie-policy .ot-sdk-button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy button.ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=submit].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=reset].ot-sdk-button-primary:focus,#ot-sdk-cookie-policy input[type=button].ot-sdk-button-primary:focus{color:#fff;background-color:#1eaedb;border-color:#1eaedb}#onetrust-banner-sdk input[type=text],#onetrust-pc-sdk input[type=text],#ot-sdk-cookie-policy input[type=text]{height:38px;padding:6px 10px;background-color:#fff;border:1px solid #d1d1d1;border-radius:4px;box-shadow:none;box-sizing:border-box}#onetrust-banner-sdk input[type=text],#onetrust-pc-sdk input[type=text],#ot-sdk-cookie-policy input[type=text]{-webkit-appearance:none;-moz-appearance:none;appearance:none}#onetrust-banner-sdk input[type=text]:focus,#onetrust-pc-sdk input[type=text]:focus,#ot-sdk-cookie-policy input[type=text]:focus{border:1px solid #000;outline:0}#onetrust-banner-sdk label,#onetrust-pc-sdk label,#ot-sdk-cookie-policy label{display:block;margin-bottom:.5rem;font-weight:600}#onetrust-banner-sdk input[type=checkbox],#onetrust-pc-sdk input[type=checkbox],#ot-sdk-cookie-policy input[type=checkbox]{display:inline}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{list-style:circle inside}#onetrust-banner-sdk ul,#onetrust-pc-sdk ul,#ot-sdk-cookie-policy ul{padding-left:0;margin-top:0}#onetrust-banner-sdk ul ul,#onetrust-pc-sdk ul ul,#ot-sdk-cookie-policy ul ul{margin:1.5rem 0 1.5rem 3rem;font-size:90%}#onetrust-banner-sdk li,#onetrust-pc-sdk li,#ot-sdk-cookie-policy li{margin-bottom:1rem}#onetrust-banner-sdk th,#onetrust-banner-sdk td,#onetrust-pc-sdk th,#onetrust-pc-sdk td,#ot-sdk-cookie-policy th,#ot-sdk-cookie-policy td{padding:12px 15px;text-align:left;border-bottom:1px solid #e1e1e1}#onetrust-banner-sdk button,#onetrust-pc-sdk button,#ot-sdk-cookie-policy button{margin-bottom:1rem;font-family:inherit}#onetrust-banner-sdk .ot-sdk-container:after,#onetrust-banner-sdk .ot-sdk-row:after,#onetrust-pc-sdk .ot-sdk-container:after,#onetrust-pc-sdk .ot-sdk-row:after,#ot-sdk-cookie-policy .ot-sdk-container:after,#ot-sdk-cookie-policy .ot-sdk-row:after{content:"";display:table;clear:both}#onetrust-banner-sdk .ot-sdk-row,#onetrust-pc-sdk .ot-sdk-row,#ot-sdk-cookie-policy .ot-sdk-row{margin:0;max-width:none;display:block} #onetrust-banner-sdk{box-shadow:0 0 18px rgba(0,0,0,.2)}#onetrust-banner-sdk.otFlat{position:fixed;z-index:2147483645;bottom:0;right:0;left:0;background-color:#fff;max-height:90%;overflow-x:hidden;overflow-y:auto}#onetrust-banner-sdk.otFlat.top{top:0px;bottom:auto}#onetrust-banner-sdk.otRelFont{font-size:1rem}#onetrust-banner-sdk>.ot-sdk-container{overflow:hidden}#onetrust-banner-sdk::-webkit-scrollbar{width:11px}#onetrust-banner-sdk::-webkit-scrollbar-thumb{border-radius:10px;background:#c1c1c1}#onetrust-banner-sdk{scrollbar-arrow-color:#c1c1c1;scrollbar-darkshadow-color:#c1c1c1;scrollbar-face-color:#c1c1c1;scrollbar-shadow-color:#c1c1c1}#onetrust-banner-sdk #onetrust-policy{margin:1.25em 0 .625em 2em;overflow:hidden}#onetrust-banner-sdk #onetrust-policy .ot-gv-list-handler{float:left;font-size:.82em;padding:0;margin-bottom:0;border:0;line-height:normal;height:auto;width:auto}#onetrust-banner-sdk #onetrust-policy-title{font-size:1.2em;line-height:1.3;margin-bottom:10px}#onetrust-banner-sdk #onetrust-policy-text{clear:both;text-align:left;font-size:.88em;line-height:1.4}#onetrust-banner-sdk #onetrust-policy-text *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk #onetrust-policy-text a{font-weight:bold;margin-left:5px}#onetrust-banner-sdk #onetrust-policy-title,#onetrust-banner-sdk #onetrust-policy-text{color:dimgray;float:left}#onetrust-banner-sdk #onetrust-button-group-parent{min-height:1px;text-align:center}#onetrust-banner-sdk #onetrust-button-group{display:inline-block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{background-color:#68b631;color:#fff;border-color:#68b631;margin-right:1em;min-width:125px;height:auto;white-space:normal;word-break:break-word;word-wrap:break-word;padding:12px 10px;line-height:1.2;font-size:.813em;font-weight:600}#onetrust-banner-sdk #onetrust-pc-btn-handler.cookie-setting-link{background-color:#fff;border:none;color:#68b631;text-decoration:underline;padding-left:0;padding-right:0}#onetrust-banner-sdk .onetrust-close-btn-ui{width:44px;height:44px;background-size:12px;border:none;position:relative;margin:auto;padding:0}#onetrust-banner-sdk .banner_logo{display:none}#onetrust-banner-sdk.ot-bnr-w-logo .ot-bnr-logo{position:absolute;top:50%;transform:translateY(-50%);left:0px}#onetrust-banner-sdk.ot-bnr-w-logo #onetrust-policy{margin-left:65px}#onetrust-banner-sdk .ot-b-addl-desc{clear:both;float:left;display:block}#onetrust-banner-sdk #banner-options{float:left;display:table;margin-right:0;margin-left:1em;width:calc(100% - 1em)}#onetrust-banner-sdk .banner-option-input{cursor:pointer;width:auto;height:auto;border:none;padding:0;padding-right:3px;margin:0 0 10px;font-size:.82em;line-height:1.4}#onetrust-banner-sdk .banner-option-input *{pointer-events:none;font-size:inherit;line-height:inherit}#onetrust-banner-sdk .banner-option-input[aria-expanded=true]~.banner-option-details{display:block;height:auto}#onetrust-banner-sdk .banner-option-input[aria-expanded=true] .ot-arrow-container{transform:rotate(90deg)}#onetrust-banner-sdk .banner-option{margin-bottom:12px;margin-left:0;border:none;float:left;padding:0}#onetrust-banner-sdk .banner-option:first-child{padding-left:2px}#onetrust-banner-sdk .banner-option:not(:first-child){padding:0;border:none}#onetrust-banner-sdk .banner-option-header{cursor:pointer;display:inline-block}#onetrust-banner-sdk .banner-option-header :first-child{color:dimgray;font-weight:bold;float:left}#onetrust-banner-sdk .banner-option-header .ot-arrow-container{display:inline-block;border-top:6px solid rgba(0,0,0,0);border-bottom:6px solid rgba(0,0,0,0);border-left:6px solid dimgray;margin-left:10px;vertical-align:middle}#onetrust-banner-sdk .banner-option-details{display:none;font-size:.83em;line-height:1.5;padding:10px 0px 5px 10px;margin-right:10px;height:0px}#onetrust-banner-sdk .banner-option-details *{font-size:inherit;line-height:inherit;color:dimgray}#onetrust-banner-sdk .ot-arrow-container,#onetrust-banner-sdk .banner-option-details{transition:all 300ms ease-in 0s;-webkit-transition:all 300ms ease-in 0s;-moz-transition:all 300ms ease-in 0s;-o-transition:all 300ms ease-in 0s}#onetrust-banner-sdk .ot-dpd-container{float:left}#onetrust-banner-sdk .ot-dpd-title{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-title,#onetrust-banner-sdk .ot-dpd-desc{font-size:.88em;line-height:1.4;color:dimgray}#onetrust-banner-sdk .ot-dpd-title *,#onetrust-banner-sdk .ot-dpd-desc *{font-size:inherit;line-height:inherit}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text *{margin-bottom:0}#onetrust-banner-sdk.ot-iab-2 .onetrust-vendors-list-handler{display:block;margin-left:0;margin-top:5px;clear:both;margin-bottom:0;padding:0;border:0;height:auto;width:auto}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk.ot-close-btn-link{padding-top:25px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container{top:15px;transform:none;right:15px}#onetrust-banner-sdk.ot-close-btn-link #onetrust-close-btn-container button{padding:0;white-space:pre-wrap;border:none;height:auto;line-height:1.5;text-decoration:underline;font-size:.69em}#onetrust-banner-sdk #onetrust-policy-text,#onetrust-banner-sdk .ot-dpd-desc,#onetrust-banner-sdk .ot-b-addl-desc{font-size:.813em;line-height:1.5}#onetrust-banner-sdk .ot-dpd-desc{margin-bottom:10px}#onetrust-banner-sdk .ot-dpd-desc>.ot-b-addl-desc{margin-top:10px;margin-bottom:10px;font-size:1em}@media only screen and (max-width: 425px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:6px;right:2px}#onetrust-banner-sdk #onetrust-policy{margin-left:0;margin-top:3em}#onetrust-banner-sdk #onetrust-button-group{display:block}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{width:100%}#onetrust-banner-sdk .onetrust-close-btn-ui{top:auto;transform:none}#onetrust-banner-sdk #onetrust-policy-title{display:inline;float:none}#onetrust-banner-sdk #banner-options{margin:0;padding:0;width:100%}}@media only screen and (min-width: 426px)and (max-width: 896px){#onetrust-banner-sdk #onetrust-close-btn-container{position:absolute;top:0;right:0}#onetrust-banner-sdk #onetrust-policy{margin-left:1em;margin-right:1em}#onetrust-banner-sdk .onetrust-close-btn-ui{top:10px;right:10px}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:95%}#onetrust-banner-sdk.ot-iab-2 #onetrust-group-container{width:100%}#onetrust-banner-sdk.ot-bnr-w-logo #onetrust-button-group-parent{padding-left:50px}#onetrust-banner-sdk #onetrust-button-group-parent{width:100%;position:relative;margin-left:0}#onetrust-banner-sdk #onetrust-button-group button{display:inline-block}#onetrust-banner-sdk #onetrust-button-group{margin-right:0;text-align:center}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler{float:left}#onetrust-banner-sdk .has-reject-all-button #onetrust-reject-all-handler,#onetrust-banner-sdk .has-reject-all-button #onetrust-accept-btn-handler{float:right}#onetrust-banner-sdk .has-reject-all-button #onetrust-button-group{width:calc(100% - 2em);margin-right:0}#onetrust-banner-sdk .has-reject-all-button #onetrust-pc-btn-handler.cookie-setting-link{padding-left:0px;text-align:left}#onetrust-banner-sdk.ot-buttons-fw .ot-sdk-three button{width:100%;text-align:center}#onetrust-banner-sdk.ot-buttons-fw #onetrust-button-group-parent button{float:none}#onetrust-banner-sdk.ot-buttons-fw #onetrust-pc-btn-handler.cookie-setting-link{text-align:center}}@media only screen and (min-width: 550px){#onetrust-banner-sdk .banner-option:not(:first-child){border-left:1px solid #d8d8d8;padding-left:25px}}@media only screen and (min-width: 425px)and (max-width: 550px){#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group,#onetrust-banner-sdk.ot-iab-2 #onetrust-policy,#onetrust-banner-sdk.ot-iab-2 .banner-option{width:100%}}@media only screen and (min-width: 769px){#onetrust-banner-sdk #onetrust-button-group{margin-right:30%}#onetrust-banner-sdk #banner-options{margin-left:2em;margin-right:5em;margin-bottom:1.25em;width:calc(100% - 7em)}}@media only screen and (min-width: 897px)and (max-width: 1023px){#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:75%;transform:translateY(-50%)}#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;padding:0;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{position:relative;margin:0;right:-22px;top:2px}}@media only screen and (min-width: 1024px){#onetrust-banner-sdk #onetrust-close-btn-container{top:50%;margin:auto;transform:translate(-50%, -50%);position:absolute;right:0}#onetrust-banner-sdk #onetrust-close-btn-container button{right:-12px}#onetrust-banner-sdk #onetrust-policy{margin-left:2em}#onetrust-banner-sdk.vertical-align-content #onetrust-button-group-parent{position:absolute;top:50%;left:60%;transform:translateY(-50%)}#onetrust-banner-sdk .ot-optout-signal{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-title{width:50%}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text,#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:1em;width:50%;border-right:1px solid #d8d8d8;padding-right:1rem}#onetrust-banner-sdk.ot-iab-2 #onetrust-policy-text{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 :not(.ot-dpd-desc)>.ot-b-addl-desc{margin-bottom:0;padding-bottom:1em}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-container{width:45%;padding-left:1rem;display:inline-block;float:none}#onetrust-banner-sdk.ot-iab-2 .ot-dpd-title{line-height:1.7}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group-parent{left:auto;right:4%;margin-left:0}#onetrust-banner-sdk.ot-iab-2 #onetrust-button-group button{display:block}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{margin:auto;width:30%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:60%}#onetrust-banner-sdk #onetrust-button-group{margin-right:auto}#onetrust-banner-sdk #onetrust-accept-btn-handler,#onetrust-banner-sdk #onetrust-reject-all-handler,#onetrust-banner-sdk #onetrust-pc-btn-handler{margin-top:1em}}@media only screen and (min-width: 890px){#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group-parent{padding-left:3%;padding-right:4%;margin-left:0}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group{margin-right:0;margin-top:1.25em;width:100%}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button{width:100%;margin-bottom:5px;margin-top:5px}#onetrust-banner-sdk.ot-buttons-fw:not(.ot-iab-2) #onetrust-button-group button:last-of-type{margin-bottom:20px}}@media only screen and (min-width: 1280px){#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-group-container{width:55%}#onetrust-banner-sdk:not(.ot-iab-2) #onetrust-button-group-parent{width:44%;padding-left:2%;padding-right:2%}#onetrust-banner-sdk:not(.ot-iab-2).vertical-align-content #onetrust-button-group-parent{position:absolute;left:55%}}
 #onetrust-consent-sdk #onetrust-banner-sdk {background-color: #F5F6EA;}
 #onetrust-consent-sdk #onetrust-policy-title,
 #onetrust-consent-sdk #onetrust-policy-text,
@@ -134,60 +122,82 @@ margin-top: 5%;
 #onetrust-consent-sdk #onetrust-banner-sdk {
 display: none;
 }
+/* Add privacy icon for Investopedia Simulator */
+#ot-sdk-btn.ot-sdk-show-settings::after {
+content: '';
+background: url("https://cdn.cookielaw.org/logos/static/opt_in_out_icon.png") no-repeat;
+background-size: contain;
+position: relative;
+width: 1.875rem;
+height: 1.875rem;
+top: 0.75rem;
+display: inline-block;
+}
 /* hides banner after it has already been interacted with */
 #onetrust-consent-sdk:not(.show-banner) #onetrust-banner-sdk {
 display: none;
 }</style>
-					
-					<script type="text/javascript" data-glb-js="top" src="/static/1.130.0/cache/eNqFk2FuwyAMhS80xhm2qdqvSlXVCxBwiBsCmW0ytacfiaau7WgqRVHi9xmM_dAsRtDqwUQJoG0axhQhCutgTimLPnJ5lO3A9i_6Fj7O0PnEeIZCpNiiv0d-_wI2fIPXlkrGgasINqUeqylZMKDUtTaqNdmlYVU3bgtCaPlAxvZAFeRzd6hEJ4gukZaOkpRQhSAoTIZlYYy-QgzlQzUEph8TlllckLmwEAgsjqXlD-u_mqJlapdXZZsxN5ybivCx3VWi-8N7JSrzMfbSbCa4rvTqMObUwEqFxi3WyBG_MigOSdRskecZYsiDlA4qNi0EZLnk_If9KLUOGA9qQvhe2c3LsLgwoO2VPBjavc_5NccJMHTFu2vjYaFsJRO4-QJJic3pbFUp-3kHCH0nigyG5yyW6xlRQP0lqQKXBlDVoy0Bd6YJ8Ob4B5HEkNU.min.js"></script>
-
-					
-					<script type="text/javascript">var Mntl = window.Mntl || {};window.Mntl = window.Mntl || {};
-window.Mntl.csrf = window.Mntl.csrf || window.Mntl.csrfInit('5479712555c66c1e22590bba48d853d3', true);(function() {
-    Mntl.utilities.onLoad(function() {
-        var geolocationResponse = {};
-        const externalJS = {
-            src: '\//cdn.cookielaw.org/scripttemplates/otSDKStub.js',
-            'data-domain-script': '63a0b6bc-e912-4c8d-adfd-3b8a4b698c6c',
-            'data-ignore-ga': true,
-            'data-language': 'en',
-            async: true,
-            charset: 'UTF-8',
-            onerror: 'Mntl.CMP.onError()',
-            id: 'onetrust-script'
-        };
-        geolocationResponse.stateCode = 'MA';
-        geolocationResponse.countryCode = 'US';
-        geolocationResponse.regionCode = 'US';
-        if (Object.keys(geolocationResponse).length) {
-            window.OneTrust = window.OneTrust || {};
-            window.OneTrust.geolocationResponse = geolocationResponse;
-        }
-        const preferenceCenterTrigger = document.querySelector('.ot-pref-trigger');
-        preferenceCenterTrigger.addEventListener('click', (e) => {
-            e.preventDefault();
-            Mntl.utilities.loadExternalJS(
-                externalJS
-            , () => {
-                Mntl.CMP.onSdkLoaded(() => {
-                    OneTrust.ToggleInfoDisplay();
-                })
-            });
-        },
-        { once: true });
-    });
-    Mntl.CMP.init(true, 'ccpa', false, false, 3000);
+<script type="text/javascript" data-glb-js="top" src="/static/2.56.0/cache/eNqNU1FuwyAMvdAYZ9imaV-TqqkXIOAQNwQybDKlp58TTW3a0W4SIPB7tp8NaGLDaPVgIgfQNg1jihCZdDBzKqwPJEPZDmz_oC_Jh4V0nAmPIIwUW_TXlJ9TwIYu6RgZMoFlTLEWNxkHrgLYlHoEqiCFMSDXsTaqe7BLw118guhS1tzlxGKqMAbZqCaD6cckpZ2DCGZCyGBxlKpvJtn03VJu16WSZiwNlaYCvLzvztbkSoC13x_752Xegjgb28vmdYKt5k1ZZm6g5v222y-zBpWInwUUhcRquesah032wBi9ItNCQOIai6wyjmpIBlFcYL_olygnyqaN4rkw_ci1PhoPakL4unMPnof1wQW0veLrTBdi2gzUmSbAk6O_fgA9ljgBhk4e8u_aNvkz-o5VNhjWJKfT_31QfmREBnU2K1EltedvjTh-OA.min.js"></script>
+<script type="text/javascript">
+window.Mntl = window.Mntl || {};
+window.Mntl.csrf = window.Mntl.csrf || window.Mntl.csrfInit('04a91214e948e7d9f48fd86200e288e7', true);(function() {
+Mntl.utilities.onLoad(function() {
+const geolocationResponse = {};
+const externalJS = {
+src: '\//cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+'data-domain-script': '63a0b6bc-e912-4c8d-adfd-3b8a4b698c6c',
+'data-ignore-ga': true,
+'data-language': 'en',
+async: true,
+charset: 'UTF-8',
+onerror: 'Mntl.CMP.onError()',
+id: 'onetrust-script'
+};
+geolocationResponse.stateCode = 'IL';
+geolocationResponse.countryCode = 'US';
+geolocationResponse.regionCode = 'US';
+if (Object.keys(geolocationResponse).length) {
+window.OneTrust = window.OneTrust || {};
+window.OneTrust.geolocationResponse = geolocationResponse;
+}
+const preferenceCenterTrigger = document.querySelector('.ot-pref-trigger');
+preferenceCenterTrigger.addEventListener('click', (e) => {
+e.preventDefault();
+Mntl.utilities.loadExternalJS(
+externalJS
+, () => {
+Mntl.CMP.onSdkLoaded(() => {
+OneTrust.ToggleInfoDisplay();
+})
+});
+},
+{ once: true });
+});
+Mntl.CMP.init({
+isConsentRequired: true,
+oneTrustTemplateName: 'ccpa',
+showConsentBanner: false,
+isCcpaApplicableRequest: false,
+isTcfEnabled: true,
+scriptTimeout: 3000
+});
 })();
 window.Mntl = window.Mntl || {};
 Mntl.RTB = Mntl.RTB || {};
+Mntl.RTB.setUseConsentManagement(false);
+Mntl.RTB.setUseLiveRamp(true);
+Mntl.RTB.setUseGDPREnforcement(false);
+Mntl.RTB.setUseXandrS2S(false);
+Mntl.RTB.setRemoveAdTiers(true);
 Mntl.RTB.setUserIdAuctionDelay(500);
 Mntl.RTB.setTaxonomyStampValues({"tax1":"alr_Recipes","tax2":"alr_Cuisine","tax0":"alr_homepage","tax3":"alr_EuropeanRecipes","tax4":"alr_ItalianRecipes"});
 Mntl.RTB.setTimeoutLength(1250);
-Mntl.RTB.Plugins.amazon.amazonConfigs = {"mapTaxValues":{"tax1":"alr_Recipes","tax2":"alr_Cuisine","si_section":"alr_Cuisine","tax0":"alr_homepage","tax3":"alr_EuropeanRecipes"},"mapFBValues":{"adunitid":"mapFBID"},"amazonSlotName":false,"amazonSection":"European Recipes"};
+Mntl.RTB.Plugins.amazon.amazonConfigs = {"mapTaxValues":{"tax1":"alr_Recipes","tax2":"alr_Cuisine","si_section":"alr_Cuisine","tax0":"alr_homepage","tax3":"alr_EuropeanRecipes"},"amazonSlotName":false,"mapFBValues":{"adunitid":"mapFBID"},"amazonSection":"European Recipes"};
 Mntl.RTB.Plugins.prebid.setPriceGranularity({"buckets":[{"max":"20","increment":"0.05"},{"max":"70","increment":"1"}]});
 Mntl.RTB.initVideoBidders([{ type: 'amazon', id: '3446' }, { type: 'prebid', id: 'true' } ]);
-Mntl.RTB.initDisplayAndOutstreamBidders([{ type: "amazon", id: '3446'},{ type: "msg", id: 'true'},{ type: "ixid", id: 'true'},{ type: "prebid", id: 'true'}]);
-Mntl.RTB.Plugins.prebid.setConfig({"square-fixed\/tier1":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440842","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21640","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478952","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060088","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboardac\/tier3":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}}],"leaderboard-fixed\/tier2":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440834","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060080","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478944","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}},{"bidder":"trustx","params":{"uid":"21632","useNewFormat":true,"type":"display"}}],"leaderboard-fixed\/tier1":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440832","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060079","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478943","type":"display"}},{"bidder":"trustx","params":{"uid":"21631","useNewFormat":true,"type":"display"}}],"square-fixed\/tier2":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440844","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060089","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478953","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"trustx","params":{"uid":"21641","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboardac\/tier2":[{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}}],"square-fixed\/tier3":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440846","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060090","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478954","type":"display"}},{"bidder":"trustx","params":{"uid":"21642","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"square-fixed\/tier4":[{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060091","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"trustx","params":{"uid":"21643","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478955","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440848","type":"display"}}],"preroll":[{"bidder":"ix","params":{"siteId":"1005792","type":"instream"}},{"bidder":"trustx","params":{"uid":"345600","useNewFormat":true,"type":"instream"}},{"bidder":"appnexus","params":{"placementId":"24425890","type":"instream"}},{"bidder":"roundel","params":{"siteId":578566,"type":"instream"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440854","type":"instream"}},{"bidder":"criteo","params":{"networkId":7764,"type":"instream"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4297343","type":"instream"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"instream"}}],"leaderboard-fixed\/tier3":[{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060081","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440836","type":"display"}},{"bidder":"trustx","params":{"uid":"21633","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478945","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}}],"leaderboardfooter-flex\/tier2":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}],"leaderboardfooter-flex\/tier1":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}],"leaderboardfooter-flex\/tier4":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}],"leaderboardfooter-flex\/tier3":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}}],"square-flex\/tier1":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478956","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060092","type":"display"}},{"bidder":"ix","params":{"siteId":"1005791","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440850","type":"display"}},{"bidder":"trustx","params":{"uid":"21644","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"square-flex\/tier2":[{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478959","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440852","type":"display"}},{"bidder":"ix","params":{"siteId":"1005791","type":"display"}},{"bidder":"trustx","params":{"uid":"21647","useNewFormat":true,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060095","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"leaderboard-flex\/tier2":[{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}}],"leaderboard-flex\/tier1":[{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}]});
+Mntl.RTB.initDisplayAndOutstreamBidders([{ type: "amazon", id: '3446'},{ type: "msg", id: 'true'},{ type: "ixid", id: 'true'},{ type: "prebid", id: 'true'},{ type: "liveConnect", id: 'a-01b5'}]);
+Mntl.RTBTracking.init();
+Mntl.RTB.Plugins.prebid.setConfig({"square-fixed\/tier1":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21640","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440842","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060088","type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478952","type":"display"}}],"leaderboardac\/tier3":[{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"leaderboard-fixed\/tier2":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440834","type":"display"}},{"bidder":"trustx","params":{"uid":"21632","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478944","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060080","type":"display"}}],"square-fixed\/tier2":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21641","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440844","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060089","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478953","type":"display"}}],"leaderboardac\/tier2":[{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"leaderboard-fixed\/tier1":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440832","type":"display"}},{"bidder":"trustx","params":{"uid":"21631","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060079","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478943","type":"display"}}],"square-fixed\/tier3":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21642","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440846","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478954","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060090","type":"display"}}],"preroll":[{"bidder":"ix","params":{"siteId":"1005792","type":"instream"}},{"bidder":"trustx","params":{"uid":"345600","useNewFormat":true,"type":"instream"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440854","type":"instream"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"instream"}},{"bidder":"appnexus","params":{"placementId":"24425890","type":"instream"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"4297343","type":"instream"}},{"bidder":"criteo","params":{"networkId":7764,"type":"instream"}},{"bidder":"roundel","params":{"siteId":578566,"type":"instream"}}],"leaderboard-fixed\/tier3":[{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"trustx","params":{"uid":"21633","useNewFormat":true,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440836","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"ix","params":{"siteId":"1005786","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060081","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478945","type":"display"}}],"square-fixed\/tier4":[{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440848","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21643","useNewFormat":true,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005790","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478955","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060091","type":"display"}}],"leaderboardfooter-flex\/tier2":[{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"leaderboardfooter-flex\/tier1":[{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"leaderboardfooter-flex\/tier4":[{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"leaderboardfooter-flex\/tier3":[{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005789","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}}],"square-flex\/tier1":[{"bidder":"ix","params":{"siteId":"1005791","type":"display"}},{"bidder":"trustx","params":{"uid":"21644","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478956","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060092","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440850","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboardac\/tier1":[{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005788","type":"display"}}],"square-flex\/tier2":[{"bidder":"ix","params":{"siteId":"1005791","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440852","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478959","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"trustx","params":{"uid":"21647","useNewFormat":true,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060095","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboard-flex\/tier2":[{"bidder":"appnexus","params":{"placementId":"21060085","type":"display"}},{"bidder":"trustx","params":{"uid":"21637","useNewFormat":true,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}},{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440840","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478949","type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}}],"leaderboard-flex\/tier1":[{"bidder":"criteo","params":{"networkId":7764,"type":"display"}},{"bidder":"ix","params":{"siteId":"1005787","type":"display"}},{"bidder":"rubicon","params":{"accountId":"7499","siteId":"426712","zoneId":"2440838","type":"display"}},{"bidder":"trustx","params":{"uid":"21634","useNewFormat":true,"type":"display"}},{"bidder":"ttd","params":{"supplySourceId":"dotdash","publisherId":"1","type":"display"}},{"bidder":"pubmatic","params":{"publisherId":"158139","adSlot":"3478946","type":"display"}},{"bidder":"roundel","params":{"siteId":382319,"type":"display"}},{"bidder":"appnexus","params":{"placementId":"21060082","type":"display"}}]});
 Mntl.RTB.Plugins.prebid.setUserIdConfig({"liveIntentPublisherId":"443"});
 Mntl.RTB.setLatencyBuffer(0);
 (function(){
@@ -195,24 +205,20 @@ const pageTargeting = {
 customSeries: ''
 ,abtest: 'lcid1'
 ,tax0: 'Allrecipes'
+,rid: 'nb0e3cd855e144c73b1a3502bbe3cd23b21'
 ,custom: ''
-,rid: 'nd00c11d041104581bced15ae05ed134701'
-,sid: 'n92148e470e5249bba5bf2cb02a76265801'
+,sid: 'n92fb7040bdf94a89851ddd3952fa4f9319'
 }
 ;
 const baseSlotTargeting = {
-inf: '0'
-,entryType: 'direct'
-,gtemplate: 'recipe'
+gtemplate: 'recipe'
 ,leaid: '1015024'
 ,revenueGroup: ''
 ,docId: '6586301'
-,viewtype: 'broadvideo'
+,viewtype: ''
 ,type: 'recipe'
-,ptax: 'alr_Cuisine'
 ,tax1: 'alr_Recipes'
 ,tax2: 'alr_Cuisine'
-,chpg: '1'
 ,t: '120'
 ,au: '1015024'
 ,tier: 'L'
@@ -226,6 +232,7 @@ inf: '0'
 ,tax4: 'alr_ItalianRecipes'
 }
 ;
+const adLazyOffset = {};
 pageTargeting.mtax = ['12291','17387','24418','17389','11184','16752','18098','17384','12550','16751','17382','25281','11802','11109','16811','12213','12257','12019','13149','12852','13623','17354','17592','17394','12384','11098','11252','13692','12263','11053','17590','17393','21733','12606','12801','16806','32452','11693','11374','13398','11750','10444','17359'];
 pageTargeting.sentiment = 'positive';
 pageTargeting.concepts = ['Margherita Pizza','version','feta cheese','flavor','classic','Italian','life','cheese pizzas','dish','tomatoes'];
@@ -236,7 +243,7 @@ initialSlots.push({
 config: {
 id: 'square-flex-1',
 sizes: [[300, 250],[299, 251],[300, 600],[300, 1050],[160, 600]],
-type: 'billboard',
+type: 'square',
 rtb: true,
 timedRefresh: 30000,
 waitForThirdParty: false
@@ -274,24 +281,25 @@ domain: 'www.allrecipes.com',
 templateName: 'recipesc',
 isMobile: false,
 dfpId: '3865',
-publisherProvidedId: '7c4ee15a-daa6-479b-88bb-42a5147fa732',
+publisherProvidedId: '0232beda-105c-411a-9e94-24bc972fde83',
 singleRequest: false,
 useLmdFormat: true,
 useOxygen: true,
+prebidConfigApi: false,
 useInfiniteRightRail: true,
-useAuctionFloorSearch: true,
-bundlePrebid: false,
 fiftyPercentAdRefresh: true,
+revenueGroupAllowList: '',
 sponsIngredients: ['2384','2896','1299','2308','1544','2236','1277','1246','2974','2543'],
 lmdSiteCode: 'hlt',
 pageTargeting,
 baseSlotTargeting,
+adLazyOffset,
 geo: {
 isInEurope: false,
 isInUsa: true
 },
 initialSlots,
-auctionFloors: {"other":{"floor":"50","id":"d7a3b093016043cc9e10326bb02e071e"},"leaderboardac":{"floor":"145","id":"950a04939af74aea9ae169d2bfdefc18"},"leaderboard-flex-1":{"floor":"120","id":"6a0a01a5fbe64ca7b15afbade40bd25c"},"square-flex-2":{"floor":"130","id":"972b50ed9e9e4051960c44d62a8e50f9"},"square-flex-1":{"floor":"115","id":"e98e9a51177943ef95289d13a31b6e3c"},"square-fixed-4":{"floor":"100","id":"a1277700dae44506941578dcee47c091"},"leaderboard-fixed-3":{"floor":"5","id":"ec09e846a4a24700b08838f2e99db991"},"mob-square-fixed-4":{"floor":"85","id":"a730da7f89b846f7aca58df1c9e4d803"},"square-fixed-3":{"floor":"100","id":"d5039c32ec00432dac0c632325ad50b0"},"leaderboard-fixed-4":{"floor":"5","id":"1e9fbc4b3fd94c5093f3ceb80420c985"},"mob-square-fixed-5":{"floor":"80","id":"5bb0867b5ae546908ffe41ab99ea89db"},"square-fixed-2":{"floor":"110","id":"fa68dc67c69b4f7fb026993399c76bbb"},"leaderboard-fixed-1":{"floor":"20","id":"6f2cd7dea6e14d7c8c2f6b969df43aaa"},"mob-square-fixed-6":{"floor":"80","id":"5b03a7eaf420434fa690d4f49aaace01"},"square-fixed-1":{"floor":"100","id":"4b93fcac6e4d4cd88442785ecffac73a"},"leaderboard-fixed-2":{"floor":"5","id":"e1fbdf18a64543cda97e1d30b0679e90"},"mob-square-fixed-7":{"floor":"80","id":"4cd8f604e4564981a2f14c0647acbfcd"},"square-fixed-8":{"floor":"80","id":"a3793835f4bc45edb411f100f1eabb88"},"square-fixed-7":{"floor":"95","id":"3692ae8ad3dc48449fd23533f154347f"},"mob-square-flex-1":{"floor":"55","id":"c5f032643b0146c7a8a5233248ec80f2"},"square-fixed-6":{"floor":"80","id":"620b6d02485a44dfb7a4d53252d2f8d2"},"leaderboardfooter-flex-2":{"floor":"5","id":"9b042bc38c184064b7353901a265c9b2"},"leaderboard-fixed-5":{"floor":"35","id":"316312e8d1724d5ca06f0dd5b829925c"},"square-fixed-5":{"floor":"95","id":"90a63b0798bd41a88225c7e964b895c0"},"leaderboardfooter-flex-1":{"floor":"35","id":"80064526390d4b72b228782c8fe03bba"},"leaderboard-fixed-0":{"floor":"100","id":"60f4c890be9d4834b2d8e54d46c21660"},"mob-square-fixed-1":{"floor":"165","id":"eb33d2eb0a1a48c6a21b7cd594215763"},"mob-square-fixed-2":{"floor":"5","id":"7c4b09f332374873a98174118176a79d"},"mob-square-fixed-3":{"floor":"5","id":"f80dd53c9a3a497797c2c0274e47895a"},"mob-square-fixed-rvw-1":{"floor":"140","id":"cf466f269f9d473b94bf39e363698077"},"inline":{"floor":"5","id":"e2b261fedd514971ae3df756db4479f4"},"square-fixed":{"floor":"5","id":"464bcfcf16d8416bb130b43d51b0ea17"},"mob-square-fixed-rvw-2":{"floor":"130","id":"37331b2939b441ecb647d9b87aaa4546"},"mob-squarefooter-fixed-2":{"floor":"130","id":"3956f347bdb14e3f9fdd2f9c74ed817a"},"square-fixed-9":{"floor":"5","id":"09ead751434648d3bd35cd0beb6eceef"},"mob-adhesive-banner-fixed":{"floor":"125","id":"8b43ce9cdc554c7f89b3f16d3410a9dc"}},
+auctionFloors: {"other":{"id":"d7a3b093016043cc9e10326bb02e071e","floor":"50"},"leaderboardac":{"id":"950a04939af74aea9ae169d2bfdefc18","floor":"330"},"leaderboard-flex-1":{"id":"6a0a01a5fbe64ca7b15afbade40bd25c","floor":"30"},"square-flex-2":{"id":"972b50ed9e9e4051960c44d62a8e50f9","floor":"125"},"square-flex-1":{"id":"e98e9a51177943ef95289d13a31b6e3c","floor":"95"},"square-fixed-4":{"id":"a1277700dae44506941578dcee47c091","floor":"135"},"leaderboard-fixed-3":{"id":"ec09e846a4a24700b08838f2e99db991","floor":"110"},"mob-square-fixed-4":{"id":"a730da7f89b846f7aca58df1c9e4d803","floor":"100"},"square-fixed-3":{"id":"d5039c32ec00432dac0c632325ad50b0","floor":"110"},"leaderboard-fixed-4":{"id":"1e9fbc4b3fd94c5093f3ceb80420c985","floor":"90"},"mob-square-fixed-5":{"id":"5bb0867b5ae546908ffe41ab99ea89db","floor":"5"},"square-fixed-2":{"id":"fa68dc67c69b4f7fb026993399c76bbb","floor":"145"},"leaderboard-fixed-1":{"id":"6f2cd7dea6e14d7c8c2f6b969df43aaa","floor":"55"},"mob-square-fixed-6":{"id":"5b03a7eaf420434fa690d4f49aaace01","floor":"5"},"square-fixed-1":{"id":"4b93fcac6e4d4cd88442785ecffac73a","floor":"70"},"leaderboard-fixed-2":{"id":"e1fbdf18a64543cda97e1d30b0679e90","floor":"145"},"mob-square-fixed-7":{"id":"4cd8f604e4564981a2f14c0647acbfcd","floor":"5"},"square-fixed-8":{"id":"a3793835f4bc45edb411f100f1eabb88","floor":"115"},"square-fixed-7":{"id":"3692ae8ad3dc48449fd23533f154347f","floor":"90"},"mob-square-flex-1":{"id":"c5f032643b0146c7a8a5233248ec80f2","floor":"95"},"square-fixed-6":{"id":"620b6d02485a44dfb7a4d53252d2f8d2","floor":"135"},"leaderboardfooter-flex-2":{"id":"9b042bc38c184064b7353901a265c9b2","floor":"505"},"leaderboard-fixed-5":{"id":"316312e8d1724d5ca06f0dd5b829925c","floor":"220"},"square-fixed-5":{"id":"90a63b0798bd41a88225c7e964b895c0","floor":"135"},"leaderboardfooter-flex-1":{"id":"80064526390d4b72b228782c8fe03bba","floor":"425"},"leaderboard-fixed-0":{"id":"60f4c890be9d4834b2d8e54d46c21660","floor":"5"},"mob-square-fixed-1":{"id":"eb33d2eb0a1a48c6a21b7cd594215763","floor":"205"},"mob-square-fixed-2":{"id":"7c4b09f332374873a98174118176a79d","floor":"200"},"mob-square-fixed-3":{"id":"f80dd53c9a3a497797c2c0274e47895a","floor":"110"},"mob-square-fixed-rvw-1":{"id":"cf466f269f9d473b94bf39e363698077","floor":"115"},"inline":{"id":"e2b261fedd514971ae3df756db4479f4","floor":"5"},"square-fixed":{"id":"464bcfcf16d8416bb130b43d51b0ea17","floor":"5"},"mob-square-fixed-rvw-2":{"id":"37331b2939b441ecb647d9b87aaa4546","floor":"140"},"mob-squarefooter-fixed-2":{"id":"3956f347bdb14e3f9fdd2f9c74ed817a","floor":"100"},"square-fixed-9":{"id":"09ead751434648d3bd35cd0beb6eceef","floor":"115"},"mob-adhesive-banner-fixed":{"id":"8b43ce9cdc554c7f89b3f16d3410a9dc","floor":"125"}},
 utils: {
 generateSlotId: Allrecipes.GPT.generateSlotId
 },
@@ -300,126 +308,147 @@ displayOnConsent: true,
 adsToCollapse: ['leaderboard*','square*']
 };
 if (Mntl.AdMetrics) {
-Mntl.AdMetrics.init("6586301", "nd00c11d041104581bced15ae05ed134701", initialSlots.map(slot => slot.config.id), Date.now());
+Mntl.AdMetrics.init("6586301", "nb0e3cd855e144c73b1a3502bbe3cd23b21", initialSlots.map(slot => slot.config.id), Date.now());
 } else {
 Mntl.AdMetrics = { pushMetrics: () => {} };
 }
 Mntl.GPT.init(options);
 }());window.addEventListener('readyForThirdPartyTracking', () => {
-    // Set a delay for loading the script
-    // Specify the delay duration in pushly.xml
-    const delay = '8';
-
-    window.setTimeout(() => {
-        Mntl.utilities.loadExternalJS({
-            src: 'https://cdn.p-n.io/pushly-sdk.min.js?domain_key=1s505zJTcPgEUiiSrtvjQaixszhrrYRtqwpR',
-            async: true
-        });
-        
-        window.PushlySDK = window.PushlySDK || [];
-        
-        // eslint-disable-next-line prefer-rest-params
-        function pushly() { window.PushlySDK.push(arguments) }
-        pushly('load', {
-            domainKey: '1s505zJTcPgEUiiSrtvjQaixszhrrYRtqwpR',
-            sw: '/pushly-sdk-worker.js'
-        });
-    }, parseFloat(delay) * 1000);
+// Set a delay for loading the script
+// Specify the delay duration in pushly.xml
+const delay = '8';
+window.setTimeout(() => {
+Mntl.utilities.loadExternalJS({
+src: 'https://cdn.p-n.io/pushly-sdk.min.js?domain_key=1s505zJTcPgEUiiSrtvjQaixszhrrYRtqwpR',
+async: true
+});
+window.PushlySDK = window.PushlySDK || [];
+// eslint-disable-next-line prefer-rest-params
+function pushly() { window.PushlySDK.push(arguments); }
+pushly('load', {
+domainKey: '1s505zJTcPgEUiiSrtvjQaixszhrrYRtqwpR',
+sw: '/pushly-sdk-worker.js'
+});
+}, parseFloat(delay) * 1000);
 });
 // moved from gtm.ftl so we can initialize GTM only onLoad. From https://support.google.com/tagmanager/answer/6103696?hl=en
 Mntl.utilities.onLoad(function() {
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;defer=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-P3X3VT7');
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;defer=true;j.src='//www.googletagmanager.com/gtm.js?id='+i+dl;j.type="text/javascript";f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-P3X3VT7');
 });
-var dataLayer = dataLayer || [];
-dataLayer.push({
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({
 event: 'ab-proctor',
 'abTests-proctor': {
 "99-0"
-: "useOxygen | useOxygen | use the Oxygenated ad unit format and slot names | 1"
+: "useFloorSearch | active | Use Floor Search | 1"
 ,
-"99-1"
-: "vanillaJSLazyAdRecipeSC | active | vanillaLazyAd.js enabled | 1"
-,
-"99-2"
-: "userIdAuctionDelay | active | active | 1"
-,
-"82"
-: "pushlyNotifications | active | Active: Pushly enabled | 1"
-,
-"99-4"
-: "useFloorSearch | active | search API flooring system | 1"
-,
-"54"
+"50"
 : "lazyloadOffsetTimeoutDesktop | control | Default payload (inactive) | 0"
 ,
-"99-6"
+"99-2"
+: "testJiraTicketRevDev | active | Active | 1"
+,
+"99-3"
 : "fiftyPercentAdRefresh | active | Ads refresh when 50% in view | 1"
 ,
-"99-7"
+"99-4"
 : "recipescDesktopAdRefresh | active | active, right rail ads timed refresh active | 1"
 ,
-"75"
-: "enableReviewChips | control | control - review chips are not enabled | 0"
+"99-5"
+: "gamVideoUsePlcmt | active | Pass plcmt | 1"
 ,
-"99-9"
-: "liveIntentConnectedIdTest | control | LiveIntent ConnectedID is enabled | 0"
+"99-6"
+: "useDynamicVideoSizes | active | active | 1"
+,
+"99-7"
+: "rtbTracking | newevents | | 2"
+,
+"99-8"
+: "orion | control | Control | 0"
+,
+"55"
+: "relatedArticlesAlgorithm | useRecommendationService | Enables usage of proximity API | 1"
 ,
 "99-10"
-: "orion | active | Active | 1"
+: "testJiraTicketPRM2 | active | doesn\'t do anything | 1"
 ,
-"71"
-: "mobileStickySearchRecipeSC | active | Active: Show sticky search | 1"
+"99-11"
+: "useLiveRamp | active | active | 1"
 ,
-"72"
-: "desktopNavOpenSearch | control | control: Do not display new open search in global nav | 0"
+"63"
+: "jumpToRecipe | active | Active: Hide Jump to Recipe button | 1"
+,
+"99-13"
+: "useOxygen | useOxygen | use the Oxygenated ad unit format and slot names | 1"
+,
+"99-14"
+: "vanillaJSLazyAdRecipeSC | active | vanillaLazyAd.js enabled | 1"
+,
+"99-15"
+: "userIdAuctionDelay | lmd | LMD (Carbon) domains | 1"
+,
+"77"
+: "enableReviewChips | chipsOptional | chipsOptional - review chips are enabled and NOT required to submit reviews | 2"
+,
+"99-17"
+: "liveIntentConnectedIdTest | control | LiveIntent ConnectedID is enabled | 0"
+,
+"99-18"
+: "prebidVideoUsePlcmt | active | Pass plcmt | 1"
+,
+"99-19"
+: "testJiraTicket | active | Active | 1"
+,
+"99-20"
+: "removeAdTiers | active | active | 1"
 ,
 "58"
 : "holdPrimaryVideo | control | Enable immediate sticky | 0"
 ,
-"99-14"
-: "scAdsScript | active | Sc-ads.js is loaded in mantle inside listScCommerceTemplates. Sc-ads.js stops loading through commerce | 1"
+"78"
+: "recipeCard | control | control: Only show decision block | 0"
 ,
-"65"
-: "categorySearchBlock | active | Active: Show category search block | 1"
+"99-23"
+: "enableAdLazyOffsetIntro1 | active | updates lazy offset for intro1 ad in recipes | 1"
 ,
-"63"
-: "jumpToRecipe | active | Active: Hide Jump to Recipe button | 1"
+"64"
+: "categorySearchBlock | control | Control: Do not show category search block | 0"
 }
 });
-dataLayer.push({
+window.dataLayer.push({
 envData: {
 environment: {
 environment: "k8s-prod",
 application: "allrecipes",
-dataCenter: "us-east-1"
+dataCenter: "us-west-1"
 },
 server: {
-version: "1.130.0",
+version: "2.56.0",
 title: "allrecipes-launcher"
 },
 client : {
 browserUA: navigator.userAgent,
-serverUA: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0",
+serverUA: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
 deviceType: "pc",
-usStateCode: "MA"
+usStateCode: "IL"
 },
-mantle: "3.14.359",
+mantle: "4.0.432",
 commerce: ""
 }
 });
-(function(win, fnUtils, CMP) {
-var deferLoadTime = 5000;
-var readyForThirdPartyTrackingEvent = new CustomEvent('readyForThirdPartyTracking', { bubbles: true });
-var readyForThirdPartyTracking = fnUtils.once(function() {
-dataLayer.push({event: 'readyForThirdPartyTracking'});
+(function(fnUtils, CMP) {
+const deferLoadTime = 5000;
+const readyForThirdPartyTrackingEvent = new CustomEvent('readyForThirdPartyTracking', { bubbles: true });
+const readyForThirdPartyTracking = fnUtils.once(function() {
+window.dataLayer.push({event: 'readyForThirdPartyTracking'});
 window.dispatchEvent(readyForThirdPartyTrackingEvent);
 });
-var readyForDeferredScriptsEvent = new CustomEvent('readyForDeferredScripts', { bubbles: true });
-var readyForDeferredScripts = fnUtils.once(function() {
-dataLayer.push({event: 'readyForDeferredScripts'});
+const readyForDeferredScriptsEvent = new CustomEvent('readyForDeferredScripts', { bubbles: true });
+const readyForDeferredScripts = fnUtils.once(function() {
+window.dataLayer.push({event: 'readyForDeferredScripts'});
 window.dispatchEvent(readyForDeferredScriptsEvent);
 });
-var hasTargetingConsentHandler = function() {
+const hasTargetingConsentHandler = function() {
 const hasConsent = CMP.hasTargetingConsent();
 if (hasConsent) {
 readyForThirdPartyTracking();
@@ -432,32 +461,43 @@ readyForDeferredScripts();
 }
 return hasConsent;
 };
-var onRequiredDomEvent = fnUtils.once(function() {
+const purposeOneConsentHandler = async function() {
+const hasPurposeOneConsent = await CMP.hasPurposeOneConsent();
+if (hasPurposeOneConsent) {
+readyForThirdPartyTracking();
+}
+if (hasPurposeOneConsent || CMP.isAlertBoxClosed()) {
+readyForDeferredScripts();
+}
+return hasPurposeOneConsent;
+};
+const onRequiredDomEvent = fnUtils.once(function() {
 if (!CMP) {
 readyForThirdPartyTracking();
 readyForDeferredScripts();
 return;
 }
+const handler = CMP.supportsTCData() ? purposeOneConsentHandler : hasTargetingConsentHandler;
 if (!CMP.isLoading()) {
-hasTargetingConsentHandler();
+handler();
 }
-CMP.onConsentChange(hasTargetingConsentHandler);
+CMP.onConsentChange(handler);
 });
 [
 ['adRendered', onRequiredDomEvent],
 ['beforeunload', onRequiredDomEvent],
 ['load', function() { setTimeout(onRequiredDomEvent, deferLoadTime); }]
 ].forEach(function(event) {
-win.addEventListener(event[0], event[1], { once: true });
+window.addEventListener(event[0], event[1], { once: true });
 });
-})(window || {}, Mntl.fnUtilities || {}, Mntl.CMP);window.dataLayer = window.dataLayer || [];
+})(Mntl.fnUtilities || {}, Mntl.CMP);window.dataLayer = window.dataLayer || [];
 (function() {
-var pageViewDataAsJSON = {"country":"US","description":"These delicious four cheese pizzas are bursting with flavor, and ready in under one hour.","fullUrl":"https://www.allrecipes.com/recipe/133948/four-cheese-margherita-pizza/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"internalSessionId":"n92148e470e5249bba5bf2cb02a76265801","internalRequestId":"nd00c11d041104581bced15ae05ed134701","hid":"","experienceTypeName":"","recircDocIdsFooter":"S-7971911|S-7255338|S-6574612|S-6569204|S-6737021|S-6650739|S-6567179|S-6568220","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"3.14.359","commerceVersion":"","primaryTaxonomyIds":"6502448|6651953|6651964|6653161|6653052","primaryTaxonomyNames":"Allrecipes|Recipes|Cuisine|European|Italian","title":"Four Cheese Margherita Pizza Recipe" || document.title || '',"viewType":"BROADVIDEO","templateId":"120","lastEditingAuthorId":"1015024","lastEditingUserId":"151378030080892","templateName":"RECIPESC","muid":"7c4ee15a-daa6-479b-88bb-42a5147fa732","documentId":6586301,"authorId":"1015024","contentGroup":"Other","revenueGroup":""};
+var pageViewDataAsJSON = {"country":"US","fullUrl":"https://www.allrecipes.com/recipe/133948/four-cheese-margherita-pizza/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"internalSessionId":"n92fb7040bdf94a89851ddd3952fa4f9319","internalRequestId":"nb0e3cd855e144c73b1a3502bbe3cd23b21","hid":"","experienceTypeName":"","recircDocIdsFooter":"S-6597026|S-6567179|S-6601340|S-6736485|S-6650739|S-6578682|S-6571874|S-6600809|S-6577149|S-6603087|S-6584723|S-6586681|S-6737818|S-6599509|S-6606211|S-6593716","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"4.0.432","commerceVersion":"","primaryTaxonomyIds":"6502448|6651953|6651964|6653161|6653052","primaryTaxonomyNames":"Allrecipes|Recipes|Cuisine|European|Italian","description":"These delicious four cheese pizzas are bursting with flavor, and ready in under one hour.","title":"Four Cheese Margherita Pizza Recipe" || document.title || '',"authorId":"1015024","contentGroup":"Other","viewType":"","revenueGroup":"","templateName":"RECIPESC","templateId":"120","muid":"0232beda-105c-411a-9e94-24bc972fde83","lastEditingAuthorId":"1015024","lastEditingUserId":"151378030080892","documentId":6586301};
 var scrolledPageData = {};
 var scrolledDocOrdinal;
 var scrolledPage;
 pageViewDataAsJSON.breakpointName = Allrecipes.utilities.getW();
-pageViewDataAsJSON.bounceExchangeId = '2548';
+pageViewDataAsJSON.bounceExchangeId = 2548;
 pageViewDataAsJSON.descriptiveTaxonomy = '12291,17387,24418,17389,11184,16752,18098,17384,12550,16751,10250,17382,10239,25281,11802,11109,16811,12213,12257,12019,13149,12852,13623,17354,18087,17592,17394,12384,11098,11252,13692,12263,11053,17590,17393,21733,12606,12801,16806,32452,11693,11374,13398,11750,10444,17359';
 if ( pageViewDataAsJSON.experienceTypeName == 'continuous' ) {
 if (window.dataLayer && window.dataLayer.length) {
@@ -483,8 +523,7 @@ Mntl.utilities.onLoad(function() {
 Mntl.PageView.init(pageViewDataAsJSON);
 });
 })();</script>
-					
-					<link rel="shortcut icon" href="/favicon.ico">
+<link rel="shortcut icon" href="/favicon.ico">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/apple-touch-icon-57x57.png">
 <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/apple-touch-icon-60x60.png">
@@ -492,18 +531,13 @@ Mntl.PageView.init(pageViewDataAsJSON);
 <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/apple-touch-icon-120x120.png">
 <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/apple-touch-icon-152x152.png">
 <link rel="apple-touch-icon-precomposed" sizes="180x180" href="/apple-touch-icon-180x180.png">
-
 <meta name="msapplication-TileColor" content="#F4F4F4"/>
-<meta name="msapplication-TileImage" content="/static/1.130.0/icons/favicons/mstile-144x144.png">
-<meta name="msapplication-square70x70logo" content="/static/1.130.0/icons/favicons/mstile-70x70.png">
-<meta name="msapplication-square150x150logo" content="/static/1.130.0/icons/favicons/mstile-150x150.png">
-<meta name="msapplication-square310x310logo" content="/static/1.130.0/icons/favicons/mstile-310x310.png">
-<meta name="msapplication-wide310x150logo" content="/static/1.130.0/icons/favicons/mstile-310x150.png">
-
-
-					
-					<script id="allrecipes-schema_1-0" class="comp  allrecipes-schema mntl-schema-unified" type="application/ld+json">				
-[
+<meta name="msapplication-TileImage" content="/static/2.56.0/icons/favicons/mstile-144x144.png">
+<meta name="msapplication-square70x70logo" content="/static/2.56.0/icons/favicons/mstile-70x70.png">
+<meta name="msapplication-square150x150logo" content="/static/2.56.0/icons/favicons/mstile-150x150.png">
+<meta name="msapplication-square310x310logo" content="/static/2.56.0/icons/favicons/mstile-310x310.png">
+<meta name="msapplication-wide310x150logo" content="/static/2.56.0/icons/favicons/mstile-310x150.png">
+<script id="allrecipes-schema_1-0" class="comp allrecipes-schema mntl-schema-unified" type="application/ld+json">[
 {
 "@context": "http://schema.org",
 "@type": ["Recipe"]
@@ -543,17 +577,14 @@ Mntl.PageView.init(pageViewDataAsJSON);
 "https://twitter.com/Allrecipes",
 "https://flipboard.com/@Allrecipes",
 "https://en.wikipedia.org/wiki/Allrecipes.com",
-"https://apps.apple.com/us/app/allrecipes-dinner-spinner/id299515267",
-"https://play.google.com/store/apps/details?id=com.allrecipes.spinner.free&hl=en_US&gl=US",
-"https://www.youtube.com/c/foodwishes",
-"https://www.linkedin.com/company/19312/admin/"
+"http://linkedin.com/company/allrecipes.com"
 ]
 }
 ,"name": "Four Cheese Margherita Pizza"
 ,"aggregateRating": {
 "@type": "AggregateRating",
 "ratingValue": "4.8",
-"ratingCount": "487"
+"ratingCount": "489"
 }
 ,"cookTime": "PT10M"
 ,"nutrition": {
@@ -605,9 +636,51 @@ Mntl.PageView.init(pageViewDataAsJSON);
 },
 "author": {
 "@type": "Person",
+"name": "G8RTCHR"
+}
+,
+"reviewBody": "This was great - even if I just used the mozzarella and parmesan cheeses. Don't make the same mistake I did, though, only brush the oil on the crust - I added the leftover on top later and it was too oily after baking. If you have leftover oil, just throw it out..."
+},
+{
+"@type": "Review",
+"reviewRating": {
+"@type": "Rating",
+"ratingValue": "4"
+},
+"author": {
+"@type": "Person",
+"name": "Sue"
+},
+"reviewBody": "This was so good! I made only one 12\" pizza for two. I added more freshly chopped basil when I served it, as I didn't add enough when I topped the tomatoes. Definitely needs a lot of the basil for flavor. Maybe add some Italian seasoning the next time I make it. Used all four of the cheeses. I did make my own crust, didn't pre cook it, and baked for 20 minutes at 425 degrees. I didn't get a chance to take a picture as it was gone before I could get to it. No leftovers this week.",
+"datePublished": "2024-03-01T23:02:55.425Z"
+}
+,
+{
+"@type": "Review",
+"reviewRating": {
+"@type": "Rating",
+"ratingValue": "5"
+},
+"author": {
+"@type": "Person",
+"name": "Allrecipes Member"
+},
+"reviewBody": "I made three mini pizzas, so I had too many tomatoes but I used them for the salad. The pizzas were VERY tasty, especially with balsamic vinegar drizzled on top after baking. I even froze one uncooked in a plastic container. My son heated in air fryer and they couldn’t believe it was homemade! Will definitely make again!! The pic is before baking.",
+"datePublished": "2024-02-25T14:06:08.954Z"
+}
+,
+{
+"@type": "Review",
+"reviewRating": {
+"@type": "Rating",
+"ratingValue": "5"
+},
+"author": {
+"@type": "Person",
 "name": "cmach"
 },
-"reviewBody": "Yum, Yum, Yum,! Perfect as is- I was making 1 pizza and one-half was different for my husband, so I reduced recipe to 1/4. My Roma was large so just used one but pizza was out of this world- next time I am making a whole one just for me!"
+"reviewBody": "Yum, Yum, Yum,! Perfect as is- I was making 1 pizza and one-half was different for my husband, so I reduced recipe to 1/4. My Roma was large so just used one but pizza was out of this world- next time I am making a whole one just for me!",
+"datePublished": "2023-12-05T03:03:48.325Z"
 }
 ,
 {
@@ -620,7 +693,8 @@ Mntl.PageView.init(pageViewDataAsJSON);
 "@type": "Person",
 "name": "Emily B"
 },
-"reviewBody": "Made this for a potluck and it got great reviews!"
+"reviewBody": "Made this for a potluck and it got great reviews!",
+"datePublished": "2023-04-24T14:33:47.401Z"
 }
 ,
 {
@@ -633,7 +707,8 @@ Mntl.PageView.init(pageViewDataAsJSON);
 "@type": "Person",
 "name": "Allrecipes Member"
 },
-"reviewBody": "great"
+"reviewBody": "great",
+"datePublished": "2022-10-19T17:04:21.904Z"
 }
 ,
 {
@@ -646,7 +721,8 @@ Mntl.PageView.init(pageViewDataAsJSON);
 "@type": "Person",
 "name": "DREGINEK"
 },
-"reviewBody": "Michelle - this was awesome! Although it only ended up being a 3 cheese pizza (no Fontina) - loved the combo of creamy and nutty! Loved the feta! While the tomatoes were marinating, pre-baked the crust a bit (based on the pre-baked brand I had) and followed instructions and cook time according to the recipe. Delicious! Only change; only add the basil for the last couple min - a few of my leaves got overly brown/toasty. While not the best cold - reheated leftovers the next day were really good! Thank you!!"
+"reviewBody": "Michelle - this was awesome! Although it only ended up being a 3 cheese pizza (no Fontina) - loved the combo of creamy and nutty! Loved the feta! While the tomatoes were marinating, pre-baked the crust a bit (based on the pre-baked brand I had) and followed instructions and cook time according to the recipe. Delicious! Only change; only add the basil for the last couple min - a few of my leaves got overly brown/toasty. While not the best cold - reheated leftovers the next day were really good! Thank you!!",
+"datePublished": "2022-08-04T00:19:47.330Z"
 }
 ,
 {
@@ -659,7 +735,8 @@ Mntl.PageView.init(pageViewDataAsJSON);
 "@type": "Person",
 "name": "PUPDEF"
 },
-"reviewBody": "This is one of my all-time favorite recipes. I have probably made it a hundred times or more. The only comment I have is to cut down or even eliminate the salt in the marinade - with all that cheese, it's got a lot in it already."
+"reviewBody": "This is one of my all-time favorite recipes. I have probably made it a hundred times or more. The only comment I have is to cut down or even eliminate the salt in the marinade - with all that cheese, it's got a lot in it already.",
+"datePublished": "2022-07-01T13:56:43.219Z"
 }
 ,
 {
@@ -672,7 +749,8 @@ Mntl.PageView.init(pageViewDataAsJSON);
 "@type": "Person",
 "name": "Deb"
 },
-"reviewBody": "I have made this several times since my sister served it in September. I follow it as written, although if you don`t have fresh basil, use \"lightly dried\". it's a hit in our house!"
+"reviewBody": "I have made this several times since my sister served it in September. I follow it as written, although if you don`t have fresh basil, use \"lightly dried\". it's a hit in our house!",
+"datePublished": "2022-01-09T03:37:33.720Z"
 }
 ,
 {
@@ -685,1203 +763,8 @@ Mntl.PageView.init(pageViewDataAsJSON);
 "@type": "Person",
 "name": "Bobbie"
 },
-"reviewBody": "WOW. My family loves this pizza. I was a little skeptical about the combination but I have a thing for gorgonzola so I gave it a try. Fantastic. Tastes like an expensive gourmet pizza. I followed the ingredient list but just put on however much I wanted. I also pre baked the crust. Thank you so much for sharing this."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "UnusualGoober"
-},
-"reviewBody": "I made it with two cheeses and it tasted amazing!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "LIZZIE SANGI Sangi (Lizzie)"
-},
-"reviewBody": "Yeah, when it comes to BASILEGO, (pronounced not spelled), you've purchased in beautiful fresh bunches and brought home for not immediate use - it can be a quandary. Putting it back in water in fresh bunches only goes so far. So leave it out to dry on the counter or on a sunny sill. The aroma is incredible, first off. Let aroma therapy envelope you. The dried leaves will be a deep deep green, almost black green. Crumble the dried leaves with your fingers. Take out any pointy hard stems. If your fingers can crumble what's in your hand, crumble it as finely as you can by more or less rubbing it between your finger and thumb. You still don't want any right angles. Stems can be tricky. And it might take more than one day for your fresh herb to completely dry out (this goes for more than just basil. You can dry out any fresh herb). Keep the dried product in a sealed container and I've found that peeled garlic cloves keep well in the freshly dried basil ! The finished product is delightful! The fragrance is all there and the taste - the flavor of the dried herb you've made is awesome. I have come to LOVE this method of keeping fresh herbs. You can never have enough. It's SO MUCH BETTER than buying the same thing because even though it's dried, it's not the same thing. Did I mention you can never have enough? You can't. People may say it's simple but it's a great gift giver and I think you'll understand why when you make your dried herb. Ya. You can never have enough of it."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "1"
-},
-"author": {
-"@type": "Person",
-"name": "trollhammer101"
-},
-"reviewBody": "i hated this recipe . i followed the instructions to a t and i couldn't even eat it its so bad"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "JenS"
-},
-"reviewBody": "OMG AMAZING! Made this as a last minute thing for a New Year's Eve gathering and it was a HIT! So simple and easy, will be making this again and again!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Renee"
-},
-"reviewBody": "I made this pizza last week. I did 1/2 the recipe since there were just 2 of us and it was the best pizza we have ever had! I used Pillsbury thin pizza crust and cooked it for 8 minutes and then added the toppings. Perfection!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Lori Oswalt Breeze"
-},
-"reviewBody": "Great recipe! I have made this numerous times! Always turns out great! I used naan bread for my crust. Didn’t change anything else."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Maur62"
-},
-"reviewBody": "I spread basil pesto on the crust because I didn't have fresh basil then I brushed the tomato-garlic-olive oil on. It was excellent. This is a keeper"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Elijah Deckard"
-},
-"reviewBody": "great"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Nancy G"
-},
-"reviewBody": "Delicious! I will be making this again and again. Tried to stay as close to the original recipe as possible but didn't have any Fontina cheese or Roma tomatoes so I substituted vine ripe tomatoes (removed the center to avoid getting too soggy as one reviewer noted). Cooked till cheese started to brown. Seasoned with cracked pepper."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Cheryl Bombalicki Ryder"
-},
-"reviewBody": "I t was really good! It tasted like the frozen pizza I usually purchase."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Undercover Louky"
-},
-"reviewBody": "I didn't want to grate my own fontina, so I used a pre-grated blend of fontina and parmesan. Also, the person before me grabbed the last fresh basil so I used dried. The pizza came out great!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Rhonda Proctor"
-},
-"reviewBody": "I made this tonight after my two sons requested this kind of pizza. I had never had this kind before. HOLY PEPPERONI! Do yourself a favor and make this! Followed this recipe to the T. Turned out so good they ate it standing at the island WITHOUT plates. If that’s not testimony of how good it is, I don’t know what is!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "veronwilkins"
-},
-"reviewBody": "First time posting here. Second time making this dish. First time used store bought crust, this time I made my own crust from another recipe on here. For me, that made it 5 stars. Simply delicious."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Louis"
-},
-"reviewBody": "I didn’t have Fontina on hand so I used what I did have... blue cheese. Tasted fantastic just in case you were wondering. Also, I somehow forgot to prebake the crust so I let it bake for 20 minutes and it was perfect!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Stacy Snyder"
-},
-"reviewBody": "The feta adds such a nice saltiness that I love! It’s such a fantastic meatless pizza. My family says it could be served in any restaurant!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "K. Edwards"
-},
-"reviewBody": "The whole family loved it. I used fresh tomatoes and basil from the garden. So good!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Chef wannabe"
-},
-"reviewBody": "Outstanding!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Allrecipes Member"
-},
-"reviewBody": "DELICIOUS! I made two, one exactly to the recipe specs minus feta (forgot to grab at the store) and a 2nd adding onions, green peppers and mushrooms. BOY OH BOY.....both pizzas were excellent! This recipe is a keeper. Thanks for sharing."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "rawls99"
-},
-"reviewBody": "DELICIOUS! I made two, one exactly to the recipe specs minus feta (forgot to grab at the store) and a 2nd adding onions, green peppers and mushrooms. BOY OH BOY.....both pizzas were excellent! This recipe is a keeper. Thanks for sharing."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Christina"
-},
-"reviewBody": "LOVED this! Great flavors...a definite keeper~YUM!!!! Thanks for sharing. :)"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Jackie Don"
-},
-"reviewBody": "Instead of the pre-baked pizza crust, I used garlic naan...it was delicious!!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Grandpop"
-},
-"reviewBody": "Made this several times. It is just great."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "jswentor11"
-},
-"reviewBody": "This is simply delicious. One of the best homemade margherita pizza we've ever made. Used Boboli thin crust, and one 8oz Italian blend shredded cheese(Fontina,mozzarella,parmesan,asiago) per pizza along with feta and. grated parmesan. Yummy!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "IhateCooking"
-},
-"reviewBody": "The first pizza I made was very wet because I veered from the recipe. I used fresh sliced moz and didnt marinade tomatoes.\nThe second one I only changed the garlic to rough chopped and increased it and the basil for my family's tastes. It got voted in the rotation list for taste and it's EASY.\nThe 3rd one i made I added shredded Swiss Chard to the basil. Also, delish"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "4"
-},
-"author": {
-"@type": "Person",
-"name": "Victoria Matheus"
-},
-"reviewBody": "I used cherry tomato halves from my garden, Fontina instead of Feta &amp; a Boboli thin crust. This was excellent, but next time I will use only 1/8 cups of olive oil, 1 teaspoon of minced garlic &amp; 1/4 teaspoon of salt. Otherwise, it is as good as any Margherita Pizza I've ever had. (I pretty much cut out real salt years ago, so it may be my own taste, but it just seemed far too salty &amp; I had to soak up lots of oil from the top after cooking, not to mention that it dripped off in the oven, so less oil)"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "londonlinn"
-},
-"reviewBody": "My husband loved this pizza, I also added spinach."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Fool4Food"
-},
-"reviewBody": "Thank you for a wonderful recipe - I made this tonight and we just loved it! My changes were minimal: I didn't add salt to the olive oil and garlic, I used fresh whole wheat pizza dough, I didn't have any fontina cheese, and I used fresh, ripe tomatoes from my garden instead of roma. I added the basil (also from my garden) to the pizza before baking as directed, but added a little extra fresh basil just before serving. It really was delicious and not a morsel left - we will be making this again and again!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Roger"
-},
-"reviewBody": "Easy to make, great flavor. I used an ultra thin crust, and it came out fantastic."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "bmarv44"
-},
-"reviewBody": "Yum! I made with just mozzarella and Parmesan and it was still delicious! Would love to try with the four cheese next time."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "money farter"
-},
-"reviewBody": "cool"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Joseph Brady"
-},
-"reviewBody": "Best Pizza EVER!!! I LOVE IT!!!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "tb14"
-},
-"reviewBody": "so good"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Shellee"
-},
-"reviewBody": "I really enjoyed this pizza!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Lizzybee"
-},
-"reviewBody": "Amazingly delicious! I have also added small bites of chicken breast stir fried with italian seasoning and garlic powder. Thank you so much for such a delicious pizza recipe. I use with Chef Rider's quick and easy pizza crust recipe posted on Allrecipes."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Rose Herring Cobb"
-},
-"reviewBody": "Wah-wah-wee-wah! This pizza was delicious!! Who knew pizza without sauce could be so fulfilling!!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "4"
-},
-"author": {
-"@type": "Person",
-"name": "R2S"
-},
-"reviewBody": "I reduced the servings to 4, but kept the olive oil &amp; garlic at 8 servings to have enough liquid to coat the tomatoes. We like basil, so I also kept the basil at the 8 serving level. Instead of shredded Fontina cheese, I used slices of Provolone. The base was zesty Italian flatbread."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "3"
-},
-"author": {
-"@type": "Person",
-"name": "lacey"
-},
-"reviewBody": "This was very tasty, but make sure you like the crust you are getting."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Ms Jean"
-},
-"reviewBody": "One of the best pizzas I've made! It's definitely restaurant quality. I had to go with dried basil, but it would be much better with fresh! I used TJoe's pizza dough and their four-cheese blend. It didn't have feta in it so I also added a little of that. I used regular tomatoes, 1 1/2 for a 12\" pizza. The Roma would have held up much better. I did squeeze most of the marinade from the tomatoes which didn't help in keeping their shape. I also added most of the garlic pieces to the pizza which made it so delicious! Thanks - this is a definite keeper! UPDATE 2/9/18: Used the recommended Roma tomatoes, and they kept their shape much better than regular ones. I only used two Romas for a 12\" pizza. I scaled the recipe down to 2 tblsp olive oil. That amount worked great - hardly any wasted oil."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Dice Family"
-},
-"reviewBody": "DELICIOUS!!! I made it with Pillsbury pizza dough. I baked the dough first and then added the topping and cooked as instructed. It tasted even better when the crust gets really crispy. A new family favorite and a great appetizer."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Jeanie"
-},
-"reviewBody": "I took this to share at Triva Night, even the men loved it."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Joey"
-},
-"reviewBody": "I had a Culinary project and chose this because it sounded delicious, and my family loves pizzas! It turned out really good, though I do wish that the cheese melted a little bit better. The crust was crunchy, the tomatoes blended well in the pizza, and the cheeses blended together for a savory, awesome flavor. One tip I used was to brush the crust with oil, and let it sit for a minute. That really worked well, and gave the crust a nice flavor. A tip I would use is instead of slicing and placing the tomatoes on top, I diced them, and placed them on top, diced. Some of the tomatoes sank in the cheese, and the juices flowed out in the cheese, giving it a nice flavor, and it makes it easier to bite into the pizza, rather than huge tomato slices."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "DJ Sak"
-},
-"reviewBody": "This turned out great! The only thing is that I had a lot of leftover tomatoes about 4 and I only started with 7. Other than that I used a blend of cheeses and didn't use feta."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Brenda"
-},
-"reviewBody": "So easy to make and sooooo delicious! Coupled with a good red wine, it's the perfect way to end the day."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "JDeSmedt"
-},
-"reviewBody": "Making again the next day - so good! We wanted a super thin crust so used thicker tortillas instead of pizza crust and threw on the grill over low heat for about 5 minutes."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Libby"
-},
-"reviewBody": "Made with frozen pizza dough, otherwise followed directions exactly. Took 12-13 min to cook. Used one clove of garlic, did not experience any raw garlic intensity. Overall really excellent, would make again."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Hannah"
-},
-"reviewBody": "The pizza itself was amazing! However next time I would use a homemade dough since the store bought pre-baked one down graded the whole thing."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Jillybean"
-},
-"reviewBody": "This recipe is awesome - I've made it many times and it always gets rave reviews. I try to marinate the tomatoes at least 30 minutes. I've never used Fontina cheese (can't find it) and I've only used feta a few times. I don't think it really adds anything. I make individual pizzas using Stone Baked Naan breads from Costco. Yummy!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "CJWood"
-},
-"reviewBody": "I didn't change a thing whole family loves it"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Jeanne"
-},
-"reviewBody": "The tomato marinade made this recipe. I didn't have fresh basil so I put dried basil in the marinade and used cherry tomatoes from my garden, cut in half. I did marinate them for quite some time while waiting for guests to arrive. Used Flat-out pizza bread for the crust but followed the recipe directions for assembling the pizza. It was a great hit! Will make again! Thanks for the recipe."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Cooking Monster Bryan"
-},
-"reviewBody": "By far one of the best pizzas I've had in a while. I used a pre-made thin crust and used cheddar cheese instead of fontina only due to what I had available at home. It also took almost no time to prepare. Highly recommend."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "4"
-},
-"author": {
-"@type": "Person",
-"name": "THE_SHAMPOO"
-},
-"reviewBody": "The only thing I omitted was the salt, it does NOT need it. The cheeses have plenty. I didn't precook the pizza crust, but it did need a few more minutes than usual because of the heavy cheese. I used tomatoes from the garden and just put as many as I wanted. I doubled the garlic because I love it. I think this would be just as good without the feta, maybe because I'm not a huge fan of it. Never used fontina cheese before...it's fun to try new things!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Margie Forbes-Skubic"
-},
-"reviewBody": "This was excellent! I didn't have feta this time but will the next time. I used reduced calorie mozzarella and my family still loved it! Even my vegetable picky granddaughter liked it!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Kallentide"
-},
-"reviewBody": "This is very tasty. My grocery store is not cool enough to have all these types of cheese but I bought a mixed bag that had most. My husband cant stop stealing the tomatoes out of the bowl when they are marinating."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Amanda Banks"
-},
-"reviewBody": "Oh my goodness! I LOVED it! Followed the recipe with the exception of not having fontina cheese (used extra mozzarella instead), but I will try to get some for next time. Some people say they also left off the feta, but that was part of what made it amazing! Go for the fancy cheese, it's worth it!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Bess"
-},
-"reviewBody": "This was just awesome! I was a bit worried since my boyfriend and I have never had pizza without marinara, but this just changed our view on it completely! It had a perfect garlic flavor, and we and our roommates loved it. If you have a hard time locating Fontina cheese (we did as our grocery store didn't have it) try Muenster!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "4"
-},
-"author": {
-"@type": "Person",
-"name": "geminigurl89"
-},
-"reviewBody": "This was decent, but I think a lot of it depends on the pizza crust you use and I wasn't really a fan of the one I got (Mama Mary's). I only made one pizza, but I used only 2 and 1/2 tomatoes instead of 4. I left out the salt and fontina and just sprinkled on some of the basil we keep in the spice rack. The feta didn't really melt much, I'm not sure if it was supposed to or not, but I was kind of disappointed by that aspect. Not sure if I will make it again or not."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Jackie"
-},
-"reviewBody": "Excellent!!! I used naan for the crust but made no other changes. Will definitely be making this again!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Rochelle"
-},
-"reviewBody": "I made this with my God-sin. It turned out great. It was our first pizza together!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Shirley"
-},
-"reviewBody": "Delicious! Didn't use garlic. I ground an Italian Blend Seasoning plus a few shakes of Oregano in to the olive oil and let that \"stew\" for a while before brushing on to the crust. I only made one pizza."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "4"
-},
-"author": {
-"@type": "Person",
-"name": "Shelli-Jason Clark (The Clarks"
-},
-"reviewBody": "I just made this for our NYE dinner. Wow! I would give 5 stars; however it was various tips from other reviews that elevated the pizza to 5 stars. I hate to be \" one of those reviewers\" who change a recipe and comment on how great it is, but I must. 1) NEVER use pre-baked store bought crust...it ain't homemade pizza! Like many others I used Jay's Signature Pizza Crust...I pre-baked it for 10 minutes before adding toppings. Best crust ever! 2) I used 8 Roma tomatoes from Costco. After slicing I placed between paper towels to drain, then I marinated for 45 minutes. 3) while tomatoes marinated, I raised my top oven rack to top, fired up oven, put my stone in and heated the stone for 45 minutes. Makes a better crust! 4) I strained the marinade and put the tomatoes in a bowl. Made it easier to brush marinade on crust. 5) use all the tomatoes!! I used Asiago (couldn't find fontina) and mozzarella on first, then tomatoes, basil, Parmesan and feta in that order. 6). I baked pizza at 400 for 15 minutes. I let it rest on cutting board for 5 minutes before slicing. Bottom line...my kids ate 5 slices each! We cut small slices and they even ate tomatoes! If you take the time to make your own crust, preheat stone, and marinate tomatoes longer, it is THE best pizza ever!!!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Alisa1182"
-},
-"reviewBody": "Just made this for dinner and it was excellent! The combination of cheeses was perfect and I had just enough tomatoes for the 2 pizzas. Prep time was about 20-30 mins, cook time 10 mins. We will definitely be making this again!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "kassbee"
-},
-"reviewBody": "I made this on a homemade crust. It was delicious! I used some extra garlic, which was a big hit."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Lara Verdone"
-},
-"reviewBody": "Super Easy and Super Tasty! I made this for my boyfriend and I but ended up sharing it with my roommates too. One of my roommates actually thought I picked it up from somewhere it was so good. \n\nUnfortunately when I was shopping for supplies the market I go to was out of fresh basil leaves, but dried basil worked just as well.\n\nAlso budget wise it was totally in the broke college student range... so I just ended up buying a pre-made crust. \n\nYou might end up with a lot of extra cheese that you can sprinkle into other food. :)\n\nWould make again. 5/5"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "figgy"
-},
-"reviewBody": "Okay I did have to change this some because I didn't have fresh basil and I didn't want dried so instead of marinating the tomato in olive oil I used some pesto as my base. I then layered on sliced grape tomatoes, fresh mozzarella slices, the crumbled feta and shredded parmesan cheeses, didn't have any Fontina. One thing for sure was DRAIN most of the oil off the pesto if you use it. My pizza was sort of swimming in olive oil but other than that the taste was amazing. My older son would have like it even more with extra Feta, as he loves that cheese. My mom who is Mrs. \"It's too spicy, I can't eat spicy!\" said it was too bland. 'What'? And my younger son wouldn't touch either pesto or fresh tomatoes with a 10 foot pole anyway. Fortunately I had 3 crusts so they got their sausage and pepperoni pizzas too but I was looking for something besides the usual meat and tomato sauce taste. I would definitely make it again with the fresh basil and Fontina or with Basil pesto that's been drained of most of the oil. All in all an excellent recipe. Thanks Michelle."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "AmoniChanel"
-},
-"reviewBody": "Made this very easy and very good I don't like Feta cheese so I used three random cheese blends by sarge to Amazing. My family loved it got enough left to make another one."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Jessie "
-},
-"reviewBody": "this pizza is one of the best homemade pizzas ive ever experienced, we used all fresh ingredients from our garden, making the flavors pop! there was a strong taste of garlic and basil which blended beautifully. definitely a crowd pleaser, great for any party, the best hands down."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "4"
-},
-"author": {
-"@type": "Person",
-"name": "Sandi King"
-},
-"reviewBody": "Wonderful recipe. I used freshly made XL crust which I baked 6 minutes first, and also used fresh mozzarella because that's what I had on hand, with Parmesan on top, no feta or fontina on hand so left that out. Our garden had several kinds of heirloom tomatoes so I sliced three different ones and alternated between red/striped/yellow tomatoes and it was beautiful. Since the tomatoes were really juicy the baking time was longer, about 20 minutes total, plus I increased the oven temp to 425 degrees. The end result was stunningly delicious. Also, don't discard the extra olive oil marinade! Use it to dress your side salad or avocado slices served with the pizza. Thanks for the recipe, we will be making this one again and again!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "JenJen"
-},
-"reviewBody": "I loved this pizza!! I didn't have fontina cheese on hand but don't think I missed it at all. I added a little bit more garlic than called for and let it marinate with the tomatoes for 1/2 hour. I will definitely make it again."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Allison Raines"
-},
-"reviewBody": "Needs to be broiled for 2-3 minutes after cooking for 10. Otherwise this is perfect!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "2"
-},
-"author": {
-"@type": "Person",
-"name": "Maryb935"
-},
-"reviewBody": "Just ok.."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "djaurora"
-},
-"reviewBody": "This recipe is fantastic!!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Pamaloo"
-},
-"reviewBody": "Yummy!!! I have been looking for a good, easy recipe for Margherita Pizza and finally found it! This is delish!! Next time I will try it with marinated cooked chicken. Thank you for sharing this. It will be added to my top favorites!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "faircook03"
-},
-"reviewBody": "This was amazing. Could not stop eating it. Even after I was full, I just kept going back and picking off little pieces because it made my mouth so happy!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "1"
-},
-"author": {
-"@type": "Person",
-"name": "MICHEMC"
-},
-"reviewBody": "good but boring"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "floridascrubtech"
-},
-"reviewBody": "Thought This Recipe Was Awesome!\nI Think \"I\" Got A Little Heavy Handed With The Salt And Garlic.\nBut I Will Be Making This Again For Sure.\nMy First Home Made Pizza (Still A Learning Curve With The Dough, \nI Like Mine Thin). But I Am Very Happy With This Recipe.\nThank You From Florida!!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Sally"
-},
-"reviewBody": "Tried it following the recipe. I loved it."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "saxeman"
-},
-"reviewBody": "Fun time with my wife drinking some wine and making this dinner. Was as good as the restaurant versions. I expect the choice of pizza crust is important. It's worked out. .. was thin and crispy. And our selection of tomatoes was limited but it was still very tasty."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "TasteBudz"
-},
-"reviewBody": "Very simple recipe with excellent results. I used a pre-made whole wheat pizza crust. I followed the directions but tweaked them just a pinch:I sauteed the garlic in olive oil over medium heat for about 1-2 minutes, then poured that over the roma tomatoes and I let them marinate for about 20-25 minutes. I used a mix of fontina cheese, italian blend shredded cheese, and parmesan cheese. I didn't use a pizza stone, I just put it right on the oven rack because we prefer a crispier crust. Do yourself a favor and make this tonight!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Chef Janet"
-},
-"reviewBody": "The best pizza we have ever made!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Ed's Kitchen"
-},
-"reviewBody": "Delicious! Make sure the feta goes on first"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Tanya"
-},
-"reviewBody": "Super tasty! I had a bunch of fresh tomatoes and basil and found this recipe in a search. So glad I did! Will definitely be coming back to this one"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Kiely"
-},
-"reviewBody": "My husband who rarely cooks made this last night and we both couldn't stop eating even though we were full! This was so good and I usually don't like pizza without red sauce. I told him he can make this anytime."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Leah13"
-},
-"reviewBody": "This turned out great! I only used mozzarella, feta, and Parmesan, because I didn't have fontina. It was still really good. I also found that I didn't need quite that many Roma tomatoes. I used Jay's signature crust, but scaled it down to use rapid rise pizza crust yeast, and it made a very nice thinner crust. I think the thinner crust makes the flavors pop more."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "4"
-},
-"author": {
-"@type": "Person",
-"name": "jw-1"
-},
-"reviewBody": "The pizza is delicious. Although 8 Roma tomatoes is way to much unless you like soggy pizza.We added some grilled chicken to one pizza and left the other as the recipe is written."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "music8485"
-},
-"reviewBody": "Absolutely delicious and restaurant-quality! Due to our budget, we only used mozzarella and freshly grated parmesan, but it was so good!Also used homemade crust (Jay's signature from this site, partially cooked first. Can't wait to make again and excited for tomorrow's leftovers!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "nanaofthree"
-},
-"reviewBody": "We made our own pizza dough - but other than that, followed the recipe as written. Excellent!!!! Thank you Michelle."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "dst405"
-},
-"reviewBody": "Really love this pizza! I thought it may be to bland at first, however, each bite just got better and better. The cheeses blended well, but, the tomatoes and garlic are the stars! Yummy!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "Patty Wiley"
-},
-"reviewBody": "Used Boboli whole wheat crust. Marinated tomatoes for an hour. Baked for 15 minutes."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "ALLSPRTMOM"
-},
-"reviewBody": "I think this is a wonderful recipe and will use homemade pizza dough or pre-packaged whatever my time allows."
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "5"
-},
-"author": {
-"@type": "Person",
-"name": "mysticquest"
-},
-"reviewBody": "I don't think I've ever had a pizza that tasted so good and I've had more than my share of pizzas in my life. Something this easy shouldn't taste this good. I'll be definitely making this one again and again!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "3"
-},
-"author": {
-"@type": "Person",
-"name": "linny"
-},
-"reviewBody": "The pre bought crust ruins this recipe as far as I'm concerned. I tried again 1 time with rhodes frozen bread dough and another with my home made recipe and everyone gobbled it up. I guess my friends and family like Chicago style thicker more tender crusts. Topping part of recipe was great. Thanks!"
-}
-,
-{
-"@type": "Review",
-"reviewRating": {
-"@type": "Rating",
-"ratingValue": "3"
-},
-"author": {
-"@type": "Person",
-"name": "shannon"
-},
-"reviewBody": "Good, simple pizza. Me, I'm an avid pizza fan and would rather make my crust from scratch, such as using Jay's Signature Pizza Crust recipe, as part of the adventure. I also prefer not to add salt to this recipe as there's plenty already in the cheeses. I added a couple pinches of ground anise seed and coarse black pepper on top which worked excellent. I always have best results by using a pre-heated pizza stone with either pre-made or scratch crusts. Pre-bake fresh dough crust for a few minutes prior to topping and finishing in the oven."
+"reviewBody": "WOW. My family loves this pizza. I was a little skeptical about the combination but I have a thing for gorgonzola so I gave it a try. Fantastic. Tastes like an expensive gourmet pizza. I followed the ingredient list but just put on however much I wanted. I also pre baked the crust. Thank you so much for sharing this.",
+"datePublished": "2021-04-18T22:04:52.400Z"
 }
 ]
 ,"mainEntityOfPage": {
@@ -1917,67 +800,101 @@ Mntl.PageView.init(pageViewDataAsJSON);
 }
 }
 ]
-}
-}
-, "about": [
-]
-}
-]</script><!-- end: comp allrecipes-schema mntl-schema-unified -->		
-
-					
-					<meta property="fb:pages" content="71158748377" />
-</head>		
-<body>
+}} }
+]</script>
+<meta property="fb:pages" content="71158748377" />
+</head><body>
+<!-- resourcesvgftl -->
 <svg class="mntl-svg-resource is-hidden">
 <defs>
-<symbol id="icon-chevron_right">
+<symbol id="icon-menu">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 18h18v-2H3v2Zm0-5h18v-2H3v2Zm0-7v2h18V6H3Z"/></svg> </symbol>
+<symbol id="icon-close">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 5.61143L18.3886 4L12 10.3886L5.61143 4L4 5.61143L10.3886 12L4 18.3886L5.61143 20L12 13.6114L18.3886 20L20 18.3886L13.6114 12L20 5.61143Z"/></svg> </symbol>
+<symbol id="icon-logo">
+<svg viewBox="0 0 127 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M126.7 6.91231C126.7 3.0266 124.524 0.0315247 122.026 0.0315247C119.535 0.0315247 117.352 3.03448 117.352 6.91231C117.352 10.2699 118.983 12.3429 121.033 12.8473C121.017 13.6591 120.875 21.3202 120.103 29.7379C120.103 29.7379 120.78 30.0217 122.073 30.0217C123.366 30.0217 124.272 29.7379 124.272 29.7379C123.523 22.2975 123.2 15.1172 123.121 13.1704C123.121 13.1547 122.885 13.2414 122.554 13.1468C122.278 13.0759 122.128 12.9655 122.144 12.9655C122.16 12.9655 122.175 12.9655 122.191 12.9655C122.459 12.9655 122.743 12.9103 122.924 12.8709C122.932 12.8709 122.94 12.8709 122.948 12.8631C123.05 12.8394 123.113 12.8236 123.113 12.8236C125.123 12.2719 126.7 10.2148 126.7 6.91231Z" fill="#F7AF31"/><path fill-rule="evenodd" clip-rule="evenodd" d="M0.0393066 23.7635C0.0393066 20.8236 2.08857 19.7123 4.6265 19.0581L8.81172 18.0256V17.868C8.81172 16.3783 7.85014 15.8502 5.95852 15.8502C4.38216 15.8502 2.87674 16.2207 1.19793 16.7094L1.49743 12.9497C3.22354 12.4138 5.10729 12.0039 7.21172 12.0039C11.1447 12.0039 13.1309 13.3911 13.1309 17.2296V27.3025H8.81172V25.4818C7.51911 27.0424 5.72995 27.6493 4.09054 27.6493C1.97034 27.6493 0.0393066 26.6089 0.0393066 23.7635ZM4.51615 23.1488C4.51615 24.1655 5.20187 24.5754 6.04522 24.5754C6.90433 24.5754 7.95261 24.1182 8.80384 23.3773V20.2798L7.67674 20.6108C5.52502 21.2098 4.51615 21.9192 4.51615 23.1488Z" fill="#F15025"/><path d="M15.3931 7.21181V27.3025H19.7202V6.72314L15.3931 7.21181ZM22.1399 7.21181V27.3025H26.4749V6.72314L22.1399 7.21181ZM28.8945 12.6424V27.2946H33.2295V18.3882C34.798 17.3872 36.6896 17.1113 38.3133 17.1901L38.5418 12.0434C35.7201 12.0434 34.2857 13.1941 33.2295 17.0246V12.1379L28.8945 12.6424Z" fill="#F15025"/><path fill-rule="evenodd" clip-rule="evenodd" d="M52.8394 15.8187L53.1153 16.4965C53.4778 17.3635 53.0916 18.1438 52.2325 18.53L44.1301 22.3054C44.8315 23.0699 45.935 23.535 47.5035 23.535C49.0956 23.535 51.4207 23.0699 53.1547 21.7537L52.8709 26.0493C51.7517 26.7901 49.7655 27.6414 46.999 27.6414C41.9468 27.6414 39.0542 24.5202 39.0542 19.7675C39.0542 14.3054 42.9478 11.996 46.7468 11.996C50.002 11.9803 51.9803 13.6827 52.8394 15.8187ZM46.8177 15.4089C44.8709 15.4089 43.1448 16.6069 43.1448 19.3892C43.1448 19.4532 43.1469 19.5173 43.1489 19.5803C43.1508 19.6414 43.1527 19.7014 43.1527 19.7596L49.3242 16.8827C48.8907 16.0552 48.2049 15.4089 46.8177 15.4089Z" fill="#F15025"/><path d="M62.3448 15.8502C63.5113 15.8502 64.6699 16.2364 65.5054 16.6699V12.5635C64.2364 12.1695 62.7389 12.0039 61.5645 12.0039 56.6463 12.0039 54.0847 15.0778 54.0847 19.8227 54.0847 24.5596 56.6463 27.6414 61.5724 27.6414 62.7862 27.6414 64.3704 27.4128 65.8601 26.8532V22.7941C64.7803 23.2906 63.5428 23.6926 62.3527 23.6926 60.0827 23.6926 58.4276 22.463 58.4276 19.8069 58.4276 17.1665 60.0827 15.8502 62.3448 15.8502ZM67.6492 27.3025H71.9841V12.1537L67.6492 12.6424V27.3025ZM69.8008 5.85616C68.0668 5.85616 66.9949 6.90443 66.9949 8.36256 66.9949 9.84433 68.0589 10.8926 69.8008 10.8926 71.5348 10.8926 72.5515 9.84433 72.5515 8.36256 72.5594 6.90443 71.5348 5.85616 69.8008 5.85616Z" fill="#F15025"/><path fill-rule="evenodd" clip-rule="evenodd" d="M74.4038 31.9842V12.6424L78.7388 12.1458V13.9744C79.7792 12.934 81.2137 12.0039 83.2629 12.0039 86.392 12.0039 88.6777 14.203 88.6777 19.1921 88.6777 24.7566 85.3989 27.6493 81.0797 27.6493 80.1811 27.6493 79.4009 27.5074 78.7388 27.3025V31.9842H74.4038ZM84.1378 19.6414C84.1536 17.4975 83.4284 15.5586 80.9851 15.5586 80.0866 15.5586 79.3614 15.8424 78.7388 16.2364V24.0709C79.1802 24.1655 79.6688 24.2207 80.1969 24.2207 82.8846 24.2207 84.1457 22.534 84.1378 19.6414ZM103.558 15.8187 103.834 16.4965C104.197 17.3635 103.811 18.1438 102.952 18.53L94.8491 22.3054C95.5505 23.0699 96.654 23.535 98.2225 23.535 99.8146 23.535 102.14 23.0699 103.874 21.7537L103.59 26.0493C102.471 26.7901 100.485 27.6414 97.718 27.6414 92.6658 27.6414 89.7732 24.5202 89.7732 19.7675 89.7732 14.3054 93.6668 11.996 97.4658 11.996 100.721 11.9803 102.699 13.6827 103.558 15.8187ZM97.5367 15.4089C95.5899 15.4089 93.8638 16.6069 93.8638 19.3892 93.8638 19.4532 93.8659 19.5173 93.8679 19.5803 93.8698 19.6414 93.8717 19.7014 93.8717 19.7596L100.043 16.8827C99.6096 16.0552 98.9239 15.4089 97.5367 15.4089Z" fill="#F15025"/><path d="M109.226 16.6542C109.226 15.7163 110.51 15.4798 111.748 15.4798C112.961 15.4798 114.427 15.6768 116.185 16.4571L116.067 12.8473C114.971 12.3586 113.505 12.0039 111.629 12.0039C106.829 12.0039 105.261 14.3133 105.261 16.7803C105.261 22.7862 112.686 20.3586 112.686 22.7941C112.686 23.7872 111.606 24.0158 110.55 24.0158C108.429 24.0158 106.656 23.4089 105.237 22.597L104.985 26.4118C106.475 27.1685 108.445 27.6414 110.542 27.6414C115.153 27.6414 116.918 25.3793 116.918 22.4552C116.934 16.6463 109.226 18.9163 109.226 16.6542Z" fill="#F15025"/></svg> </symbol>
+<symbol id="icon-caret_down">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8 10L12 14L16 10H8Z"/></svg> </symbol>
+<symbol id="icon-account">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2C6.48 2 2 6.48 2 12ZM12 5C13.66 5 15 6.34 15 8C15 9.66 13.66 11 12 11C10.34 11 9 9.66 9 8C9 6.34 10.34 5 12 5ZM12 19.2C9.5 19.2 7.29 17.92 6 15.98C6.03 13.99 10 12.9 12 12.9C13.99 12.9 17.97 13.99 18 15.98C16.71 17.92 14.5 19.2 12 19.2Z"/></svg> </symbol>
+<symbol id="icon-search">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.5 14H14.71L14.43 13.73C15.41 12.59 16 11.11 16 9.5C16 5.91 13.09 3 9.5 3C5.91 3 3 5.91 3 9.5C3 13.09 5.91 16 9.5 16C11.11 16 12.59 15.41 13.73 14.43L14 14.71V15.5L19 20.49L20.49 19L15.5 14ZM9.5 14C7.01 14 5 11.99 5 9.5C5 7.01 7.01 5 9.5 5C11.99 5 14 7.01 14 9.5C14 11.99 11.99 14 9.5 14Z"/></svg> </symbol>
+<symbol id="icon-error">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2V2ZM13 17H11V15H13V17V17ZM13 13H11V7H13V13V13Z" fill="#C00"/></svg> </symbol>
+<symbol id="icon-chevron">
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M10 6L8.59003 7.41L13.17 12L8.59003 16.59L10 18L16 12L10 6Z"/></svg> </symbol>
+<symbol id="icon-arrow-left">
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M16 8L14.59 6.59L9 12.17V0H7V12.17L1.42 6.58L0 8L8 16L16 8Z"/></svg> </symbol>
+<symbol id="icon-facebook">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.282 8.46782H13.12V6.39482C13.12 5.61682 13.637 5.43482 14 5.43482H16.23V2.01182L13.157 1.99982C9.748 1.99982 8.972 4.55382 8.972 6.18682V8.46782H7V11.9938H8.972V21.9728H13.12V11.9938H15.919L16.282 8.46782Z"/></svg> </symbol>
+<symbol id="icon-instagram">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8.27326 3.05416C9.23411 3.01036 9.54091 3 11.9876 3C14.4343 3 14.7411 3.01036 15.7019 3.05416C16.6608 3.09785 17.3157 3.25001 17.8888 3.47247C18.4812 3.70247 18.9836 4.01021 19.4844 4.51055C19.9852 5.01092 20.2933 5.51283 20.5235 6.10466C20.7462 6.67712 20.8985 7.33137 20.9423 8.28931C20.9861 9.24926 20.9965 9.55575 20.9965 12C20.9965 14.4443 20.9861 14.7507 20.9423 15.7107C20.8985 16.6686 20.7462 17.3229 20.5235 17.8953C20.2933 18.4872 19.9852 18.9891 19.4844 19.4895C18.9836 19.9898 18.4812 20.2975 17.8888 20.5275C17.3157 20.75 16.6608 20.9021 15.7019 20.9458C14.7411 20.9896 14.4343 21 11.9876 21C9.54091 21 9.23411 20.9896 8.27326 20.9458C7.31433 20.9021 6.65948 20.75 6.08642 20.5275C5.494 20.2975 4.9916 19.9898 4.49077 19.4895C3.98994 18.9891 3.6819 18.4872 3.45167 17.8953C3.22895 17.3229 3.07668 16.6686 3.03291 15.7107C2.98907 14.7507 2.9787 14.4443 2.9787 12C2.9787 9.55575 2.98907 9.24926 3.03291 8.28931C3.07668 7.33137 3.22895 6.67712 3.45167 6.10466C3.6819 5.51283 3.98994 5.01092 4.49077 4.51055C4.9916 4.01021 5.494 3.70247 6.08642 3.47247C6.65948 3.25001 7.31433 3.09785 8.27326 3.05416ZM15.6279 4.6741C14.678 4.6308 14.3931 4.62162 11.9876 4.62162C9.5821 4.62162 9.2972 4.6308 8.34721 4.6741C7.46889 4.71411 6.99184 4.86073 6.6744 4.98398C6.25392 5.14725 5.95382 5.34227 5.63855 5.65723C5.32332 5.97215 5.12806 6.27196 4.96464 6.69206C4.8413 7.00919 4.69454 7.48574 4.65445 8.36323C4.61111 9.31224 4.60195 9.5969 4.60195 12C4.60195 14.4031 4.61111 14.6878 4.65445 15.6368C4.69454 16.5143 4.8413 16.9908 4.96464 17.3079C5.12806 17.728 5.32332 18.0278 5.63855 18.3428C5.95382 18.6577 6.25392 18.8528 6.6744 19.016C6.99184 19.1393 7.46889 19.2859 8.34725 19.3259C9.29705 19.3692 9.58196 19.3784 11.9876 19.3784C14.3932 19.3784 14.6781 19.3692 15.6279 19.3259C16.5063 19.2859 16.9833 19.1393 17.3008 19.016C17.7213 18.8528 18.0214 18.6577 18.3366 18.3428C18.6519 18.0278 18.8471 17.728 19.0105 17.3079C19.1339 16.9908 19.2806 16.5143 19.3207 15.6368C19.3641 14.6878 19.3732 14.4031 19.3732 12C19.3732 9.5969 19.3641 9.31224 19.3207 8.36323C19.2806 7.48574 19.1339 7.00919 19.0105 6.69206C18.8471 6.27196 18.6519 5.97215 18.3366 5.65723C18.0214 5.34227 17.7213 5.14725 17.3008 4.98398C16.9833 4.86073 16.5063 4.71411 15.6279 4.6741ZM8.99787 12.009C8.99787 13.6324 10.3424 14.9485 12.0008 14.9485C13.6593 14.9485 15.0038 13.6324 15.0038 12.009C15.0038 10.3855 13.6593 9.06948 12.0008 9.06948C10.3424 9.06948 8.99787 10.3855 8.99787 12.009ZM7.37466 12.009C7.37466 9.50799 9.44588 7.48056 12.0008 7.48056C14.5558 7.48056 16.627 9.50799 16.627 12.009C16.627 14.51 14.5558 16.5374 12.0008 16.5374C9.44588 16.5374 7.37466 14.51 7.37466 12.009ZM16.1487 8.49799C16.7457 8.49799 17.2297 8.02423 17.2297 7.43978C17.2297 6.85533 16.7457 6.38157 16.1487 6.38157C15.5516 6.38157 15.0676 6.85533 15.0676 7.43978C15.0676 8.02423 15.5516 8.49799 16.1487 8.49799Z"/></svg> </symbol>
+<symbol id="icon-pinterest">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.00043 9.157C4.00043 11.129 4.74543 12.882 6.34643 13.535C6.60843 13.642 6.84443 13.539 6.91943 13.249C6.97343 13.048 7.09743 12.54 7.15343 12.329C7.23043 12.041 7.20143 11.941 6.98943 11.69C6.52743 11.146 6.23343 10.441 6.23343 9.443C6.23343 6.548 8.39943 3.955 11.8744 3.955C14.9504 3.955 16.6424 5.835 16.6424 8.347C16.6424 11.651 15.1794 14.439 13.0084 14.439C11.8094 14.439 10.9134 13.447 11.2004 12.231C11.5454 10.78 12.2114 9.214 12.2114 8.166C12.2114 7.228 11.7094 6.445 10.6674 6.445C9.44143 6.445 8.45643 7.713 8.45643 9.411C8.45643 10.493 8.82243 11.224 8.82243 11.224C8.82243 11.224 7.56843 16.538 7.34843 17.468C6.91043 19.321 7.28243 21.593 7.31443 21.823C7.33243 21.958 7.50743 21.991 7.58743 21.888C7.69943 21.74 9.15843 19.938 9.65543 18.138C9.79543 17.629 10.4614 14.988 10.4614 14.988C10.8604 15.748 12.0234 16.417 13.2604 16.417C16.9444 16.417 19.4434 13.059 19.4434 8.564C19.4434 5.165 16.5644 2 12.1894 2C6.74443 2 4.00043 5.903 4.00043 9.157Z"/></svg> </symbol>
+<symbol id="icon-tiktok">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M20.4761 9.49649C20.3086 9.5129 20.1411 9.52165 19.9736 9.52293C18.1346 9.52293 16.4192 8.5702 15.4105 6.98779V15.6201C15.4105 19.1431 12.6324 22 9.20399 22C5.77554 22 3 19.1431 3 15.6201C3 12.097 5.77798 9.24008 9.20644 9.24008C9.33604 9.24008 9.4632 9.25266 9.59036 9.26023V12.4037C9.4632 12.3886 9.33727 12.3635 9.20644 12.3635C7.45675 12.3635 6.03964 13.8215 6.03964 15.6188C6.03964 17.4174 7.45798 18.8741 9.20644 18.8741C10.9561 18.8741 12.5016 17.4576 12.5016 15.659L12.5322 1H15.4581C15.7344 3.69727 17.8497 5.8038 20.481 6.00113V9.4953"/></svg> </symbol>
+<symbol id="icon-youtube">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.8139 5.42068C20.6744 5.65216 21.352 6.3342 21.582 7.20034C22 8.77011 22 12.0455 22 12.0455C22 12.0455 22 15.3207 21.582 16.8907C21.352 17.7567 20.6744 18.4387 19.8139 18.6703C18.2542 19.0909 12 19.0909 12 19.0909C12 19.0909 5.7458 19.0909 4.18614 18.6703C3.32568 18.4387 2.64795 17.7567 2.41795 16.8907C2 15.3207 2 12.0455 2 12.0455C2 12.0455 2 8.77011 2.41795 7.20034C2.64795 6.3342 3.32568 5.65216 4.18614 5.42068C5.7458 5 12 5 12 5C12 5 18.2542 5 19.8139 5.42068ZM15.1818 12.0456L9.95455 15.0192V9.0717L15.1818 12.0456Z"/></svg> </symbol>
+<symbol id="icon-x">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.6468 10.4686L20.9321 2H19.2057L12.8799 9.3532L7.82741 2H2L9.6403 13.1193L2 22H3.72649L10.4068 14.2348L15.7425 22H21.57L13.6468 10.4686ZM11.2821 13.2173L10.508 12.1101L4.34857 3.29968H7.00037L11.9711 10.4099L12.7452 11.5172L19.2066 20.7594H16.5548L11.2821 13.2173Z"/></svg> </symbol>
+<symbol id="icon-linkedin">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5.90187 7.78789C4.8515 7.78789 4 6.98834 4 5.8944C4 4.8003 4.8515 4 5.90187 4C6.95223 4 7.80373 4.8003 7.80373 5.8944C7.80373 6.98834 6.95223 7.78789 5.90187 7.78789ZM4.25243 19.7198H7.55133V9.24009H4.25243V19.7198ZM16.4144 19.7279H19.7132V13.2463C19.7132 10.0453 17.724 8.95331 15.8832 8.95331C14.1812 8.95331 13.0668 10.0549 12.7477 10.6999H12.7056V9.24802H9.53307V19.7279H12.8318V14.046C12.8318 12.5311 13.7917 11.7943 14.7704 11.7943C15.6964 11.7943 16.4144 12.3151 16.4144 14.004V19.7279Z"/></svg> </symbol>
+<symbol id="icon-website">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2V2ZM11 19.93C7.05 19.44 4 16.08 4 12C4 11.38 4.08 10.79 4.21 10.21L9 15V16C9 17.1 9.9 18 11 18V19.93V19.93ZM17.9 17.39C17.64 16.58 16.9 16 16 16H15V13C15 12.45 14.55 12 14 12H8V10H10C10.55 10 11 9.55 11 9V7H13C14.1 7 15 6.1 15 5V4.59C17.93 5.78 20 8.65 20 12C20 14.08 19.2 15.97 17.9 17.39V17.39Z"/></svg> </symbol>
+<symbol id="icon-flipboard">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M8 0H0V24H8V0Z"/><path d="M16.0533 0H7.97858V8.01068H16.0533 23.9999V0H16.0533ZM15.9893 8.01074H7.97858V16.0214H15.9893V8.01074Z"/></svg> </symbol>
+<symbol id="icon-myr-close">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.69 6.809A1.06 1.06 0 0 0 17.19 5.31L12 10.502 6.809 5.31A1.06 1.06 0 0 0 5.31 6.81L10.502 12 5.31 17.191A1.06 1.06 0 0 0 6.81 18.69L12 13.498l5.191 5.192a1.06 1.06 0 0 0 1.499-1.499L13.498 12l5.192-5.191Z" fill-opacity=".95"/></svg> </symbol>
+<symbol id="icon-myr-favorite-flat">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 19"><path d="M14.32 1.668a4.866 4.866 0 0 0-2.038.463c-.64.302-1.212.74-1.68 1.286l-.6.717-.6-.717a5.038 5.038 0 0 0-1.68-1.286 4.842 4.842 0 0 0-2.037-.463 4.214 4.214 0 0 0-1.701.31 4.343 4.343 0 0 0-1.452.975 4.552 4.552 0 0 0-.976 1.484A4.709 4.709 0 0 0 1.208 6.2c0 1.516.632 2.974 2.063 4.748a60.049 60.049 0 0 0 5.868 5.832l.863.832.864-.79a61.466 61.466 0 0 0 5.868-5.832c1.43-1.825 2.063-3.283 2.063-4.79a4.722 4.722 0 0 0-.348-1.763 4.55 4.55 0 0 0-.976-1.484 4.352 4.352 0 0 0-1.452-.974 4.213 4.213 0 0 0-1.701-.31Z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12.282 2.131c.64-.3 1.335-.458 2.037-.463.582-.015 1.16.09 1.702.31.541.222 1.035.552 1.452.975.418.422.75.927.977 1.484.226.558.345 1.157.347 1.763 0 1.507-.632 2.965-2.063 4.79a61.456 61.456 0 0 1-5.868 5.831l-.864.791-.863-.832a60.05 60.05 0 0 1-5.868-5.832C1.84 9.174 1.208 7.716 1.208 6.2c.002-.606.12-1.205.348-1.763a4.552 4.552 0 0 1 .975-1.484c.417-.423.911-.754 1.453-.974a4.214 4.214 0 0 1 1.7-.31 4.842 4.842 0 0 1 2.038.462c.64.302 1.213.74 1.68 1.286l.6.717.6-.717a5.037 5.037 0 0 1 1.68-1.286Zm-2.28.706a5.867 5.867 0 0 1 1.925-1.46 5.702 5.702 0 0 1 2.379-.542 5.045 5.045 0 0 1 2.029.372 5.185 5.185 0 0 1 1.73 1.16 5.382 5.382 0 0 1 1.156 1.756c.268.657.407 1.362.409 2.074V6.2c0 1.772-.755 3.41-2.24 5.304l-.015.019-.016.017a62.298 62.298 0 0 1-5.939 5.903l-1.432 1.313-1.412-1.361a60.888 60.888 0 0 1-5.932-5.897l-.011-.013-.011-.014C1.129 9.62.375 7.981.375 6.2v-.003c.002-.71.14-1.417.409-2.074a5.385 5.385 0 0 1 1.154-1.756 5.176 5.176 0 0 1 1.731-1.16A5.05 5.05 0 0 1 5.7.835a5.676 5.676 0 0 1 2.377.542 5.87 5.87 0 0 1 1.926 1.46Z" fill="#000"/></svg> </symbol>
+<symbol id="icon-myr-logo">
+<svg viewBox="0 0 159 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20.896 25.227H31.05c-2.156-2.44-1.718-5.974-1.755-8.662-.022-1.54.214-5.918-.34-7.338-.265-.679-1.394-2.503-4.024-2.371-3.17.162-5.83 3.019-5.83 3.019s-.278-3.175-3.83-3.022c-3.322.143-6.19 3.293-6.19 3.293v-3.03L.448 7.68v17.537h8.62v-9.275c0-.515 0-1.63.016-1.667.054-.641.264-1.3 1.038-1.203.818.1.803 1.247.803 2.214v9.94h8.138V15.109c0-.659-.117-2.177 1.034-2.036.818.1.802 1.247.802 2.214l-.004 9.94Z" fill="#FF3FA4"/><path d="M64.16 6.87v7.946c-2.01-.243-4.158-.207-6.064.621v9.778h-6.722V7.594l6.722-.688v6.806c1.212-5.634 2.252-6.913 6.064-6.843ZM75.529 19.929c2.217 0 4.504-.933 6.513-2.35l-.52 6.254c-1.35.864-3.673 1.797-7.132 1.797-5.821 0-9.875-3.49-9.875-9.398 0-6.53 4.816-9.433 9.529-9.433 3.95-.034 6.583 1.867 7.692 4.562l.416 1c.519 1.28.034 2.455-1.213 3.008l-8.39 3.8c.762.483 1.731.76 2.98.76Zm-4.888-4.492v.345l5.751-2.59c-.449-.726-1.108-1.318-2.39-1.318-1.696.004-3.36 1.007-3.36 3.563ZM82.685 16.197c0-5.596 2.876-9.398 9.598-9.398 2.08 0 3.86.581 4.799 1.054l-.013 5.853c-.867-.415-2.36-1.003-3.955-1.003-2.246 0-3.707 1.07-3.707 3.489 0 2.418 1.453 3.352 3.707 3.352 1.594 0 2.617-.413 3.963-.897l-.014 6.128c-1.144.483-2.499.85-4.785.85-7.099.005-9.593-3.796-9.593-9.428ZM97.751 3.766c0-2.212 1.593-3.766 4.123-3.766 2.529 0 4.017 1.554 4.017 3.766 0 2.177-1.49 3.766-4.02 3.766-2.53 0-4.12-1.589-4.12-3.766Zm.692 4.684 6.723-.725v17.49h-6.722V8.45ZM124.647 15.467c0 6.808-3.81 10.158-8.904 10.158a9.196 9.196 0 0 1-2.356-.275v5.532h-6.729V7.593l6.515-.69v2.004c1.074-1.037 2.529-2.108 4.92-2.108 3.707 0 6.554 2.591 6.554 8.668Zm-7 .79c0-1.52-.209-4.007-3.153-4.007a5.304 5.304 0 0 0-1.11.102v8.155h.521c3.213.01 3.702-1.926 3.742-4.24v-.01ZM136.139 19.929c2.218 0 4.505-.726 6.514-2.098l.008 5.965c-1.352.82-4.201 1.834-7.662 1.834-5.821 0-9.875-3.49-9.875-9.398 0-6.53 4.816-9.433 9.529-9.433 3.95-.034 6.584 1.867 7.692 4.562l.416 1c.52 1.28.034 2.455-1.213 3.008l-8.385 3.8c.755.483 1.724.76 2.976.76Zm-4.887-4.492v.345l5.753-2.59c-.451-.726-1.11-1.318-2.393-1.318-1.7.004-3.36 1.007-3.36 3.563ZM158.149 12.95a21.57 21.57 0 0 0-6.167-.9c-.66 0-1.87.036-1.87.66 0 .76 1.801.658 3.846.966 2.806.415 4.989 1.382 4.989 5.321 0 3.524-1.94 6.634-8.524 6.634a17.02 17.02 0 0 1-6.504-1.338l-.01-5.84c2.01 1.098 4.124 1.685 6.376 1.685 1.524 0 2.356-.276 2.356-.83 0-.691-1.321-.76-3.084-.968-2.46-.275-5.648-.898-5.648-5.32 0-3.178 1.663-6.22 8.177-6.22 2.391 0 4.297.381 5.68 1.037l.383 5.112Z" fill="currentColor"/><path d="M49.72 7.331h-8.572v9.86c0 .658 0 2.239-1.146 2.092-.818-.1-.802-1.247-.802-2.214V7.331h-9.466c.84.988 1.097 2.778 1.097 3.889 0 0-.05 8.256.107 9.84.157 1.585 1.232 4.084 5.17 4.375 3.017.224 4.422-1.306 5.035-1.996.174.415-.17 2.558-2.95 3.293-2.655.697-5.02-.337-5.64-.659-.175 1.696-.518 4.19-.518 4.19s3.46 2.396 9.146 1.56c7.329-1.078 8.536-7.059 8.537-9.203.003-3.24.003-14.04.003-15.289Z" fill="#FF3FA4"/></svg> </symbol>
+<symbol id="save-icon-favorite">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z"/></svg> </symbol>
+<symbol id="icon-privacy-options">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 14"><path fill="#FFF" d="M7.4 12.8h6.8l3.1-11.6H7.4C4.2 1.2 1.6 3.8 1.6 7s2.6 5.8 5.8 5.8z"/><path fill="#06f" d="M22.6 0H7.4c-3.9 0-7 3.1-7 7s3.1 7 7 7h15.2c3.9 0 7-3.1 7-7s-3.2-7-7-7zm-21 7c0-3.2 2.6-5.8 5.8-5.8h9.9l-3.1 11.6H7.4c-3.2 0-5.8-2.6-5.8-5.8z"/><path fill="#FFF" d="M24.6 4c.2.2.2.6 0 .8L22.5 7l2.2 2.2c.2.2.2.6 0 .8-.2.2-.6.2-.8 0l-2.2-2.2-2.2 2.2c-.2.2-.6.2-.8 0-.2-.2-.2-.6 0-.8L20.8 7l-2.2-2.2c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0l2.2 2.2L23.8 4c.2-.2.6-.2.8 0z"/><path fill="#06f" d="M12.7 4.1c.2.2.3.6.1.8L8.6 9.8c-.1.1-.2.2-.3.2-.2.1-.5.1-.7-.1L5.4 7.7c-.2-.2-.2-.6 0-.8.2-.2.6-.2.8 0L8 8.6l3.8-4.5c.2-.2.6-.2.9 0z"/>​</svg> </symbol>
+<symbol id="mntl-dotdash-universal-nav__logo">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="5 2.8 290 69"><circle cx="39.6" cy="37.4" r="34.3" fill="#f44b34"/><path fill="#fff" d="M50.4 17.9c-1.7-1.8-4-2.6-7-2.6-9.1-.1-12.4-.1-13.2-.1L27.3 22h8.1L30 28v21h-.1l.1.1v6.7l-3.6 4h18.5L53 51V25c0-.1.1-4.3-2.6-7.1zm-5.2 19.6-7.4 7.8V41l7.4-7.8v4.3zm-7.4-15.4h3c.9 0 2.1-.1 3.1.9s1.4 2.5 1.4 4.9v3.6l-7.4 7.8-.1-17.2zm-4.9 30.1 3.3-3.6 9-9.5v13.1c0 .1-12.3.1-12.3 0z"/><path fill="#009ad9" d="m99.645 22.637 6.505-6.506 4.172 4.172-6.505 6.506zM121 44l4.2 4.2 6.5-6.5-4.2-4.2zm-3.2-31.2c1.8-1.8 4.7-1.8 6.5 0 1.9 1.9 1.7 4.8 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c2-2 4.9-1.6 6.5 0 2 2 1.6 4.9 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c4.2-4.2 4-10.8 0-14.8-2.8-2.8-6.1-3.1-7.6-3.1.1-1.5-.3-4.8-3.1-7.6-3.9-3.9-10.6-4.2-14.8 0l-3.3 3.3 4.2 4.2 3.2-3.4zm-7.5 20.6 4.2 4.1L121 31l-4.2-4.1-6.5 6.5z"/><path fill="#6ebd44" d="m99.6 52.4 6.6 6.5 4.1-4.2-6.5-6.5zm36.3-14.9-4.2 4.2L135 45c1.6 1.6 2 4.5 0 6.5-1.6 1.6-4.5 2.1-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c1.7 1.7 1.9 4.6 0 6.5-1.8 1.8-4.7 1.8-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c4.2 4.2 10.9 3.9 14.8 0 2.8-2.8 3.1-6.1 3.1-7.6 1.5 0 4.8-.3 7.6-3.1 4-4 4.2-10.6 0-14.8l-3.2-3.4zm-25.6 4.2 6.5 6.5L121 44l-6.5-6.5zm14.9-14.8L121 31l6.5 6.5 4.2-4.1-6.5-6.5z"/><path fill="#f68f1e" d="m110.332 54.607 6.506-6.506 4.172 4.172-6.506 6.505zM102.8 62.2c-1.6 1.6-4.5 2-6.5 0-1.6-1.6-2.1-4.5 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-1.7 1.7-4.6 1.9-6.5 0-1.8-1.8-1.8-4.7 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-4.2 4.2-3.9 10.9 0 14.8 2.8 2.8 6.1 3.1 7.6 3.1 0 1.5.3 4.8 3.1 7.6 4 4 10.6 4.2 14.8 0l3.3-3.3-4.2-4.2-3.2 3.4zm3.4-24.7L99.6 44l4.2 4.2 6.5-6.5zM95.5 26.9 89 33.4l4.1 4.1 6.5-6.5z"/><path fill="#ec174c" d="m99.6 44-6.5-6.5-4.1 4.2 6.5 6.5zm-14-14c-1.8-1.8-1.8-4.7 0-6.5 1.9-1.9 4.8-1.7 6.5 0l3.3 3.3 4.2-4.2-3.3-3.3c-2-2-1.6-4.9 0-6.5 2-2 4.9-1.6 6.5 0l3.3 3.3 4.2-4.2-3.3-3.2c-4.2-4.2-10.8-4-14.8 0-2.8 2.8-3.1 6.1-3.1 7.6-1.5-.1-4.9.3-7.6 3.1-3.9 3.9-4.2 10.6 0 14.8l3.3 3.3 4.2-4.2-3.4-3.3zm24.73-9.682 4.172-4.172 6.505 6.505-4.172 4.172zM106.2 37.5l4.1-4.1-6.5-6.5-4.2 4.1 6.6 6.5z"/><path fill="#573357" d="m106.142 16.042 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#be272d" d="m84.81 37.543 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#008e4c" d="m127.497 37.555 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#7a773e" d="m106.172 58.866 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#443639" d="m116.856 26.74 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#803136" d="m95.455 48.169 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#593438" d="m95.446 26.753 4.172-4.172 4.172 4.173-4.172 4.171z"/><path fill="#443639" d="m106.155 37.456 4.172-4.172 4.172 4.171-4.172 4.172z"/><path fill="#2a6442" d="m116.871 48.153 4.172-4.172 4.172 4.172-4.172 4.172z"/><path d="M170.4 13.5c-2.5-2.2-5.7-3.3-9.6-3.3h-7.2v23.6h7.6c3.8 0 7-1.1 9.4-3.3s3.6-5 3.6-8.5-1.3-6.3-3.8-8.5zm.1 8.5c0 2.6-.9 4.7-2.6 6.2-1.7 1.6-4.1 2.3-7 2.3h-3.8V13.4h3.8c2.9 0 5.2.8 7 2.3 1.7 1.5 2.6 3.7 2.6 6.3zm14.6-6.3c-2.5 0-4.7.9-6.4 2.7s-2.6 4-2.6 6.6.9 4.8 2.6 6.6c1.7 1.8 3.9 2.7 6.4 2.7h.1v-.1c2.5 0 4.7-.9 6.4-2.7s2.6-4 2.6-6.6c0-2.5-.9-4.8-2.6-6.6-1.8-1.7-3.9-2.6-6.5-2.6zm4.1 13.7c-.5.6-1.1 1-1.8 1.3s-1.4.3-2.2.3c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 3 .6 4 1.7 1.1 1.2 1.6 2.6 1.6 4.3 0 1.9-.5 3.4-1.6 4.6zm16.9.8c-.5.6-1.3.9-2.3.9-1.6 0-2.4-.9-2.4-2.7v-9.2h5v-3h-5v-4.4h-3.3v4.4h-2.9l.1 3h2.9v9.3c0 1.9.5 3.3 1.4 4.3s2.2 1.5 3.9 1.5c1.8 0 3.2-.5 4.2-1.5l-1.6-2.6zm38.1-11.6c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V16.1h-3.4v2.5h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-.5.6-1.1 1-1.8 1.3s-1.4.4-2.2.4c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6.1 2.9.6 4 1.8zm17.9 3.6c-.9-.3-1.9-.6-3-.9-1-.3-1.9-.6-2.5-1-.7-.4-1-1-1-1.6l.1-.1c0-.7.3-1.2.9-1.6.6-.4 1.4-.6 2.3-.6 2 0 3.4.7 4.5 2l2-2c-1.3-1.8-3.5-2.7-6.6-2.7-1.9 0-3.5.5-4.7 1.4-1.2 1-1.7 2.1-1.7 3.5 0 1.2.3 2.1 1 2.9s1.5 1.3 2.6 1.7c1.1.4 2 .7 2.9 1 1 .3 1.8.7 2.4 1.1.7.5 1 1 1 1.8s-.3 1.4-.9 1.8c-.6.5-1.4.7-2.5.7-2.3 0-4.1-.8-5.3-2.3l-2 2.2c1.5 1.9 3.9 2.9 7.1 2.9 2.2 0 3.9-.5 5.1-1.5s1.8-2.3 1.8-3.8c0-1.2-.3-2.2-1-3-.6-.9-1.5-1.4-2.5-1.9zm14.9-8.6c-2.3 0-4.1.8-5.2 2.5V8.4h-3.4v25.4h3.4l.1-10.3c0-1.4.4-2.6 1.2-3.4.8-.8 1.8-1.2 3.2-1.2 1.3 0 2.4.4 3.2 1.3.8.8 1.2 2 1.2 3.4v10.3h3.4V23c0-2.3-.6-4-1.9-5.4-1.4-1.4-3.1-2-5.2-2zm-52.2 3c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V8.4h-3.4v10.2h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-1.1 1.2-2.4 1.8-4 1.8-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 2.9.5 4 1.7zm48.8 19.9h-3.6v19.1c0 2.4.7 4.1 2.1 5.1 1.2.9 3.1 1.4 5.6 1.4h.1v-3h-.1c-1.2 0-2.1-.2-2.7-.6-.9-.6-1.4-1.7-1.4-3.3V51h4.1v-3h-4.1v-7.5zm-96.2 7c-1.4 0-2.6.3-3.7 1-1 .6-1.7 1.5-2.3 2.6-1.2-2.4-3.2-3.6-6-3.6-2.2 0-4 .9-5.2 2.6V48h-3.5v18.2h3.5l.2-10.7c0-1.5.4-2.6 1.1-3.5.7-.9 1.8-1.3 3.1-1.3s2.3.4 3.1 1.3c.8.9 1.2 2 1.2 3.5v10.6h3.4V55.5c0-1.5.4-2.6 1.2-3.5s1.8-1.3 3.2-1.3c1.3 0 2.3.4 3.1 1.3.7.9 1.1 2 1.1 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5-1.3-1.3-3-2-5.1-2zm18.9 0c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7 1-.9 2.2-1.4 3.6-1.4zm22.5-2.3c-.6-.5-1.6-.8-2.8-.8-1.9 0-3.4.9-4.5 2.6v-2H205v18.2h3.5l-.1-10.5c0-1.5.3-2.7.9-3.6.6-.9 1.5-1.3 2.6-1.3.9 0 1.7.2 2.3.7h.1l1.4-3.3zm9-.7c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7.9-.9 2.1-1.4 3.6-1.4zm26.1 0c-1.5-2-3.6-3.1-6.3-3.1-2.5 0-4.6.9-6.3 2.7s-2.5 4.1-2.5 6.8.9 5 2.5 6.8c1.7 1.8 3.8 2.7 6.3 2.7 2.6 0 4.7-1.1 6.3-3.2v2.7h3.5V40.5h-3.5v10zm-1.7 2c1.1 1.2 1.6 2.7 1.6 4.5 0 1.7-.6 3.3-1.6 4.5-1.1 1.2-2.4 1.8-4.2 1.8-1.7 0-3.1-.6-4.2-1.8-1.1-1.2-1.7-2.7-1.7-4.5s.6-3.3 1.7-4.5c1.1-1.2 2.5-1.8 4.2-1.8 1.8.1 3.1.7 4.2 1.8zm43.5-3c-1.3-1.4-3-2.1-5.2-2.1-2.4 0-4.2.9-5.4 2.6v-9.6h-3.5v25.7h3.5l.1-10.5c0-1.5.4-2.6 1.2-3.5.8-.9 1.8-1.3 3.2-1.3 1.4 0 2.5.4 3.3 1.3.8.9 1.2 2 1.2 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5zM259.1 48h3.5v18.2h-3.5zm0-7.5h3.4v3.4h-3.4z"/></svg> </symbol>
+<symbol id="icon-arrow">
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="M16 8L14.59 6.59L9 12.17V0H7V12.17L1.42 6.58L0 8L8 16L16 8Z"/></svg> </symbol>
+<symbol id="icon-myr-plus-flat">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24.81 24.61"><path d="M.234 2.826L3.062-.002l21.75 21.75-2.828 2.829z"/><path d="M-.003 21.796L21.726.067l2.828 2.828-21.729 21.73z"/></svg> </symbol>
+<symbol id="icon-myr-delete">
+<svg viewBox="0 0 20 21" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5 16.758c0 .916.75 1.666 1.667 1.666h6.666c.917 0 1.667-.75 1.667-1.666v-10H5v10Zm10.833-12.5h-2.916l-.834-.834H7.917l-.834.834H4.167v1.666h11.666V4.258Z" fill-opacity=".95"/></svg> </symbol>
+<symbol id="icon-new-collection">
+<svg viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg"><path d="m 10.7567,1.748 c 2.0332,0.01666 3.8392,0.66823 5.3873,1.99041 1.5879,1.35677 2.5553,3.08458 2.8477,5.15396 0.3431,2.44853 -0.2624,4.65733 -1.8398,6.56753 -1.3587,1.6418 -2.6446,2.6072 -4.7527,2.9322 -0.2513,0.0436 -0.2649,0.0228 -0.2838,-0.2461 -0.0592,-0.7672 -0.1302,-1.5336 -0.1882,-2.3014 -0.0397,-0.5048 -0.0778,-0.9985 -0.1145,-1.5007 -0.0326,-0.4842 -0.0678,-0.9632 -0.088,-1.4507 -0.0162,-0.4096 0.0652,-0.7955 0.3341,-1.1239 0.3241,-0.3781 0.6438,-0.7696 0.9264,-1.1788 0.4499,-0.66803 0.668,-1.41719 0.7487,-2.2023 C 13.8088,7.65404 13.743,6.94664 13.4911,6.25091 13.3523,5.84372 13.1479,5.45539 12.8843,5.10893 12.5735,4.70758 11.9286,4.47331 11.4318,4.38456 10.7625,4.26633 9.89399,4.35675 9.34003,4.78258 8.9917,5.04362 8.53409,5.41956 8.35493,5.81102 7.6968,7.24716 7.75993,8.68258 8.3992,10.1108 c 0.24166,0.5299 0.62312,0.9753 0.99812,1.4132 0.25323,0.2914 0.23635,0.5919 0.28521,0.9907 0.02333,0.2238 0.01885,0.4466 0.00646,0.6715 -0.07167,1.018 -0.14584,2.0359 -0.22688,3.0502 -0.04198,0.6142 -0.09729,1.2244 -0.14,1.8365 C 9.2918,18.423 9.53013,18.424 9.19222,18.3725 7.63888,18.1124 6.49888,17.4735 5.31014,16.4335 3.96076,15.2576 3.04409,13.8068 2.65191,12.0595 2.04712,9.33518 2.60962,6.86049 4.40191,4.71081 5.79909,3.03456 7.61482,2.08216 9.77493,1.79695 10.1037,1.75779 10.4298,1.73195 10.7567,1.748 Z"/></svg> </symbol>
+<symbol id="icon-check-circle">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 12C2 6.48 6.48 2 12 2C17.52 2 22 6.48 22 12C22 17.52 17.52 22 12 22C6.48 22 2 17.52 2 12ZM5 12L10 17L19 8L17.59 6.58L10 14.17L6.41 10.59L5 12Z" fill="green"/></svg> </symbol>
 <symbol id="trending-icon">
 <svg width="24" height="24" viewBox="2 6 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M16 6L18.29 8.29L13.41 13.17L9.41 9.17L2 16.59L3.41 18L9.41 12L13.41 16L19.71 9.71L22 12V6L16 6Z"/></svg> </symbol>
 <symbol id="close-icon">
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24.81 24.61"><path d="M.234 2.826L3.062-.002l21.75 21.75-2.828 2.829z"/><path d="M-.003 21.796L21.726.067l2.828 2.828-21.729 21.73z"/></svg> </symbol>
 <symbol id="jw-player-cc">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240"><path d="M215,40H25c-2.7,0-5,2.2-5,5v150c0,2.7,2.2,5,5,5h190c2.7,0,5-2.2,5-5V45C220,42.2,217.8,40,215,40z M108.1,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C90.4,141.7,102,143.5,108.1,137.7z M152.9,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C135.2,141.7,146.8,143.5,152.9,137.7z"/></svg> </symbol>
-<symbol id="icon-add-photo">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1V4H0V6H3V9H5V6H8V4H5V1H3ZM6 7V10H3V20C3 21.1 3.9 22 5 22H21C22.1 22 23 21.1 23 20V8C23 6.9 22.1 6 21 6H17.83L16 4H9V7H6ZM13 19C15.76 19 18 16.76 18 14C18 11.24 15.76 9 13 9C10.24 9 8 11.24 8 14C8 16.76 10.24 19 13 19ZM13 17.2C11.23 17.2 9.8 15.77 9.8 14C9.8 12.23 11.23 10.8 13 10.8C14.77 10.8 16.2 12.23 16.2 14C16.2 15.77 14.77 17.2 13 17.2Z"/></svg> </symbol>
-<symbol id="icon-star-empty">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" focusable="false"><path d="M215,40H25c-2.7,0-5,2.2-5,5v150c0,2.7,2.2,5,5,5h190c2.7,0,5-2.2,5-5V45C220,42.2,217.8,40,215,40z M108.1,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C90.4,141.7,102,143.5,108.1,137.7z M152.9,137.7c0.7-0.7,1.5-1.5,2.4-2.3l6.6,7.8c-2.2,2.4-5,4.4-8,5.8c-8,3.5-17.3,2.4-24.3-2.9c-3.9-3.6-5.9-8.7-5.5-14v-25.6c0-2.7,0.5-5.3,1.5-7.8c0.9-2.2,2.4-4.3,4.2-5.9c5.7-4.5,13.2-6.2,20.3-4.6c3.3,0.5,6.3,2,8.7,4.3c1.3,1.3,2.5,2.6,3.5,4.2l-7.1,6.9c-2.4-3.7-6.5-5.9-10.9-5.9c-2.4-0.2-4.8,0.7-6.6,2.3c-1.7,1.7-2.5,4.1-2.4,6.5v25.6C135.2,141.7,146.8,143.5,152.9,137.7z"/></svg> </symbol>
+<symbol id="reviewer-icon">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m15.73975,0.45073l-3.73975,1.6059l-3.73866,-1.6059l-2.07997,3.50878l-3.97075,0.89094l0.37398,4.06865l-2.68383,3.07975l2.68383,3.06885l-0.37398,4.07091l3.97075,0.90079l2.07997,3.50987l3.73866,-1.61694l3.73975,1.60593l2.07889,-3.50987l3.97182,-0.90079l-0.37508,-4.0599l2.68385,-3.06885l-2.68385,-3.06875l0.37508,-4.05874l-3.97182,-0.90195l-2.07889,-3.51868zm0.59395,7.02856l1.62795,1.6279l-8.06252,8.08344l-4.17974,-4.18972l1.6279,-1.62787l2.55184,2.5629l6.43457,-6.45665z"/></svg> </symbol>
+<symbol id="icon-share">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 9V5L21 12L14 19V14.9C9 14.9 5.5 16.5 3 20C4 15 7 10 14 9Z"/></svg> </symbol>
+<symbol id="icon-recipe-social-share-star-empty">
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 9.24L14.81 8.62L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27L18.18 21L16.55 13.97L22 9.24ZM12 15.4L8.24 17.67L9.24 13.39L5.92 10.51L10.3 10.13L12 6.1L13.71 10.14L18.09 10.52L14.77 13.4L15.77 17.68L12 15.4Z"/></svg> </symbol>
-<symbol id="icon-spoon">
-<svg viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg"><path d="m 10.7567,1.748 c 2.0332,0.01666 3.8392,0.66823 5.3873,1.99041 1.5879,1.35677 2.5553,3.08458 2.8477,5.15396 0.3431,2.44853 -0.2624,4.65733 -1.8398,6.56753 -1.3587,1.6418 -2.6446,2.6072 -4.7527,2.9322 -0.2513,0.0436 -0.2649,0.0228 -0.2838,-0.2461 -0.0592,-0.7672 -0.1302,-1.5336 -0.1882,-2.3014 -0.0397,-0.5048 -0.0778,-0.9985 -0.1145,-1.5007 -0.0326,-0.4842 -0.0678,-0.9632 -0.088,-1.4507 -0.0162,-0.4096 0.0652,-0.7955 0.3341,-1.1239 0.3241,-0.3781 0.6438,-0.7696 0.9264,-1.1788 0.4499,-0.66803 0.668,-1.41719 0.7487,-2.2023 C 13.8088,7.65404 13.743,6.94664 13.4911,6.25091 13.3523,5.84372 13.1479,5.45539 12.8843,5.10893 12.5735,4.70758 11.9286,4.47331 11.4318,4.38456 10.7625,4.26633 9.89399,4.35675 9.34003,4.78258 8.9917,5.04362 8.53409,5.41956 8.35493,5.81102 7.6968,7.24716 7.75993,8.68258 8.3992,10.1108 c 0.24166,0.5299 0.62312,0.9753 0.99812,1.4132 0.25323,0.2914 0.23635,0.5919 0.28521,0.9907 0.02333,0.2238 0.01885,0.4466 0.00646,0.6715 -0.07167,1.018 -0.14584,2.0359 -0.22688,3.0502 -0.04198,0.6142 -0.09729,1.2244 -0.14,1.8365 C 9.2918,18.423 9.53013,18.424 9.19222,18.3725 7.63888,18.1124 6.49888,17.4735 5.31014,16.4335 3.96076,15.2576 3.04409,13.8068 2.65191,12.0595 2.04712,9.33518 2.60962,6.86049 4.40191,4.71081 5.79909,3.03456 7.61482,2.08216 9.77493,1.79695 10.1037,1.75779 10.4298,1.73195 10.7567,1.748 Z"/></svg> </symbol>
 <symbol id="icon-print">
-<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.8337 6.66667H4.16699C2.78366 6.66667 1.66699 7.78333 1.66699 9.16667V14.1667H5.00033V17.5H15.0003V14.1667H18.3337V9.16667C18.3337 7.78333 17.217 6.66667 15.8337 6.66667ZM13.3337 15.8333H6.66699V11.6667H13.3337V15.8333ZM15.8337 10C15.3753 10 15.0003 9.625 15.0003 9.16667C15.0003 8.70833 15.3753 8.33333 15.8337 8.33333C16.292 8.33333 16.667 8.70833 16.667 9.16667C16.667 9.625 16.292 10 15.8337 10ZM15.0003 2.5H5.00033V5.83333H15.0003V2.5Z"/></svg> </symbol>
-<symbol id="icon-tip-hat">
-<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#a)"><circle cx="24" cy="24" r="24" fill="#E7AB46"/><path d="M46 17.629C46 12.2545 41.5093 7.88203 35.9807 7.88203C34.7716 7.88033 33.5719 8.09435 32.438 8.51401C31.5099 7.12519 30.2536 5.98667 28.7805 5.1993C27.3073 4.41193 25.6627 4 23.9923 4C22.3219 4 20.6773 4.41193 19.2041 5.1993C17.7309 5.98667 16.4747 7.12519 15.5466 8.51401C14.4175 8.09615 13.2232 7.88216 12.0193 7.88203C6.49839 7.88203 2 12.2494 2 17.629C2 22.4177 5.5684 26.4074 10.2492 27.2218V43.8358C10.2499 44.2108 10.3993 44.5702 10.6647 44.8351C10.9301 45.1 11.2898 45.2488 11.6647 45.2488H36.3276C36.7025 45.2488 37.0622 45.1 37.3276 44.8351C37.593 44.5702 37.7424 44.2108 37.7431 43.8358V27.2218C42.4316 26.4074 46 22.4177 46 17.629ZM35.9807 25.9989C34.4227 26.0014 32.8918 25.591 31.544 24.8095C31.3874 24.7297 31.2062 24.7128 31.0376 24.7622C30.869 24.8117 30.7256 24.9238 30.637 25.0755C30.5483 25.2272 30.521 25.4071 30.5607 25.5783C30.6003 25.7495 30.704 25.8991 30.8504 25.9964C32.4103 26.9043 34.1835 27.3812 35.9884 27.3785C36.1169 27.3785 36.2453 27.3785 36.3738 27.3785V43.8486C36.3738 43.8588 36.3697 43.8686 36.3625 43.8759C36.3553 43.8831 36.3455 43.8872 36.3353 43.8872H11.6724C11.662 43.8872 11.6519 43.8832 11.6443 43.876C11.6366 43.8689 11.632 43.8591 11.6313 43.8486V27.3785C11.7624 27.3785 11.8882 27.3785 12.0193 27.3785C13.8251 27.3779 15.5983 26.8973 17.1574 25.9861C17.2486 25.9488 17.3308 25.8923 17.3984 25.8204C17.466 25.7486 17.5173 25.6631 17.549 25.5697C17.5806 25.4763 17.5918 25.3772 17.5818 25.2791C17.5719 25.181 17.5409 25.0861 17.4911 25.001C17.4413 24.9159 17.3738 24.8425 17.2931 24.7857C17.2125 24.729 17.1206 24.6902 17.0237 24.672C16.9268 24.6539 16.8271 24.6567 16.7313 24.6804C16.6356 24.7042 16.5461 24.7481 16.4689 24.8095C15.1172 25.5932 13.5817 26.0037 12.0193 25.9989C7.24856 25.9989 3.37444 22.2404 3.37444 17.629C3.37444 13.0175 7.24856 9.25647 12.0193 9.25647C13.2412 9.25425 14.4503 9.50621 15.5697 9.99635C15.7251 10.0651 15.9004 10.0737 16.0618 10.0205C16.2232 9.96739 16.3591 9.85624 16.4432 9.70862C17.2165 8.38917 18.3215 7.29494 19.6485 6.53459C20.9755 5.77424 22.4783 5.37421 24.0077 5.37421C25.5371 5.37421 27.0399 5.77424 28.3669 6.53459C29.6939 7.29494 30.7989 8.38917 31.5723 9.70862C31.6568 9.85581 31.7927 9.9666 31.9539 10.0197C32.1151 10.0728 32.2903 10.0645 32.4457 9.99635C33.5651 9.50621 34.7742 9.25425 35.9961 9.25647C40.7592 9.25647 44.6333 13.0124 44.6333 17.629C44.6333 22.2455 40.7514 25.9989 35.9884 25.9989H35.9807Z" fill="#040707"/><path d="M29.4865 36.3135V39.7509H24.685V36.3135C24.6907 36.2198 24.6772 36.1258 24.6452 36.0374C24.6133 35.9491 24.5636 35.8682 24.4992 35.7998C24.4349 35.7313 24.3572 35.6768 24.2709 35.6395C24.1847 35.6022 24.0917 35.583 23.9977 35.583C23.9038 35.583 23.8108 35.6022 23.7246 35.6395C23.6383 35.6768 23.5606 35.7313 23.4963 35.7998C23.4319 35.8682 23.3822 35.9491 23.3502 36.0374C23.3183 36.1258 23.3048 36.2198 23.3105 36.3135V39.7509H18.4987V36.3135C18.4987 36.1309 18.4262 35.9558 18.297 35.8267C18.1679 35.6976 17.9928 35.625 17.8102 35.625C17.6276 35.625 17.4525 35.6976 17.3234 35.8267C17.1942 35.9558 17.1217 36.1309 17.1217 36.3135V39.7509H13.0112V41.1254H35.01V39.7509H30.8712V36.3135C30.877 36.2198 30.8634 36.1258 30.8315 36.0374C30.7996 35.9491 30.7499 35.8682 30.6855 35.7998C30.6211 35.7313 30.5434 35.6768 30.4572 35.6395C30.3709 35.6022 30.278 35.583 30.184 35.583C30.09 35.583 29.9971 35.6022 29.9108 35.6395C29.8246 35.6768 29.7469 35.7313 29.6825 35.7998C29.6181 35.8682 29.5684 35.9491 29.5365 36.0374C29.5046 36.1258 29.491 36.2198 29.4968 36.3135H29.4865Z" fill="#040707"/><path d="M35.9872 9.25726C34.7652 9.25505 33.5561 9.50701 32.4367 9.99715C32.2813 10.0653 32.1061 10.0736 31.9449 10.0205C31.7837 9.96739 31.6478 9.85661 31.5633 9.70941C30.7899 8.38996 29.6849 7.29574 28.3579 6.53539C27.0309 5.77503 25.5281 5.375 23.9987 5.375C22.4693 5.375 20.9665 5.77503 19.6395 6.53539C18.3126 7.29574 17.2075 8.38996 16.4342 9.70941C16.3501 9.85703 16.2142 9.96819 16.0528 10.0213C15.8914 10.0745 15.7161 10.0659 15.5607 9.99715C14.4437 9.50805 13.2374 9.25611 12.018 9.25726C7.25498 9.25726 3.38086 13.0132 3.38086 17.6298C3.38086 22.2463 7.24727 25.9997 12.018 25.9997C13.5804 26.0045 15.116 25.594 16.4676 24.8103C16.5448 24.7489 16.6343 24.7049 16.73 24.6812C16.8258 24.6575 16.9255 24.6547 17.0224 24.6728C17.1193 24.691 17.2112 24.7298 17.2919 24.7865C17.3725 24.8433 17.44 24.9167 17.4898 25.0018C17.5396 25.0869 17.5706 25.1818 17.5805 25.2799C17.5905 25.378 17.5793 25.4771 17.5477 25.5705C17.516 25.6639 17.4647 25.7494 17.3971 25.8212C17.3296 25.8931 17.2474 25.9496 17.1561 25.9869C15.597 26.8981 13.8238 27.3787 12.018 27.3793C11.8895 27.3793 11.7611 27.3793 11.6301 27.3793V43.8494C11.6307 43.8599 11.6353 43.8697 11.643 43.8768C11.6506 43.884 11.6607 43.888 11.6712 43.888H36.334C36.3442 43.888 36.354 43.8839 36.3612 43.8767C36.3684 43.8695 36.3725 43.8597 36.3725 43.8494V27.3793C36.2441 27.3793 36.1156 27.3793 35.9872 27.3793C34.1772 27.382 32.3992 26.9022 30.8362 25.9894C30.6911 25.8905 30.5893 25.7399 30.5517 25.5684C30.514 25.3968 30.5433 25.2174 30.6335 25.0668C30.7238 24.9161 30.8682 24.8057 31.0372 24.758C31.2062 24.7103 31.387 24.729 31.5427 24.8103C32.8956 25.5989 34.4341 26.013 36 26.01C40.763 26.01 44.6371 22.2566 44.6371 17.6401C44.6371 13.0235 40.7502 9.25726 35.9872 9.25726ZM30.8722 36.3144V39.7518H34.9981V41.1262H12.9994V39.7518H17.1098V36.3144C17.1098 36.1318 17.1824 35.9567 17.3115 35.8276C17.4406 35.6985 17.6157 35.6259 17.7983 35.6259C17.9809 35.6259 18.1561 35.6985 18.2852 35.8276C18.4143 35.9567 18.4868 36.1318 18.4868 36.3144V39.7518H23.3218V36.3144C23.316 36.2206 23.3296 36.1267 23.3615 36.0383C23.3934 35.95 23.4431 35.8691 23.5075 35.8006C23.5719 35.7322 23.6496 35.6777 23.7358 35.6404C23.8221 35.6031 23.915 35.5839 24.009 35.5839C24.1029 35.5839 24.1959 35.6031 24.2822 35.6404C24.3684 35.6777 24.4461 35.7322 24.5105 35.8006C24.5749 35.8691 24.6245 35.95 24.6565 36.0383C24.6884 36.1267 24.7019 36.2206 24.6962 36.3144V39.7518H29.4875V36.3144C29.4817 36.2206 29.4953 36.1267 29.5272 36.0383C29.5591 35.95 29.6088 35.8691 29.6732 35.8006C29.7376 35.7322 29.8153 35.6777 29.9015 35.6404C29.9878 35.6031 30.0807 35.5839 30.1747 35.5839C30.2686 35.5839 30.3616 35.6031 30.4479 35.6404C30.5341 35.6777 30.6118 35.7322 30.6762 35.8006C30.7406 35.8691 30.7902 35.95 30.8222 36.0383C30.8541 36.1267 30.8676 36.2206 30.8619 36.3144H30.8722Z" fill="#F5F6EA"/></g><defs><clipPath id="a"><path fill="#fff" d="M0 0H48V48H0z"/></clipPath></defs></svg> </symbol>
-<symbol id="icon-search">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.5 14H14.71L14.43 13.73C15.41 12.59 16 11.11 16 9.5C16 5.91 13.09 3 9.5 3C5.91 3 3 5.91 3 9.5C3 13.09 5.91 16 9.5 16C11.11 16 12.59 15.41 13.73 14.43L14 14.71V15.5L19 20.49L20.49 19L15.5 14ZM9.5 14C7.01 14 5 11.99 5 9.5C5 7.01 7.01 5 9.5 5C11.99 5 14 7.01 14 9.5C14 11.99 11.99 14 9.5 14Z"/></svg> </symbol>
-<symbol id="icon-close">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 5.61143L18.3886 4L12 10.3886L5.61143 4L4 5.61143L10.3886 12L4 18.3886L5.61143 20L12 13.6114L18.3886 20L20 18.3886L13.6114 12L20 5.61143Z"/></svg> </symbol>
-<symbol id="icon-info">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM13 17H11V11H13V17ZM13 9H11V7H13V9Z"/></svg> </symbol>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M15.834 6.667H4.167c-1.383 0-2.5 1.117-2.5 2.5v5H5V17.5h10v-3.333h3.333v-5c0-1.383-1.117-2.5-2.5-2.5zm-2.5 9.167H6.667v-4.167h6.667v4.167zm2.5-5.833c-.458 0-.833-.375-.833-.833s.375-.833.833-.833.833.375.833.833-.375.833-.833.833zM15 2.5H5v3.333h10V2.5z"/></svg> </symbol>
+<symbol id="icon-twitter">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.647 10.469 20.932 2h-1.726L12.88 9.353 7.827 2H2l7.64 11.12L2 22h1.726l6.68-7.765L15.743 22h5.828l-7.923-11.531Zm-2.365 2.748-.774-1.107-6.16-8.81H7l4.971 7.11.774 1.107 6.462 9.242h-2.652l-5.273-7.542Z"/></svg> </symbol>
+<symbol id="icon-email">
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.667 3.33334H3.33366C2.41699 3.33334 1.67533 4.08334 1.67533 5.00001L1.66699 15C1.66699 15.9167 2.41699 16.6667 3.33366 16.6667H16.667C17.5837 16.6667 18.3337 15.9167 18.3337 15V5.00001C18.3337 4.08334 17.5837 3.33334 16.667 3.33334ZM16.667 6.66668L10.0003 10.8333L3.33366 6.66668V5.00001L10.0003 9.16668L16.667 5.00001V6.66668Z"/></svg> </symbol>
 <symbol id="icon-star">
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 17.27L18.18 21L16.54 13.97L22 9.24L14.81 8.63L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27Z"/></svg> </symbol>
 <symbol id="icon-star-half">
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 9.74L14.81 9.12L12 2.5L9.19 9.13L2 9.74L7.46 14.47L5.82 21.5L12 17.77L18.18 21.5L16.55 14.47L22 9.74ZM12 15.9V6.6L13.71 10.64L18.09 11.02L14.77 13.9L15.77 18.18L12 15.9Z"/></svg> </symbol>
-<symbol id="reviewer-icon">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m15.73975,0.45073l-3.73975,1.6059l-3.73866,-1.6059l-2.07997,3.50878l-3.97075,0.89094l0.37398,4.06865l-2.68383,3.07975l2.68383,3.06885l-0.37398,4.07091l3.97075,0.90079l2.07997,3.50987l3.73866,-1.61694l3.73975,1.60593l2.07889,-3.50987l3.97182,-0.90079l-0.37508,-4.0599l2.68385,-3.06885l-2.68385,-3.06875l0.37508,-4.05874l-3.97182,-0.90195l-2.07889,-3.51868zm0.59395,7.02856l1.62795,1.6279l-8.06252,8.08344l-4.17974,-4.18972l1.6279,-1.62787l2.55184,2.5629l6.43457,-6.45665z"/></svg> </symbol>
-<symbol id="reviewer-icon">
-<svg viewBox="0 0 153.4 122.3"><path d="M150.1,7.2l-3.9-3.9c-4.3-4.3-11.4-4.3-15.8,0L55.2,87.4L22.9,55.2c-4.3-4.3-11.5-4.3-15.8,0l-3.9,3.9c-4.3,4.3-4.3,11.4,0,15.8L43.1,115c0.1,0.1,0.1,0.1,0.2,0.2l3.9,3.9c4.3,4.3,11.4,4.3,15.8,0l87.2-96.1C154.5,18.6,154.5,11.5,150.1,7.2z"/></svg> </symbol>
-<symbol id="icon-share">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 9V5L21 12L14 19V14.9C9 14.9 5.5 16.5 3 20C4 15 7 10 14 9Z"/></svg> </symbol>
-<symbol id="icon-check-circle">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm-2 15-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9Z"/></svg> </symbol>
-<symbol id="save-icon-favorite">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 21.35L10.55 20.03C5.4 15.36 2 12.28 2 8.5C2 5.42 4.42 3 7.5 3C9.24 3 10.91 3.81 12 5.09C13.09 3.81 14.76 3 16.5 3C19.58 3 22 5.42 22 8.5C22 12.28 18.6 15.36 13.45 20.04L12 21.35Z"/></svg> </symbol>
-<symbol id="icon-twitter">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M21.689 5.894C20.966 6.215 20.187 6.432 19.37 6.53C20.204 6.03 20.843 5.238 21.146 4.295C20.365 4.758 19.499 5.094 18.58 5.275C17.844 4.49 16.793 4 15.632 4C13.401 4 11.592 5.808 11.592 8.039C11.592 8.356 11.628 8.664 11.697 8.96C8.34 8.791 5.362 7.183 3.371 4.739C3.024 5.336 2.824 6.03 2.824 6.77C2.824 8.171 3.537 9.408 4.621 10.132C3.959 10.111 3.336 9.929 2.791 9.627V9.678C2.791 11.635 4.185 13.267 6.031 13.638C5.693 13.731 5.336 13.78 4.967 13.78C4.706 13.78 4.454 13.755 4.208 13.708C4.721 15.312 6.213 16.481 7.98 16.513C6.598 17.596 4.858 18.242 2.964 18.242C2.638 18.242 2.317 18.223 2 18.186C3.788 19.332 5.91 20 8.192 20C15.623 20 19.686 13.845 19.686 8.508C19.686 8.332 19.682 8.158 19.674 7.985C20.463 7.415 21.148 6.704 21.689 5.894Z"/></svg> </symbol>
-<symbol id="icon-facebook">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.282 8.46782H13.12V6.39482C13.12 5.61682 13.637 5.43482 14 5.43482H16.23V2.01182L13.157 1.99982C9.748 1.99982 8.972 4.55382 8.972 6.18682V8.46782H7V11.9938H8.972V21.9728H13.12V11.9938H15.919L16.282 8.46782Z"/></svg> </symbol>
-<symbol id="icon-pinterest">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.00043 9.157C4.00043 11.129 4.74543 12.882 6.34643 13.535C6.60843 13.642 6.84443 13.539 6.91943 13.249C6.97343 13.048 7.09743 12.54 7.15343 12.329C7.23043 12.041 7.20143 11.941 6.98943 11.69C6.52743 11.146 6.23343 10.441 6.23343 9.443C6.23343 6.548 8.39943 3.955 11.8744 3.955C14.9504 3.955 16.6424 5.835 16.6424 8.347C16.6424 11.651 15.1794 14.439 13.0084 14.439C11.8094 14.439 10.9134 13.447 11.2004 12.231C11.5454 10.78 12.2114 9.214 12.2114 8.166C12.2114 7.228 11.7094 6.445 10.6674 6.445C9.44143 6.445 8.45643 7.713 8.45643 9.411C8.45643 10.493 8.82243 11.224 8.82243 11.224C8.82243 11.224 7.56843 16.538 7.34843 17.468C6.91043 19.321 7.28243 21.593 7.31443 21.823C7.33243 21.958 7.50743 21.991 7.58743 21.888C7.69943 21.74 9.15843 19.938 9.65543 18.138C9.79543 17.629 10.4614 14.988 10.4614 14.988C10.8604 15.748 12.0234 16.417 13.2604 16.417C16.9444 16.417 19.4434 13.059 19.4434 8.564C19.4434 5.165 16.5644 2 12.1894 2C6.74443 2 4.00043 5.903 4.00043 9.157Z"/></svg> </symbol>
-<symbol id="icon-email">
-<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.667 3.33334H3.33366C2.41699 3.33334 1.67533 4.08334 1.67533 5.00001L1.66699 15C1.66699 15.9167 2.41699 16.6667 3.33366 16.6667H16.667C17.5837 16.6667 18.3337 15.9167 18.3337 15V5.00001C18.3337 4.08334 17.5837 3.33334 16.667 3.33334ZM16.667 6.66668L10.0003 10.8333L3.33366 6.66668V5.00001L10.0003 9.16668L16.667 5.00001V6.66668Z"/></svg> </symbol>
-<symbol id="icon-chevron_left">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.41 7.41L14 6L8 12L14 18L15.41 16.59L10.83 12L15.41 7.41Z"/></svg> </symbol>
+<symbol id="icon-star-empty">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 9.24L14.81 8.62L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27L18.18 21L16.55 13.97L22 9.24ZM12 15.4L8.24 17.67L9.24 13.39L5.92 10.51L10.3 10.13L12 6.1L13.71 10.14L18.09 10.52L14.77 13.4L15.77 17.68L12 15.4Z"/></svg> </symbol>
+<symbol id="icon-add-photo">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1V4H0V6H3V9H5V6H8V4H5V1H3ZM6 7V10H3V20C3 21.1 3.9 22 5 22H21C22.1 22 23 21.1 23 20V8C23 6.9 22.1 6 21 6H17.83L16 4H9V7H6ZM13 19C15.76 19 18 16.76 18 14C18 11.24 15.76 9 13 9C10.24 9 8 11.24 8 14C8 16.76 10.24 19 13 19ZM13 17.2C11.23 17.2 9.8 15.77 9.8 14C9.8 12.23 11.23 10.8 13 10.8C14.77 10.8 16.2 12.23 16.2 14C16.2 15.77 14.77 17.2 13 17.2Z"/></svg> </symbol>
+<symbol id="icon-recipes-rate-print-star-empty">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 9.24L14.81 8.62L12 2L9.19 8.63L2 9.24L7.46 13.97L5.82 21L12 17.27L18.18 21L16.55 13.97L22 9.24ZM12 15.4L8.24 17.67L9.24 13.39L5.92 10.51L10.3 10.13L12 6.1L13.71 10.14L18.09 10.52L14.77 13.4L15.77 17.68L12 15.4Z"/></svg> </symbol>
+<symbol id="icon-spoon">
+<svg viewBox="0 0 21 21" xmlns="http://www.w3.org/2000/svg"><path d="m 10.7567,1.748 c 2.0332,0.01666 3.8392,0.66823 5.3873,1.99041 1.5879,1.35677 2.5553,3.08458 2.8477,5.15396 0.3431,2.44853 -0.2624,4.65733 -1.8398,6.56753 -1.3587,1.6418 -2.6446,2.6072 -4.7527,2.9322 -0.2513,0.0436 -0.2649,0.0228 -0.2838,-0.2461 -0.0592,-0.7672 -0.1302,-1.5336 -0.1882,-2.3014 -0.0397,-0.5048 -0.0778,-0.9985 -0.1145,-1.5007 -0.0326,-0.4842 -0.0678,-0.9632 -0.088,-1.4507 -0.0162,-0.4096 0.0652,-0.7955 0.3341,-1.1239 0.3241,-0.3781 0.6438,-0.7696 0.9264,-1.1788 0.4499,-0.66803 0.668,-1.41719 0.7487,-2.2023 C 13.8088,7.65404 13.743,6.94664 13.4911,6.25091 13.3523,5.84372 13.1479,5.45539 12.8843,5.10893 12.5735,4.70758 11.9286,4.47331 11.4318,4.38456 10.7625,4.26633 9.89399,4.35675 9.34003,4.78258 8.9917,5.04362 8.53409,5.41956 8.35493,5.81102 7.6968,7.24716 7.75993,8.68258 8.3992,10.1108 c 0.24166,0.5299 0.62312,0.9753 0.99812,1.4132 0.25323,0.2914 0.23635,0.5919 0.28521,0.9907 0.02333,0.2238 0.01885,0.4466 0.00646,0.6715 -0.07167,1.018 -0.14584,2.0359 -0.22688,3.0502 -0.04198,0.6142 -0.09729,1.2244 -0.14,1.8365 C 9.2918,18.423 9.53013,18.424 9.19222,18.3725 7.63888,18.1124 6.49888,17.4735 5.31014,16.4335 3.96076,15.2576 3.04409,13.8068 2.65191,12.0595 2.04712,9.33518 2.60962,6.86049 4.40191,4.71081 5.79909,3.03456 7.61482,2.08216 9.77493,1.79695 10.1037,1.75779 10.4298,1.73195 10.7567,1.748 Z"/></svg> </symbol>
 <symbol id="icon-arrow_left">
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 11H7.83L13.42 5.41L12 4L4 12L12 20L13.41 18.59L7.83 13H20V11Z"/></svg> </symbol>
 <symbol id="icon-avatar-1">
@@ -1992,1019 +909,967 @@ Mntl.PageView.init(pageViewDataAsJSON);
 <svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg"><image width="80" height="80" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAYAAACOEfKtAAA34HpUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjapZ1ZluQ4ki3/uYpaAjEDy8FAntM76OW3CD0yunLoj3ovszLcw93MSAKqd1AoUNfz3//1Xv/6179CLCFfubReR603/+SRR5x80++ff+b3Z7jz9+f3T/n1K/7+p59fv38R+VHia/r5a6+/Xv/Hz8PvD/j5Mvmu/NsH9f3rF+vPvxj51+f3v3xQ/PmSvCO/P78+aPz6oBR/fhF+fcD8eay7jt7+/RHW8/P1/PEk/ee/yz9y//Nt/+3vjdE7heukGJ8U0s2fKcWfG0j+F680/QV/3inzwpAK35fUvp//cScMyD+N0+9/Bnf0eqv5H1/0p1n5/V34559ff52tHH+9JP1lkOvvr//48yuUv/wi/b5O/Pcr5/7ru/jnn48c3587+svo+9/7nv5+z8xTzFwZ6vrrof54lO87Xre4hJfuF7dW78Z/hY9o37+DfztRvQmFc+978e8OI0Rm5Q05nDDDG57v6w6bW8zxuWLjmxh3TN8Pe2pxxJ2cv+y/4Y0tjXRSZ5L3N+05xd/3Er7Ljntf39U6Vz6Bl8bAhwXj4j/99/pP3/C+pkIId/89VtxXjA42t+HM+ScvY0bC+2tQyzfAf/z713+c18QMFkfZFBkM7Pr5iFXC/yJB+iY68cLC158cDO38+gCGiEsXbiYkZoBZIytCDXeLsYXAQHYmaHLrkZxZzEAoJR5uMuaUKnPTo5fmLS18L40l8uOLnwNmzERJlQzrzNBksnIuxE/LnRiaJZVcSqmllV5GmTXVXEuttVVBcbbU8tVKq6213kabPfXcS6+99d5HnyOOBGiWUUcbfYwxJ9ecfPLk3ZMXzLniSiuvcq262uprrLkJn5132XW33ffY88STDvhx6mmnn3HmEx5C6clPeerTnv6MZ76E2puuN7/lrW97+zve+XvWfk3r3/79D2Yt/Jq1+M2UL2y/Z42ftvbHRwThpDhnTFi8cmDGm1NAQEfn7O4h5+jMOWf3iGRFIcVDcc5OcMaYwfxAQ2/4Y+6u+DOjztz/17xdLf9p3uL/68xdTt1/OHN/n7d/mrUjDe1vxn6y0EG9E9nH758+Y5+S3d++Xj/frCLy3E+d64ltPW0xqs9pz0kAXQg8Wtq75G2ChDRqvFup4R2nlZDeDYycvHIdp5aTZ11hzHMy98wo5cajvdxMz63t1uYz0xNWmTvM3Pp8nsl7+7sXQ1+vzdjGsnp8elvviYvp7nuWwgfU5yl7htjzGjXzAU8oL8kczylzJT4sxnW4es7z2nc86+wcc90Hmmyg5X6ezRVHeh/g4O0lpf3MMPfDT9bKheitzzo5LxB55bGfeg2yp+4KtpT7mfs80xnuudSn8/OSnoPWqfnJ925vmqu/kfnu3F6dxAFPCWKVcHXgPPcRGWPehaQIeaRVeyk9xvHul5kW+kPZu/XFnPS38F8D4UdLkUALBdi9NslwdiEu42Yu0prxHcibh0BNY/an5AB7zPKOOxNQpxFrSLQ10w6M8ssz9Oct1yxKHVTTwxTzl1n46Ccx2rvz7Ocm0TbB0cICSQtcl3JtPP0b9ugwD6JjELvXibn32uKz3vtNedTUX4bzeQnB89bh150PSbXKI7QUEqKOuBrpys3zVKRPyded6sNzvBDoG8o5TAd5V56nEl+bnGnEFUwINzKRc60+WmTgawuHgCEgN+Fc1nWeF7wBZtK+uY38rHlSNCDfGN/4kOTnublYI/V477sCWVrewv2+G5q73zpTQvrNtzG33F0pBwh6DgH4pMhcEXqMLikyD6zYDhHxlj6eeu6nnUgGZb5fT95M/PVGPoMUus94R1hvX7HN8Sye8p6L1xdQ4Y1plf2SQKbpAtf+lrbX/53PRH9qT9ik5GFyWj+p1FMrefu0vMcjqkJ9cXPxSK4xdIsYbGHXUNYCX5I4sEFWbi1UYGoAnu/ep44SxikM986g2v06F60+qcxrEa5lr3vwtD7y4WpIkw3SjvaU7wKrvQGiyOnUdaYTHHj1NngZopEqaXMt8L0+h6mCyDuzHrfTi85dAFKZkUDMJ7anpvLeo5+9wawU95yVSMhlOaTPue4NxQMqaQ3CiKds4TaCAG7gNr/zVJ4OGHj7w13kBcTPvNcikFu9I3ECPrR11ZTO5B7TPumuPL/8s0rc6w3E4KkZlCELSiEgJyqQFGxvqxXyGpMRgwACkH+FSSaTVETc3ZP5l08CPIlvsAzC6/NdjD1R8OTDeAZALryJMTvQSVtNlAEhuXYRGDJYdi9y4yaw4cp59oIZiQMmXvAnOybIteWz+xCsnfsBCfjERcKStNBLwWK0QciBXKgkGC2E00hhnrZx5+t5yM4EQMTMbY37nZUHezpPX3Ii39pFfECWG+dRw0H9ln24WF6TW4IYxAoGERrk0dZgrKCOzeDEyK2vApTu8uw6rv0wNCeBq9wgsUHwhgNOcFUicKF5wXHQC1Ri4iq/nS/xt/Be8wHh0Aqk5duvTNaWG4zJTO8klF7CCww993i5u1bINsCOoAYyxRDeCJRWHhCqay2QluFMxiidlUZgbCbUh/jngm8Pc+1uwOeaBuYvAmvB0WPoQIQbCHtVDYiPM0Zf87kqEZ6elMEVaIjRNJ4QBD3O+bxqp+dWJXQQDwcIMC+mMb+9Y1Y2X6ZhGhrmuHJ9OA0qrfHZL0HBfCBrnwMJlJU22QVwNFIMQPCaEB7CkVtSU5S+yIV9vSRCe2ep8x1wPhKL30AahOmcE4LPRB1Rxp01sDubIGTLgryZEqY68dSz3RczCNBBZGQ0H7EP6guaiO9qcPPdkTcbJib10TGoG17M76FFQI5PQU6lle75AdvK/4B4H7BlLswnJaGmc7G3kMMVaFmDQH5iENthkZkLlA1dM5t7nAVWPwDzQx7KrmMFPmHCKbM+s+Q2G9Iq9xOZE7L4wzcQWvVxX880xshx8GaAR0BVASvG2Bm23CuAKQe9cT4URUyUASU9PBICLWc5eyGBGOxIOsGrXajbk6vnRwX8EI9z7+795uegGoj0BI/tUBj1oj781A2EdOB3hBbSmBybgNg5qER0yB3nXdcsgZ8FmC3fb0aVlDKfiuxCSKdwmBVujABGpLWzri1i86SVnGJuAhydwH0ei8Se4xiq6C2EL3mPiiFybvAW5EcRkEc1LCNlX2PFcUAJbjuASGQcWbFKXZEbQ8yAeWkvoKcArWAnULUlGBK84XYzD1+QAdBRQ41AE2gQ3hMhQxwf9AOTEV08M14XFQoYEgEPOZh5desDIbhnzmQVfBae9wI6NykNvETmjbkBVlQgL0wA/ynUFP+AXrzvCUMh4DqRUtGJPl6DZFSRFzruKZ2RStxjVmOc0LAcD0oH209E5OOgo7GRj2ATOt0L9VNUtnys5quPC0iD/RF++Y1cBsND/lbGlIka8OR7YwkQ3edBWuOLznrJ2wdlhAic3DbSR+9xvQwB+hcMf3UKDa0Ein+Cm5ejLwj7jGJDJnOpCiqocjPIP8lIWJtBzaTVBQiAQkBNJ4hgUn4De/AY77Pvl/j6HkTFfWM2kqDZCWmGvZ6xMBngMP7ovXA+6ZQM4pUTJKBcPzm2CQ4GBRu00dizQbcSwyEgBqODlxnFEWGSa36fcaGcGFsm4t6qi01yIBmIfIAa23OWsbMfZhhtl2GPg/pGZz9M9bPPHUBiJiZeUBK8+M05ari+Yywk40HGVOYV4znR6WsjreutKXwF0rsAq4VPB8x5oGen5+qFyEdtMGfgvQUkwj+gC9+ofAsoWWjcdGor79f/PsqDcQfy41jpwQwx2Pv7924Ja8Dghmc2iKCAXOQwqjYzCqjeMd5zM6kFDc58PkItor8z5sjT3a/R0aC3npBR0Qcd8O6EhDSFcRKPD1QSLyQRlMUN1LX14ruJYxOYgTEAoSvoaGpD74E1vh0KkqAnTvYHdxep8X13k+04tozAmh37E9cKp3Kdxq1fQMkeqjT4GWwCKAOs0ZkneBpN5OcTUw8ghh2c6BB0gZwNOPW9UYxYFe6LXFOFbYLxHnhBLADGdFXFHn64zs/9lREz2Y6CYOB5KDgaWiBuAfeFvSDUL80rsh8IJckikDN56MmXeYhV+YDBT8TihI6QDmVYANINAF4pKjTJpv5eIXLLAzcE7e2OhxrkJkyKwyCiiUIUcyUuGUl+I7we7gO7AXQ8qYGsKDco6bLegCJCUS4iHXmQIjGT+l15ZtI2kyxoZuCeB0INRRI2YfhGgLi36hNhgGK4cGq7AjPr1ekQsch2pCmiH+JAvjxkZOZd3cmF7Ro5xvQzCRm+Bkf1UITTdecYyWmGG0UGU/BhC/0ZdFSwAkRAjD9qlg4CQdUxBVwMiI7Y4CWJiIIRyyUgF8ZIGkMh4pGhXsuXBeVDsjMXAAIBX25CQg1K/MQXJQP4wYWD2Y4MH9PP96DqJPmwUADjPOHegXHFMIwOEhQxEOqeX1koYubI7cXIkZATQQ4MPPPiIWFtRNZLHGKEJ8iayS/MNvpwc5GJxkaUQPylxILuJGKW/IGgbpIkyfWeKyL8jtKTsWCY17PFdFDnybgEQkAQQwA9QV9PyiF1kG1MfGYOGIPdmd7aLqEerGCawBcYiLQGj/t5RF6mGLJDLaDXJz/e5OLQRvshG9YZKgeUcLgvhPsGiKbYh47Dm8mQ4UNqUnU8PELaCF/GNQSjFXyS8AeJ9vTmJ5OX6yr4T2iUyEE3Fkwnd/jWw5QXIb+TPQtNP6HVOaKE5N9girtHGI20uHuGOUDICFsQ6C+jNPLy8VAiBArkkwn58VUUJjRPeEPJwCxYy70y3IwWIHOA3XJZjyMQ0iaeN0Emc0xkZoLYMewVv78Q8yhrRmXd5j2kgD/IRF4lkGLlnsK4OhrA9YBPXL1OT0w4tXxQYg2m2AQg+Z34CP5VdQFYPK0qF1wiHlZTm1yRx2E6jjUEHFoafWyYG2BuKLGItZ7owfXCgTNDBmY46JuY3f0T2vtVfVw8+CCAmad8E3pvQfyBu195CvX2kKpqezUsoRCUbo9m24jDHCYQtEvl148OBmdQ4udlpKCQZ3p99LvyAUyC5bDvZNpEPyGz8L+du+POiY3wtrAQESQ8PhMNjiPC6MyZgUR8DqlAGq3PcGFI0OSY0U3gckVxmO8iL0RdBQd2XC8in78hqeFYQQe1Ruj5PVaoHyumb40vKhMnnPqRx8M78R3A5OZj0oMK2hfECdUR/FgTIJRZJn2xpqSpVyJ5O7nyWXHQdSNOineFFAmoC5A/Dyb3jhcuBkRSIxNlARAg+jMiP23wZHVDSKCe4CpEOdNX2FOug+hIIECFLIL3L5De2g7gv1CMiClMYLKSDkpgqYEA5nHfwNwDASLWYY2fmIM6iQYsWbnfMRGjZOnGX6pZHmzvzZPCIG/Y8DbPgrR2Ispr1fcg77gaf71hw4c0hgQtolpAwEq6OAEBFkCMkX1RRChgPh01BixOHtsHZlS7X0kGywrxwUWmGMo9EO4X/EI6L+wGXLRBvBIR14QfSs3Vk3vzv9uhg2vBUOZj6mb0N+iRyiiiYs64iEsgIStVYYRFvpLZhANhx7W3JXcYlptJKIxw3gL0x7H52GVCo2LSePjfdQMsGG+QoDl9qDc0ZEIsva/BHmC1CNLkXCbMgx/RWA4gPJI7ZB2/tmoyrhreBzhpXO0O8bUUzpPzpPU+25zvr2UYQgHTH6alGBysy4B8RfLwjsrw8EFICligMGUZI34EIf7Ydx7aRivTrfaiWswW47F2YEiHkfFNRxt1HkZjWWNjBBHMeIE9G3MKCwzmuybmG21CfFnWrpqrDIkglV9SR20Ny0NzN4+GGH1XQM9iUyvjHBwnftvjI0Ap2ciA6EoMk8E8IPxyel0zHsZ8Np+Qd4DORVTiJlDDX4Rjm8FE0g5VDL0cb3w1xN5CuRaC4nMyaI0IVeXJIAMZGx/N9BP4xYu+UZaeM5qzOS1uq3SS4Sjg0Ct3y5sL8bnEfYdtkyVi4hIJ5EIdpsVyFfhC5OBi3iVTjtrITj66pgYuy1kdcYyq6T/V7wFgHmWOLnwh0C6ANsMwTDss6/M0P2g56kbnfCU8EpgRaSjeWwUfxGq1Njp4zLkfBudiCKvfciHuP1tDgOrVhpCY9e/betDmzXxeDDxFqZAeMoxIs+iP78C7pmuje/IiwrBaJXMDsSyyQn+F7wA9cADwR8GikNslt0acotc6pPo0NBlXXqdA2fOkByP4ZhDqMOhZLXxcKMnImiRKwx1cgVklu8pJ8UWhMlGWY9BPA78wGOyufrQICzUj3lTIb8mprzQ3z4UqHynAPhUNTgANos+KPRzZbhOriXAHxZaW8VytZmDxoUrsvK6Gh0Ps8TvYqGGN0a6kfIdYpiVpMIF4svp2bjnzAgyy3mNDSiEC9VyIiYEKHaadNsxmeC9iAXC8yScsKPCqi/ugDCNfYr1SQvMAjg2ljYN8rV4TEmu8jFr91iJuHhxNBEEUCJJJ+0g/T6tIXKTq+woOUkwDQY8r6xOWjVDOQBcUFxuYYW5kEmX6VSvQD8OCW04uiQ0XEUZ8O9NPbALrOJ18G6UNpujWFpknAQnCBkMKzDae9pWC0PUBCmdYGyKLWeVnIMRVdE2kr74YzTIA5/IZdKBpkZXkRZVvsRwPcnG23JFeT/F6b+Vp0Rgtn3otohwGQp02TE8FrgpMcH9LUwWwl1qWa22MGOmYUeQb3RKQXrkkVH92tbE/19dDQ64dtDnRofsefA6SDZMejYyeEcPeb/iKdeQGIgBi7GhEcI9PZlT35VLHuxd3VcATBKpVS3mEgAL5LbQT0czziwUZKkuU3Ms0EfYgQe0db4TyuKBlBBuxiqGEB1wNOstFrfwMngQTQk4RJwjcBfzBZuTRnkDo8yBI8L8GZngupFoFksgzPQ+59W6NHY8RiVg7m1q2HePMhn9BO4MyD7OMe6sPv+feoO09rtmhkwJVmSHAJzTjjQEaIHhC6j7gPvIQK4H2L6UzlgOjPj6wi5r8jDq/L/QalLpiH+dTNdqXw21qBrgrBhQRyCSDwxUh8iJLXRZAeiUxDEFFtCK5rhcmkB6xWYirIcphNAP0+HS4sPOUOjMEK8E2NWELHhPAm0vf3D8iZJR4YQn4AZbrG/6PIMPbmeKC10BIJKIUKMTpE50PNggZu6AWHqwi2FtzEe3O90Ukt1W0YcGKLHJGjnYVd+IPYLG7IZqRd8mSjuEBzDzRmjnedkCZhIieFsZOA54gLhH5OHBsz0smt2AZTkWAwjdKkcLwOt6WqSj1zgg/xp4gJOyZ8WtmVMtdgYl4cBIHGTUdm4pgOYV7c36RIxCTi5GudyRw7bWlAIVV9HQwabym4rIG2Afd2NM0YQmXhosmFWDVtgE1nAOoVx4UUcFHmRxw00Hx44CaFf2LD1UhMzoTxIFb1lcQYuJHKxIiccQ0MJMutleIFJhyFWBJ40wOfNFr69de/Sv8wGiavGnNExKqlhBwPvY1IKCja0hF0YD/xF4C1cUkmLIREFkaSbsPQQySMc8vPHWYkGY1B/BrPNtdd987kokk92GsYJ0G/CYSBYwpw0Xg0K+AgkdSDD5kYYyOKqbf2o6fRSfQgtCFZGaD8AY6j3xD9VaiuyODtK6gwnMV66nhq5+vn6IGcRS/lZb908lAvMc0UeJxIXsLppXw7ricwMSSDdkFg/vKL7OAlhZ54wi5RjByq2K+sgvJA/1UbofYPnwIf8kELQYZr4XP/ol2UsQFG2QNv7IfTS1C/jD0cBepEcBJpSg8HiwkB+gKcsKrPApyBWp1oeRplxKFkZb1VlJoZVMEBhjZIkhACAnJj8uF2ICbUdR1VKSJi3/I9ZUXUXMt7hnXNLJqih/AuERDbMHlRBn/9TO7f1VvIFxATfIFuAGFDV90FCF42d2BMAL4qq7MtNbBxxscBJzxTfr4kg8IhfEEvG7V5U7WasjAdodaYwWzYYVvNRnqsQunR/xNhAGB7K9kj1V2tWDnXeXYlMDOtbDgzM1R7Wt79rmgDkUWAY+bJZZMbKswNwZkumQDpqOpE1FOqIfxLSW8gG8DJFKqhCkoNMcVY2XwJykJzlhms/b9YCJqHC+ClsthlYFVeJJ8N5YgKCFsevGSMGO281jzr/NbwCWI1viW5ER/xn10CCFKL3fBdwYSi5sjJyZiA7gb41tsxVqQRReKphrc8SDYrPdWex/2tvtnTeuBB06evE03h2P8UuCrdJUblbZBETA74/tv267OR0FjA8c4aIvIx8J7GQXxIke/CBJIrX8rzxg/pK1Fc5Hu61C50NRIHatY5PoLISLfEPPcP7qGiWYceznIqoLYKlXGVbsR/mV+S/qrWyB7L+gJs6TKNRR36ygMhnAaMXiprX6pCEHrv+15gRMCDO8C/96qTS6Ecl7lQo73alUFjuTTn/wt1aJxm2uVRHd2vQ25W/FeHbaEB5g7+z9qj6ZxtFSQLsgS8OTxEf+jVfUEw3Ar78k/wiAjl97nWWm7XoYpIGNRV7B5xgtW0G4o+S/4s2GDgGbuhNFLwAavKk9/v+rRUP1jGQjVe8FM381VSbM+9rJA205Hvvg4vCD6rGh6owXPB4Czvcw2nginqfNwPQApYc+bTUlr+RpUbVhiaM+VPxfTFfYbE0aYTNVAbg9DzVCiYzVbxC6/sWPECkzSoBTA2mYJYKCncuXkD2CjG8nYTHpiChTBc2uIXIwW+NFk1TU9/BeuCDFjF8mKK472ubZ8lULSMY8VVA+2wz14igQa3C+YEmVHNMSyHPUgOHIoR6vDqKAimGi4/uy7pwu7BE1xxxMIyGttyKPWZr6Fb52rH4wDKMXtgqrIlmI9zh6PbvHb/iqMVblAnWe/PLEa2kJgqB8QveE5X+5mmATIIDPQ0cBGdp1J8VaZThB1usq40/UOFINL7wA+shJRiIzCvSlHjlpz5v2g4+ob7E+D0VHXRCL6D50xdclqtHzVyfR2JguB8YPAjKotefcTul2BcfLQ0YowEiK5oGVl+gCn8x7M+3Hp/cm26JXTI2yREroaIQa6E5026lXlqquiO38UT24+ZldB1ZH/GAOyA+u6C+6Ix3MlAInLq4rtOIhSpKTvDriXYyg4VJ1UJC1dFkUpmdZ6CMQJPoFL4Pu/snJ2UpK1EHviTr/RgQQ/yVAaSguJfPCu2OBkVQR/FFAnIPlNoBtu5bLKdGcCGWBa62s2xWWJDlZtlIXYeAxLQylyJ7cLmvg6Qg0OKuhS0vgFzq8VlGPzW79A8d7MG9NDMG1b+hhiInAhptIwGF0YAD6eSMB634uff62PaEiBnAct3E+wwwlxxcNJOij/11aOoLhrX8ljg4onBLtHSeMVXDia+I0nXJYmbsuoxf5jV9C4qDiR0iTWGGAcSrMwWzOSdtuYStgUKJSf12/heAEqF9p3ojdx1i6yRRIxE3bc/cZwgEO4J/B327jmIiaRZO+k66EZniJTziHgQ0GxVV7B7Q/rwUhwSBGNjIDDEJ/btaKGRRwWBuCjo3NLeBvyIH1LMAL9Xee1VmXYcYt2AhKTTC288NloKBXp96A5P4s2MCdaTdQH+ZjKItpI2lu1O9/LBttkrwBYjJcDEklSfpNuG4rQQa6ZY9U6UgmXAIHiS/AMSE98ZvjlzvC0Hz8LFy09GPhZe/pY3Z7f3Ylw62AMJIGHqEdanOC6CbKlNmW/XRe7pxfB3lAqwHwkaRgYhvrYLwvSRsvH/f5WBJfOQ9UOqiMkJjyjDYFKbQZk2C6ka8nkA5jV/R7N4qo9Hs0e9ldFG0gENBPJ2mDaJuv3/vWV2U/BbTW7fQAfUvXu7imwhsmMY08SaoZhQzOYkzAmIhbMB4bBR/shzH9X93ARgBcAfREW6WOCjKw/thKCVoAOwtjCqKvzYDoIvBCoLq41jTtjjd7BDEAXw9Lce7k4klEuKxfbnbKdaI96koi2VZh7wVW4ykF67kWWMQ+vpYjFGPew7Mxy+kXFYtfu1gFDkX1hkRkYpqnbzcHV0dRS2ovxzNYWb0s1jISggv5Hk5Ii3jOjC0uf5ofyAJXxYlBBRJmSl5HriuqWXKf+ymgMMTqdzMdfkyr89oqvTXiKZ64frSE0pv282MLX9himCNGS8cRZs4hARigSJfK8onIaHwTBVYfLzfXcxO3XaQ5iZHCt8jQJye4yLz6YW4PAQNBhuipebJE4MH2BK2GeS+v8YnJw8wf4JJnxjg+3fWZGcHwtd1zdni4IyZxBNqdJdOMxwv0A7QI0s2bEZqPeZT4e8hPkrh23g69g+MHE8bm7UVyiDF+j6LfOBBR8DEoo7GvYPw85FYLYVXa7RKARgthtNUTgixtv37I8t5UXbI5tHoDSpyMhL1KX2L1cgHQIuQkMGPFXy+20I6UaJon4ISyJNVcKGCFmK9tv8SInmT5EFfMNxc2L8bD3PfxUH1VWriQAOXadt49sSbJuK4RLm6+L5xa8AKLoHgBoFiF7yqX7qVrBhJFfd+83mL6YGZd5LarhQUCfpdhFd2gzk1Wu9FMFIuQg7rDfyyIP9tNuo0mGr4ZoZXIB/fD1O9p7sC1Ifv1e9o+9Jb4ruwA2UhNSE7z02DEuH5yAr4KDXaYmbb8mEl6HUM9fP6evsQLJO8nb6qIJlgI21H5yX/VKY8jya+J6MrMS79u2JdGKmbZdH696mgvqTAiRgNVHIJJhDcWALN+2qTBGxdUihqQfvApJyfy6NeQTHowPANKRtOTIgM1RyXjST09B5+ABpHXsSH3XRUrbScebEDPAv/1gMA0DfDO4Sq1NWk7zHr3vQrhmnSAhjLJj5I46fn3pElCi0ZIVryVSeBc+zwKIvcJ8Fkms3UMARKt2RElNny0muLCaDJYf9DVLkE0pnvaQfV/rIyjStx2L1gFdpdFWoPjJkiCm2Kyfu4XAI2YO8Bc1cn89amQjTmht2Op9dAnfSE1tib07zJrhb49+TaiaF8XycL/WWXoFwmBajCpiD5BytcM2RMtvEumDjopMIPBKHtjINsE+ty48agIIlnRlFlB/tV0wYC9pVBfqyGpmhHgNbtmwRSHb+RNKglIXwHIvbpyZIMSUg92CAzIXBiiXbX+37g9axlZhAcX8mD8Is9PbPSIRW5E+EYAMfNIbQiFaAZaO2yDFK+D/EQqhiZYhktRa0UXYk5tLh6hz0BMKQLQkFwf3AyrKVGiq254XC3C43cms2RUOj7n6jW1GAYavQRMoOSDy09FNyQpiQrikqG0HdrEwj1o8BWluxHkl4l0AykrswIsJsGpPibtHLcjx3HGGT5qUyWVdC+N+RMnhggWDZMfkZfsAL9vunW1Tjsg2I6CLwDib0EcmJmYsm7RnwsEIENxNuDwkUr/nioRA+WdiAj605YEQe75FMBJjTF0SDBJc7E42zuQDYdhViPVmdjD0cdncTriina94btjy6+1t06Xyr49N1Q1sID+ZgA7JJ2gS64uABmVB3uLeHzeg2CKMc9jX+9RXgbi/7T+3XctYXuCjulrizgFbGa1AfBLtAMfgKPwaRFVzJPH0L8rfXSfoozBbsdF/wb+EMRQY8ouKsl2ig99xfg/OjT0bpYfgYP7HVxZSY9bLGt20/wfAwKS5AS1bYd7WVaEd09AdQ3AaATLs4UEA/qwq8VML4OWGwy/GyR6MrARm5my/iXXY2AmVuGEC581HwXMZc/CgY7erZl/XaGZq3tPdEJWwEKt/3dQMqH3MG5GG9K6hfo2xrzRxc7MoXzsfC9L/6TZrkamZ6c/uPoELrncSI3ia8LoGa/ew0ITQyxkUiVprLa+CRzuOi4Cjx1qg+LZGiep8MH7xsn5rYztD9Lhxb67JPyrabyXuq+/zLejSRjwkEBE2wGlLtjDYm92YBCNfWIYMte9u80o4b8NR2sCC7R9j3a47Mw/bBlDLuJbNebeKhszf44UFGUOSlol+AXtw+l42G7nDoTgWdyVQ+AOLll2FdjmKqUtvsrATbReAopGvT7LeeqU1F/H5osSTVjtq38B9K08voXbsgZ/rWw1+5aKJ6bfgDbnc9higNIOlMTXjclNN7S7+WAHCEuFFgDKsEtERbSXgowALEA2kLcONYMSH7ndZKznnvhDM74SQEPDZ1pcXPjsMAIn42Cfogj1Rd+vkyYyl0EIAzfUssJiU2Nzd2/tFPmUX3dzB9qKxgDTpAtrOCF07WhkBVAn2UP5rDEfIH1cnUonRgMlj3PMClfGz2+6P5CKbjbPzQXj2CBhsN0blm4gGaEoLWH43NzEttlEVQc+NuQPp99NlgJ3sqAaGz2ZqwFHn2ci38Ug/CZu0Xgzy4A+cN0rYtj6Q/+Wtm/B5rzwYYvwigy+RgDHo0LitOBJ665Yz11hd3UzmqmjQ1XNgjgAHlM6AHYBG4qhzryDDi+PrXTGNLe88ScokVWVC5I9eIw8D4hGEQeENTxx9/csdFibo4irdPTjFLRy82NW8vFyxcH2BGFkWM0D65voZg8mNYq725nEx2iWs0sHgcbWvUxM9gyQStedBclhfU0ASs/dTbHJmhorbJc+p6jmcq0vQDvqyP7kg/eaTSWe3T4dnCfDEq4bWZ55o+vrTAJSJDI3g8M644P11ggBgbiNJuV4WKFp157q1+q5G6ja3B5cJOjLtFS9gY7exVOYR/4/5JM+Uw68CsuFk+uWmDStT6at1WZ93vRy67GjqlawNuXNFevl6n10X+Cor7gmwSa25VbgEd9SlrXPMkw/MX11hav9sY4bYoQxQ8Xb50y2FNsraxgFxM9jg7MCGWW24xprejdd97OTB0MMnxeMjVKwuAbwmgUuN7rBkRHf/BBDUbJMumTMxTWD24/EDSWflERhHbic2mWbEF94dEnibEaO0OONXQS9bmkHAWOX4TqW48i29Mp84Ql7PYMPsRWn7ukciEQjbbewbY4he03KTcsVi2uwIyFCMloMY9e7s5uJJXp/+4N9UiwB8tKrdvtohOArjPu6HICahJGspjZxF0PPWZ+HXjqY5qDBXxI4cdHs1Gtw9u1207OO1flFcebZgcFtlcNekzfy3+vit7yXe5BfEt8MFW9k8P8C+MiRJBKfL19gAT6i8EDeA7wHMPPCAICGXvk4SzDHmCb0HEK6A7naT13SFAlol7DqpHOxdz64CFNcD3dKyugtm8TvPYbvxdaZ0EefG2dLhPnA4HFm4c0Sne0NR3oTNQpiMT6czMuRQcGsxSWUnmQ1lEFO5IqqmR/uaVFIAPPcREfzH1nLkoVu7SfdIuOD2ZSJ0uI2YCsbwOONf5fbqvgzHsaIPzWNEd4ncJX1tDeWTwki4Zo91z0DjskxuH1R7rF273x062jxasq6fbOPJGokHJu3InGEZ43mnO1tix4V2mB3nZgnP0h8j1ZO90G4mWVgIUb+qG9/bwoyLYADts3u2DxYwz+1rk3x4bFubUQ/vxi0D3rjsvq0qE1U4SMd1Mo2qq8G0c2M2o79AV1csEZjbpQkTGdom5Ddo4H6hYjUUTBjPOJdrMnU9VubxB8rmT6q4ESvbQ0MML2jEDUIoI6vROYDnVaVlG3Sz8yDj+wPCbEO0Ybsbat3VWn9brz02uxO92YILOu2WN6xQpJkJWTe55PyrBXLxQVAB0nm+sW53xKB47IMou7p/Dsx9e/NpnxZR6BgUy+zlfHYdfcEwYTAeYhy/Zv7a1Y5rQhTCD8RSdBuBzZR2MpBy3BJQ42Y9O6kexDQs1cKZ0QXyMO+qg6zzWxjHark468Z0Psei4vjZbXl/MMO8GZ7fVr/gtpPs/hOiw+0wb7ueB1oMWERn5+v05Z2EPcmvm4ITRytuAGl2ZGcbtaBQO31sTwGa9kdt++o2zn+QaXeWwTrctQgH7MfWxm93trYADQHHfovAtrQRC8g5TzZAUjzhXHA1CORmCpTWpxGTe8irGwEs8mai3hXuo2p2mxMf/bX9facK7DQxqti1eA0+3ioR95Af4CvXl3Bz793T7s8MJqQZbGKDeWPEEMkZ8TTd5sSAkR8byB0XCWHdyb2vFkLtqmc0guU/7J1dUYDBBhG41Hn94NcaPdeQRQCTo4W01w9j/7Xau50G5+uui+1m+2RF+4TzLQUioZE4nrIDrT+IBH7JM75n2+U2kHtXc/Gc+E/2JuNDMXs3yud4tAWGhnHiiiu793e+iexzK3UBqXYB3uHy9lj0SpenBYwdUMduDsRODPemrWYzWUQ5b1Io2xS53GdSLd8TiK41ItHWZ+LwhmNd9i8cONyjh1xqVHdkHwkCefAlHbfI5Fg6cEGa8IrKiDtYlhLLi12au13oF5kYweKe1pV7URN6CoJ742yGejQBKn0rBion1wcY+QV34+0LFjB5/lH+ru0CoFBPVEdoCNHPXbqPHrVnB1Mkr6cSxFMX5o1Ws4eAoAL9IzBjIcr2x4kSb9LPFCbsnQPKSAUmO7tr2YI2fpiUncwdQIxK3S7SonFmIfPO5c5fbBDyALMIqwF4qOcwmusv4Iiym7tFboN1uCT38eTk9r0ILmP1MuEPzV1u10wuRM7l9tDqZgibk90UBjZ6htAcS0UE6W63anwbh8XF4oor4pVR2tZqiXYbrl8Pz3B5xiL/s+uxIa4i54vlAOK0NLvobN9vrhrY7dWhotqMznrB8Zo3K+x896saigx9gmsbRAkTPqzkP0RbQTLxCivZPBC+XobOdiByR+6FB3cAUil420/D8ExVNXeXwC8PWjnfqo+LvQp28M22ywh1Dpv2e0VoJXSNvds2m2al9nCvxt2IWJ7INd2vvxR+wRAVZsFWRR5p2TI0vgVMyLRfLtsgahDd3dpM+db4EGrYnv4O+6CIqla4u4BoAbngt6/ju6mAu+oCfZvyZS0huRVJQHc72fH8CoEGcruz2xa7dZuzrb36m45YOHaUhOSZVJYWMU/Xt9M9LGDHDercsBYI8sNyWbp4EQ72dq1PfE2rzMU9Ltl9hbgOO5RzVWff2DwGcn7eIr06k5m5zvro0OMcLPxzs3aslK90bzFhuiX8LBt+Z2iIDab/XlYaPSkDSwFdoW9JhfhVjDC3wXOyWty3RkNCbMs9Pk/99vZhleAFIJGALAov4Ayz6q6r/jWRFffdPt+2IJyaDYWuKKJsQdjiRgnJpX0yS2Lp83o8MSZOuC96HMDJkKl7WFQCYLF93Y8nMKQvDvgD8RT3eQhK4sDqpD37B/BHSuOGGHrDimSP7nOz9pXUmmjwrzy+JS8s+nHG3bgCbiKBg8trn3TC07oJcAKthF+zrI6zb6VZTLVBuMMxtvegMj38AK4qL6yANU34fdcrXAyY7bqZD4QvrM+PbeP8FlPM92DT4kA68JzdY1xet+XCCtGydbCKQ1zxSsLRjblN70vIexIHEtjt3VDbQBQdLBB3jniuNpNuV9buplYjchNKNvWD8oyPKuKCmkeHq5DvCrZn9R+lb7W7fy2eGfEAm7nHdtjc4QEUHjZRwqnuOLSCvqAjbhKEI/Z5gmVTk0Vtbh1f9OJEb0AlwOTtQWgDZWtBWI/7EXRN7wROPYhgXsl2SdBP1DiEmk2f+IvbKjPvfSwZQczMAZq7+eyYUYA+VxVtX70KdjF/a5DWrYdxSNzipu1I21ZZPX1juQbk8TzFi9jqHt0F6jkeROtxy1Jzxem6SRnMR3Wq8nZhg0fu+LOFWFFqEt8qGg/Yam5t9gg69wK+qPaJFfJgsXSea65lMa0w38NDCrj6h+3uE0wj2bf1tXB1XUBTnTEkAS7gVo+d19uu2Kdf97e/cJJQyfOu8hOCSIiUzfhA4k5F80kIkJ4fRswWpmK7USgA24HxtJHxenD4g5+4AHnv8+32AS09Z8btEfK3PViQsB6H0JRku4OQbMAmgZbFdBASeYjEVmLhEm0BbrZjPbaqbJc8Facu/rljxeMQnuGSEqKjKeGJvvR5Cg93SQloCyC2C4PvtuqZ7QsOedsAPUgUd1V2O8RRHxGxsOvI1jkeey46g1kvRu6O7uV32zMRWmzHQ0vUn30/QLVHzb1qk2EDHMkHctpL3NvIHvXSotLy0lozqx4bMJFfvfzARuLnBH9ybxmanrDryPv+tboYbi9u4IvPb9/M28t1bMNCXrV3fVWGQxw9p4JIOOlO+iS0vWecFTesuAztaSDbfTRuSwQJeGNz/1p1qxFvwPLeHuxgW4tgQlwf460GZjNB/3bRQQdDkws46JkfhgJBOnpNl6X9G8iuz08v99d7ZJ18ElOkxv5Yjih21biczZ8gchCTIJIxwsG88b7LbTlMi0VMuE4stb1yalbUdIgyEPz8HKAkmPffB4kwI68tl/ys5YU+Qrsf9VK1ucpQRii4rLwSE/K6CGtaFqKCp3ycquqpLvs7vcQqe5ou+RDH1eIHw8GbPpvdPeHo28pdkMlWcZVUGO0fZ4nlckOlXbV7tIeHRaufK9ofRkrCyeFnQ0AgJ283t34L0C7tuPeJlOB3n5oaN0nh4rM1yrW5W0bh4vlzm9+GG680UQtuWWSM2raD4bbW8v7odaAKa9F0bNWDvCB6Z7CgxfNlL+bwXJqCvX9xsu/+vdQ6PaMMhcQwAAwAdkX+rOc7h+ubkuF2Zc+vK5E4gpQyoTpwUWF7qsqId3+RRfbWBxHsK/k3tz0Nj2x7YU0LSU/16AaebmFdbPUMNodazyiaX08RgeZS/1iDWVG43cHz1yyu7vktEMN5UAmQcr7Di8qBae0Ld1+7B9/BPCiLb7sYI+jRWPjHr+MV++BBTmaM5aSAeVi2OVeCkNnQQqgtPUrOY4gskms89lieCtBAKY+fcfbsK+cO8Q3QR/cIkgTKVM+Tc6WJFLHEBYx7YuJ4bRJ0WcN2fFVpvO/2sxTougP8enjUjlpttjd51M36NgYdBntHkGFHpm7ahOm5Ld8OfhD7PIrKpHx07wX2xG0M+TwZsxKLFY6kBWJWr/ntFsE9kRQ/vWGIN/KxuD+7eQSrbYLTNvZjo2NAkmu6c7SpuwTX/zxI4CIeRGNbbfGZHlJRww2jYMuCm2890egNd8USu5sQ+2iNBZ4lIm67qxWgnuuXPMdlwj8Tj+XeRSuQvbmi4wEcKRuOL07p17rRQszuiBtzG3a2yJbcfdYvTdBRPrgwrj9FNAAQM2itSXF4HIlVPCfOFjWsde5ZwsI9fEdEuE/GneKWz8OZHlWgQA7BOrJV81yDuyWCG7G/jmShCdsTmHJ7t2GAjTcpx8ONzrmae5VAQ/MzWhRbnkQCEtgH4P70kvn4rw3MbpmXe9bN6l+SxYvpllvg4voaj15P0ukzmX7BjdL1O6Vo3Z4OkuPy7EYinUFpUDaekYGzZ64iKJwYCOGaBIq7P4KnP73uo6rjs0U38PDrnJDgepFLRvfvr54UtTFuHiZW0WPT46+YCcvfz0DEEBJx2JON9Adqz9epBRYmF25ta0C4uM2vzWBXHMnJeGOb4jVT+sHazgcl9+C05aZ2q3PDMXVp//nO0NRqgetYcluvhiU06x8gKYN6PTxXsEfPM0CwR3d2Y8pL+gekDpbyyB+mV2o/7T/ozB0+33vQ8Cro47k1lvy+vUQeUIHaifhAoYo0758gMH4xoh4KUtJ9bHLDpzRwcqLDrAsPfHi9Rvz4hFsmYoml572tJR+PX4qLJ5aWmUxAtsMlVmG5+XJXexg9wQoeLmDpRZDej03gLiW9y/2CMXgCBpHppnb3/ntsCiFS9W7gsk0lj56/WuYlMpmOcX3yxjOmmDB3S4fgopxv3B7CFJOVVI9jcQGpuJV/tZc3ZR0lISBGAdfj+tpdGgn68pBkQn2+LedShOsMVhemu7XkGoxBZwIKhhjrM1xBKOSxotXDXQhQHNYjJpAckZGzy0MZNl3jz54YBfFyC9OW7MycJQ/qgqEsymLnEELp8gBepMfEaSvrmKNpZcztMQlod4eva6k7ejKXMvfe93cqFQixYWFCNRhJF3L6PKKTJ4h9HQuFi4+vgbDgYxMKrDxKcBcKYrIJFUgsYXhegA7PjSedMcqdJD/AZ0VBBByER5/iyWu1w3uT4m1/G03doTPFYrLJHQjB1m/QGfGGofjOicjuZKv7p+nMLpDXU16YrGwV1hG83fLsE2OcsBMwj6fW2VuafrYo3hf4yCSSVdGuRs8B8pjO6bFpuhrMHBoYLsy5I7K+xu5d3J4EytpAhEhxs0EHIQ0Az5G5XdIm8pXfFdHqKV7W8RkRMntuT3+yu9hCHlQRjxOLOzMPWrq482ayY+M8HGTZjkc64Zzsh92eKdPdmHH8n3Wkpv21UbR6NnqDZYiJkiDIkCau23LJ9trNvnXUo93+Geh5gTL7KeLt5o1+//VQpF9fr7/+4E+nJlk+DNHqTFNDoszBdObUDTeYcnuoY3psZM54EU88xRtbIfS8rvJA1SiujtzmqYe7nl1mCbFvG/Nq+5x4n1+F73lUEYDLZZRBEzr2kWwVzNZyDRXbZt1o5vMlnnuut3kMTq56hVneUAkrZFRTj1ziSkBylhtp7Akl7qcaz3fUy64xVlvK7GAsb/r6V3gWIsBucmQHsIK+PRZ9gSIdjKd9huf+Sq9WHJ/2tbah9N8XNPeYr/S6F/KAlDyYzXwxPuMj8oYXuJo7XJbna4AbthpL68d92NKHp/nxeChVcCnaW7kR6kH4s6fTcur6jv/p10OsQzNmGKn5nUbAS9+jQ7wBXrcQPx6nMTzTMHlo1Hvb+lXdw9V+TuTstsQwA+Me3zbth/czsu5DIjcymnh69hGG/dfOOVTpsHHWbZsY2/ptV/edY18diRK+1rzn1SRXPTvi5tum7ha34fEKy3vu9gsh8zxHB5dlS8T9tbu5y+tab//a7abn3ebEaG4rE9sTlFNwPwTWpnsUCGqBhEDPkRjI47S+/5uE7+AUzz1e6NBmAfl2EQBTe+wrfwHi8IGbBy4GEu9FihvPdlk7Lyrux121enI08oV6cS9uV1p7ws3jVnsIAseBkrAJL3kImJXD4jd8vtthXLVzMLlGEBK6hwRtCeM7ya7j91NBaz9uPAZwt7vccHSwwI6Y3NvDE6PbWtAyS8BFbHU4nOlH4N+mmp2PyXPHpl7XjXDHZrKYPHflJSpGdx8sNhtNTo4wChEALdFKyUDVDkLlJ+M9qP5vQujnayAAzrj+B4MqfLDZSqXjAAABhGlDQ1BJQ0MgcHJvZmlsZQAAeJx9kT1Iw0AcxV/TSqVUHNpBxCFDdbIgKtJRq1CECqFWaNXB5NIvaNKSpLg4Cq4FBz8Wqw4uzro6uAqC4AeIo5OToouU+L+k0CLGg+N+vLv3uHsHCK0q08zABKDplpFJJcVcflUMviKEACJIQJSZWZ+TpDQ8x9c9fHy9i/Ms73N/jgG1YDLAJxLPsrphEW8Qz2xadc77xFFWllXic+Jxgy5I/Mh1xeU3ziWHBZ4ZNbKZeeIosVjqYaWHWdnQiKeJY6qmU76Qc1nlvMVZqzZY5578heGCvrLMdZojSGERS5AgQkEDFVRhIU6rToqJDO0nPfzDjl8il0KuChg5FlCDBtnxg//B727N4tSkmxROAn0vtv0xCgR3gXbTtr+Pbbt9AvifgSu966+1gMQn6c2uFjsCBreBi+uupuwBlzvA0FNdNmRH8tMUikXg/Yy+KQ9EboHQmttbZx+nD0CWukrfAAeHwFiJstc93t3f29u/Zzr9/QCdZnK4lMRQrQAADXppVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+Cjx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDQuNC4wLUV4aXYyIj4KIDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+CiAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIgogICAgeG1sbnM6c3RFdnQ9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZUV2ZW50IyIKICAgIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIKICAgIHhtbG5zOkdJTVA9Imh0dHA6Ly93d3cuZ2ltcC5vcmcveG1wLyIKICAgIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIgogICAgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIgogICB4bXBNTTpEb2N1bWVudElEPSJnaW1wOmRvY2lkOmdpbXA6ODM2MTRjYzQtN2ZmYy00ODk4LWFmZTQtYTdjZmMxMjFmNDliIgogICB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjNiNzRkYzYzLTBiOGEtNDQ1OC1iMjVkLWM5ZTY4MGRhZmE1NCIKICAgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOjcxZDc1ODJkLTJlMzUtNDY4Zi05NmIyLTYwMDkzMWEyYjhmNCIKICAgZGM6Rm9ybWF0PSJpbWFnZS9wbmciCiAgIEdJTVA6QVBJPSIyLjAiCiAgIEdJTVA6UGxhdGZvcm09Ik1hYyBPUyIKICAgR0lNUDpUaW1lU3RhbXA9IjE2NjQ5MTM0MzYxNDcxODkiCiAgIEdJTVA6VmVyc2lvbj0iMi4xMC4zMiIKICAgdGlmZjpPcmllbnRhdGlvbj0iMSIKICAgeG1wOkNyZWF0b3JUb29sPSJHSU1QIDIuMTAiCiAgIHhtcDpNZXRhZGF0YURhdGU9IjIwMjI6MTA6MDRUMTU6NTc6MTQtMDQ6MDAiCiAgIHhtcDpNb2RpZnlEYXRlPSIyMDIyOjEwOjA0VDE1OjU3OjE0LTA0OjAwIj4KICAgPHhtcE1NOkhpc3Rvcnk+CiAgICA8cmRmOlNlcT4KICAgICA8cmRmOmxpCiAgICAgIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiCiAgICAgIHN0RXZ0OmNoYW5nZWQ9Ii8iCiAgICAgIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6NzgzZmNkMGUtNjAyYS00NTUyLWI4NjMtODg2Y2M5OGEyM2FmIgogICAgICBzdEV2dDpzb2Z0d2FyZUFnZW50PSJHaW1wIDIuMTAgKE1hYyBPUykiCiAgICAgIHN0RXZ0OndoZW49IjIwMjItMTAtMDRUMTU6NTc6MTYtMDQ6MDAiLz4KICAgIDwvcmRmOlNlcT4KICAgPC94bXBNTTpIaXN0b3J5PgogIDwvcmRmOkRlc2NyaXB0aW9uPgogPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgICAgIAo8P3hwYWNrZXQgZW5kPSJ3Ij8+uJe5zwAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+YKBBM5EMRIXT4AACAASURBVHja3Lx5sG3pWd73+6Y17unM59x77nxvD1KPak2tWUgKAlGAwKQEBhQcG1whDomTglCusl0pk0Q2pLAwFIODg2IQBiGBAEmgoaVWS2qpUXeLVqv7zvO594x73mv6hvyxr3BRdgBXwpDsf9au2lV77/Ws93u+533eZy3BX9Pr9tmPiN2dydqJM6dfFoK4v65mZ8Afr6tiQ3iz/IkvfKr1O5/71dj5gA/TKmlHk1Yn21NK3orj/Iox5nzt7HMuhKeliLb/1Y9/Ifx1nIf4q/yxgwu/14qr/ltdcuTt06Z+s3P+dKvVk9rkFLMx5f5lVLZEFLcZT3b4gy98lo88+RsEGrI8Ic4FcZoSRTFRlFI7iw/CC/QFIeRjwfiPaZ194r3/8BOT/98AePHsE6qb1m8TVrzbFeN3eOfbgYKyidAiEGVtnMiIZGD32lfoLZ9ERS3qasilrZv81Pv/V8pqwtJyjzQXSKnAKOI4xQeNFwYlLVLEBGmIkniMCL8fmvJX+vv7H/8//pevuL/M85N/WV/8lr+90H70LcmPXLzw4rlmcvDRphi9K8i47THUVtNdWsMYTbCBerSLlp71E6+gHF6nmN5EULG21MEog/fQNJayrildQ103WNsgsAihCEFT2wLhPXVp2/j4XdWMj373G/+rc89+8qd+5OmP/av2/2cAdB/dzD/6nqM/mmtxUYrw07NpdVLpDniHlpqs3SNNcwiCqqxBOkQ9oShrnC1pLW2iZ3vEUYSRmjSJSJIUgsR7SQgKUFSVpa5LpLcINMEZZsUEZRKCz/jet/4g951+8OTSxn0/vXrk9MX+jed+dHL7+fxvLIDhsWURPrX23UKXz7/1vuI9/+29akVrjfFDhC0xaY+mGODKPlJAaMZ0FrsY7fH1gGLcxxVD6iZAvoxQBp1koDRaC0IINIVF+fn74BXOQV2PwWqkiPBNoChLvull38rx5U0o9glNQdm/vDIbb73HBvv8/qXPfPfWhU+Iv1EAhk+unfCWjwT4NSHlMaUDb3yp5L9+JGfj8DG8c6hmhAoV0/EWrqqZjcfYUiFMj/bGPbRaLfAeV40IpoVzAduUVGVB08y5r2kqnLU453DO453CNoG6GaKFQcmYu9Ye5szqYYwUSDnD+CHl4Da7Z79ANd49FoL7NTerP3Lzxc+c+BsBYPjk6vcFEZ7B83Z8IBAQQiCV5x0PS/S4j3cB7zwySml1N7C+QWqNEA5X19iyJM4X0XmbJM+RweJKh2gaBAJnK0JwKKnwPhBCwHtPCGAtOO9wdoqQml6aUxUDqnKKyY8SrT7C6t1vZu3Ug8xuvcDzj72PLIvfnrdaz+x/7Te/768NQPfpI4n/xNovIsX7kKKLl+ACwgd8cCA9Sew4wlm8jhkNbuCcZ7hznVQ5Eu0RWtEUfYa3XiS4ArzFTbaJsOhMUFoPSmKimCQC7zxVZbHWUtc1ddXgPFgvqJuaphxzZvM0eW+RuLXCZLxPObmNSmJM3CVaOMZSp0X/1k0qK7oh3Xjf1ad+9Rf/8D1vTf5KAfTvW1wTs/pTVOHvhVogfCA4N+emMNezQQlwnk7z28STs6S9TcrZAUYKpv3rYD12NkWrmN76cah3kFgOBn0aIhARWgkW4x7OWqyXJGkL13hEJVFK4ZwnOPAV2JBweu0BTq8fR/mA9xNaSRvhFULFyCQj6x0hP/RqpsMB2+efgQB5q/f3Dp++51M3P/sTa38lANrfWz8dTPgc0+bRYAN4R/ABHAgnwSlEMOAUSIHQFd3+r6CnWzDeYrZ/nihqUU738E2NDAGJpr8/pXGBztpLkSZDmTZCRdRWzpeo8ygl0JFAxBopJUKAsw5rLQTD5tpJpBEEV2GrAc5bEA2+LrEWvK1IVg/R6vVYWV+kHt/GESHijUedWfvc9Wc/ePovFUD7iZV7cfaxUMhTeIlA3AFOwG7AzeZA+sYS+g3IgJACzRZR/ylcOaIeHlBNbhKQCCU4uPUVdrdepJqM8Y1kNh4QjMIGz2x8QFXXNI3DWY+1d461wzZuzoGuwTlPU8/IWj3K2YwkzdF6ETvbpzy4RTHsE2xAKY1wFYsnXoKUKdV0RqgaZtuXqev6lMA/tv2137/3LwVA/8TmaWr+UNiwyZUG/Hzp0gRc6eG8haGDmUNc9QRAKAEEggtk7tMkdh+yHiFkNI0lEFDxMktHHiJd6CJkzUIvw02HiPKAKEtZ6h0ieEHdWJzzcz1Ye6wNd0C1jMcTlDccXV4kiRNCECA8PkTUswF1OcP7AhsEvqjYee4JbN2gzAKzYp/8xMvobd5PQG/ubl/9w/f8z//l6f9XAQyPb6xB+BhBbDIQkClC7QmFI1gIVz1+IBG3LOG5Cj8FkSqCl4AkBBBhyqL8JAtqAINn0YOnkfvP0slimukORiRMB3sob0mSFjZEeOfotrp4H+Zypa7wzmGdw3tPU1p8KQhecO/m3SykOQbATan713D1AVK22btxhWo2IwRL1N0g3zhFObiGySWt9hqDmxdxLkGqlA9/9unNx5/7+Me+/ftO/YU4Uf+54H3hcBJq9yHh/SmZgD9bIxY0+ICfekI/0DzjiVoeLnkCAvWKgPcBESA4B0KAEBhVst78LjILoAUBQRgkDJuH6ItX4nSLg9k2cd4h6B7lrGBr9wp5noGYXywCKOHxwuJtwDWCtaVNXn3PQ8RxzmxyjbyzQNruMtjfx4uAn+ySRA+AsEgTE5uYRtZIGVNM99HpAj5MoBmi5RQh7CkT6w99z98/9Q2/9vMXy/9nADr/XuBR/JzPSAEbYM/T3ASxZRGVguCoCkmyIgjeI70k1A6MRKo7hS4ExBLqhiAFQgSELOhFXySpb9KX30V/NENEPZrZFv1RxbXtiwgJcaJRSqGUpJnWjIdTpDR4Lzhz6Ag9aambGaqylKJAqIhUK3ySs/DyN6MyQ1POGPTPk0YtbDDU0wOsUPQOHcV7x8G4z629LZRWCBEeDfBe4Af/LHzUn9NhfJ+w7p8hxRy0xmFvBnzpmXyxobkMdhTQQF0J0p4g9AJeG4JxiFwhtITg7+AnEPIOsEIg7lSmkAItBiTNc6jOK1D5YYrZhOevbPPU154lBIt3DmcbbNPQ1BZrPXXl8D7Qibs8+qo3kKcZJuug7AgfFDLuYMt98CP2r15ARS1EXWCbGUl7CZ22UFIj7Q6T8T6/9MF/x83JDaQAqQSNrR+56/740tmvzP74P5kDn//dkyfGUv5MKdS8crwkDAXFVuDsp+DsM5btrYrx0FKOa4yZ96r1roIViVqQCC3+BDxgrhMbCyEgEAQnCNZD7RAetByzVP4b4ulTDCYFv/nY7yNVNBfntacpHE3ZYK0lWI9vLFSOh1/6ALGU+LKkGu3g9BLGeIT0xJ0Nglpl//oVAFpL63SWV5FJm8m4z3TvCqg2N3bH3BheYzYr0EaB8IRgyfLsZ/7uj5458Z8E4P/wEyfFv35m+nP/5GOT7gvjNl4EQjWvmksvWA5mjnHj2Z7BpACbRVjlkMuC6NUG2REIL6AOCAvCBYT1COvxdUBIBT6A9WAlwSuCmFerimcsuF+jE25ggsBIjzEp3kvK0lPMwDaaJkiEVITgOdpr0VS7iOBRKme2f53aGVApKIPJEk6+4s3Ycg8pFQGB9AoZIuJ0kYvXrvCvf+9/JwgQwgEBay1aG9I07drG/tx/8Q9Pir8wB+qo9a77s/LtLzne5mjXgRKIOjC4WnK90cSZID+ZkY8teVsRtT2sxbh1gccRVXouc6JACNypwkAoAa8ImZ8v5znHghcEJAT5J9W5zIu8/f5jTGdT9kvBUzevYZynbGq89/hgERje+Mjb6PR6aNWiv3OO2c5lNu56BQrDeO8qJumRZSnVrKDYPo9EYLI1yvF1Ku8RScb7//B3caGmsQ1ZlqJUIDjI0oQQApXn7VLJdwHv/3M50H/mWL7ZUR987UnfO5w7cuMIkcQLyfOfszTRBkoqFg8ruquK7FhAb0ZEhzXRkkXHcg5WEOAs1AEK8AeOcAtkTyBMAAt4MQcszDWl8GFOFxKSNIf2m+nkHU7fdR+vfuhR3vjKN2BsTP9gD9topmVJ0yjuvfsldLIYW8xoRlsonZH0NqhHt/HTPqEcUdYziFfJ2is0VUk52WMy2OYLL17i6YtPUjczugttIqNREiITI5XCBYcQEiHly1/2hrVfevZzu82fU4HVD9+dlceoIAgIXiIDuEVFfGqDjRVBN47piglBSKpaMotKTGTmVeTnAITSQenxU09zDbTRiIcUoafAgJDgHMgKaMJcdAtABDACESyHjx7iyKlTVE2DiXLKekb+6Kt5zV3r7N44x+644HLfs7m0ClKStlcpBjPGB5dJuj2SfIXd536XtL1MfPgByp0XGZaXiRaPI2TN088/wwe//HlqX7C00sUYhZQCiULHktrVSOsIThPgmPfuh4F//n9bgf7JIx0R+PUQqVwYkHrOMwQP5x2t1BEBxgwJRKhWwHmJiRQhKHT278GzlWZ6JTDZSzCPGMyjMWpZIBOFiBVCgWhHiMU7K1xJ0BJMAK0IokfovglFRWv5OHWI0EKwsrZKb3GDVnuNsq45vmjotQw+eKrJDt21NRbXNqgnE4KExgV0q4PUUFkFQtFeeQnXb57lvR/4DeJMEScR7U4XISTaSHQM3tfYxtI0Aq8ipAQQDz382o1f+Mrnd6r/aAWK4H4AE1aEDPgQEFpBY0Eq8I5M1eRLBcUsQXUdty56Dp+O8ZMS5wXWSVQ7UJCQ9WpMR9NalehcEpQnSHlHtkiCCAhhCUEiegImzXy+IRUIsHYD01nFVVMObl4gigJ59zC1a8jaXaIkZvXUKerJAa6YEkgobE0iKrxtmA72iVEky4ewdUOoFSEEkl6L/t5X+MrFXYKWSBXotjvESiIVKAUh2Hn/HQRWBrRsCAgQcsWK5geAf/kfVOBv//xRdeqI+bdKNAtBe4ScE7yMFGIaCApCS8JigjgoMT1B75hCtQR6KUKuBppZRDSuiUpL8JJoVYNxoCVSCYRWc+1HQMjwJ+I63NGCeA9SEdJTHFQPo7NNgskYjBtCMyHpnaCcXCIWCUG1EXafVvsw2ClxIknyhChbR0qBF4FieBtry/mGJgTS7iNRXLh0k3/xq79MnAjSdkKsDeBBO6R2eC9o6oCU+o7gF/N2VAq00Xe97I1HfvbZx2+FP1WBf7Rbv+35P3Qn716N0Upwc6y5f1Fx5mib1fUxYTpDGg3BoV+ZwrSZE74GlEXKmDSZwWWH3NWIYPE3LfIhRYj8nU3Ffb3UEV9vTsId8CKN04qGd0Hv1QyuPYE3V8g2H2H1+D3oqE2oZgTXIpgEbVKsXkcY0J1N6mJGM7zKTE6JI0PeWSLP2kwORjihiWKBVS2mjec3PvEkUki0FJgAtbOIOEKhaOq5dlVSY50HNR8nhBAwxhAEJ5Vo3gZ87E8BaJ1997CBJ66VzKY1Kuvy1V3Dw+MOf2exg+QiOIFHoJWDbH7VXBUIOiFcnCEuOcgi3EsCQknkgiAohbCCID0ySFBibjA4RxCe+Z4tQQZC/kNMRksYL1m67+2EpmS8/Szet+geOUmka7qrGzivCZEmHEyoSkvSPkyStwh5iog6hHLEcP8SOs5YOH6IUNc09R7KHKW/X/Diza+RGEWwjsZ5lLOoRs5bSzGXe1IKhJp7jkrNDdwgQAqJgHd/HUAF8E9/8ngL/C+EUMWN9eAB7xEiwruGV917Bu33ofdSyO4lxEcI8SZBHsGKBxGDW8h2jDwekEcUclUhVg20c2hlSNMgtCL4gDDMfUIl7yyNcGcJSxpejc3uxgVF2uvhgsE5aC2ug+oghWJ0sEOIl0niCGEUB1eeJ87a8xmxTghhhkwWiBaPIqM2TT0lhEBdFgRvEUpx7txNFhc2GZS3kVKhTHRn1jJnkRAEXoEXASnn4EkZIIBWishExx592+Gf+eInt2oF8KpvaH2zVPL7Q/AEGgJhPg0rLAtRymte8Tp0cgQR9kDUCBkQtYLS0JQKV+4jV45BfBeCK/P+V4FQFiFr0AJ0mLd2EpB3emCYi3QhaVrvppCPUO6+iGqtU06mSATZ0mFEtkpTDBmPpggJRoNJckQwdFaPMx7u4F0gWT7NeOcGxd6LREkXrRXFYBsdS5xXFCVMDq7ypte/ibe+5T9D+haXtp5HKIE2mnCn7ZRSzblPSqQUGGNQSmCQSB3R4OOmKp56+vHdFzVAUbm3xyZCihwVB7xv0MYzq6dza150cHKBGS+nHt3k1pXHyXSbLO0R50fYHktEfZgT978NM8wQ9qMQJCLMnZmARIpAEB7C100ECNYR5AJWfiMFL8eWfXTWZXDxCapyQO/46wkqZbp/nSiGhfUjBBFTDPvsXb9FrAUqW0YnGTrq0Ez3UXGL7uqDNJWkGR2gpUKLNknmyVoSV96mvv0cqar55re8hUtbX+Pq7rn5jqrUnbmOR/i5HlRKobVGyjlvCwG2rvG2eDvw2+rbf7glbDP9KaXMklQaJRVGBsAxm1k6aonXv+pNBOeok9M8/uSTPH1xgV73HpLeA6iV+5iULY6fOoFQCtF9OdhthL+BCP5O/EYCnvD1roP5MgkemvjvMuQR2kfvI1vYJFpaJ8kWENPriGxj3qmkCStnHsHjaSpB0uoRpRlp+xje1dhqghA12qSE4MDHSBNDpAmuQsUxwZd3Pi8QOmNy6yukSYv7X/oqXrxwhf3xzh2+03jvMUYiJUgpcX4+j0E6rCsIviYQOg+9bu1n1StfH61XVfMTTYMwcY6JJMr4uffGUSLnue/0PQQZ0egeH/vIh3jkgddzaPMknXZCOdhnqZMj6gKEQZgWXj6I95u4RkOSIqMpwTsk4NR9uPStjIu7Gbm30R9HOOnJF+8neEcxG1JPJ/hsjWo0xrmCJEuxzhMbQTnYIeptIIKgnO2AabP1mZ9H+xKRrhG3lwmRxOgMHxp05wizg1t4OyPUDdokd+hphNCSOEt48N5H+PxzX0JpgVIC7/0cTCkwUqFig7U11tYIEbC2wdqwIDC/oP63n/lnbzh57BXfe/nqRSbFiPbqJtK0kDpj5fAm3SP3UFz+A6Rv4eJlWkmLE4fvpd3toYxmYe0oUdYGoZF5D6MktuhjOYRrvw6RvwnHW6D3nTT6Nbj8LTQcpW7aVFaitAKhseUQa6eMty+g8x5RrOmtnSJuL+OLPr4aEoSl2j9HUwdMtkDV36a1epjQQF1cw2THKGqLq0YoE1EPtxA+YvvC02gdSHvrmGyZ6WiE0DGj/i2MDySdNpeubLE32UVKUAikBB1HyDgi0NA0DSGAc4G6LnHOCuvKx9Tf+jvf9h3t1sZbT52+l+ee/yxp2mVh7QHiOKW7eIaq2WanyXjgpe/E7d1kuX2K7spxsDNarZh6648ILkJqSz2tMfkCRAlSd/EqQkUJIl2C5DA2Xp+nsaYjlNLErUPzRj1eJISKZniTKF+ls34c4Rqq/Yuo/BC6t4xOOjSzEoGgrEYoEUi6G3MhHrepCo80kjhKiIyhCnL+HeU+IKmHVyA0yLhHa3GNpik42LqE0R4lLIc3T/L4M08SQkArRZLNd17va8q6wjlHY2uqenYnFREIPjyn3vl9b/mBpgkvS7MVrl69TVVu0+sepb34UrLOcVTcYjS4ykOr9+DtiLR3AldPyfIUHWUI3aEpi/kPR22iyBBsyayomVx6nCjLCKLHZH+P8ZUv45yknt5ivH0BYXfwJqW9dgoTaUyriw+aoDpE+QIiMky2XsALTT28TpIo9PLd+BCBrxnvngM07aVD9I7eDyEgZcNsPCJpLaFkQlPXJGkH3TnMZPss5c7zRAvHkSohmBRXBVy1z/LGMaZjxf5ga+6qiXlQwDbNnxyrqsJ5h9Ya6yzBq6vqnX/7zf+NIDrZhCmL3YybV67QCM/q6sMkOkNrg3IN9516K1JG6KxFcXCdztJhlB3ga4vRDrd/lsY2CO3QboaMNKp9iPHWeZrgyDo5eZagzYTW4hEixmgZIfJVZJQzPRjjzQqmvYpO2ngihImJOutIadHZYVTU5eDas1TDAWl3EakSprMarzO0jknTGCXm5oedHKDyRQbX/giZ95DEdNbuIl44PJ9MuQbhZkStVYrxHjrt0Olu8NS5L+KDQwCNredtofVIIQBBABAenCE2nb761u986Y9NRpdWiskWsTL0uku88LVn6SwtkebLFLMdTvdO0I0VebrBbHCFYrjN2vH7UfECMkmRcUYodumff5yQn8QsnwGZYIshunOIzvJh8HY+vlw4hSAQtMH6GBNniHLMaPcsOs2JQkExvE6QER6PdlOayWB+zj4gETT1BOfsPCbnI1xVoaRDSUE92UZlC0z3t4jay7RWjiL8lNneFVSckXQWqWY3oamQcYdxMaUY75FGAmkUn/rSE1RNSWNrnGuwtqaqKsqyxNWe4AUeEBaSeKFU3/LOh/9JVdzOR4MdytkMLRxVOZ6biQTa3eO8auMowjk6nS6zG1+iu3yIdOlevAd0dy48oxbNwYtEUQ/rBdOdC0wPbtLZvA+tA4QaO7yNl12IOmglcL7EK4NOWmTtVUx7A5Hm2KqZC3bnEGoZmSSoVFNN9lFKU0xGjPu3iZIMG8YgNELESOmpqgbTOozUBleXyGyRYrSLlhHNtI9KYnS0ChTURYFWGtPML6CJBK14iT+++NU7/0FircN78G5u8SdJgkIQjMETgs4nVetg0GfU7zOZbKFlyqgoMWaI1jtY06Z96gx7/SFKOrTOaHZeYNbZJI5TnOkhpEYLyA+9HJmsIKME2ofRJqaZ7aM6i4isR4nE969i7ClEtk7QmungBr3NNarpdUToY/JVsqVDTA626F/5DHHrCMt3vRbTymmbRUJTEYQGV2LLEWlrGZHEiCTHOYX0NXZ0G6Vj9q+eJR7vgS+RzYzW0gmmezcRyiBUQGpNFPeYDS4i1AKTG5d4ycYasV6k9n2qqr6TrnAkqSFJDc7XNB6UVAAt9T++7vD/tDDbkWJUcmvrgJ2dAw52DigmB1g/o7N4ivuP3YdzkjxLYbpH7RpUdpSks0wzGRJcQzWrSNrLKKXwIoagqNUCaWogQDnax1cjXLVL09QMd69x4+xTDK+eo9WKGezfwihFMRoynQ5IY00xHGFay0TtjGp4CyUVMlJIZZAmQScpykQoJCrJEUajTIO3JWVVI3TC9S99mPbKBlG2wWy2R7Jygrk7KrHlBJPmJN27scMbJJ1FpIlZXDzB89dfmG9KCJIsJooMznqq2mKDIEtzTBRJ/XD3ANFLCesad1fOzbHjl5/Z44lbfcriPMudS4RHJQvdJcLoBvXe15iUHZbuXUBMhkhfo5IuYbaLVQtEUY6dltTVDMbb6JXXEEKNaa3ivcdaTyMW+cAHPsDnv/AE7Ry+Yxx49RvfCFGMG+ySZYepgyEog7cTcJ5gPdPpkHbUw2QtrIAwuE1Tz/BRQqJToGA2GaLjBD8bIJXk9Fv/PuMbX0QuKWK9Qrl/HZW0Obj4OZZOvILBxSfIDr+M/PgjzC49TpR22GjHBNdgtMEoRRBfn0G7uSOjBaDwwaD+8bcd/TGpjAGDlBHdxPDAkqIYSr62NWYw3qK1cJi7TtyDrveoBpdpnXk7SRrjAFeMqZuKKM/QSU49uIKptxDFAJF3EaYFpk09GWGtpqDHh3/rt/nkpx/DoplW8LVzNzm9JlhqeRqgnI6hqVhcP402nsn2OUzWIVgoigKvMuIoox7uMty5BOkCptWjCdDMxhSzKXHcoqlmUPQpZmNMvoZOWjgvUHHC+PZ5omSReGGTau8FdLLIYOciQjjyhUUu3hzjQomX4MN8juScm+/EwqBVgnWuVP/0HUd+BKlykAjRQghFpCLuWowp+55BYUkXNnn4JffhmiHkh1g8+tC8moY3wZeEomC0e5Woe4g4O4RPO2hhIVrEVSPq/gWasqAY73Bl64AP/9YfMB5P5kMrJWmcpZsITt19H0IpotBQVzOESUjaPQSeYDrIMMCVBcJNSLrLlNMB/Rt/jHUWUTcoGdHfepbhfp+os0EcpwQ5Y9q/yWz7ItPBLlIbdNSitXEGaVKCiYjSHFn3wTiKwQ5GWnrZAk9deA7nHU1tcd7Oba4AJlYI5fG+6ctg0r1gWgSVzcM+3iBFm3ba410PrPHyjbv4rm/5ToxKkPEKShimkwYRdYh7K5jFTfRCjyhqqCZDmiCwLqL0S9R0Me0l0jwnS2O00cRC8MDrvxFncmoXqG0DWuNUG5116C5vYtIuSeKJwxQnYmS+ThSBUClV7dm98FVmwz5xb4XWofvptHt4GqSYkcQLBB9TzIb0B1tEyQq9tTN0Dx3G+oobX/0041tfJXiNrcdE8SLT/W0a1aaa1Yz6OzR2Sre3fKdtq2kai/df9wMNQiq8t3hv96RMzC0RRcg4RSgNeISdom1BO1c8cvoYC51FRCiw05sImVKPtgjlEGUEOpSkK/ewcPc7SJKUarJPNbjN3q3z8xivbFHqFVR3lXTpCL7YJc0Tjt71EpAaIQQayT13rSMFVHWJ7KwRdY6hEqAeEUmJrw/ACbq9NkX/Gjvnn6UoBFl3Dd3ZRMdr2Nox9W2u3drlF37h1/n0hz9Mv38bdI6KV+ltnGbl5P1MRzt459DeUzUT4oWTlINtsvV70NkirinwWtE0hrqe98C2sVg7nxF7G7CNwzt3SxN1riAkwdcI7xEiATHfqJT3LGQnCdYiYk3UO4ZKFmnKKV4agu6ggqFoHEpnkOaYsIsrp7QyEM0ORuaAoJkpTKtFryO58PH3sXTmtZyta5T2vPoV93Hvw68lai8iRE0z3KN3/CW4YkA5GNJeXoJCMxlepr30Ek6/4fvZv3GB4dZ58jyle+g+hvuXGR7s8Uu/+EFePHeRaVVwIUl44JXXWFzu0Vs5ihtPCc4y6e/SGlwlXz2NxvW4LAAAGDZJREFUmE0IwTDavURKRT0ZY0zKjWvP4cMMpSLqusYYTRwnCATKC2SaYYy6or2fnRdBIjygNdCAlAjfEFyNy9sIUdI4hVGaoAxxZ4X64BxWHKWxCXZygEm7ZN3DNCLAbIzafBlC51R1ycHOLlHnEOt5l837X8sP/XeGizuSjWzKwtIyr3nDN5AudLBVQattqMOM/s5llpfXybspttxjtH0WR4uimpFGCVoZOgvr1PWU6eA21577LM+8sMdOIamEQsmEQVly7vJN3nTXPRSjPfLuBlJK8DOa6S7VQUyysEGYDeideDnj3WuEaoYrHeNJQWMrQKC1IklivPdorcmyDG8kQnBeByuewwZQFqo7cQStYDZBNTWt/RdBvJm4lVI1guAatI7QvSO4coJRHULksLNbjG1N1soJSkOc4m2gHPdJWh18PcZOriPKEaun7qOzPuHB+8+A7yNEIMvXqNjB1g3R0hFk2TC4fQ3yTbQugQzvC5SRSDul012laAqiJKK/f500cfjJDpFO8M7TNAVSCSaTEa5WSKmpptuYfAPTXmZw8wImXUEIQTWbUfWvkHe62CP3UAwu0D8Y0FQKqQJJEtM0zdzeR5FHMVPRIOA5KZV6mvHUh9KBj+Z5lukUihkGS2f8ZfzME3yC1i2yrIMPFq1aGKOx1Q7BlXgPWjmKyYCod5qqcngdIaI2CEO8/2Umf/SbVP1tuPEcun8BPb1JFEqSTBDckN7CIpOdc/jJFKd6NLpDPd3j4PIlfNLl+vkrDLfOI7Smrm8i8VgvaeUpqnWcw/c8zLS/g3OWKNI0Vc3Ju+6jKvYwps10+zrV4Cyt1iLDvQm+PKCuAioWBFvh7ZgGgXOCR156jJXWIlGUAIE4irh/4QTftn4f7+ic5FjoeCXTp6XfHm17JS64coKvSkJdgwjIOEZoRfSy70HpAiUcdT3DhxitImpnUekCJltGCogXDqFMihSauhoRixo520HaijhJUcv3EQlJdP5D6Eu/g7r8BDrRWBKs04y3z1P7mihPKRykvQ4dXdLOO4wOzvLU41/gdz7+DDJU9LcugcpxtqKaDAgmA9HlgVe+nm/+ptcTIbCN5cTxdVYWF+iu3I1QAlsOCbpLWQdWj99NOa3Yu/AYjYM4XwcvqEMJSZfewgrL7fRPgqGv37iH1588RXspRbUcD+adC0sq29b6Rz4V7Pu/8zHZd3cpE2OHM1Se49MuwY/ROkEuniGIhjC5gTc5yIZ69zq2vU7SjondhCAO4/0MnS7gxteoywLZ1PhZhZtA0u4SnflGbj35bxGTAdpUVM9/mFnrfjYefCvDrfMkoxGVjxle/jLIhKW1Y8h6hknX+cxTH+d1r3oJUfsQ5fA25aykvXYYvGbc32f92FGKcsyjjz7MyXvu5sIzj/PgKx7BCMd4+wpLh45D3EWKHBsKsu4Scecupge32T3/WbpZQrSwSW0lB/sD9nYbrg33SY3goeWTnF7eIAgJUuKwAI/93HufDhrAT4cfkwvdH/LTEpHkWA9S5oQ0xvWv40JAq0CcL1FPrpLmGboVYURNaFrMakluwE1u06gFkt4x5HQL7wJpFuaTfhUjjCF/6NsZX34S6yPa6/fQ7q4zs5bl049SDg7w5IT2KWb7tzDZAq1Oj2vXDrixtc/O6DjT6ZAkyinrKVoaVGRJOofAzVDlAaIccezYSzl55LuYjq6jLAyufwXjStIswTYjTJwz2r9CNR3hgNbiPYz7z+Grs1Dsc+6gYFDWuAAqMjywdhR0yqSc0mrFqJDTXu/9+8H6P/rP774hq+ofkLVi4TWiqvFeImRM89C7kIkhypepqz2EjjBRhtSL2OAIOsIHSXFwHZX1EMUQJxSz288RhERrj0rWCcwn/SbqMfVtqnpKJROitMeNpz6AEBqvEraf/wiLax3SNMdOBhyMLPsTz9nzW3zt+a/RygRra6tM+3ukWUzZRAQVEfmCenqAinoMb14gXz5FlrUJkwGTc5/DvvhpxOwK7tazhPYK2IZ8YY0gR8RJF6EU7c5RxpMt9maSTz79ebTWtKM2D6zeiw0FURKjVASCcYT54fd//LlaAiTf+9GJbaLfD8MRQc6tbhkEzeprSI49iJASfI3ULfxsjIwXkTpCaEOwFUkSkK4AYGZneAutzdcR5zlR1kLFGcHkRO1DiCjQWcpZO36Uxdzhmppb585x+ZnPcfnZJ/nVf/dFRkUK8Qr96ZTZ/g3irE1V11gCUhuS9iIyW8Ala4xH+wx3byOyHunSCeJ8hSzPKLe/zPT2JfpP/R5cfZbxlbMUt26g5QSBoqwLyukO5cFtJvs3kDrDiYI4a7GY1sQ6ns+Kg2Y6mSKQeB+QxmKS+Pe/9Ud/dfKnMtLNZPQrZTEiuBp8hTdd9NVPU73wJN7peelHAhcgBIPQGqQhEiWumWAWDxMAPxlRDLexAUx2HCGWsfWQ8bWn2L7yVaI4p5UrTNrFIkgWlzn9tnfjqpKvPPMML1wf8P4PfJLd/hCjM84/92We/NznOH7mbhpbc2R9ARN3aC8dBuG5cX2Hpz7zWYrxBOIepr1EtrSJThLcdId0ZY3paEDRSPyRN+NPfw9Bdmkvn0RGC0xGjuHOWab9GxTjA2zj2RnMrfxISw61F3HlCEnACYFzHlcVv/If5ANlK/84E3vJjnZOBpOjbIWXIK58CXH0OFQBFXeQrmFycInW6kkkgqqaEXcO4Zk7wB6FDlO0CdTCo5jRjC8RJluY1gaz0pJ3jiG4istzqCccPnYaWd6m4llefe8KTbTBL773/2Ry6yY3JiMaK3j0lfcjPDS1ZzCcEsKUWRn44G9/nOFowMOvfoSNdImm3CXSBpsdJtFtXCsl2f8OmF5j4d7Xki1tMN15EesC08kBC8fup56sM94/z3T3HE1wbOQaoySOhluTq5yJl8iDwM803stLjR5+/D8AMP+hj7niXzz63mCin6aaYMsBJtGErc/jw3cQdBcrFPHqKcY3z8LqKbwMKJXhxgO8cHid01o7Q9ZdxbsSEWqCKxFEmM46hEBZVLR6y0iTkLTXqcsSHbdZPvFKIlWz2NNsHcy40n6AL966TqfX4Z3f+bc4udllbAUfe+zLnLi4xzN//CyNzxju7/Fd3/0t9JZXmQ1v0Gp1qasxoaxRkaKROXrzNHnRJURtnFRMmyk0AhUfYnDrq6ydeBAnHXFrhZ1rT7G106emJjJQR1DpHIcDG6hH9Xvf/ZMfdv/RhKqO0n8TIvWPCH7FNw0+CAgVYTZDdA6ho4wQGpLlE9SDq5juUZpyiswWoBoilMDb6TzchcFOtojubEBN3VBNrpOIGNdUBLlAkAVEgdpWGK3oLG1SNp5sER468hBvfvPL8E3D4VP3MB7d5o2P7vCh3/wQly5uQWRYXYR3/uD38/JXPMBCr8Perav4sEjU3kRFQ1Q1wmbL9I5l1NUxTJwSXI2SyxR7X4T2CZI05+DWVymHl9jtb5NGOT7K0UYRx6C04KDY5tBsHYnY1Sb75T/zuTH2Z1/7o9S8JwRP0BluOqBcfSXxt/z3mPbS/AERkxlZp4X3BskY24xpaBGnXexkSDAxk4PLdNfuQalANT7ANQFbThBaYm1D3s4opyVpmjG89sd4nSK7J3CzMSbLUUbRVDWjnXNIs0zSWWLv5lfoLrTZvrmLqycomRAvHiFMrnLsZe+gGOzTjLeJeptE2lONb2Pax9m9/lVUsLRW7qaxM4Rz7L/wW6SdNUynh1Nddi9/iYP9W4ybKe//wnMEA8pY8qyFRZE3kk219mPv+eUv/vM/80Yb5bs/G5L8KolCGEUl4OqLn6GeTajLKcGOEMJSNzVCeappgY4OI+2EpvHIbAGlNXm+jK8nIBTN8AbOOYrJHo0NJJ0VgukSddbAFVSj88wmE6hLOr2crNMlyVvEsWZx/S7aPYVohiyvbJIkGyRhypHjp4m0wlBTV57paEi2vIFMMupZH+vg6rOfwtuSvLuAMoEQalw5YjbbpnvXN1FJwWh/h2LnLO31kyyeegBvEirf4H3Au8Bd9givKU/yusW3Xc0X7/7ZP/dOJfEPPjKVndaPizhGuQPqSZ/zl4d87lf+JW50C2kWkEKjFQgq6uk+ttxHK4FuCprpAShF3F1DSo1rCqLeEbB93Pg6tr+LLRxeJtgApKvo1Ucw3WXypSVkkmPrGUFElGWB9aBNl6S3SbZ8ivbSMmmm8EiUgSTL6fTWmfW3UAo6iz1a7QWEgI3738547xyhrinHM6ajbYRJ5iEnodC6RYgCg+kAGfXwRUNVy/ljC2TgeHyEMyywmneJZtd+/B//5Pumf6FbvWTY+nXppx8jWIT36DiC2W1sXWLLKQJLqC2hHqKzlBC1EKZL4yrc9CbNrMAHhcPhqgEyXSDuLoIw1PU+zWQLUY9pRrepZlPyheMkJqcoZ5RVIEoiXHGbZnSDanAb39TYpp7nFqOc7vq9yP+ruzP7key66/jnLHepe6uruquml+lpj7fxOA6xBbFFBCgErDggEgUZyYoQCMLLCFnCQvETEgJhEwkpD0gEgxQ/RChRhMUW5MQZkViOcWIHeR/v4xn3TE9P9/RWe9VdzsZD+xUxtsN6/oCrez66D/ec3+/7+amU7tHjpElE+8gyzSzDz2a4wlCMd0niBnHeoJqOIWqRL56kGq1Tj0cE0ThslsyPINQKcawY9d/CsseLZ8+927/taKiIOEAa69Od5cW/veqsnPjNHwUR1L3eyGFwgkYzI+aA/XNv4E2FkgqhmoR4CRkOw4jCBdLGPHa2hatHmHJKpBKkq7HjA9K5o7RWT+Jnl4gSQah7NOa6ONND+AnpwiLTrbfZO/sUxqfIaJ7W4hrK7jCaTLD1lMOoACRzS6TNnNHBDq6YYewAqSJ8cFQ+UBtH3ND4Yog1Ff0rGwgdI2QDEYOOm1TVGGdKiv4GqtFBGoMRTSZkRJFACM+m2GVd9YfV7v69dz/w9fCe4q5/8uilwR/+wuLl6czePZ4/QtpsUA8vYmjRWfsJvKgJKkPUNVoZZOMIVgakaiNMD2VGOFsjGqtIZTHVlDhNaHRvRPgamS8h0CBSpqMh7ZU18DX4Go2gqmfErTVknJDqhLIqQAiSLMfaMQRDPRhycO4pirKmfewWgjc448HVxK0V6vEAb2virIueXyKgseMtmt016mrAcO9NQtVjPNxjWhX889MvsdXfQGtPUKCzmP3UnPriV1988n3lhR98fOfMqbtOHGNu6XaVZkgdU0/2aJ24g+BGyCg/7FKSliiZB1MgZISIIryew4sUb0pkqvA2UIwPSFprCBkRVEqQGlNNIGjKyZTOylESVWLKIagWwgfq6QGT0iN0TrvdQpgZ0/4uwUuyuTZ6/jray8eI8iWk8JTWouVh/bmYHRCqMcbOiGVCmgisKSimE2SaUG2/QSPPKYop3zvzEq9fvoCUgSoE0iwlSeKH//6hi1/8QM6EQfuG+6JG45lGI0dJCa6iGgxIqCi3z1C+ayaqhu9AnIHMUFELrRPixgIqa+FKi4oy4tYawnucFSTJHFoLEhUhtMGONzm4fB6RLGOcZ9zfojZTaqERZkCSK+J8DqtzfPA0V04i80XmV0/gnSeOE4LzCCGpvaSe9oiEZ657DXPdVWbFPkhJkIK62GO48QJxe4Xa7eCUpzQKpd4NhQuB1uoZqeR9H1g68bEvPFJGSXq3EPL84Qtq9s49h6sDSdQkbH+fycVz2CKAL4iYEaab6ETj3BBXT4nmlhAywgx3mRxsUVZTvK2QAlSiiHWgtXaCerjFeDyhuXIbrc4RYuXIsowoUmRpxnQ6wweFEDFmengtFaU5rc4xAtPDs/p4l1a7ewhDSsp6hifFzPaZTsaUVYGIDkMz06KiKhyvbfY43zuP0gJrPZGKzksl7/67L2+U/xkfdTVmiocefXl672due8wa+2uouFWNd3HRAq3lY8gkY3jx+0z7Q3Q6T9xqIUQNOiWUQ/z4IlXpSPMFvOkThptICsa9bappRZQtHDb/xDlxvkx/81XqYkbWWUVUe8ikhYwzgkwRoiT4Ct2YQwTB/vrLSKlI28voMCJppJTDIUEf/mYdbLxBc66NkAFTHryb9xA444g7q/S33+D85U2eOP8SzlucDZSl30x0etdjX9u5dDVsrgogwF9960zv1Gc+erouil+djoetrXOv0jx+B/MrNxKHCeVog3K8TZQfI5Lg/RipYmTjGFJqrJOH6fHGHJEylDtnCMYjkkXqwSWCyojzNqOts1SjHeqqZn75elAKWxp00sSakjiZR6UZZtZjcP55XNUjml9Cu0OzG2kTRIb1ge7yCQIGcNTViLS5SJo2KQYbJM0uF69s80/PPQ26xjuLM2rT1vGnnvxW/+zVcrlqgABfeezM/j0f6j4qTO/TZb/fubRXcd1Hfoq41UXWE0SS46zFWEdjbvXwq1EeO97FTseoJCfK55BSoLN5TPDIVHNw6RUAss4aOs2JhKKRNTBOELdW0bKmnvZIU8m4t02adyn7G/hql2K0zfzabZTFDO81TqR4YzGjbYQrcdYQ5SsIqalm+wSgLvepRj3eOfcs66MdkAFTR+erStz19HfGZ98Lk/cEEODr/7bR+8rnb3zkxPGjPzdvr1wz2i9pn7ydKFGgFTo5gisGGNqkzQ7WTFDxHLUdIYREpXOEoJHRAlHaJUhNZ6FzWGsQCq0aNDpH0Y0O1kyppmOS9lFUnIBIUTrFln0wBfHyreSLNyAITEf7zEYTmgtL6CzBlYbxpI8rLVJ6ss4xRgeX0Tpn3HuNN7ev8MSFV9FCcHl98Iwr7ad+eLq49F55vC97W+PUD3aSanrnkq4eXt78JsMfPY5oXE+2cBKpHEkeU+4+y3DrLMgWxBlZvoSKYszgMq4sIAiCLUnjjJC2UXGDSApmO68Qyh183Sdu5NTDywzWX8PXDh8COopQaQvRXEE60NkizYWj4BXOBzwa7yKi9gIiztl6+TGmswleCOKkibc1tWjxwvY6S0dvprfrHvbO3/nD75qd98NC8z6X/N3HS+CUeejjT4XdM18eXfhQOz++TKNzLcEUhNCg6L3NzvZbdE7+DDqNwTjKwSY61HDkFnScHoYQXRNCia09cd7FC4V1Cb4akC0dZ3awjatHJO0uwRrE7ABtDMYr3MxQSEl7+Til9QhTUoz38XZGM8vp3Phh2nNdlLNE2nBl7wo/uHgJmc8PG82F3/uXb+5+7YMIGBUfcD342MaZB+5sPjK58OzN49A9IbI2Sd7FFgeIJCdfu4HBlUvIqHkY2os0gYDOl3AywZMQpRng0VGOUBI37R8KZ72nkXewpjx8pnMY41FpmyhvIWSCCNDbfhUsRNIh/AgzeodysIEjI20foyh6jAZb1CLhnd6I8+Pt0zbw2T//wj88+UH3/4EBAjx4+sLgjz6++o3h+ktvvfLWpTusjOY7x28h6JgkXqDRbNHffJOqKnEG0vYqSIGZ7TPZeh1vLWl7HlMMSZtdgpeU4w0QCqmauOIy6CYiBFQUUQ1HJPkig8uv40xN3j2OjiLirEmUdUlb12Iqx2D/IiKKcBI2BiPe3LlycXuyd68Q8R986fe/0f9x7P3HAhDgz564wF/+6/qrn71p8vDW+beHc8sf/skQJ3kSHdaZYx2BnWKsII4sKE2kG9TjdRQW5KEYouztoLM2KpIkaQsZQdLo4LxF6BglNSoYSCLwJaP9LUSUkc0fPfQLljWoCFOXBF/i0y4Tr/f6hXqgZ6vP3/9bf/rCk99+/n+/yfzh+3+2dfKn7/kdfaR73+LStTcstht4Y7BB4x0kiSPKjmCFRFQls/1zpIvXo+OUuq6x0wN02kbakt7FF7HllKVbfwkVZTg7IziPsxWT3jbZwgrIjFhrZv0dpqNtssVrmPU23tmaFH9xZXD5q79+zx+P/k+q4P/6S59QwxDu+pU77//ttYXVTxsznqusImk0UTIgkzm01rhQ4KuCJE6pyhF1f5PKeForN2KLKbYek3aOMdhYp3O0C6rNpL9PsBUya1MVU4RwWGvHAvHtIO3fEOx3b7r9c/+lKvj/1mEEF57/x+Z6b++TL7z++C9/8udP/WK32TqBdTKJNWkW4Z3A2gJ0jsTBuzfDoRhTjMYEZ6iFoNW9Fh9KTBEwduzz5pFz/YvPPYGqTod0+Xs3f+xz/3+GEfxH69KFN4UdX1kOTn+0lde3BmdvQmfXiXjhKKE+ghk1g2wmCoezVeWKg0mAfZ+sbsdpemE82X07ldkr48nmC6YwOx/5xG/8j4zD+HfczXCNHF8WQgAAAABJRU5ErkJggg=="/></svg> </symbol>
 <symbol id="icon-time">
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11.99 22C6.47 22 2 17.52 2 12C2 6.48 6.47 2 11.99 2C17.52 2 22 6.48 22 12C22 17.52 17.52 22 11.99 22ZM12 4C7.58 4 4 7.58 4 12C4 16.42 7.58 20 12 20C16.42 20 20 16.42 20 12C20 7.58 16.42 4 12 4ZM12.5 17H11V11L16.25 7.85L17 9.08L12.5 11.75V17Z"/></svg> </symbol>
-<symbol id="icon-menu">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 18h18v-2H3v2Zm0-5h18v-2H3v2Zm0-7v2h18V6H3Z"/></svg> </symbol>
-<symbol id="icon-hamburger-close">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 5.61143L18.3886 4L12 10.3886L5.61143 4L4 5.61143L10.3886 12L4 18.3886L5.61143 20L12 13.6114L18.3886 20L20 18.3886L13.6114 12L20 5.61143Z"/></svg> </symbol>
-<symbol id="icon-logo">
-<svg viewBox="0 0 127 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M126.7 6.91231C126.7 3.0266 124.524 0.0315247 122.026 0.0315247C119.535 0.0315247 117.352 3.03448 117.352 6.91231C117.352 10.2699 118.983 12.3429 121.033 12.8473C121.017 13.6591 120.875 21.3202 120.103 29.7379C120.103 29.7379 120.78 30.0217 122.073 30.0217C123.366 30.0217 124.272 29.7379 124.272 29.7379C123.523 22.2975 123.2 15.1172 123.121 13.1704C123.121 13.1547 122.885 13.2414 122.554 13.1468C122.278 13.0759 122.128 12.9655 122.144 12.9655C122.16 12.9655 122.175 12.9655 122.191 12.9655C122.459 12.9655 122.743 12.9103 122.924 12.8709C122.932 12.8709 122.94 12.8709 122.948 12.8631C123.05 12.8394 123.113 12.8236 123.113 12.8236C125.123 12.2719 126.7 10.2148 126.7 6.91231Z" fill="#F7AF31"/><path fill-rule="evenodd" clip-rule="evenodd" d="M0.0393066 23.7635C0.0393066 20.8236 2.08857 19.7123 4.6265 19.0581L8.81172 18.0256V17.868C8.81172 16.3783 7.85014 15.8502 5.95852 15.8502C4.38216 15.8502 2.87674 16.2207 1.19793 16.7094L1.49743 12.9497C3.22354 12.4138 5.10729 12.0039 7.21172 12.0039C11.1447 12.0039 13.1309 13.3911 13.1309 17.2296V27.3025H8.81172V25.4818C7.51911 27.0424 5.72995 27.6493 4.09054 27.6493C1.97034 27.6493 0.0393066 26.6089 0.0393066 23.7635ZM4.51615 23.1488C4.51615 24.1655 5.20187 24.5754 6.04522 24.5754C6.90433 24.5754 7.95261 24.1182 8.80384 23.3773V20.2798L7.67674 20.6108C5.52502 21.2098 4.51615 21.9192 4.51615 23.1488Z" fill="#F15025"/><path d="M15.3931 7.21181V27.3025H19.7202V6.72314L15.3931 7.21181ZM22.1399 7.21181V27.3025H26.4749V6.72314L22.1399 7.21181ZM28.8945 12.6424V27.2946H33.2295V18.3882C34.798 17.3872 36.6896 17.1113 38.3133 17.1901L38.5418 12.0434C35.7201 12.0434 34.2857 13.1941 33.2295 17.0246V12.1379L28.8945 12.6424Z" fill="#F15025"/><path fill-rule="evenodd" clip-rule="evenodd" d="M52.8394 15.8187L53.1153 16.4965C53.4778 17.3635 53.0916 18.1438 52.2325 18.53L44.1301 22.3054C44.8315 23.0699 45.935 23.535 47.5035 23.535C49.0956 23.535 51.4207 23.0699 53.1547 21.7537L52.8709 26.0493C51.7517 26.7901 49.7655 27.6414 46.999 27.6414C41.9468 27.6414 39.0542 24.5202 39.0542 19.7675C39.0542 14.3054 42.9478 11.996 46.7468 11.996C50.002 11.9803 51.9803 13.6827 52.8394 15.8187ZM46.8177 15.4089C44.8709 15.4089 43.1448 16.6069 43.1448 19.3892C43.1448 19.4532 43.1469 19.5173 43.1489 19.5803C43.1508 19.6414 43.1527 19.7014 43.1527 19.7596L49.3242 16.8827C48.8907 16.0552 48.2049 15.4089 46.8177 15.4089Z" fill="#F15025"/><path d="M62.3448 15.8502C63.5113 15.8502 64.6699 16.2364 65.5054 16.6699V12.5635C64.2364 12.1695 62.7389 12.0039 61.5645 12.0039 56.6463 12.0039 54.0847 15.0778 54.0847 19.8227 54.0847 24.5596 56.6463 27.6414 61.5724 27.6414 62.7862 27.6414 64.3704 27.4128 65.8601 26.8532V22.7941C64.7803 23.2906 63.5428 23.6926 62.3527 23.6926 60.0827 23.6926 58.4276 22.463 58.4276 19.8069 58.4276 17.1665 60.0827 15.8502 62.3448 15.8502ZM67.6492 27.3025H71.9841V12.1537L67.6492 12.6424V27.3025ZM69.8008 5.85616C68.0668 5.85616 66.9949 6.90443 66.9949 8.36256 66.9949 9.84433 68.0589 10.8926 69.8008 10.8926 71.5348 10.8926 72.5515 9.84433 72.5515 8.36256 72.5594 6.90443 71.5348 5.85616 69.8008 5.85616Z" fill="#F15025"/><path fill-rule="evenodd" clip-rule="evenodd" d="M74.4038 31.9842V12.6424L78.7388 12.1458V13.9744C79.7792 12.934 81.2137 12.0039 83.2629 12.0039 86.392 12.0039 88.6777 14.203 88.6777 19.1921 88.6777 24.7566 85.3989 27.6493 81.0797 27.6493 80.1811 27.6493 79.4009 27.5074 78.7388 27.3025V31.9842H74.4038ZM84.1378 19.6414C84.1536 17.4975 83.4284 15.5586 80.9851 15.5586 80.0866 15.5586 79.3614 15.8424 78.7388 16.2364V24.0709C79.1802 24.1655 79.6688 24.2207 80.1969 24.2207 82.8846 24.2207 84.1457 22.534 84.1378 19.6414ZM103.558 15.8187 103.834 16.4965C104.197 17.3635 103.811 18.1438 102.952 18.53L94.8491 22.3054C95.5505 23.0699 96.654 23.535 98.2225 23.535 99.8146 23.535 102.14 23.0699 103.874 21.7537L103.59 26.0493C102.471 26.7901 100.485 27.6414 97.718 27.6414 92.6658 27.6414 89.7732 24.5202 89.7732 19.7675 89.7732 14.3054 93.6668 11.996 97.4658 11.996 100.721 11.9803 102.699 13.6827 103.558 15.8187ZM97.5367 15.4089C95.5899 15.4089 93.8638 16.6069 93.8638 19.3892 93.8638 19.4532 93.8659 19.5173 93.8679 19.5803 93.8698 19.6414 93.8717 19.7014 93.8717 19.7596L100.043 16.8827C99.6096 16.0552 98.9239 15.4089 97.5367 15.4089Z" fill="#F15025"/><path d="M109.226 16.6542C109.226 15.7163 110.51 15.4798 111.748 15.4798C112.961 15.4798 114.427 15.6768 116.185 16.4571L116.067 12.8473C114.971 12.3586 113.505 12.0039 111.629 12.0039C106.829 12.0039 105.261 14.3133 105.261 16.7803C105.261 22.7862 112.686 20.3586 112.686 22.7941C112.686 23.7872 111.606 24.0158 110.55 24.0158C108.429 24.0158 106.656 23.4089 105.237 22.597L104.985 26.4118C106.475 27.1685 108.445 27.6414 110.542 27.6414C115.153 27.6414 116.918 25.3793 116.918 22.4552C116.934 16.6463 109.226 18.9163 109.226 16.6542Z" fill="#F15025"/></svg> </symbol>
-<symbol id="icon-account">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2C6.48 2 2 6.48 2 12ZM12 5C13.66 5 15 6.34 15 8C15 9.66 13.66 11 12 11C10.34 11 9 9.66 9 8C9 6.34 10.34 5 12 5ZM12 19.2C9.5 19.2 7.29 17.92 6 15.98C6.03 13.99 10 12.9 12 12.9C13.99 12.9 17.97 13.99 18 15.98C16.71 17.92 14.5 19.2 12 19.2Z"/></svg> </symbol>
-<symbol id="icon-caret_down">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8 10L12 14L16 10H8Z"/></svg> </symbol>
-<symbol id="icon-instagram">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8.27326 3.05416C9.23411 3.01036 9.54091 3 11.9876 3C14.4343 3 14.7411 3.01036 15.7019 3.05416C16.6608 3.09785 17.3157 3.25001 17.8888 3.47247C18.4812 3.70247 18.9836 4.01021 19.4844 4.51055C19.9852 5.01092 20.2933 5.51283 20.5235 6.10466C20.7462 6.67712 20.8985 7.33137 20.9423 8.28931C20.9861 9.24926 20.9965 9.55575 20.9965 12C20.9965 14.4443 20.9861 14.7507 20.9423 15.7107C20.8985 16.6686 20.7462 17.3229 20.5235 17.8953C20.2933 18.4872 19.9852 18.9891 19.4844 19.4895C18.9836 19.9898 18.4812 20.2975 17.8888 20.5275C17.3157 20.75 16.6608 20.9021 15.7019 20.9458C14.7411 20.9896 14.4343 21 11.9876 21C9.54091 21 9.23411 20.9896 8.27326 20.9458C7.31433 20.9021 6.65948 20.75 6.08642 20.5275C5.494 20.2975 4.9916 19.9898 4.49077 19.4895C3.98994 18.9891 3.6819 18.4872 3.45167 17.8953C3.22895 17.3229 3.07668 16.6686 3.03291 15.7107C2.98907 14.7507 2.9787 14.4443 2.9787 12C2.9787 9.55575 2.98907 9.24926 3.03291 8.28931C3.07668 7.33137 3.22895 6.67712 3.45167 6.10466C3.6819 5.51283 3.98994 5.01092 4.49077 4.51055C4.9916 4.01021 5.494 3.70247 6.08642 3.47247C6.65948 3.25001 7.31433 3.09785 8.27326 3.05416ZM15.6279 4.6741C14.678 4.6308 14.3931 4.62162 11.9876 4.62162C9.5821 4.62162 9.2972 4.6308 8.34721 4.6741C7.46889 4.71411 6.99184 4.86073 6.6744 4.98398C6.25392 5.14725 5.95382 5.34227 5.63855 5.65723C5.32332 5.97215 5.12806 6.27196 4.96464 6.69206C4.8413 7.00919 4.69454 7.48574 4.65445 8.36323C4.61111 9.31224 4.60195 9.5969 4.60195 12C4.60195 14.4031 4.61111 14.6878 4.65445 15.6368C4.69454 16.5143 4.8413 16.9908 4.96464 17.3079C5.12806 17.728 5.32332 18.0278 5.63855 18.3428C5.95382 18.6577 6.25392 18.8528 6.6744 19.016C6.99184 19.1393 7.46889 19.2859 8.34725 19.3259C9.29705 19.3692 9.58196 19.3784 11.9876 19.3784C14.3932 19.3784 14.6781 19.3692 15.6279 19.3259C16.5063 19.2859 16.9833 19.1393 17.3008 19.016C17.7213 18.8528 18.0214 18.6577 18.3366 18.3428C18.6519 18.0278 18.8471 17.728 19.0105 17.3079C19.1339 16.9908 19.2806 16.5143 19.3207 15.6368C19.3641 14.6878 19.3732 14.4031 19.3732 12C19.3732 9.5969 19.3641 9.31224 19.3207 8.36323C19.2806 7.48574 19.1339 7.00919 19.0105 6.69206C18.8471 6.27196 18.6519 5.97215 18.3366 5.65723C18.0214 5.34227 17.7213 5.14725 17.3008 4.98398C16.9833 4.86073 16.5063 4.71411 15.6279 4.6741ZM8.99787 12.009C8.99787 13.6324 10.3424 14.9485 12.0008 14.9485C13.6593 14.9485 15.0038 13.6324 15.0038 12.009C15.0038 10.3855 13.6593 9.06948 12.0008 9.06948C10.3424 9.06948 8.99787 10.3855 8.99787 12.009ZM7.37466 12.009C7.37466 9.50799 9.44588 7.48056 12.0008 7.48056C14.5558 7.48056 16.627 9.50799 16.627 12.009C16.627 14.51 14.5558 16.5374 12.0008 16.5374C9.44588 16.5374 7.37466 14.51 7.37466 12.009ZM16.1487 8.49799C16.7457 8.49799 17.2297 8.02423 17.2297 7.43978C17.2297 6.85533 16.7457 6.38157 16.1487 6.38157C15.5516 6.38157 15.0676 6.85533 15.0676 7.43978C15.0676 8.02423 15.5516 8.49799 16.1487 8.49799Z"/></svg> </symbol>
-<symbol id="icon-tiktok">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M20.4761 9.49649C20.3086 9.5129 20.1411 9.52165 19.9736 9.52293C18.1346 9.52293 16.4192 8.5702 15.4105 6.98779V15.6201C15.4105 19.1431 12.6324 22 9.20399 22C5.77554 22 3 19.1431 3 15.6201C3 12.097 5.77798 9.24008 9.20644 9.24008C9.33604 9.24008 9.4632 9.25266 9.59036 9.26023V12.4037C9.4632 12.3886 9.33727 12.3635 9.20644 12.3635C7.45675 12.3635 6.03964 13.8215 6.03964 15.6188C6.03964 17.4174 7.45798 18.8741 9.20644 18.8741C10.9561 18.8741 12.5016 17.4576 12.5016 15.659L12.5322 1H15.4581C15.7344 3.69727 17.8497 5.8038 20.481 6.00113V9.4953"/></svg> </symbol>
-<symbol id="icon-youtube">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.8139 5.42068C20.6744 5.65216 21.352 6.3342 21.582 7.20034C22 8.77011 22 12.0455 22 12.0455C22 12.0455 22 15.3207 21.582 16.8907C21.352 17.7567 20.6744 18.4387 19.8139 18.6703C18.2542 19.0909 12 19.0909 12 19.0909C12 19.0909 5.7458 19.0909 4.18614 18.6703C3.32568 18.4387 2.64795 17.7567 2.41795 16.8907C2 15.3207 2 12.0455 2 12.0455C2 12.0455 2 8.77011 2.41795 7.20034C2.64795 6.3342 3.32568 5.65216 4.18614 5.42068C5.7458 5 12 5 12 5C12 5 18.2542 5 19.8139 5.42068ZM15.1818 12.0456L9.95455 15.0192V9.0717L15.1818 12.0456Z"/></svg> </symbol>
-<symbol id="icon-linkedin">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5.90187 7.78789C4.8515 7.78789 4 6.98834 4 5.8944C4 4.8003 4.8515 4 5.90187 4C6.95223 4 7.80373 4.8003 7.80373 5.8944C7.80373 6.98834 6.95223 7.78789 5.90187 7.78789ZM4.25243 19.7198H7.55133V9.24009H4.25243V19.7198ZM16.4144 19.7279H19.7132V13.2463C19.7132 10.0453 17.724 8.95331 15.8832 8.95331C14.1812 8.95331 13.0668 10.0549 12.7477 10.6999H12.7056V9.24802H9.53307V19.7279H12.8318V14.046C12.8318 12.5311 13.7917 11.7943 14.7704 11.7943C15.6964 11.7943 16.4144 12.3151 16.4144 14.004V19.7279Z"/></svg> </symbol>
-<symbol id="icon-website">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2V2ZM11 19.93C7.05 19.44 4 16.08 4 12C4 11.38 4.08 10.79 4.21 10.21L9 15V16C9 17.1 9.9 18 11 18V19.93V19.93ZM17.9 17.39C17.64 16.58 16.9 16 16 16H15V13C15 12.45 14.55 12 14 12H8V10H10C10.55 10 11 9.55 11 9V7H13C14.1 7 15 6.1 15 5V4.59C17.93 5.78 20 8.65 20 12C20 14.08 19.2 15.97 17.9 17.39V17.39Z"/></svg> </symbol>
-<symbol id="icon-flipboard">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M8 0H0V24H8V0Z"/><path d="M16.0533 0H7.97858V8.01068H16.0533 23.9999V0H16.0533ZM15.9893 8.01074H7.97858V16.0214H15.9893V8.01074Z"/></svg> </symbol>
-<symbol id="icon-privacy-choices">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 14" style="enable-background:new 0 0 30 14" xml:space="preserve"><path d="M7.4,12.8h6.8l3.1-11.6H7.4C4.2,1.2,1.6,3.8,1.6,7S4.2,12.8,7.4,12.8z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#fff"/><path d="M22.6,0H7.4c-3.9,0-7,3.1-7,7s3.1,7,7,7h15.2c3.9,0,7-3.1,7-7S26.4,0,22.6,0z M1.6,7c0-3.2,2.6-5.8,5.8-5.8 h9.9l-3.1,11.6H7.4C4.2,12.8,1.6,10.2,1.6,7z" style="fill-rule:evenodd;clip-rule:evenodd;fill:#06f"/><path d="M24.6,4c0.2,0.2,0.2,0.6,0,0.8l0,0L22.5,7l2.2,2.2c0.2,0.2,0.2,0.6,0,0.8c-0.2,0.2-0.6,0.2-0.8,0 l0,0l-2.2-2.2L19.5,10c-0.2,0.2-0.6,0.2-0.8,0c-0.2-0.2-0.2-0.6,0-0.8l0,0L20.8,7l-2.2-2.2c-0.2-0.2-0.2-0.6,0-0.8 c0.2-0.2,0.6-0.2,0.8,0l0,0l2.2,2.2L23.8,4C24,3.8,24.4,3.8,24.6,4z" style="fill:#fff"/><path d="M12.7,4.1c0.2,0.2,0.3,0.6,0.1,0.8l0,0L8.6,9.8C8.5,9.9,8.4,10,8.3,10c-0.2,0.1-0.5,0.1-0.7-0.1l0,0 L5.4,7.7c-0.2-0.2-0.2-0.6,0-0.8c0.2-0.2,0.6-0.2,0.8,0l0,0L8,8.6l3.8-4.5C12,3.9,12.4,3.9,12.7,4.1z" style="fill:#06f"/></svg> </symbol>
-<symbol id="mntl-dotdash-universal-nav__logo">
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="5 2.8 290 69"><circle cx="39.6" cy="37.4" r="34.3" fill="#f44b34"/><path fill="#fff" d="M50.4 17.9c-1.7-1.8-4-2.6-7-2.6-9.1-.1-12.4-.1-13.2-.1L27.3 22h8.1L30 28v21h-.1l.1.1v6.7l-3.6 4h18.5L53 51V25c0-.1.1-4.3-2.6-7.1zm-5.2 19.6-7.4 7.8V41l7.4-7.8v4.3zm-7.4-15.4h3c.9 0 2.1-.1 3.1.9s1.4 2.5 1.4 4.9v3.6l-7.4 7.8-.1-17.2zm-4.9 30.1 3.3-3.6 9-9.5v13.1c0 .1-12.3.1-12.3 0z"/><path fill="#009ad9" d="m99.645 22.637 6.505-6.506 4.172 4.172-6.505 6.506zM121 44l4.2 4.2 6.5-6.5-4.2-4.2zm-3.2-31.2c1.8-1.8 4.7-1.8 6.5 0 1.9 1.9 1.7 4.8 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c2-2 4.9-1.6 6.5 0 2 2 1.6 4.9 0 6.5l-3.3 3.3 4.2 4.2 3.3-3.3c4.2-4.2 4-10.8 0-14.8-2.8-2.8-6.1-3.1-7.6-3.1.1-1.5-.3-4.8-3.1-7.6-3.9-3.9-10.6-4.2-14.8 0l-3.3 3.3 4.2 4.2 3.2-3.4zm-7.5 20.6 4.2 4.1L121 31l-4.2-4.1-6.5 6.5z"/><path fill="#6ebd44" d="m99.6 52.4 6.6 6.5 4.1-4.2-6.5-6.5zm36.3-14.9-4.2 4.2L135 45c1.6 1.6 2 4.5 0 6.5-1.6 1.6-4.5 2.1-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c1.7 1.7 1.9 4.6 0 6.5-1.8 1.8-4.7 1.8-6.5 0l-3.3-3.3-4.2 4.2 3.3 3.3c4.2 4.2 10.9 3.9 14.8 0 2.8-2.8 3.1-6.1 3.1-7.6 1.5 0 4.8-.3 7.6-3.1 4-4 4.2-10.6 0-14.8l-3.2-3.4zm-25.6 4.2 6.5 6.5L121 44l-6.5-6.5zm14.9-14.8L121 31l6.5 6.5 4.2-4.1-6.5-6.5z"/><path fill="#f68f1e" d="m110.332 54.607 6.506-6.506 4.172 4.172-6.506 6.505zM102.8 62.2c-1.6 1.6-4.5 2-6.5 0-1.6-1.6-2.1-4.5 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-1.7 1.7-4.6 1.9-6.5 0-1.8-1.8-1.8-4.7 0-6.5l3.3-3.3-4.2-4.2-3.3 3.3c-4.2 4.2-3.9 10.9 0 14.8 2.8 2.8 6.1 3.1 7.6 3.1 0 1.5.3 4.8 3.1 7.6 4 4 10.6 4.2 14.8 0l3.3-3.3-4.2-4.2-3.2 3.4zm3.4-24.7L99.6 44l4.2 4.2 6.5-6.5zM95.5 26.9 89 33.4l4.1 4.1 6.5-6.5z"/><path fill="#ec174c" d="m99.6 44-6.5-6.5-4.1 4.2 6.5 6.5zm-14-14c-1.8-1.8-1.8-4.7 0-6.5 1.9-1.9 4.8-1.7 6.5 0l3.3 3.3 4.2-4.2-3.3-3.3c-2-2-1.6-4.9 0-6.5 2-2 4.9-1.6 6.5 0l3.3 3.3 4.2-4.2-3.3-3.2c-4.2-4.2-10.8-4-14.8 0-2.8 2.8-3.1 6.1-3.1 7.6-1.5-.1-4.9.3-7.6 3.1-3.9 3.9-4.2 10.6 0 14.8l3.3 3.3 4.2-4.2-3.4-3.3zm24.73-9.682 4.172-4.172 6.505 6.505-4.172 4.172zM106.2 37.5l4.1-4.1-6.5-6.5-4.2 4.1 6.6 6.5z"/><path fill="#573357" d="m106.142 16.042 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#be272d" d="m84.81 37.543 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#008e4c" d="m127.497 37.555 4.171-4.172 4.172 4.172-4.171 4.172z"/><path fill="#7a773e" d="m106.172 58.866 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#443639" d="m116.856 26.74 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#803136" d="m95.455 48.169 4.172-4.172 4.172 4.172-4.172 4.172z"/><path fill="#593438" d="m95.446 26.753 4.172-4.172 4.172 4.173-4.172 4.171z"/><path fill="#443639" d="m106.155 37.456 4.172-4.172 4.172 4.171-4.172 4.172z"/><path fill="#2a6442" d="m116.871 48.153 4.172-4.172 4.172 4.172-4.172 4.172z"/><path d="M170.4 13.5c-2.5-2.2-5.7-3.3-9.6-3.3h-7.2v23.6h7.6c3.8 0 7-1.1 9.4-3.3s3.6-5 3.6-8.5-1.3-6.3-3.8-8.5zm.1 8.5c0 2.6-.9 4.7-2.6 6.2-1.7 1.6-4.1 2.3-7 2.3h-3.8V13.4h3.8c2.9 0 5.2.8 7 2.3 1.7 1.5 2.6 3.7 2.6 6.3zm14.6-6.3c-2.5 0-4.7.9-6.4 2.7s-2.6 4-2.6 6.6.9 4.8 2.6 6.6c1.7 1.8 3.9 2.7 6.4 2.7h.1v-.1c2.5 0 4.7-.9 6.4-2.7s2.6-4 2.6-6.6c0-2.5-.9-4.8-2.6-6.6-1.8-1.7-3.9-2.6-6.5-2.6zm4.1 13.7c-.5.6-1.1 1-1.8 1.3s-1.4.3-2.2.3c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 3 .6 4 1.7 1.1 1.2 1.6 2.6 1.6 4.3 0 1.9-.5 3.4-1.6 4.6zm16.9.8c-.5.6-1.3.9-2.3.9-1.6 0-2.4-.9-2.4-2.7v-9.2h5v-3h-5v-4.4h-3.3v4.4h-2.9l.1 3h2.9v9.3c0 1.9.5 3.3 1.4 4.3s2.2 1.5 3.9 1.5c1.8 0 3.2-.5 4.2-1.5l-1.6-2.6zm38.1-11.6c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V16.1h-3.4v2.5h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-.5.6-1.1 1-1.8 1.3s-1.4.4-2.2.4c-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6.1 2.9.6 4 1.8zm17.9 3.6c-.9-.3-1.9-.6-3-.9-1-.3-1.9-.6-2.5-1-.7-.4-1-1-1-1.6l.1-.1c0-.7.3-1.2.9-1.6.6-.4 1.4-.6 2.3-.6 2 0 3.4.7 4.5 2l2-2c-1.3-1.8-3.5-2.7-6.6-2.7-1.9 0-3.5.5-4.7 1.4-1.2 1-1.7 2.1-1.7 3.5 0 1.2.3 2.1 1 2.9s1.5 1.3 2.6 1.7c1.1.4 2 .7 2.9 1 1 .3 1.8.7 2.4 1.1.7.5 1 1 1 1.8s-.3 1.4-.9 1.8c-.6.5-1.4.7-2.5.7-2.3 0-4.1-.8-5.3-2.3l-2 2.2c1.5 1.9 3.9 2.9 7.1 2.9 2.2 0 3.9-.5 5.1-1.5s1.8-2.3 1.8-3.8c0-1.2-.3-2.2-1-3-.6-.9-1.5-1.4-2.5-1.9zm14.9-8.6c-2.3 0-4.1.8-5.2 2.5V8.4h-3.4v25.4h3.4l.1-10.3c0-1.4.4-2.6 1.2-3.4.8-.8 1.8-1.2 3.2-1.2 1.3 0 2.4.4 3.2 1.3.8.8 1.2 2 1.2 3.4v10.3h3.4V23c0-2.3-.6-4-1.9-5.4-1.4-1.4-3.1-2-5.2-2zm-52.2 3c-1.5-2-3.5-3-6.1-3-2.5 0-4.5.9-6.1 2.7-1.6 1.8-2.4 4-2.4 6.6 0 2.7.8 4.9 2.5 6.6 1.7 1.8 3.7 2.7 6.1 2.7 2.6 0 4.6-1 6.1-3.1v2.6h3.4V8.4h-3.4v10.2h-.1zm-1.6 2c1.1 1.2 1.6 2.6 1.6 4.3s-.5 3.2-1.6 4.4c-1.1 1.2-2.4 1.8-4 1.8-1.7 0-3-.6-4.1-1.8-1.1-1.2-1.6-2.7-1.6-4.4 0-1.7.6-3.2 1.6-4.3 1.1-1.2 2.4-1.7 4.1-1.7 1.6 0 2.9.5 4 1.7zm48.8 19.9h-3.6v19.1c0 2.4.7 4.1 2.1 5.1 1.2.9 3.1 1.4 5.6 1.4h.1v-3h-.1c-1.2 0-2.1-.2-2.7-.6-.9-.6-1.4-1.7-1.4-3.3V51h4.1v-3h-4.1v-7.5zm-96.2 7c-1.4 0-2.6.3-3.7 1-1 .6-1.7 1.5-2.3 2.6-1.2-2.4-3.2-3.6-6-3.6-2.2 0-4 .9-5.2 2.6V48h-3.5v18.2h3.5l.2-10.7c0-1.5.4-2.6 1.1-3.5.7-.9 1.8-1.3 3.1-1.3s2.3.4 3.1 1.3c.8.9 1.2 2 1.2 3.5v10.6h3.4V55.5c0-1.5.4-2.6 1.2-3.5s1.8-1.3 3.2-1.3c1.3 0 2.3.4 3.1 1.3.7.9 1.1 2 1.1 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5-1.3-1.3-3-2-5.1-2zm18.9 0c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7 1-.9 2.2-1.4 3.6-1.4zm22.5-2.3c-.6-.5-1.6-.8-2.8-.8-1.9 0-3.4.9-4.5 2.6v-2H205v18.2h3.5l-.1-10.5c0-1.5.3-2.7.9-3.6.6-.9 1.5-1.3 2.6-1.3.9 0 1.7.2 2.3.7h.1l1.4-3.3zm9-.7c-2.5 0-4.7.9-6.4 2.8-1.7 1.9-2.6 4.1-2.6 6.8s.9 5 2.7 6.8c1.8 1.8 4.1 2.8 6.8 2.8h.1v-.1c1.4 0 2.7-.3 3.9-.7 1.2-.5 2.2-1.1 3-1.9l-1.8-2.4c-1.3 1.3-3 2-5 2-1.7 0-3.1-.5-4.2-1.6-1.1-1-1.8-2.4-2-4h14.3c.1-.3.1-.7.1-1.2 0-2.5-.9-4.7-2.6-6.5-1.6-1.8-3.8-2.8-6.3-2.8zm.1 3c1.4 0 2.6.5 3.6 1.3 1 .9 1.6 2.1 1.8 3.8h-10.8c.3-1.5.9-2.7 1.8-3.7.9-.9 2.1-1.4 3.6-1.4zm26.1 0c-1.5-2-3.6-3.1-6.3-3.1-2.5 0-4.6.9-6.3 2.7s-2.5 4.1-2.5 6.8.9 5 2.5 6.8c1.7 1.8 3.8 2.7 6.3 2.7 2.6 0 4.7-1.1 6.3-3.2v2.7h3.5V40.5h-3.5v10zm-1.7 2c1.1 1.2 1.6 2.7 1.6 4.5 0 1.7-.6 3.3-1.6 4.5-1.1 1.2-2.4 1.8-4.2 1.8-1.7 0-3.1-.6-4.2-1.8-1.1-1.2-1.7-2.7-1.7-4.5s.6-3.3 1.7-4.5c1.1-1.2 2.5-1.8 4.2-1.8 1.8.1 3.1.7 4.2 1.8zm43.5-3c-1.3-1.4-3-2.1-5.2-2.1-2.4 0-4.2.9-5.4 2.6v-9.6h-3.5v25.7h3.5l.1-10.5c0-1.5.4-2.6 1.2-3.5.8-.9 1.8-1.3 3.2-1.3 1.4 0 2.5.4 3.3 1.3.8.9 1.2 2 1.2 3.5v10.6h3.5V55c0-2.3-.6-4.1-1.9-5.5zM259.1 48h3.5v18.2h-3.5zm0-7.5h3.4v3.4h-3.4z"/></svg> </symbol>
-<symbol id="icon-close">
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 5.61143L18.3886 4L12 10.3886L5.61143 4L4 5.61143L10.3886 12L4 18.3886L5.61143 20L12 13.6114L18.3886 20L20 18.3886L13.6114 12L20 5.61143Z"/></svg> </symbol>
 </defs>
 </svg>
+<!-- done svg resources -->
 <!-- Google Tag Manager (Testing) -->
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-P3X3VT7" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager -->
-<a
+<header id="header_1-0" class="comp header mntl-header mntl-header--magazine mntl-header--open-search-bar" role="banner" data-tracking-container="true"><a
 href="#main"
 rel="nocaes"
-id="skip-to-content_1-0"
-class=" skip-to-content mntl-text-link"
+id="mntl-skip-to-content_1-0"
+class="mntl-skip-to-content mntl-text-link "
 data-tracking-container="true"
-><span class="link__wrapper">Skip to content</span></a><!-- end: skip-to-content mntl-text-link -->
-<header id="header_1-0" class="comp header--magazine header" role="banner" data-tracking-container="true">
-<div class="header__menu-top">
-<div class="header__menu-button-container">
-<button class="header__menu-button" aria-label="Main menu for Allrecipes">
-<div class="header__menu-button-inner">
-<svg class="icon icon-menu "
+><span class="link__wrapper">Skip to content</span></a>
+<div class="mntl-header__menu-top">
+<div class="mntl-header__menu-button-container">
+<button class="mntl-header__menu-button" aria-label="Main menu for Allrecipes">
+<div class="mntl-header__menu-button-inner">
+<svg class="icon icon-menu mntl-header__menu-icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-menu"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-menu" href="#icon-menu"></use>
 </svg>
-<svg class="icon icon-hamburger-close "
+<svg class="icon icon-close mntl-header__close-icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-hamburger-close"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use>
 </svg>
 <div>
 </button>
 </div>
-<div class="header__logo-wrapper">
-<a id="logo_1-0" class="comp logo mntl-block" rel="home" href="/" aria-label="Home">
-<div id="mntl-text-block_1-0" class="comp is-screenreader-only mntl-text-block">
-Allrecipes</div><!-- end: comp is-screenreader-only mntl-text-block -->
+<div class="mntl-header__logo-wrapper">
+<a
+href="/"
+rel="home nocaes"
+id="header-logo_1-0"
+aria-label="Visit Allrecipes&#39; homepage"
+> <div class="is-screenreader-only">Allrecipes</div>
 <svg class="icon icon-logo "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo"></use>
-</svg>
-</a><!-- end: comp logo mntl-block -->
-</div>
-<div id="utility-nav_1-0" class="comp utility-nav">
-<ul class="utility-nav__list type--rabbit">
-<li class="loc search-bar utility-nav__search utility-nav__partial-menu-item">
-<div id="general-search_1-0" class="comp type--cat general-search" data-track-search-location="global nav search" data-click-tracked="false" data-tracking-container="true">
-<button class="general-search__icon-button" aria-label="search">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo" href="#icon-logo"></use>
+</svg></a> </div>
+<div id="mntl-utility-nav_1-0" class="comp mntl-utility-nav">
+<ul class="mntl-utility-nav__list type--rabbit">
+<li class="loc search-bar mntl-utility-nav__search mntl-utility-nav__partial-menu-item"><div id="mntl-search-form--open_1-0" class="comp mntl-search-form--open mntl-search-form type--cat" data-click-tracked="false" data-tracking-container="true">
+<form class="mntl-search-form--open__form" role="search" action="/search" method="get">
+<div class="mntl-search-form__input-group input-group">
+<label for="mntl-search-form--open__search-input" class="mntl-search-form__label is-vishidden">Search the site</label>
+<input type="text" name="q" id="mntl-search-form--open__search-input" class="mntl-search-form__input" placeholder="Find a recipe or ingredient" type="text" required="required" value="" autocomplete="off">
+<button class="mntl-search-form__button type--squirrel button--contained-standard" aria-label="Click to search">
 <svg class="icon icon-search "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
-</svg>
-</button>
-<form class="general-search__form" role="search" action="/search" method="get">
-<div class="general-search__input-group input-group">
-<label for="general-search__search-input" class="type--cat-bold">Search</label>
-<input type="text" name="q" id="general-search__search-input" class="general-search__input" placeholder="What are you looking for?" required="required" value="" autocomplete="off">
-<button class="general-search__button type--squirrel button--contained-standard-square">
-<span class="is-vishidden">Search</span>
-<svg class="icon icon-search "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
-</svg>
-</button>
-<button class="general-search__close" aria-label="Close search bar">
-<svg class="icon icon-close "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search" href="#icon-search"></use>
 </svg>
 </button>
 </div>
 </form>
-<div class="loc validation-message">
-<div id="general-search__validation-message_1-0" class="comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational">
-<svg class="icon icon-info message-banner__prefix-icon message-banner__icon "
+<div class="loc validation-message mntl-search-form__validation"><div id="mntl-search-form__validation-message_1-0" class="comp mntl-search-form__validation-message mntl-message-banner--error mntl-message-banner is-hidden mntl-message-banner--error" data-close-class="is-hidden" role="alert"> <svg class="icon icon-error mntl-message-banner__prefix-icon mntl-message-banner__icon "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-info"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-error" href="#icon-error"></use>
 </svg>
-<span class="message-banner__text ">
+<span class="type--cat-bold mntl-message-banner__text ">
 Please fill out this field.
 </span>
-<button class="message-banner__close-button js-message-banner-close" aria-label="Close informational Banner">
-<svg class="icon icon-close message-banner__icon"
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
-</svg>
-</button>
-</div><!-- end: comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational -->
 </div>
-</div><!-- end: comp type--cat general-search -->
+</div></div>
 </li>
-<li class="utility-nav__signin utility-nav__full-menu-item">
+<li class="mntl-utility-nav__signin mntl-utility-nav__full-menu-item">
 <a
 href="https://www.allrecipes.com/authentication/login?regSource=3675&relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F"
 rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+class="mntl-utility-nav__sublist-link"
 > <svg class="icon icon-account "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account" href="#icon-account"></use>
 </svg>
-<span>Log In</span>
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__account utility-nav__full-menu-item utility-nav__list-item state-sign-out">
-<button class="utility-nav__title type--rabbit">
+<span>
+Log In
+</span>
+</a> </li>
+<li class="mntl-utility-nav__account mntl-utility-nav__full-menu-item mntl-utility-nav__list-item state-sign-out">
+<button class="mntl-utility-nav__title type--rabbit">
 <svg class="icon icon-account "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account" href="#icon-account"></use>
 </svg>
 <span>My Account</span>
 <svg class="icon icon-caret_down "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-caret_down"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-caret_down" href="#icon-caret_down"></use>
 </svg>
 </button>
-<div class="utility-nav__sublist-container">
-<ul class="utility-nav__link-list">
-<li class="utility-nav__sublist-list-item">
+<div class="mntl-utility-nav__sublist-container">
+<ul class="mntl-utility-nav__link-list">
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.allrecipes.com/authentication/logout?relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F"
 rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+class="mntl-utility-nav__sublist-link"
 > Log Out
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="/account/profile"
-rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+rel="nocaes"
+class="mntl-utility-nav__sublist-link"
 > My Profile
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
-href="/account/profile#/collections"
-rel="nofollow nocaes"
-class="utility-nav__sublist-link"
-> Saved Items & Collections
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+href="/favorites"
+rel="nocaes"
+class="mntl-utility-nav__sublist-link"
+> Saved Recipes & Collections
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="/account/add-recipe"
-rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+rel="nocaes"
+class="mntl-utility-nav__sublist-link"
 > Add a Recipe
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://websupport.meredith.com/"
 target="_blank"
-rel="noopener nofollow nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nocaes"
+class="mntl-utility-nav__sublist-link"
 > Help
-</a><!-- end: utility-nav__sublist-link --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="utility-nav__magazine utility-nav__full-menu-item utility-nav__list-item">
-<button class="utility-nav__title type--rabbit">
+<li class="mntl-utility-nav__magazine mntl-utility-nav__full-menu-item mntl-utility-nav__list-item">
+<button class="mntl-utility-nav__title type--rabbit">
 <span>Magazine</span>
 <svg class="icon icon-caret_down "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-caret_down"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-caret_down" href="#icon-caret_down"></use>
 </svg>
 </button>
-<div class="utility-nav__sublist-container">
-<ul class="utility-nav__link-list">
-<li class="utility-nav__sublist-list-item">
+<div class="mntl-utility-nav__sublist-container">
+<ul class="mntl-utility-nav__link-list">
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.magazines.com/allrecipes-magazine.html?utm_source=allrecipes.com&utm_medium=owned&utm_campaign=i111arr1w2661"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Subscribe
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code=ALR"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Manage Your Subscription
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.magazines.com/allrecipes-magazine.html"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Give a Gift Subscription
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.magazines.com/customer-care"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Get Help
-</a><!-- end: utility-nav__sublist-link --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="loc newsletter-link-wrapper utility-nav__newsletter utility-nav__full-menu-item">
-<a
+<li class="loc newsletter-link-wrapper mntl-utility-nav__newsletter mntl-utility-nav__full-menu-item"><a
 href="#"
 rel="nocaes"
 data-a11y-dialog-show="newsletter-dialog-header"
-id="newsletter-dialog-header-link_1-0"
+id="mntl-newsletter-dialog--header-link_1-0"
 role="button"
-class=" newsletter-dialog-header-link dialog-link mntl-text-link"
+class="mntl-newsletter-dialog--header-link dialog-link mntl-text-link "
 data-tracking-container="true"
-><span class="link__wrapper">Newsletter</span></a><!-- end: newsletter-dialog-header-link dialog-link mntl-text-link -->
+><span class="link__wrapper">Newsletters</span></a>
 </li>
-<li class="utility-nav__sweepstakes utility-nav__full-menu-item">
+<li class="mntl-utility-nav__sweepstakes mntl-utility-nav__full-menu-item">
 <a
-href="https://www.allrecipes.com/sweepstakes/"
+href="/sweepstakes"
 rel="nocaes"
 > Sweepstakes
-</a><!-- end: --> </li>
-<li class="utility-nav__subscribe utility-nav__partial-menu-item type--squirrel">
-<a
-href="https://www.magazines.com/allrecipes-magazine.html?utm_source=allrecipes.com&utm_medium=owned&utm_campaign=i111arr1w2661"
-target="_blank"
-rel="noopener nocaes"
-> GET THE MAGAZINE
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
-</div><!-- end: comp utility-nav -->
 </div>
-<div class="header__nav-panel">
-<nav id="fullscreen-nav_1-0" class="comp fullscreen-nav" role="navigation" data-tracking-container="true">
-<div id="fullscreen-nav__search_1-0" class="comp type--cat fullscreen-nav__search general-search" data-track-search-location="fullscreen nav search" data-click-tracked="false" data-tracking-container="true">
-<form class="fullscreen-nav__search__form" role="search" action="/search" method="get">
-<div class="general-search__input-group input-group">
-<label for="fullscreen-nav__search__search-input" class="type--cat-bold">Search</label>
-<input type="text" name="q" id="fullscreen-nav__search__search-input" class="general-search__input" placeholder="What are you looking for?" required="required" value="" autocomplete="off">
-<button class="general-search__button type--squirrel button--contained-standard-square">
-<span class="is-vishidden">Search</span>
+</div>
+<div class="mntl-header__nav-panel">
+<div class="mntl-header__nav-panel-top">
+<button class="mntl-header__nav-panel-button" aria-label="Close menu for Allrecipes">
+<svg class="icon icon-close mntl-header__nav-panel-close-icon"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use>
+</svg>
+</button>
+<div class="mntl-header__nav-panel-logo">
+<a
+href="/"
+rel="home nocaes"
+id="header-logo_1-0"
+aria-label="Visit Allrecipes&#39; homepage"
+> <div class="is-screenreader-only">Allrecipes</div>
+<svg class="icon icon-logo "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo" href="#icon-logo"></use>
+</svg></a> </div>
+</div>
+<nav id="mntl-fullscreen-nav_1-0" class="comp mntl-fullscreen-nav " role="navigation" data-tracking-container="true" aria-label="Header">
+<div id="mntl-fullscreen-nav__search_1-0" class="comp mntl-fullscreen-nav__search mntl-search-form type--cat" data-tracking-container="true">
+<form class="mntl-fullscreen-nav__search__form" role="search" action="/search" method="get">
+<div class="mntl-search-form__input-group input-group">
+<label for="mntl-fullscreen-nav__search__search-input" class="mntl-search-form__label type--cat-bold">Search</label>
+<input type="text" name="q" id="mntl-fullscreen-nav__search__search-input" class="mntl-search-form__input" placeholder="What are you looking for?" type="text" required="required" value="" autocomplete="off">
+<button class="mntl-search-form__button type--squirrel button--contained-standard-square" aria-label="Click to search">
 <svg class="icon icon-search "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search" href="#icon-search"></use>
 </svg>
 </button>
 </div>
 </form>
-<div class="loc validation-message">
-<div id="general-search__validation-message_3-0" class="comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational">
-<svg class="icon icon-info message-banner__prefix-icon message-banner__icon "
+<div class="loc validation-message mntl-search-form__validation"><div id="mntl-search-form__validation-message_2-0" class="comp mntl-search-form__validation-message mntl-message-banner--error mntl-message-banner is-hidden mntl-message-banner--error" data-close-class="is-hidden" role="alert"> <svg class="icon icon-error mntl-message-banner__prefix-icon mntl-message-banner__icon "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-info"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-error" href="#icon-error"></use>
 </svg>
-<span class="message-banner__text ">
+<span class="type--cat-bold mntl-message-banner__text ">
 Please fill out this field.
 </span>
-<button class="message-banner__close-button js-message-banner-close" aria-label="Close informational Banner">
-<svg class="icon icon-close message-banner__icon"
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
-</svg>
-</button>
-</div><!-- end: comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational -->
 </div>
-</div><!-- end: comp type--cat fullscreen-nav__search general-search -->
-<ul class="fullscreen-nav__list">
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/recipes/17562/dinner/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-dinners-fullscreen-nav">
+</div></div>
+<ul class="mntl-fullscreen-nav__list">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/recipes/17562/dinner/" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-dinners-mntl-fullscreen-nav">
 Dinners
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-dinners-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-dinners-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">Dinners</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">Dinners</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/17057/everyday-cooking/more-meal-ideas/5-ingredients/main-dishes/"
 rel="nocaes"
 > 5-Ingredient Dinners
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/15436/everyday-cooking/one-pot-meals/"
 rel="nocaes"
 > One-Pot Meals
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/1947/everyday-cooking/quick-and-easy/"
 rel="nocaes"
 > Quick & Easy
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/455/everyday-cooking/more-meal-ideas/30-minute-meals/"
 rel="nocaes"
 > 30-Minute Meals
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/94/soups-stews-and-chili/"
 rel="nocaes"
 > Soups, Stews & Chili
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/16099/everyday-cooking/comfort-food/"
 rel="nocaes"
 > Comfort Food
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/80/main-dish/"
 rel="nocaes"
 > Main Dishes
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/22992/everyday-cooking/sheet-pan-dinners/"
 rel="nocaes"
 > Sheet Pan Dinners
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--squirrel-bold">
 <a
 href="https://www.allrecipes.com/recipes/17562/dinner/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/recipes-a-z-6735880" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-meals-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/recipes-a-z-6735880" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-meals-mntl-fullscreen-nav">
 Meals
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-meals-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-meals-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">Meals</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">Meals</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/78/breakfast-and-brunch/"
 rel="nocaes"
 > Breakfast & Brunch
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/17561/lunch/"
 rel="nocaes"
 > Lunch
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/84/healthy-recipes/"
 rel="nocaes"
 > Healthy
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/76/appetizers-and-snacks/"
 rel="nocaes"
 > Appetizers & Snacks
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/96/salad/"
 rel="nocaes"
 > Salads
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/81/side-dish/"
 rel="nocaes"
 > Side Dishes
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/16369/soups-stews-and-chili/soup/"
 rel="nocaes"
 > Soups
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/156/bread/"
 rel="nocaes"
 > Bread
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/77/drinks/"
 rel="nocaes"
 > Drinks
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/79/desserts/"
 rel="nocaes"
 > Desserts
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--squirrel-bold">
 <a
 href="https://www.allrecipes.com/recipes-a-z-6735880"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/ingredients-a-z-6740416" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-ingredients-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/ingredients-a-z-6740416" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-ingredients-mntl-fullscreen-nav">
 Ingredients
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-ingredients-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-ingredients-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">Ingredients</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">Ingredients</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/201/meat-and-poultry/chicken/"
 rel="nocaes"
 > Chicken
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/200/meat-and-poultry/beef/"
 rel="nocaes"
 > Beef
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/205/meat-and-poultry/pork/"
 rel="nocaes"
 > Pork
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/93/seafood/"
 rel="nocaes"
 > Seafood
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/95/pasta-and-noodles/"
 rel="nocaes"
 > Pasta
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/1058/fruits-and-vegetables/fruits/"
 rel="nocaes"
 > Fruits
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/1059/fruits-and-vegetables/vegetables/"
 rel="nocaes"
 > Vegetables
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--squirrel-bold">
 <a
 href="https://www.allrecipes.com/ingredients-a-z-6740416"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/recipes/85/holidays-and-events/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-occasions-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/recipes/85/holidays-and-events/" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-occasions-mntl-fullscreen-nav">
 Occasions
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-occasions-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-occasions-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">Occasions</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">Occasions</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
-href="https://www.allrecipes.com/recipes/841/holidays-and-events/christmas/desserts/christmas-cookies/"
+href="https://www.allrecipes.com/recipes/191/holidays-and-events/4th-of-july/"
 rel="nocaes"
-> Christmas Cookies
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+> 4th of July
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
-href="https://www.allrecipes.com/recipes/190/holidays-and-events/hanukkah/"
+href="https://www.allrecipes.com/recipes/1578/holidays-and-events/events-and-gatherings/"
 rel="nocaes"
-> Hanukkah Recipes
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+> Summer Entertaining
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
-href="https://www.allrecipes.com/recipes/187/holidays-and-events/christmas/"
+href="https://www.allrecipes.com/recipes/630/everyday-cooking/seasonal/summer/"
 rel="nocaes"
-> Christmas Recipes
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
-<a
-href="https://www.allrecipes.com/recipes/17185/everyday-cooking/entertaining/"
-rel="nocaes"
-> Holiday Entertaining
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+> More Summer Recipes
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--squirrel-bold">
 <a
 href="https://www.allrecipes.com/recipes/85/holidays-and-events/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/cuisine-a-z-6740455" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-cuisines-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/cuisine-a-z-6740455" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-cuisines-mntl-fullscreen-nav">
 Cuisines
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-cuisines-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-cuisines-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">Cuisines</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">Cuisines</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/728/world-cuisine/latin-american/mexican/"
 rel="nocaes"
 > Mexican
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/723/world-cuisine/european/italian/"
 rel="nocaes"
 > Italian
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/695/world-cuisine/asian/chinese/"
 rel="nocaes"
 > Chinese
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/233/world-cuisine/asian/indian/"
 rel="nocaes"
 > Indian
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/722/world-cuisine/european/german/"
 rel="nocaes"
 > German
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/731/world-cuisine/european/greek/"
 rel="nocaes"
 > Greek
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/696/world-cuisine/asian/filipino/"
 rel="nocaes"
 > Filipino
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/699/world-cuisine/asian/japanese/"
 rel="nocaes"
 > Japanese
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--squirrel-bold">
 <a
 href="https://www.allrecipes.com/cuisine-a-z-6740455"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/kitchen-tips/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-kitchen-tips-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/kitchen-tips/" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-kitchen-tips-mntl-fullscreen-nav">
 Kitchen Tips
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-kitchen-tips-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-kitchen-tips-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">Kitchen Tips</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">Kitchen Tips</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/22882/everyday-cooking/instant-pot/"
 rel="nocaes"
 > Instant Pot
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/23070/everyday-cooking/cookware-and-equipment/air-fryer/"
 rel="nocaes"
 > Air Fryer
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/253/everyday-cooking/slow-cooker/"
 rel="nocaes"
 > Slow Cooker
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/food-news-trends/product-reviews/"
 rel="nocaes"
-> Product Reviews
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+> Our Favorite Products
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/88/bbq-grilling/"
 rel="nocaes"
 > BBQ & Grilling
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/recipes/17583/everyday-cooking/cookware-and-equipment/"
 rel="nocaes"
-> Cookware & Equipment
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+> Cooking by Equipment
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/kitchen-tips/all-about-ingredients/substitutions/"
 rel="nocaes"
 > Ingredient Substitutions
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--squirrel-bold">
 <a
 href="https://www.allrecipes.com/kitchen-tips/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/food-news-trends/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-news-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/food-news-trends/" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-news-mntl-fullscreen-nav">
 News
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-news-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-news-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">News</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">News</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/food-news-trends/recalls/"
 rel="nocaes"
 > Recalls
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/we-tried-it/"
 rel="nocaes"
 > We Tried It
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/buying/"
 rel="nocaes"
 > Grocery
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/food-news-trends/trends/"
 rel="nocaes"
 > Trends
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/food-news-trends/celebrity-entertainment/"
 rel="nocaes"
 > Celebrity & Entertainment
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--squirrel-bold">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--squirrel-bold">
 <a
 href="https://www.allrecipes.com/food-news-trends/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/recipes/1642/everyday-cooking/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-features-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/recipes/1642/everyday-cooking/" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-features-mntl-fullscreen-nav">
 Features
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-features-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-features-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">Features</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">Features</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/dinner-fix/"
 rel="nocaes"
 > Dinner Fix
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/sweet-spot/"
 rel="nocaes"
 > Sweet Spot
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/kitchen-tips/in-the-kitchen/"
 rel="nocaes"
 > In the Kitchen
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
-<a href="https://www.allrecipes.com/recipes/" class="fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="fullscreen-nav__sublist-about-us-fullscreen-nav">
+<li class="mntl-fullscreen-nav__list-item">
+<a href="https://www.allrecipes.com/recipes/" class="mntl-fullscreen-nav__title type--squirrel" aria-expanded="false" aria-controls="mntl-fullscreen-nav__sublist-about-us-mntl-fullscreen-nav">
 About Us
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </a>
-<div class="fullscreen-nav__sublist-container" id="fullscreen-nav__sublist-about-us-fullscreen-nav">
-<div class="fullscreen-nav__sublist-header">
-<button class="fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-fullscreen-nav__sublist-container" id="mntl-fullscreen-nav__sublist-about-us-mntl-fullscreen-nav">
+<div class="mntl-fullscreen-nav__sublist-header">
+<button class="mntl-fullscreen-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
-<span class="fullscreen-nav__sublist-header-text type--goat-bold">About Us</span>
+<span class="mntl-fullscreen-nav__sublist-header-text type--goat-bold">About Us</span>
 </div>
-<ul class="fullscreen-nav__sublist">
-<li class="fullscreen-nav__sublist-item type--rabbit">
+<ul class="mntl-fullscreen-nav__sublist">
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/about-us-6648102"
 rel="nocaes"
 > About Allrecipes
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/allstars-6666204"
 rel="nocaes"
 > Allstars
-</a><!-- end: --> </li>
-<li class="fullscreen-nav__sublist-item type--rabbit">
+</a> </li>
+<li class="mntl-fullscreen-nav__sublist-item type--rabbit">
 <a
 href="https://www.allrecipes.com/article/how-to-submit-recipes/"
 rel="nocaes"
 > How to Add a Recipe
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="fullscreen-nav__list-item">
+<li class="mntl-fullscreen-nav__list-item">
 <a
 href="https://www.magazines.com/allrecipes-magazine.html?utm_source=allrecipes.com&utm_medium=owned&utm_campaign=i111arr1w2661"
 target="_blank"
-rel="noopener nocaes"
-class="fullscreen-nav__link type--squirrel"
+rel="noopener nofollow nocaes"
+class="mntl-fullscreen-nav__link type--squirrel"
 > GET THE MAGAZINE
-</a><!-- end: fullscreen-nav__link type--squirrel --> </li>
+</a> </li>
 </ul>
-<div id="utility-nav_2-0" class="comp utility-nav">
-<ul class="utility-nav__list type--rabbit">
-<li class="utility-nav__signin utility-nav__full-menu-item">
+<div id="mntl-fullscreen-nav__utility-nav_1-0" class="comp mntl-fullscreen-nav__utility-nav mntl-utility-nav">
+<ul class="mntl-utility-nav__list type--rabbit">
+<li class="mntl-utility-nav__signin mntl-utility-nav__full-menu-item">
 <a
 href="https://www.allrecipes.com/authentication/login?regSource=3675&relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F"
 rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+class="mntl-utility-nav__sublist-link"
 > <svg class="icon icon-account "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account" href="#icon-account"></use>
 </svg>
-<span>Log In</span>
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__account utility-nav__full-menu-item utility-nav__list-item state-sign-out">
-<button class="utility-nav__title type--rabbit">
+<span>
+Log In
+</span>
+</a> </li>
+<li class="mntl-utility-nav__account mntl-utility-nav__full-menu-item mntl-utility-nav__list-item state-sign-out">
+<button class="mntl-utility-nav__title type--rabbit">
 <svg class="icon icon-account "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-account" href="#icon-account"></use>
 </svg>
 <span>My Account</span>
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </button>
-<div class="utility-nav__sublist-container">
-<div class="utility-nav__sublist-header">
-<button class="utility-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-utility-nav__sublist-container">
+<div class="mntl-utility-nav__sublist-header">
+<button class="mntl-utility-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
 <span class="type--goat-bold">My Account</span>
 </div>
-<ul class="utility-nav__link-list">
-<li class="utility-nav__sublist-list-item">
+<ul class="mntl-utility-nav__link-list">
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.allrecipes.com/authentication/logout?relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F"
 rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+class="mntl-utility-nav__sublist-link"
 > Log Out
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="/account/profile"
-rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+rel="nocaes"
+class="mntl-utility-nav__sublist-link"
 > My Profile
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
-href="/account/profile#/collections"
-rel="nofollow nocaes"
-class="utility-nav__sublist-link"
-> Saved Items & Collections
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+href="/favorites"
+rel="nocaes"
+class="mntl-utility-nav__sublist-link"
+> Saved Recipes & Collections
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="/account/add-recipe"
-rel="nofollow nocaes"
-class="utility-nav__sublist-link"
+rel="nocaes"
+class="mntl-utility-nav__sublist-link"
 > Add a Recipe
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://websupport.meredith.com/"
 target="_blank"
-rel="noopener nofollow nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nocaes"
+class="mntl-utility-nav__sublist-link"
 > Help
-</a><!-- end: utility-nav__sublist-link --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="utility-nav__magazine utility-nav__full-menu-item utility-nav__list-item">
-<button class="utility-nav__title type--rabbit">
+<li class="mntl-utility-nav__magazine mntl-utility-nav__full-menu-item mntl-utility-nav__list-item">
+<button class="mntl-utility-nav__title type--rabbit">
 <span>Magazine</span>
-<svg class="icon icon-chevron_right "
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
 </svg>
 </button>
-<div class="utility-nav__sublist-container">
-<div class="utility-nav__sublist-header">
-<button class="utility-nav__sublist-back-button" role="button" aria-label="Back to main menu">
-<svg class="icon icon-arrow_left "
+<div class="mntl-utility-nav__sublist-container">
+<div class="mntl-utility-nav__sublist-header">
+<button class="mntl-utility-nav__sublist-back-button" role="button" aria-label="Back to main menu">
+<svg class="icon icon-arrow-left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow-left" href="#icon-arrow-left"></use>
 </svg>
 </button>
 <span class="type--goat-bold">Magazine</span>
 </div>
-<ul class="utility-nav__link-list">
-<li class="utility-nav__sublist-list-item">
+<ul class="mntl-utility-nav__link-list">
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.magazines.com/allrecipes-magazine.html?utm_source=allrecipes.com&utm_medium=owned&utm_campaign=i111arr1w2661"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Subscribe
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://w1.buysub.com/servlet/CSGateway?cds_mag_code=ALR"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Manage Your Subscription
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.magazines.com/allrecipes-magazine.html"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Give a Gift Subscription
-</a><!-- end: utility-nav__sublist-link --> </li>
-<li class="utility-nav__sublist-list-item">
+</a> </li>
+<li class="mntl-utility-nav__sublist-list-item">
 <a
 href="https://www.magazines.com/customer-care"
 target="_blank"
-rel="noopener nocaes"
-class="utility-nav__sublist-link"
+rel="noopener nofollow nocaes"
+class="mntl-utility-nav__sublist-link"
 > Get Help
-</a><!-- end: utility-nav__sublist-link --> </li>
+</a> </li>
 </ul>
 </div>
 </li>
-<li class="loc newsletter-link-wrapper utility-nav__newsletter utility-nav__full-menu-item">
-<a
+<li class="loc newsletter-link-wrapper mntl-utility-nav__newsletter mntl-utility-nav__full-menu-item"><a
 href="#"
 rel="nocaes"
 data-a11y-dialog-show="newsletter-dialog-header"
-id="newsletter-dialog-header-link_2-0"
+id="mntl-newsletter-dialog--header-link_2-0"
 role="button"
-class=" newsletter-dialog-header-link dialog-link mntl-text-link"
+class="mntl-newsletter-dialog--header-link dialog-link mntl-text-link "
 data-tracking-container="true"
-><span class="link__wrapper">Newsletter</span></a><!-- end: newsletter-dialog-header-link dialog-link mntl-text-link -->
+><span class="link__wrapper">Newsletters</span></a>
 </li>
-<li class="utility-nav__sweepstakes utility-nav__full-menu-item">
+<li class="mntl-utility-nav__sweepstakes mntl-utility-nav__full-menu-item">
 <a
-href="https://www.allrecipes.com/sweepstakes/"
+href="/sweepstakes"
 rel="nocaes"
 > Sweepstakes
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
-</div><!-- end: comp utility-nav -->
-<div id="fullscreen-nav__social-nav_1-0" class="comp fullscreen-nav__social-nav allrecipes-social-nav mntl-social-nav" data-tracking-container="true">
+</div>
+<div id="mntl-fullscreen-nav__social-nav_1-0" class="comp mntl-fullscreen-nav__social-nav allrecipes-social-nav mntl-social-nav" data-tracking-container="true">
 <div class="social-nav__title">Follow Us</div>
 <ul class="social-nav__list">
 <li class="social-nav__item social-nav__item--facebook">
@@ -3016,9 +1881,9 @@ class="social-nav__link social-nav__link--facebook"
 aria-label="Visit Allrecipes&#39;s Facebook"
 > <svg class="icon icon-facebook social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook" href="#icon-facebook"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--facebook --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--instagram">
 <a
 href="https://www.instagram.com/allrecipes/"
@@ -3028,9 +1893,9 @@ class="social-nav__link social-nav__link--instagram"
 aria-label="Visit Allrecipes&#39;s Instagram"
 > <svg class="icon icon-instagram social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram" href="#icon-instagram"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--instagram --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--pinterest">
 <a
 href="https://www.pinterest.com/allrecipes/"
@@ -3040,9 +1905,9 @@ class="social-nav__link social-nav__link--pinterest"
 aria-label="Visit Allrecipes&#39;s Pinterest"
 > <svg class="icon icon-pinterest social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest" href="#icon-pinterest"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--pinterest --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--tiktok">
 <a
 href="https://www.tiktok.com/@allrecipes"
@@ -3052,9 +1917,9 @@ class="social-nav__link social-nav__link--tiktok"
 aria-label="Visit Allrecipes&#39;s TikTok"
 > <svg class="icon icon-tiktok social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tiktok"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tiktok" href="#icon-tiktok"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--tiktok --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--youtube">
 <a
 href="https://www.youtube.com/user/allrecipes/videos"
@@ -3064,21 +1929,21 @@ class="social-nav__link social-nav__link--youtube"
 aria-label="Visit Allrecipes&#39;s YouTube"
 > <svg class="icon icon-youtube social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube" href="#icon-youtube"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--youtube --> </li>
-<li class="social-nav__item social-nav__item--twitter">
+</a> </li>
+<li class="social-nav__item social-nav__item--x">
 <a
 href="https://twitter.com/Allrecipes"
 target="_blank"
 rel="noopener nocaes"
-class="social-nav__link social-nav__link--twitter"
-aria-label="Visit Allrecipes&#39;s Twitter"
-> <svg class="icon icon-twitter social-nav__icon"
+class="social-nav__link social-nav__link--x"
+aria-label="Visit Allrecipes&#39; X"
+> <svg class="icon icon-x social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-x" href="#icon-x"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--twitter --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--flipboard">
 <a
 href="https://flipboard.com/@Allrecipes"
@@ -3088,666 +1953,623 @@ class="social-nav__link social-nav__link--flipboard"
 aria-label="Visit Allrecipes&#39;s Flipboard"
 > <svg class="icon icon-flipboard social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard" href="#icon-flipboard"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--flipboard --> </li>
+</a> </li>
 </ul>
-</div><!-- end: comp fullscreen-nav__social-nav allrecipes-social-nav mntl-social-nav -->
-</nav><!-- end: comp fullscreen-nav -->
 </div>
-<nav id="header-nav_1-0" class="comp header-nav" role="navigation">
-<div class="header-nav__list-wrapper">
-<ul class="header-nav__list">
-<li class="header-nav__list-item">
+</nav> </div>
+<nav id="mntl-header-nav_1-0" class="comp mntl-header-nav" role="navigation" aria-label="Header">
+<div class="mntl-header-nav__list-wrapper">
+<ul class="mntl-header-nav__list">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/recipes/17562/dinner/"
 rel="nocaes"
 > Dinners
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/17057/everyday-cooking/more-meal-ideas/5-ingredients/main-dishes/"
 rel="nocaes"
 > 5-Ingredient Dinners
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/15436/everyday-cooking/one-pot-meals/"
 rel="nocaes"
 > One-Pot Meals
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/1947/everyday-cooking/quick-and-easy/"
 rel="nocaes"
 > Quick & Easy
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/455/everyday-cooking/more-meal-ideas/30-minute-meals/"
 rel="nocaes"
 > 30-Minute Meals
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/94/soups-stews-and-chili/"
 rel="nocaes"
 > Soups, Stews & Chili
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/16099/everyday-cooking/comfort-food/"
 rel="nocaes"
 > Comfort Food
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/80/main-dish/"
 rel="nocaes"
 > Main Dishes
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/22992/everyday-cooking/sheet-pan-dinners/"
 rel="nocaes"
 > Sheet Pan Dinners
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item type--squirrel-bold view-all">
+</a> </li>
+<li class="mntl-header-nav__sublist-item type--squirrel-bold view-all">
 <a
 href="https://www.allrecipes.com/recipes/17562/dinner/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
-<li class="header-nav__list-item">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/recipes-a-z-6735880"
 rel="nocaes"
 > Meals
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/78/breakfast-and-brunch/"
 rel="nocaes"
 > Breakfast & Brunch
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/17561/lunch/"
 rel="nocaes"
 > Lunch
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/84/healthy-recipes/"
 rel="nocaes"
 > Healthy
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/76/appetizers-and-snacks/"
 rel="nocaes"
 > Appetizers & Snacks
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/96/salad/"
 rel="nocaes"
 > Salads
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/81/side-dish/"
 rel="nocaes"
 > Side Dishes
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/16369/soups-stews-and-chili/soup/"
 rel="nocaes"
 > Soups
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/156/bread/"
 rel="nocaes"
 > Bread
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/77/drinks/"
 rel="nocaes"
 > Drinks
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/79/desserts/"
 rel="nocaes"
 > Desserts
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item type--squirrel-bold view-all">
+</a> </li>
+<li class="mntl-header-nav__sublist-item type--squirrel-bold view-all">
 <a
 href="https://www.allrecipes.com/recipes-a-z-6735880"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
-<li class="header-nav__list-item">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/ingredients-a-z-6740416"
 rel="nocaes"
 > Ingredients
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/201/meat-and-poultry/chicken/"
 rel="nocaes"
 > Chicken
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/200/meat-and-poultry/beef/"
 rel="nocaes"
 > Beef
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/205/meat-and-poultry/pork/"
 rel="nocaes"
 > Pork
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/93/seafood/"
 rel="nocaes"
 > Seafood
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/95/pasta-and-noodles/"
 rel="nocaes"
 > Pasta
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/1058/fruits-and-vegetables/fruits/"
 rel="nocaes"
 > Fruits
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/1059/fruits-and-vegetables/vegetables/"
 rel="nocaes"
 > Vegetables
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item type--squirrel-bold view-all">
+</a> </li>
+<li class="mntl-header-nav__sublist-item type--squirrel-bold view-all">
 <a
 href="https://www.allrecipes.com/ingredients-a-z-6740416"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
-<li class="header-nav__list-item">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/recipes/85/holidays-and-events/"
 rel="nocaes"
 > Occasions
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
-href="https://www.allrecipes.com/recipes/841/holidays-and-events/christmas/desserts/christmas-cookies/"
+href="https://www.allrecipes.com/recipes/191/holidays-and-events/4th-of-july/"
 rel="nocaes"
-> Christmas Cookies
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+> 4th of July
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
-href="https://www.allrecipes.com/recipes/190/holidays-and-events/hanukkah/"
+href="https://www.allrecipes.com/recipes/1578/holidays-and-events/events-and-gatherings/"
 rel="nocaes"
-> Hanukkah Recipes
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+> Summer Entertaining
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
-href="https://www.allrecipes.com/recipes/187/holidays-and-events/christmas/"
+href="https://www.allrecipes.com/recipes/630/everyday-cooking/seasonal/summer/"
 rel="nocaes"
-> Christmas Recipes
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
-<a
-href="https://www.allrecipes.com/recipes/17185/everyday-cooking/entertaining/"
-rel="nocaes"
-> Holiday Entertaining
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item type--squirrel-bold view-all">
+> More Summer Recipes
+</a> </li>
+<li class="mntl-header-nav__sublist-item type--squirrel-bold view-all">
 <a
 href="https://www.allrecipes.com/recipes/85/holidays-and-events/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
-<li class="header-nav__list-item">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/cuisine-a-z-6740455"
 rel="nocaes"
 > Cuisines
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/728/world-cuisine/latin-american/mexican/"
 rel="nocaes"
 > Mexican
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/723/world-cuisine/european/italian/"
 rel="nocaes"
 > Italian
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/695/world-cuisine/asian/chinese/"
 rel="nocaes"
 > Chinese
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/233/world-cuisine/asian/indian/"
 rel="nocaes"
 > Indian
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/722/world-cuisine/european/german/"
 rel="nocaes"
 > German
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/731/world-cuisine/european/greek/"
 rel="nocaes"
 > Greek
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/696/world-cuisine/asian/filipino/"
 rel="nocaes"
 > Filipino
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/699/world-cuisine/asian/japanese/"
 rel="nocaes"
 > Japanese
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item type--squirrel-bold view-all">
+</a> </li>
+<li class="mntl-header-nav__sublist-item type--squirrel-bold view-all">
 <a
 href="https://www.allrecipes.com/cuisine-a-z-6740455"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
-<li class="header-nav__list-item">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/kitchen-tips/"
 rel="nocaes"
 > Kitchen Tips
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/22882/everyday-cooking/instant-pot/"
 rel="nocaes"
 > Instant Pot
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/23070/everyday-cooking/cookware-and-equipment/air-fryer/"
 rel="nocaes"
 > Air Fryer
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/253/everyday-cooking/slow-cooker/"
 rel="nocaes"
 > Slow Cooker
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/food-news-trends/product-reviews/"
 rel="nocaes"
-> Product Reviews
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+> Our Favorite Products
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/88/bbq-grilling/"
 rel="nocaes"
 > BBQ & Grilling
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/recipes/17583/everyday-cooking/cookware-and-equipment/"
 rel="nocaes"
-> Cookware & Equipment
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+> Cooking by Equipment
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/kitchen-tips/all-about-ingredients/substitutions/"
 rel="nocaes"
 > Ingredient Substitutions
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item type--squirrel-bold view-all">
+</a> </li>
+<li class="mntl-header-nav__sublist-item type--squirrel-bold view-all">
 <a
 href="https://www.allrecipes.com/kitchen-tips/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
-<li class="header-nav__list-item">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/food-news-trends/"
 rel="nocaes"
 > News
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/food-news-trends/recalls/"
 rel="nocaes"
 > Recalls
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/we-tried-it/"
 rel="nocaes"
 > We Tried It
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/buying/"
 rel="nocaes"
 > Grocery
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/food-news-trends/trends/"
 rel="nocaes"
 > Trends
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/food-news-trends/celebrity-entertainment/"
 rel="nocaes"
 > Celebrity & Entertainment
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item type--squirrel-bold view-all">
+</a> </li>
+<li class="mntl-header-nav__sublist-item type--squirrel-bold view-all">
 <a
 href="https://www.allrecipes.com/food-news-trends/"
 rel="nocaes"
 > View All
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
-<li class="header-nav__list-item">
+<li class="mntl-header-nav__list-item">
 <a
 href="https://www.allrecipes.com/recipes/1642/everyday-cooking/"
 rel="nocaes"
 > Features
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/dinner-fix/"
 rel="nocaes"
 > Dinner Fix
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/kitchen-tips/how-to/sweet-spot/"
 rel="nocaes"
 > Sweet Spot
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/kitchen-tips/in-the-kitchen/"
 rel="nocaes"
 > In the Kitchen
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </li>
 </ul>
 </div>
-<div class="header-nav__list-item header-nav__list-item-about-us">
+<div class="mntl-header-nav__list-item mntl-header-nav__list-item-about-us">
 <a
 href="/about-us-6648102"
 rel="nocaes"
 > About Us
-</a><!-- end: -->
-<ul class="header-nav__sublist">
-<li class="header-nav__sublist-item">
+</a>
+<ul class="mntl-header-nav__sublist">
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/allstars-6666204"
 rel="nocaes"
 > Allstars
-</a><!-- end: --> </li>
-<li class="header-nav__sublist-item">
+</a> </li>
+<li class="mntl-header-nav__sublist-item">
 <a
 href="https://www.allrecipes.com/article/how-to-submit-recipes/"
 rel="nocaes"
 > How to Add a Recipe
-</a><!-- end: --> </li>
+</a> </li>
 </ul>
 </div>
-<div class="loc navigation-links">
-<a
+<div class="loc navigation-links"><a
 href="https://www.magazines.com/allrecipes-magazine.html?utm_source=allrecipes.com&utm_medium=owned&utm_campaign=i111arr1w2661"
 target="_blank"
 rel="noopener nofollow nocaes"
-id="header-nav__subscribe-link_1-0"
-class=" header-nav__subscribe-link mntl-text-link type--squirrel-link"
+id="mntl-header-nav__subscribe-link_1-0"
+class="mntl-header-nav__subscribe-link mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">GET THE MAGAZINE</span></a><!-- end: header-nav__subscribe-link mntl-text-link type--squirrel-link -->
+><span class="link__wrapper">GET THE MAGAZINE</span></a>
 </div>
-</nav><!-- end: comp header-nav -->
-</header><!-- end: comp header--magazine header -->
-<div id="mntl-leaderboard-header_1-0" class="comp has-right-label leaderboard mntl-leaderboard-header mntl-leaderboard-fixed-0 mntl-leaderboard-fixed mntl-gpt-adunit gpt leaderboard ">
+</nav>
+</header>
+<div id="mm-ads-leaderboard-header_1-0" class="comp mm-ads-leaderboard-header mm-ads-leaderboard-fixed-0 mm-ads-leaderboard-fixed mm-ads-gpt-adunit has-right-label leaderboard gpt leaderboard ">
 <div id="leaderboard-fixed-0" class="wrapper"
 data-timed-refresh="30000"
 ></div>
-</div><!-- end: comp has-right-label leaderboard mntl-leaderboard-header mntl-leaderboard-fixed-0 mntl-leaderboard-fixed mntl-gpt-adunit gpt leaderboard -->
-<div id="mntl-leaderboard-spacer_1-0" class="comp mntl-leaderboard-spacer mntl-block"></div><!-- end: comp mntl-leaderboard-spacer mntl-block -->
-<main id="main" class="loc main" role="main">
-<iframe id="height-change-listener" role="none" tabindex="-1" src="about:blank" aria-hidden="true"></iframe>
-<article id="allrecipes-article_1-0" class="comp mntl-article--two-column-right-rail sc-ad-container adjusted-right-rail allrecipes-article mntl-article" data-content-graph-id="cms__onecms_posts_alrcom_133948" data-tracking-container="true">
-<div class="loc article-header">
-<div id="article-preheading_1-0" class="comp article-preheading mntl-block">
-<div id="breadcrumbs_1-0" class="comp type--squirrel breadcrumbs">
-<div class="breadcrumbs__scroll-wrapper js-breadcrumbs-right-overflow">
-<ul id="breadcrumbs__list_1-0" class="comp breadcrumbs__list mntl-breadcrumbs mntl-block" data-tracking-container="true">
-<li id="mntl-breadcrumbs__item_1-0" class="comp mntl-breadcrumbs__item mntl-block">
-<a
+</div>
+<div id="mm-ads-leaderboard-spacer_1-0" class="comp mm-ads-leaderboard-spacer mntl-block"></div>
+<div id="mntl-myr-toast_1-0" class="comp mntl-myr-toast hide is-hidden" data-myr-url="/" data-close-class="hide" data-favorites-template="false" data-toast-timeout="5000" data-is-alrcom="true">
+<div class="mntl-myr-toast__content">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+<span class="mntl-myr-toast__text">
+</span>
+</div>
+<button class="mntl-myr-toast__close-button js-mntl-myr-toast-close" aria-label="Close Toast">
+<svg class="icon icon-myr-close mntl-myr-toast__icon"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-myr-close" href="#icon-myr-close"></use>
+</svg>
+</button>
+</div><main id="main" class="loc main" role="main"><iframe id="height-change-listener" role="none" tabindex="-1" src="about:blank" aria-hidden="true"></iframe>
+<article id="allrecipes-article_1-0" class="comp allrecipes-article mntl-article mntl-article--two-column-right-rail sc-ad-container adjusted-right-rail" data-content-graph-id="cms__onecms_posts_alrcom_133948" data-tracking-container="true"><div class="loc article-header"><div id="article-preheading_1-0" class="comp article-preheading mntl-block"><div id="breadcrumbs_1-0" class="comp breadcrumbs"> <div class="breadcrumbs__scroll-wrapper js-breadcrumbs-right-overflow">
+<ul id="breadcrumbs__list_1-0" class="comp breadcrumbs__list mntl-universal-breadcrumbs mntl-block type--squirrel breadcrumbs" data-tracking-container="true"><li id="mntl-breadcrumbs__item_1-0" class="comp mntl-breadcrumbs__item mntl-block"><a
 href="https://www.allrecipes.com/recipes/"
 rel="nocaes"
-id="mntl-text-link_2-0"
-class=" mntl-text-link mntl-breadcrumbs__link"
+id="mntl-text-link_9-0"
+class="mntl-text-link mntl-breadcrumbs__link"
 data-tracking-container="true"
-><span class="link__wrapper">Recipes</span></a><!-- end: mntl-text-link mntl-breadcrumbs__link -->
-<svg class="icon icon-chevron_right "
+><span class="link__wrapper">Recipes</span></a>
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
-</svg>
-</li><!-- end: comp mntl-breadcrumbs__item mntl-block -->
-<li id="mntl-breadcrumbs__item_1-0-1" class="comp mntl-breadcrumbs__item mntl-block">
-<a
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
+</svg></li>
+<li id="mntl-breadcrumbs__item_2-0" class="comp mntl-breadcrumbs__item mntl-block"><a
 href="https://www.allrecipes.com/recipes/86/world-cuisine/"
 rel="nocaes"
-id="mntl-text-link_2-0-1"
-class=" mntl-text-link mntl-breadcrumbs__link"
+id="mntl-text-link_10-0"
+class="mntl-text-link mntl-breadcrumbs__link"
 data-tracking-container="true"
-><span class="link__wrapper">Cuisine</span></a><!-- end: mntl-text-link mntl-breadcrumbs__link -->
-<svg class="icon icon-chevron_right "
+><span class="link__wrapper">Cuisine</span></a>
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
-</svg>
-</li><!-- end: comp mntl-breadcrumbs__item mntl-block -->
-<li id="mntl-breadcrumbs__item_1-0-2" class="comp mntl-breadcrumbs__item mntl-block">
-<a
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
+</svg></li>
+<li id="mntl-breadcrumbs__item_3-0" class="comp mntl-breadcrumbs__item mntl-block"><a
 href="https://www.allrecipes.com/recipes/231/world-cuisine/european/"
 rel="nocaes"
-id="mntl-text-link_2-0-2"
-class=" mntl-text-link mntl-breadcrumbs__link"
+id="mntl-text-link_11-0"
+class="mntl-text-link mntl-breadcrumbs__link"
 data-tracking-container="true"
-><span class="link__wrapper">European</span></a><!-- end: mntl-text-link mntl-breadcrumbs__link -->
-<svg class="icon icon-chevron_right "
+><span class="link__wrapper">European</span></a>
+<svg class="icon icon-chevron "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron_right"></use>
-</svg>
-</li><!-- end: comp mntl-breadcrumbs__item mntl-block -->
-<li id="mntl-breadcrumbs__item_1-0-3" class="comp mntl-breadcrumbs__item mntl-block">
-<a
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
+</svg></li>
+<li id="mntl-breadcrumbs__item_4-0" class="comp mntl-breadcrumbs__item mntl-block"><a
 href="https://www.allrecipes.com/recipes/723/world-cuisine/european/italian/"
 rel="nocaes"
-id="mntl-text-link_2-0-3"
-class=" mntl-text-link mntl-breadcrumbs__link"
+id="mntl-text-link_12-0"
+class="mntl-text-link mntl-breadcrumbs__link"
 data-tracking-container="true"
-><span class="link__wrapper">Italian</span></a><!-- end: mntl-text-link mntl-breadcrumbs__link -->
-</li><!-- end: comp mntl-breadcrumbs__item mntl-block -->
-</ul><!-- end: comp breadcrumbs__list mntl-breadcrumbs mntl-block -->
+><span class="link__wrapper">Italian</span></a></li></ul> </div>
+</div></div>
+</div><div class="loc article-post-header"><div id="article-header--recipe_1-0" class="comp article-header--recipe mm-recipes-article-header mntl-article-header">
+<h1 class="article-heading type--lion">Four Cheese Margherita Pizza</h1>
+<div id="mm-recipes-review-bar_1-0" class="comp mm-recipes-review-bar recipe-review-bar mntl-block has-ratings has-comments js-recipe-review-bar"><div id="mm-recipes-review-bar__star-rating_1-0" class="comp mm-recipes-review-bar__star-rating mntl-recipe-star-rating mm-recipes-star-rating" data-track-rating-location="Top Nav - Jump to Reviews - Stars">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
 </div>
-</div><!-- end: comp type--squirrel breadcrumbs -->
-</div><!-- end: comp article-preheading mntl-block -->
+<div id="mm-recipes-review-bar__rating_1-0" class="comp mm-recipes-review-bar__rating mntl-text-block type--squirrel-bold">4.8</div>
+<div id="mm-recipes-review-bar__rating-count_1-0" class="comp mm-recipes-review-bar__rating-count mntl-text-block type--squirrel">(489)</div>
+<div id="mm-recipes-review-bar__comment-count_1-0" class="comp mm-recipes-review-bar__comment-count mntl-text-block type--squirrel-link">330 Reviews</div>
+<div id="recipe-review-bar__photo-count_1-0" class="comp recipe-review-bar__photo-count mntl-text-block type--squirrel-link dialog-link" data-click-tracked="false" data-a11y-dialog-show="photo-dialog" data-tracking-container="true">107 Photos</div></div>
+<p class="article-subheading type--dog">This is a fantastic version of an Italian classic. The feta cheese adds a rich flavor that brings this dish to life. Incredibly easy and incredibly delicious!</p>
+<div id="mntl-article-meta-dynamic_1-0" class="comp mntl-article-meta-dynamic mntl-article-meta mntl-block" data-tracking-container="true"><div id="allrecipes-bylines_1-0" class="comp allrecipes-bylines mntl-bylines type--rabbit"><div id="mntl-bylines__group_1-0" class="comp mntl-bylines__group mntl-block mntl-bylines__group--ugc_recipe"><div id="mntl-bylines__item_1-0" class="comp mntl-bylines__item mntl-attribution__item mntl-attribution__item--has-date">
+<span class="mntl-attribution__item-descriptor">Submitted by</span>
+<span id="mntl-bylines__item_1-0" class="comp mntl-bylines__item mntl-attribution__item mntl-attribution__item-name">Michelle</span>
 </div>
-<div class="loc article-post-header">
-<h1 id="article-heading_1-0" class="comp type--lion article-heading mntl-text-block">
-Four Cheese Margherita Pizza</h1><!-- end: comp type--lion article-heading mntl-text-block -->
-<div id="review-header-component_1-0" class="comp review-header-component mntl-block">
-<div id="recipe-review-bar_1-0" class="comp has-ratings has-comments js-recipe-review-bar recipe-review-bar mntl-recipe-review-bar mntl-block">
-<div id="mntl-recipe-review-bar__star-rating_1-0" class="comp mntl-recipe-review-bar__star-rating mntl-recipe-star-rating">
-<svg class="icon icon-star "
+<div class="mntl-attribution__item-date">Updated on October 28, 2022</div></div>
+</div>
+<div id="recipe-social-share_1-0" class="comp recipe-social-share mm-recipes-social-share recipes-social-share"> <div class="mm-recipes-social-share__inner">
+<div class="loc save"><div id="mntl-favorite_1-0" class="comp mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="true"
+data-scroll-to-favorite="false"
+data-doc-id="6586301"
+data-doc-title="Four Cheese Margherita Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/yJST01PaPKnsN9I6BEMActiNTms=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/5225433-four-cheese-margherita-pizza-Christina-4x3-1-29b0fe4316b74017a5ae437e9ebb319d.jpg"
+data-tracking-on="recipe-detail"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-</div><!-- end: comp mntl-recipe-review-bar__star-rating mntl-recipe-star-rating -->
-<div id="mntl-recipe-review-bar__rating_1-0" class="comp type--squirrel-bold mntl-recipe-review-bar__rating mntl-text-block">
-4.8</div><!-- end: comp type--squirrel-bold mntl-recipe-review-bar__rating mntl-text-block -->
-<div id="mntl-recipe-review-bar__rating-count_1-0" class="comp type--squirrel mntl-recipe-review-bar__rating-count mntl-text-block">
-(487)</div><!-- end: comp type--squirrel mntl-recipe-review-bar__rating-count mntl-text-block -->
-<div id="mntl-recipe-review-bar__comment-count_1-0" class="comp type--squirrel-link mntl-recipe-review-bar__comment-count mntl-text-block">
-328 Reviews</div><!-- end: comp type--squirrel-link mntl-recipe-review-bar__comment-count mntl-text-block -->
-<div id="recipe-review-bar__photo-count_1-0" class="comp type--squirrel-link dialog-link recipe-review-bar__photo-count mntl-text-block" data-click-tracked="false" data-a11y-dialog-show="photo-dialog" data-tracking-container="true">
-106 Photos</div><!-- end: comp type--squirrel-link dialog-link recipe-review-bar__photo-count mntl-text-block -->
-</div><!-- end: comp has-ratings has-comments js-recipe-review-bar recipe-review-bar mntl-recipe-review-bar mntl-block -->
-</div><!-- end: comp review-header-component mntl-block -->
-<p id="article-subheading_1-0" class="comp type--dog article-subheading">
-This is a fantastic version of an Italian classic. The feta cheese adds a rich flavor that brings this dish to life. Incredibly easy and incredibly delicious!</p><!-- end: comp type--dog article-subheading -->
-<div id="article-meta-dynamic_1-0" class="comp article-meta-dynamic article-meta mntl-block" data-tracking-container="true">
-<div id="allrecipes-bylines_1-0" class="comp type--rabbit allrecipes-bylines mntl-bylines">
-<div id="mntl-bylines__group_1-0" class="comp mntl-bylines__group--ugc_recipe mntl-bylines__group mntl-block">
-<div id="mntl-bylines__item_1-0" class="comp mntl-bylines__item mntl-attribution__item mntl-attribution__item--has-date">
-<span class="mntl-attribution__item-descriptor">Recipe by</span>
-<span id="mntl-bylines__item_1-0" class="comp mntl-bylines__item mntl-attribution__item mntl-attribution__item-name">
-Michelle</span><!-- end: comp mntl-bylines__item mntl-attribution__item mntl-attribution__item-name -->
-<!-- end: mntl-attribution__item-name -->
-</div><!-- end: comp mntl-bylines__item mntl-attribution__item mntl-attribution__item--has-date -->
-<div class="mntl-attribution__item-date">Updated on October 28, 2022</div>
-</div><!-- end: comp mntl-bylines__group--ugc_recipe mntl-bylines__group mntl-block -->
-</div><!-- end: comp type--rabbit allrecipes-bylines mntl-bylines -->
-<div id="recipe-social-share_1-0" class="comp recipe-social-share mntl-recipe-social-share">
-<div class="mntl-recipe-social-share__inner">
-<div class="loc save">
-<div id="mntl-save_1-0" class="comp mntl-save mntl-block">
-<button id="mntl-save__link_1-0" class="comp mntl-save__link mntl-button" data-click-tracked="false" data-check-on-load="true" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" data-doc-id="6586301">
 <span>Save</span>
-<svg class="icon save-icon-favorite mntl-button__icon "
+</button>
+</div>
+</div>
+<div class="mm-recipes-social-share__rate-wrapper">
+<button aria-label="Rate" class="mm-recipes-social-share__rate-button" data-click-tracked="false"
+data-tracking-on=""
+data-myrecipes-enabled="false"
+data-unauthFlow-enabled="true"
+data-myrecipes-joinLink="/authentication/signup?regSource=&relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F%23scrollToUgc"
+data-myrecipes-loginLink="/authentication/login?regSource=&relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F%23scrollToUgc">
+<span class="mm-recipes-social-share__rate-label">Rate</span>
+<svg class="icon icon-recipe-social-share-star-empty "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-<div id="mntl-save__confirmation_1-0" class="comp mntl-save__confirmation save__confirmation-dialog mntl-save__confirmation-dialog mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="mntl-save__dialog">
-<div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
-<div role="dialog" class="dialog__content" aria-labelledby="mntl-save__confirmation_1-0-title">
-<div class="dialog__heading">
-<span id="mntl-save__confirmation_1-0-title" class="dialog__title "></span>
-<button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
-<svg class="icon icon-close "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-recipe-social-share-star-empty" href="#icon-recipe-social-share-star-empty"></use>
 </svg>
 </button>
 </div>
-<div class="loc content dialog__main">
-<svg class="icon icon-check-circle "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check-circle"></use>
-</svg>
-<div id="mntl-save__confirmation-text_1-0" class="comp type--zebra mntl-save__confirmation-text mntl-text-block">
-Saved!</div><!-- end: comp type--zebra mntl-save__confirmation-text mntl-text-block -->
-<div id="save__confirmation-saved-items_1-0" class="comp save__confirmation-saved-items mntl-text-block">
-View <a rel="nofollow" href="/account/profile#/collections">All Saved Items</a></div><!-- end: comp save__confirmation-saved-items mntl-text-block -->
-</div>
-</div>
-</div><!-- end: comp mntl-save__confirmation save__confirmation-dialog mntl-save__confirmation-dialog mntl-dialog dialog -->
-</div><!-- end: comp mntl-save mntl-block -->
-</div>
-<div class="mntl-recipe-social-share__rate-wrapper">
-<button aria-label="Rate" class="mntl-recipe-social-share__rate-button" data-click-tracked="false">
-<span class="mntl-recipe-social-share__rate-label">Rate</span>
-<svg class="icon icon-star-empty "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty"></use>
-</svg>
-</button>
-</div>
-<div class="loc print mntl-recipe-social-share__print-wrapper">
-<form id="print-button_1-0" class="comp print-button mntl-print-button" method="POST" action="/recipe/133948/four-cheese-margherita-pizza/?print" target="_blank" aria-label="Print this article." data-tracking-container="true">
-<button class="mntl-print-button__btn" aria-label="Print this article.">
+<div class="loc print mm-recipes-social-share__print-wrapper"><form id="mntl-print-button_1-0" class="comp mntl-print-button" method="POST" action="/recipe/133948/four-cheese-margherita-pizza/?print" data-tracking-container="true" aria-label="Print this article." target="_blank"> <button class="mntl-print-button__btn" aria-label="Print this article.">
 Print
 <svg class="icon icon-print mntl-print-button__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print" href="#icon-print"></use>
 </svg>
 </button>
 <input type="hidden" value="true" name="print" />
-<input type="hidden" value="5479712555c66c1e22590bba48d853d3" name="CSRFToken" />
-</form><!-- end: comp print-button mntl-print-button -->
+<input type="hidden" value="04a91214e948e7d9f48fd86200e288e7" name="CSRFToken" />
+</form>
 </div>
-<div class="mntl-recipe-social-share__share-wrapper">
-<button aria-label="Share" aria-expanded="false" class="mntl-recipe-social-share__share-button">
-<span class="mntl-recipe-social-share__share-label">Share</span>
+<div class="mm-recipes-social-share__share-wrapper">
+<button aria-label="Share" aria-expanded="false" class="mm-recipes-social-share__share-button" data-click-tracked="false" data-tracking-on="">
+<span class="mm-recipes-social-share__share-label">Share</span>
 <svg class="icon icon-share "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-share"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-share" href="#icon-share"></use>
 </svg>
 </button>
 </div>
-<div class="loc social-share">
-<ul id="social-share_1-0" class="comp social-share mntl-social-share share" data-title="Four Cheese Margherita Pizza" data-description="These delicious four cheese pizzas are bursting with flavor, and ready in under one hour." data-tracking-container="true">
-<li class="share-item share-item-facebook">
+<div class="loc social-share"><ul id="social-share_1-0" class="comp social-share mntl-universal-social-share share" data-title="Four Cheese Margherita Pizza" data-description="These delicious four cheese pizzas are bursting with flavor, and ready in under one hour." data-tracking-container="true"> <li class="share-item share-item-facebook">
 <span data-href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.allrecipes.com%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F%3Futm_source%3Dfacebook.com%26utm_medium%3Dsocial%26utm_campaign%3Dsocial-share-article"
 data-network="facebook"
 data-click-tracked="true"
@@ -3758,7 +2580,7 @@ aria-label="Share on Facebook"
 role="link">
 <svg class="icon icon-facebook "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook" href="#icon-facebook"></use>
 </svg>
 </span>
 </li>
@@ -3768,12 +2590,12 @@ data-network="twitter"
 data-click-tracked="true"
 class="share-link share-link-twitter"
 tabindex="0"
-title="Share on Twitter"
-aria-label="Share on Twitter"
+title="Post to X"
+aria-label="Post to X"
 role="link">
 <svg class="icon icon-twitter "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter" href="#icon-twitter"></use>
 </svg>
 </span>
 </li>
@@ -3788,7 +2610,7 @@ aria-label="Share on Pinterest"
 role="link">
 <svg class="icon icon-pinterest "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest" href="#icon-pinterest"></use>
 </svg>
 </span>
 </li>
@@ -3803,35 +2625,22 @@ aria-label="Email this article"
 role="link">
 <svg class="icon icon-email "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-email"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-email" href="#icon-email"></use>
 </svg>
 </span>
 </li>
-</ul><!-- end: comp social-share mntl-social-share share -->
-</div>
-</div>
-</div><!-- end: comp recipe-social-share mntl-recipe-social-share -->
-</div><!-- end: comp article-meta-dynamic article-meta mntl-block -->
-</div>
-<div class="loc article-content">
-<div id="article__primary-video-container_1-0" class="comp article__primary-video-container mntl-block"></div><!-- end: comp article__primary-video-container mntl-block -->
-<div id="article__broad-video-jw_1-0" class="comp is-hidden article__broad-video-jw mntl-jwplayer-broad mntl-block" data-pixel-depth="100">
-<div id="mntl-jwplayer-broad__title_1-0" class="comp mntl-jwplayer-broad__title mntl-block">
-<svg class="icon trending-icon mntl-jwplayer-broad__title-icon--trending"
+</ul>
+</div> </div>
+</div></div></div>
+</div><div class="loc article-content"><div id="article__primary-video-container_1-0" class="comp article__primary-video-container mntl-block"></div>
+<div id="article__broad-video-jw_1-0" class="comp article__broad-video-jw mntl-jwplayer-broad mntl-block is-hidden" data-pixel-depth="100"><div id="mntl-jwplayer-broad__video_1-0" class="comp mntl-jwplayer-broad__video mntl-jwplayer mm-video lazyload" data-bgset data-sizes="auto"></div>
+<div id="mntl-jwplayer-broad__title_1-0" class="comp mntl-jwplayer-broad__title mntl-block"><div id="mntl-jwplayer-broad__title--text_1-0" class="comp mntl-jwplayer-broad__title--text mntl-text-block type--mouse"></div>
+<button id="mntl-jwplayer-broad__title-icon--close_1-0" class="comp mntl-jwplayer-broad__title-icon--close mntl-block type--shrew-bold" data-click-tracked="false"><span id="mntl-text-block_1-0" class="comp mntl-text-block">Close</span>
+<svg class="icon close-icon "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#trending-icon"></use>
-</svg>
-<div id="mntl-jwplayer-broad__title--text_1-0" class="comp type--monkey-bold mntl-jwplayer-broad__title--text mntl-text-block">
-Trending Videos</div><!-- end: comp type--monkey-bold mntl-jwplayer-broad__title--text mntl-text-block -->
-<svg class="icon close-icon mntl-jwplayer-broad__title-icon--close"
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close-icon"></use>
-</svg>
-</div><!-- end: comp mntl-jwplayer-broad__title mntl-block -->
-<div id="mntl-jwplayer-broad__video_1-0" class="comp lazyload mntl-jwplayer-broad__video mntl-jwplayer" data-bgset data-sizes="auto"></div><!-- end: comp lazyload mntl-jwplayer-broad__video mntl-jwplayer -->
-</div><!-- end: comp is-hidden article__broad-video-jw mntl-jwplayer-broad mntl-block -->
-<figure id="figure-article_1-0" class="comp right-rail__offset type--mouse figure-landscape figure-article mntl-universal-primary-image primary-image">
-<div class="primary-image__media">
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#close-icon" href="#close-icon"></use>
+</svg></button></div></div>
+<figure id="figure-article_1-0" class="comp figure-article mntl-universal-primary-image right-rail__offset type--mouse figure-landscape has-photo-ribbon primary-image" data-click-tracked="false"> <div class="primary-image__media">
 <div class="img-placeholder" style="padding-bottom:75.0%;">
 <img
 src="https://www.allrecipes.com/thmb/P0PpfS51uACFadRILnDpJhEFbRo=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/5225433-four-cheese-margherita-pizza-Christina-4x3-1-29b0fe4316b74017a5ae437e9ebb319d.jpg"
@@ -3856,25 +2665,17 @@ alt="close up view of Four Cheese Margherita Pizza on a platter"
 />
 </noscript>
 </div> </div>
-</figure><!-- end: comp right-rail__offset type--mouse figure-landscape figure-article mntl-universal-primary-image primary-image -->
-<div id="article__photo-ribbon_1-0" class="comp total-photos106 article__photo-ribbon mntl-block">
-<button id="add-photo_1-0" class="comp add-photo mntl-button">
-Add Photo
-<svg class="icon icon-add-photo mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-add-photo"></use>
-</svg>
-</button><!-- end: comp add-photo mntl-button -->
-<a
+</figure>
+<div id="article__photo-ribbon_1-0" class="comp article__photo-ribbon mntl-block total-photos107"><a
 href="#"
 rel="nocaes"
 data-click-tracked="false"
 data-a11y-dialog-show="photo-dialog"
 role="button"
-id="gallery-photos_1-0"
-class=" gallery-photos dialog-link mntl-text-link"
+id="gallery-photo_1-0"
+class="gallery-photo dialog-link mntl-text-link "
 data-tracking-container="true"
-><span class="link__wrapper">106</span>
+><span class="link__wrapper">107</span>
 <div class="img-placeholder" style="padding-bottom:56.2%;">
 <img
 class=" lazyload universal-image__image"
@@ -3884,19 +2685,19 @@ height="90"
 alt=""
 role=""
 data-expand="0"
-data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fpublic-assets.meredithcorp.io%2Fd7b0d535005f8623ddabcd35289415d5%2F1659572371CF3BCC73-2FBD-4DCA-969B-493ACC39E704.jpeg&q=60&c=sc&orient=true&w=160&poi=auto&h=90"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fpublic-assets.meredithcorp.io%2F7884ec3daedf375238715c3aa5111ab7%2F1708869895968IMG_0710.jpeg&w=160&q=60&c=sc&poi=auto&orient=true&h=90"
 />
-</div></a><!-- end: gallery-photos dialog-link mntl-text-link -->
+</div></a>
 <a
 href="#"
 rel="nocaes"
 data-click-tracked="false"
 data-a11y-dialog-show="photo-dialog"
 role="button"
-id="gallery-photos_1-0-1"
-class=" gallery-photos dialog-link mntl-text-link"
+id="gallery-photo_2-0"
+class="gallery-photo dialog-link mntl-text-link "
 data-tracking-container="true"
-><span class="link__wrapper">106</span>
+><span class="link__wrapper">107</span>
 <div class="img-placeholder" style="padding-bottom:56.2%;">
 <img
 class=" lazyload universal-image__image"
@@ -3906,19 +2707,19 @@ height="90"
 alt=""
 role=""
 data-expand="0"
-data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F9160611.jpg&q=60&c=sc&orient=true&w=160&poi=auto&h=90"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fpublic-assets.meredithcorp.io%2Fd7b0d535005f8623ddabcd35289415d5%2F1659572371CF3BCC73-2FBD-4DCA-969B-493ACC39E704.jpeg&w=160&q=60&c=sc&poi=auto&orient=true&h=90"
 />
-</div></a><!-- end: gallery-photos dialog-link mntl-text-link -->
+</div></a>
 <a
 href="#"
 rel="nocaes"
 data-click-tracked="false"
 data-a11y-dialog-show="photo-dialog"
 role="button"
-id="gallery-photos_1-0-2"
-class=" gallery-photos dialog-link mntl-text-link"
+id="gallery-photo_3-0"
+class="gallery-photo dialog-link mntl-text-link "
 data-tracking-container="true"
-><span class="link__wrapper">106</span>
+><span class="link__wrapper">107</span>
 <div class="img-placeholder" style="padding-bottom:56.2%;">
 <img
 class=" lazyload universal-image__image"
@@ -3928,19 +2729,19 @@ height="90"
 alt=""
 role=""
 data-expand="0"
-data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8657339.jpg&q=60&c=sc&orient=true&w=160&poi=auto&h=90"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F9160611.jpg&w=160&q=60&c=sc&poi=auto&orient=true&h=90"
 />
-</div></a><!-- end: gallery-photos dialog-link mntl-text-link -->
+</div></a>
 <a
 href="#"
 rel="nocaes"
 data-click-tracked="false"
 data-a11y-dialog-show="photo-dialog"
 role="button"
-id="gallery-photos_1-0-3"
-class=" gallery-photos dialog-link mntl-text-link"
+id="gallery-photo_4-0"
+class="gallery-photo dialog-link mntl-text-link "
 data-tracking-container="true"
-><span class="link__wrapper">106</span>
+><span class="link__wrapper">107</span>
 <div class="img-placeholder" style="padding-bottom:56.2%;">
 <img
 class=" lazyload universal-image__image"
@@ -3950,224 +2751,217 @@ height="90"
 alt=""
 role=""
 data-expand="0"
-data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8613814.jpg&q=60&c=sc&orient=true&w=160&poi=auto&h=90"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8657339.jpg&w=160&q=60&c=sc&poi=auto&orient=true&h=90"
 />
-</div></a><!-- end: gallery-photos dialog-link mntl-text-link -->
-</div><!-- end: comp total-photos106 article__photo-ribbon mntl-block -->
-<div id="article-content_1-0" class="comp article-content mntl-block">
-<div id="recipe-details_1-0" class="comp recipe-details mntl-recipe-details">
-<div class="mntl-recipe-details__content">
-<div class="mntl-recipe-details__item">
-<div class="mntl-recipe-details__label">Prep Time:</div>
-<div class="mntl-recipe-details__value">15 mins</div>
+</div></a>
+<a
+href="#"
+rel="nocaes"
+data-click-tracked="false"
+data-a11y-dialog-show="photo-dialog"
+role="button"
+id="gallery-photo_5-0"
+class="gallery-photo dialog-link mntl-text-link "
+data-tracking-container="true"
+><span class="link__wrapper">107</span>
+<div class="img-placeholder" style="padding-bottom:56.2%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="160"
+height="90"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8613814.jpg&w=160&q=60&c=sc&poi=auto&orient=true&h=90"
+/>
+</div></a></div>
+<div id="article-content_1-0" class="comp article-content mntl-block"><div id="mm-recipes-details_1-0" class="comp mm-recipes-details"> <div class="mm-recipes-details__content">
+<div class="mm-recipes-details__item">
+<div class="mm-recipes-details__label">Prep Time:</div>
+<div class="mm-recipes-details__value">15 mins</div>
 </div>
-<div class="mntl-recipe-details__item">
-<div class="mntl-recipe-details__label">Cook Time:</div>
-<div class="mntl-recipe-details__value">10 mins</div>
+<div class="mm-recipes-details__item">
+<div class="mm-recipes-details__label">Cook Time:</div>
+<div class="mm-recipes-details__value">10 mins</div>
 </div>
-<div class="mntl-recipe-details__item">
-<div class="mntl-recipe-details__label">Additional Time:</div>
-<div class="mntl-recipe-details__value">15 mins</div>
+<div class="mm-recipes-details__item">
+<div class="mm-recipes-details__label">Additional Time:</div>
+<div class="mm-recipes-details__value">15 mins</div>
 </div>
-<div class="mntl-recipe-details__item">
-<div class="mntl-recipe-details__label">Total Time:</div>
-<div class="mntl-recipe-details__value">40 mins</div>
+<div class="mm-recipes-details__item">
+<div class="mm-recipes-details__label">Total Time:</div>
+<div class="mm-recipes-details__value">40 mins</div>
 </div>
-<div class="mntl-recipe-details__item">
-<div class="mntl-recipe-details__label">Servings:</div>
-<div class="mntl-recipe-details__value">8 </div>
+<div class="mm-recipes-details__item">
+<div class="mm-recipes-details__label">Servings:</div>
+<div class="mm-recipes-details__value">8 </div>
 </div>
-<div class="mntl-recipe-details__item">
-<div class="mntl-recipe-details__label">Yield:</div>
-<div class="mntl-recipe-details__value">2 pizzas</div>
+<div class="mm-recipes-details__item">
+<div class="mm-recipes-details__label">Yield:</div>
+<div class="mm-recipes-details__value">2 pizzas</div>
 </div>
 </div>
-<div class="loc nutrition-link mntl-recipe-details__nutrition-link-container">
-<span id="mntl-recipe-details__nutrition-link_1-0" class="comp mntl-recipe-details__nutrition-link mntl-text-block">
-Jump to Nutrition Facts</span><!-- end: comp mntl-recipe-details__nutrition-link mntl-text-block -->
-</div>
-</div><!-- end: comp recipe-details mntl-recipe-details -->
-<div id="mntl-recipe-intro_1-0" class="comp mntl-recipe-intro mntl-block">
-<div id="mntl-recipe-intro__content_1-0" class="comp mntl-recipe-intro__content mntl-sc-page mntl-block" data-sc-sticky-offset="190" data-sc-ad-label-height="24" data-sc-ad-track-spacing="100" data-sc-min-track-height="250" data-sc-max-track-height="600" data-sc-breakpoint="50em" data-sc-load-immediate="3" data-sc-content-positions="[1, 1250, 1550, 1950, 2350, 2750, 3150, 3550, 3950]" data-bind-scroll-on-start="true"></div><!-- end: comp mntl-recipe-intro__content mntl-sc-page mntl-block -->
-</div><!-- end: comp mntl-recipe-intro mntl-block -->
-<div id="mntl-native-fluid_1-0" class="comp mntl-native-fluid mntl-native" style="--native-ad-height: auto">
-<div id="mntl-native__adunit_1-0" class="comp scads-to-load mntl-native__adunit mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt native dynamic">
+<div class="loc nutrition-link mm-recipes-details__nutrition-link-container"><span id="mm-recipes-details__nutrition-link_1-0" class="comp mm-recipes-details__nutrition-link mntl-text-block">Jump to Nutrition Facts</span>
+</div></div>
+<div id="mm-recipes-intro_1-0" class="comp mm-recipes-intro mntl-block"><div id="mm-recipes-intro__content_1-0" class="comp mm-recipes-intro__content mntl-sc-page mntl-block " data-sc-sticky-offset="190" data-sc-ad-label-height="24" data-sc-ad-track-spacing="100" data-sc-min-track-height="250" data-sc-max-track-height="600" data-sc-breakpoint="50em" data-sc-load-immediate="3" data-sc-content-positions="[1, 1250, 1550, 1950, 2350, 2750, 3150, 3550, 3950]" data-bind-scroll-on-start="true"></div></div>
+<div id="native-fluid-placeholder_1-0" class="comp native-fluid-placeholder mm-ads-native-fluid mm-ads-native " style="--native-ad-height: auto"><div id="mm-ads-native__adunit_1-0" class="comp mm-ads-native__adunit mm-ads-gpt-dynamic-adunit mm-ads-gpt-adunit scads-to-load gpt native dynamic">
 <div id="native" class="wrapper"
 data-type="native" data-pos="native" data-priority="4" data-sizes="[[1, 3],&quot;fluid&quot;]" data-rtb="false" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp scads-to-load mntl-native__adunit mntl-gpt-dynamic-adunit mntl-gpt-adunit gpt native dynamic -->
-</div><!-- end: comp mntl-native-fluid mntl-native -->
-<div id="mntl-lrs-ingredients_1-0" class="comp mntl-lrs-ingredients mntl-block" data-content-modified-date="2022-10-28T06:37:23.000Z" data-load-offset="300" data-vertical-prefix="ar">
-<div id="mntl-structured-ingredients_1-0" class="comp mntl-structured-ingredients">
-<div class="loc heading">
-<h2 id="mntl-structured-ingredients__heading_1-0" class="comp mntl-structured-ingredients__heading mntl-text-block">
-Ingredients</h2><!-- end: comp mntl-structured-ingredients__heading mntl-text-block -->
-</div>
-<ul class="mntl-structured-ingredients__list">
+</div></div>
+<div id="mm-recipes-lrs-ingredients_1-0" class="comp mm-recipes-lrs-ingredients mntl-block" data-content-modified-date="2022-10-28T06:37:23.000Z" data-load-offset="300"><div id="mm-recipes-structured-ingredients_1-0" class="comp mm-recipes-structured-ingredients"><div class="loc heading"><h2 id="mm-recipes-structured-ingredients__heading_1-0" class="comp mm-recipes-structured-ingredients__heading mntl-text-block">Ingredients</h2>
+</div> <ul class="mm-recipes-structured-ingredients__list">
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="6307"
 >
 <p><span data-ingredient-quantity="true">¼</span> <span data-ingredient-unit="true">cup</span> <span data-ingredient-name="true">olive oil</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="4342"
 >
 <p><span data-ingredient-quantity="true">1</span> <span data-ingredient-unit="true">tablespoon</span> <span data-ingredient-name="true">minced garlic</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="18752"
 >
 <p><span data-ingredient-quantity="true">½</span> <span data-ingredient-unit="true">teaspoon</span> <span data-ingredient-name="true">sea salt</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="20453"
 >
 <p><span data-ingredient-quantity="true">8</span> <span data-ingredient-unit="true"></span> <span data-ingredient-name="true">Roma tomatoes, sliced</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="20518"
 >
 <p><span data-ingredient-quantity="true">2</span> <span data-ingredient-unit="true">(12 inch)</span> <span data-ingredient-name="true">pre-baked pizza crusts</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="16234"
 >
 <p><span data-ingredient-quantity="true">8</span> <span data-ingredient-unit="true">ounces</span> <span data-ingredient-name="true">shredded Mozzarella cheese</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="16226"
 >
 <p><span data-ingredient-quantity="true">4</span> <span data-ingredient-unit="true">ounces</span> <span data-ingredient-name="true">shredded Fontina cheese</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="16159"
 >
 <p><span data-ingredient-quantity="true">10</span> <span data-ingredient-unit="true"></span> <span data-ingredient-name="true"> fresh basil leaves, washed, dried </span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="16238"
 >
 <p><span data-ingredient-quantity="true">½</span> <span data-ingredient-unit="true">cup</span> <span data-ingredient-name="true">freshly grated Parmesan cheese</span></p>
 </li>
 <li
-class="mntl-structured-ingredients__list-item "
+class="mm-recipes-structured-ingredients__list-item "
 data-id="16225"
 >
 <p><span data-ingredient-quantity="true">½</span> <span data-ingredient-unit="true">cup</span> <span data-ingredient-name="true">crumbled feta cheese</span></p>
 </li>
 </ul>
-</div><!-- end: comp mntl-structured-ingredients -->
-</div><!-- end: comp mntl-lrs-ingredients mntl-block -->
-<div id="recipe__steps_1-0" class="comp recipe__steps mntl-recipe-steps mntl-block">
-<h2 id="recipe__steps-heading_1-0" class="comp recipe__steps-heading mntl-text-block">
-Directions</h2><!-- end: comp recipe__steps-heading mntl-text-block -->
-<div id="recipe__steps-content_1-0" class="comp recipe__steps-content mntl-sc-page mntl-block">
-<OL id="mntl-sc-block_2-0" class="comp mntl-sc-block-group--OL mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--OL mntl-sc-block mntl-sc-block-startgroup -->
-<LI id="mntl-sc-block_2-0-1" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup -->
-<p id="mntl-sc-block_2-0-2" class="comp mntl-sc-block mntl-sc-block-html">
-Stir together olive oil, garlic, and salt; toss with tomatoes, and allow to stand for 15 minutes. Preheat oven to 400 degrees F (200 degrees C).
-</p><!-- end: comp mntl-sc-block mntl-sc-block-html -->
-<div id="mntl-sc-block_2-0-3" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div><!-- end: comp mntl-sc-block mntl-sc-block-adslot mntl-block -->
+</div></div>
+<div id="mm-recipes-steps_1-0" class="comp mm-recipes-steps mntl-block"><h2 id="mm-recipes-steps__heading_1-0" class="comp mm-recipes-steps__heading mntl-text-block">Directions</h2>
+<div id="mm-recipes-steps__content_1-0" class="comp mm-recipes-steps__content mntl-sc-page mntl-block "><OL id="mntl-sc-block_1-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--OL">
+<LI id="mntl-sc-block_2-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--LI">
+<p id="mntl-sc-block_3-0" class="comp mntl-sc-block mntl-sc-block-html"> Stir together olive oil, garlic, and salt; toss with tomatoes, and allow to stand for 15 minutes. Preheat oven to 400 degrees F (200 degrees C).
+</p>
+<div id="mntl-sc-block_4-0" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
 </LI>
-<LI id="mntl-sc-block_2-0-5" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup -->
-<p id="mntl-sc-block_2-0-6" class="comp mntl-sc-block mntl-sc-block-html">
-Brush each pizza crust with some of the tomato marinade. Sprinkle the pizzas evenly with Mozzarella and Fontina cheeses. Arrange tomatoes overtop, then sprinkle with shredded basil, Parmesan, and feta cheese.
-</p><!-- end: comp mntl-sc-block mntl-sc-block-html -->
-<div id="mntl-sc-block_2-0-7" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div><!-- end: comp mntl-sc-block mntl-sc-block-adslot mntl-block -->
+<LI id="mntl-sc-block_6-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--LI">
+<p id="mntl-sc-block_7-0" class="comp mntl-sc-block mntl-sc-block-html"> Brush each pizza crust with some of the tomato marinade. Sprinkle the pizzas evenly with Mozzarella and Fontina cheeses. Arrange tomatoes overtop, then sprinkle with shredded basil, Parmesan, and feta cheese.
+</p>
+<div id="mntl-sc-block_8-0" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
 </LI>
-<LI id="mntl-sc-block_2-0-9" class="comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup"><!-- end: comp mntl-sc-block-group--LI mntl-sc-block mntl-sc-block-startgroup -->
-<p id="mntl-sc-block_2-0-10" class="comp mntl-sc-block mntl-sc-block-html">
-Bake in preheated oven until the cheese is bubbly and golden brown, about 10 minutes.
-</p><!-- end: comp mntl-sc-block mntl-sc-block-html -->
-<div id="mntl-sc-block_2-0-11" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div><!-- end: comp mntl-sc-block mntl-sc-block-adslot mntl-block -->
+<LI id="mntl-sc-block_10-0" class="comp mntl-sc-block mntl-sc-block-startgroup mntl-sc-block-group--LI">
+<p id="mntl-sc-block_11-0" class="comp mntl-sc-block mntl-sc-block-html"> Bake in preheated oven until the cheese is bubbly and golden brown, about 10 minutes.
+</p>
+<div id="mntl-sc-block_12-0" class="comp mntl-sc-block mntl-sc-block-adslot mntl-block"></div>
 </LI>
-</OL>
-</div><!-- end: comp recipe__steps-content mntl-sc-page mntl-block -->
-</div><!-- end: comp recipe__steps mntl-recipe-steps mntl-block -->
-<div id="recipe-rate-print_1-0" class="comp recipe-rate-print mntl-recipe-rate-print mntl-block">
-<button id="recipe-rate-print__rate-button_1-0" class="comp button--contained-standard recipe-rate-print__rate-button mntl-button" data-click-tracked="false" data-event-action="I Made It" aria-label="I Made It">
-I Made It
+</OL></div></div>
+<div id="mm-recipes-rate-print_1-0" class="comp mm-recipes-rate-print recipe-rate-print mntl-block"><button id="mm-recipes-rate-print__rate-button_1-0" class="comp mm-recipes-rate-print__rate-button mntl-button button--contained-standard" data-click-tracked="false" data-myrecipes-enabled="false" data-event-action="I Made It" data-myrecipes-loginLink="/authentication/login?regSource=&relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F%23scrollToUgc" data-myrecipes-joinLink="/authentication/signup?regSource=&relativeRedirectUrl=%2Frecipe%2F133948%2Ffour-cheese-margherita-pizza%2F%23scrollToUgc" data-unauthFlow-enabled="true" aria-label="I Made It"> I Made It
 <svg class="icon icon-spoon mntl-button__icon "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-spoon"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-spoon" href="#icon-spoon"></use>
 </svg>
-</button><!-- end: comp button--contained-standard recipe-rate-print__rate-button mntl-button -->
-<form id="recipe-rate-print__print-button_1-0" class="comp recipe-rate-print__print-button print-button mntl-print-button" method="POST" action="/recipe/133948/four-cheese-margherita-pizza/?print" target="_blank" aria-label="Print this article." data-tracking-container="true">
-<button class="mntl-print-button__btn" aria-label="Print this article.">
+</button>
+<form id="mntl-print-button_2-0" class="comp mntl-print-button" method="POST" action="/recipe/133948/four-cheese-margherita-pizza/?print" data-tracking-container="true" aria-label="Print this article." target="_blank"> <button class="mntl-print-button__btn" aria-label="Print this article.">
 Print
 <svg class="icon icon-print mntl-print-button__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-print" href="#icon-print"></use>
 </svg>
 </button>
 <input type="hidden" value="true" name="print" />
-<input type="hidden" value="5479712555c66c1e22590bba48d853d3" name="CSRFToken" />
-</form><!-- end: comp recipe-rate-print__print-button print-button mntl-print-button -->
-</div><!-- end: comp recipe-rate-print mntl-recipe-rate-print mntl-block -->
-<div id="recipe__nutrition-facts_1-0" class="comp recipe__nutrition-facts mntl-nutrition-facts mntl-block">
-<div id="mntl-nutrition-facts-summary_1-0" class="comp mntl-nutrition-facts-summary">
-<h2 class="mntl-nutrition-facts-summary__heading type--zebra" colspan="2">Nutrition Facts <span class="mntl-nutrition-facts-summary__heading-aside type--dog">(per serving)</h2>
-<table class="mntl-nutrition-facts-summary__table">
-<tbody class="mntl-nutrition-facts-summary__table-body">
-<tr class="mntl-nutrition-facts-summary__table-row">
-<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">551</td>
-<td class="mntl-nutrition-facts-summary__table-cell type--dogg">Calories</td>
+<input type="hidden" value="04a91214e948e7d9f48fd86200e288e7" name="CSRFToken" />
+</form></div>
+<div id="mm-recipes-nutrition-facts_1-0" class="comp mm-recipes-nutrition-facts mntl-block"><div id="mm-recipes-nutrition-facts-summary_1-0" class="comp mm-recipes-nutrition-facts-summary">
+<h2 class="mm-recipes-nutrition-facts-summary__heading type--zebra" colspan="2">Nutrition Facts <span class="mm-recipes-nutrition-facts-summary__heading-aside type--dog">(per serving)</h2>
+<table class="mm-recipes-nutrition-facts-summary__table">
+<tbody class="mm-recipes-nutrition-facts-summary__table-body">
+<tr class="mm-recipes-nutrition-facts-summary__table-row">
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog-bold">551</td>
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog">Calories</td>
 </tr>
-<tr class="mntl-nutrition-facts-summary__table-row">
-<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">26g </td>
-<td class="mntl-nutrition-facts-summary__table-cell type--dog">Fat</td>
+<tr class="mm-recipes-nutrition-facts-summary__table-row">
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog-bold">26g </td>
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog">Fat</td>
 </tr>
-<tr class="mntl-nutrition-facts-summary__table-row">
-<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">54g </td>
-<td class="mntl-nutrition-facts-summary__table-cell type--dog">Carbs</td>
+<tr class="mm-recipes-nutrition-facts-summary__table-row">
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog-bold">54g </td>
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog">Carbs</td>
 </tr>
-<tr class="mntl-nutrition-facts-summary__table-row">
-<td class="mntl-nutrition-facts-summary__table-cell type--dog-bold">29g </td>
-<td class="mntl-nutrition-facts-summary__table-cell type--dog">Protein</td>
+<tr class="mm-recipes-nutrition-facts-summary__table-row">
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog-bold">29g </td>
+<td class="mm-recipes-nutrition-facts-summary__table-cell type--dog">Protein</td>
 </tr>
 </tbody>
 </table>
-</div><!-- end: comp mntl-nutrition-facts-summary -->
-<div id="mntl-nutrition-facts-label_1-0" class="comp mntl-nutrition-facts-label allrecipes-nutrition-facts-label" data-click-tracked="false">
-<button class="mntl-nutrition-facts-label__button mntl-nutrition-facts-label__button--show type--dog">
-<span class="mntl-nutrition-facts-label__button-text">Show Full Nutrition Label</span>
-<span class="mntl-nutrition-facts-label__button-text">Hide Full Nutrition Label</span>
+</div>
+<!-- daily values taken from https://www.fda.gov/food/new-nutrition-facts-label/daily-value-new-nutrition-and-supplement-facts-labels as of Feb 2023 -->
+<div id="mm-recipes-nutrition-facts-label_1-0" class="comp mm-recipes-nutrition-facts-label allrecipes-nutrition-facts-label" data-click-tracked="freemarker.template.FalseTemplateBooleanModel@5b738025"> <button class="mm-recipes-nutrition-facts-label__button mm-recipes-nutrition-facts-label__button--show type--dog">
+<span class="mm-recipes-nutrition-facts-label__button-text">Show Full Nutrition Label</span>
+<span class="mm-recipes-nutrition-facts-label__button-text">Hide Full Nutrition Label</span>
 </button>
-<div class="mntl-nutrition-facts-label__wrapper mntl-nutrition-facts-label__wrapper--collapsed">
-<div class="mntl-nutrition-facts-label__contents">
-<table class="mntl-nutrition-facts-label__table">
-<thead class="mntl-nutrition-facts-label__table-head">
+<div class="mm-recipes-nutrition-facts-label__wrapper mm-recipes-nutrition-facts-label__wrapper--collapsed">
+<div class="mm-recipes-nutrition-facts-label__contents">
+<table class="mm-recipes-nutrition-facts-label__table">
+<thead class="mm-recipes-nutrition-facts-label__table-head">
 <tr>
-<th class="mntl-nutrition-facts-label__table-head-title type--goat-bold" colspan="2">Nutrition Facts</th>
+<th class="mm-recipes-nutrition-facts-label__table-head-title type--goat-bold" colspan="2">Nutrition Facts</th>
 </tr>
-<tr class="mntl-nutrition-facts-label__servings">
-<th class="mntl-nutrition-facts-label__table-head-subtitle" colspan="2">
-<span class="mntl-nutrition-facts-label__table-head-pretext">Servings Per Recipe</span>
+<tr class="mm-recipes-nutrition-facts-label__servings">
+<th class="mm-recipes-nutrition-facts-label__table-head-subtitle" colspan="2">
+<span class="mm-recipes-nutrition-facts-label__table-head-pretext">Servings Per Recipe</span>
 <span>8</span>
 </th>
 </tr>
-<tr class="mntl-nutrition-facts-label__calories">
-<th class="mntl-nutrition-facts-label__table-head-subtitle" colspan="2">
-<span class="mntl-nutrition-facts-label__table-head-pretext">Calories</span>
+<tr class="mm-recipes-nutrition-facts-label__calories">
+<th class="mm-recipes-nutrition-facts-label__table-head-subtitle" colspan="2">
+<span class="mm-recipes-nutrition-facts-label__table-head-pretext">Calories</span>
 <span>551</span>
 </th>
 </tr>
 </thead>
-<tbody class="mntl-nutrition-facts-label__table-body type--cat">
-<tr class="mntl-nutrition-facts-label__table-dv-row type--dog">
+<tbody class="mm-recipes-nutrition-facts-label__table-body type--cat">
+<tr class="mm-recipes-nutrition-facts-label__table-dv-row type--dog">
 <td colspan="2">% Daily Value *</td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Total Fat</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Total Fat</span>
 26g
 </td>
 <td>
@@ -4175,8 +2969,8 @@ Print
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Saturated Fat</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Saturated Fat</span>
 11g
 </td>
 <td>
@@ -4184,8 +2978,8 @@ Print
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Cholesterol</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Cholesterol</span>
 58mg
 </td>
 <td>
@@ -4193,8 +2987,8 @@ Print
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Sodium</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Sodium</span>
 1183mg
 </td>
 <td>
@@ -4202,8 +2996,8 @@ Print
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Total Carbohydrate</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Total Carbohydrate</span>
 54g
 </td>
 <td>
@@ -4211,8 +3005,8 @@ Print
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Dietary Fiber</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Dietary Fiber</span>
 3g
 </td>
 <td>
@@ -4221,28 +3015,31 @@ Print
 </tr>
 <tr>
 <td colspan="2">
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Total Sugars</span>
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Total Sugars</span>
 5g
 </td>
 </tr>
 <tr>
-<td colspan="2">
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Protein</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Protein</span>
 29g
+</td>
+<td>
+58%
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Vitamin C</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Vitamin C</span>
 8mg
 </td>
 <td>
-42%
+9%
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Calcium</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Calcium</span>
 425mg
 </td>
 <td>
@@ -4250,8 +3047,8 @@ Print
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Iron</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Iron</span>
 2mg
 </td>
 <td>
@@ -4259,8 +3056,8 @@ Print
 </td>
 </tr>
 <tr>
-<td>
-<span class="mntl-nutrition-facts-label__nutrient-name mntl-nutrition-facts-label__nutrient-name--has-postfix">Potassium</span>
+<td >
+<span class="mm-recipes-nutrition-facts-label__nutrient-name mm-recipes-nutrition-facts-label__nutrient-name--has-postfix">Potassium</span>
 201mg
 </td>
 <td>
@@ -4269,614 +3066,489 @@ Print
 </tr>
 </tbody>
 </table>
-<div id="recipe__nutrition-facts-label-disclaimer_1-0" class="comp type--cat recipe__nutrition-facts-label-disclaimer mntl-block">
-<p id="mntl-text-block_3-0" class="comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block">
-* Percent Daily Values are based on a 2,000 calorie diet. Your daily values may be higher or lower depending on your calorie needs.</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block -->
-<p id="mntl-text-block_4-0" class="comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block">
-** Nutrient information is not available for all ingredients. Amount is based on available nutrient data.</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block -->
-<p id="mntl-text-block_5-0" class="comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block">
-(-) Information is not currently available for this nutrient. If you are following a medically restrictive diet, please consult your doctor or registered dietitian before preparing this recipe for personal consumption.</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-info mntl-text-block -->
-<p id="mntl-text-block_6-0" class="comp recipe__nutrition-facts-label-disclaimer-copyright mntl-text-block">
-Powered by the ESHA Research Database © 2018, <a href="https://www.esha.com/" target="_blank">ESHA Research, Inc.</a> All Rights Reserved</p><!-- end: comp recipe__nutrition-facts-label-disclaimer-copyright mntl-text-block -->
-</div><!-- end: comp type--cat recipe__nutrition-facts-label-disclaimer mntl-block -->
+<div id="mm-recipes-nutrition-facts-label-disclaimer_1-0" class="comp mm-recipes-nutrition-facts-label-disclaimer mntl-block type--cat"><p id="disclaimer-1_1-0" class="comp disclaimer-1 mntl-text-block mm-recipes-nutrition-facts-label-disclaimer-info">* Percent Daily Values are based on a 2,000 calorie diet. Your daily values may be higher or lower depending on your calorie needs.</p>
+<p id="mntl-text-block_2-0" class="comp mntl-text-block mm-recipes-nutrition-facts-label-disclaimer-info">** Nutrient information is not available for all ingredients. Amount is based on available nutrient data.</p>
+<p id="mntl-text-block_3-0" class="comp mntl-text-block mm-recipes-nutrition-facts-label-disclaimer-info">(-) Information is not currently available for this nutrient. If you are following a medically restrictive diet, please consult your doctor or registered dietitian before preparing this recipe for personal consumption.</p>
+<p id="mntl-text-block_4-0" class="comp mntl-text-block mm-recipes-nutrition-facts-label-disclaimer-copyright">Powered by the ESHA Research Database © 2018, <a href="https://www.esha.com/" target="_blank">ESHA Research, Inc.</a> All Rights Reserved</p></div> </div>
 </div>
-</div>
-</div><!-- end: comp mntl-nutrition-facts-label allrecipes-nutrition-facts-label -->
-</div><!-- end: comp recipe__nutrition-facts mntl-nutrition-facts mntl-block -->
-<div id="recipe-ugc-wrapper_1-0" class="comp recipe-ugc-wrapper mntl-block" data-scroll-defer-offset="800" data-defer="load" data-defer-params></div><!-- end: comp recipe-ugc-wrapper mntl-block -->
-<div id="related-category-search_1-0" class="comp related-category-search">
-<div class="related-category-search__search-wrapper">
-<div class="related-category-search__title-wrapper">
-<svg class="icon icon-tip-hat "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tip-hat"></use>
-</svg>
-<div id="related-category-search__title_1-0" class="comp related-category-search__title mntl-text-block">
-Not what you're looking for?</div><!-- end: comp related-category-search__title mntl-text-block -->
-</div>
-<div id="related-category-search-box_1-0" class="comp type--cat search-box--no-inline-icon related-category-search-box search-box general-search" data-track-search-location="search block bottom" data-click-tracked="false" data-tracking-container="true">
-<form class="related-category-search-box__form" role="search" action="/search" method="get">
-<div class="general-search__input-group input-group">
-<label for="related-category-search-box__search-input" class="is-vishidden">Search the site</label>
-<input type="text" name="q" id="related-category-search-box__search-input" class="general-search__input" placeholder="Find a recipe or ingredient" required="required" value="" autocomplete="off">
-<button class="general-search__button type--squirrel button--contained-standard">
-<span class="is-vishidden">Search</span>
-<svg class="icon icon-search "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-search"></use>
-</svg>
-</button>
-<button class="general-search__close" aria-label="Close search bar">
-<svg class="icon icon-close "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
-</svg>
-</button>
-</div>
-</form>
-<div class="loc validation-message">
-<div id="general-search__validation-message_7-0" class="comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational">
-<svg class="icon icon-info message-banner__prefix-icon message-banner__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-info"></use>
-</svg>
-<span class="message-banner__text ">
-Please fill out this field.
-</span>
-<button class="message-banner__close-button js-message-banner-close" aria-label="Close informational Banner">
-<svg class="icon icon-close message-banner__icon"
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
-</svg>
-</button>
-</div><!-- end: comp is-hidden general-search__validation-message message-banner--informational message-banner message-banner--informational -->
-</div>
-</div><!-- end: comp type--cat search-box--no-inline-icon related-category-search-box search-box general-search -->
-</div>
-<div id="related-category-search__category-tags_1-0" class="comp related-category-search__category-tags recipe-related-category-tags" data-click-tracked="false">
-<div id="category-tag__list-title_1-0" class="comp category-tag__list-title mntl-text-block">
-Popular Searches</div><!-- end: comp category-tag__list-title mntl-text-block -->
-<ul class="category-tag__list">
-<li class="category-tag">
-<a
-href="https://www.allrecipes.com/search?q=Dinner"
-rel="nocaes"
-data-click-tracked="false"
-data-click-tracked="false"
-class="category-tag__link"
-> Dinner </a><!-- end: category-tag__link -->
-</li>
-<li class="category-tag">
-<a
-href="https://www.allrecipes.com/search?q=Italian+Inspired"
-rel="nocaes"
-data-click-tracked="false"
-data-click-tracked="false"
-class="category-tag__link"
-> Italian Inspired </a><!-- end: category-tag__link -->
-</li>
-</ul>
-</div><!-- end: comp related-category-search__category-tags recipe-related-category-tags -->
-</div><!-- end: comp related-category-search -->
-</div><!-- end: comp article-content mntl-block -->
-</div>
-<div class="loc article-right-rail">
-<div id="mntl-right-rail_1-0" class="comp mntl-right-rail mntl-block">
-<div id="recipe-billboard-group_3-0" class="comp js-scads-inline-content recipe-billboard-group mntl-block">
-<div id="mntl-block_18-0" class="comp mntl-block">
-<div id="mntl-squareFlex1-sticky_3-0" class="comp scads-to-load right-rail__item mntl-squareFlex1-sticky mntl-sc-sticky-billboard" data-height="1090" style="height: 1090px;">
-<div id="mntl-sc-sticky-billboard-ad_34-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard ">
+</div></div>
+<div id="recipe-ugc-wrapper_1-0" class="comp recipe-ugc-wrapper mntl-block" data-defer="load" data-scroll-defer-offset="800"></div></div>
+</div><div class="loc article-right-rail"><div id="mm-ads-right-rail_1-0" class="comp mm-ads-right-rail mntl-block"><div id="recipe-billboard-group_1-0" class="comp recipe-billboard-group mntl-block js-scads-inline-content"><div id="mntl-block_2-0" class="comp mntl-block"><div id="mm-ads-squareFlex1-sticky_1-0" class="comp mm-ads-squareFlex1-sticky mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="1090" style="height: 1090px;"><div id="mm-ads-sc-sticky-square-ad_1-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square ">
 <div id="square-flex-1" class="wrapper"
 data-timed-refresh="30000"
 ></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFlex1-sticky mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-<div id="mntl-block_19-0" class="comp mntl-block">
-<div id="mntl-squareFlex2-sticky-dynamic_3-0" class="comp scads-to-load right-rail__item mntl-squareFlex2-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
-<div id="mntl-sc-sticky-billboard-ad_36-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+</div></div></div>
+<div id="mntl-block_3-0" class="comp mntl-block"><div id="mm-ads-squareFlex2-sticky-dynamic_1-0" class="comp mm-ads-squareFlex2-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;"><div id="mm-ads-sc-sticky-square-ad_2-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
 <div id="square-flex-2" class="wrapper"
 data-timed-refresh="30000"
-data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[300, 251],[300, 600],[300, 601],[2, 1],[160, 600],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFlex2-sticky-dynamic mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-<div id="mntl-block_20-0" class="comp mntl-block">
-<div id="mntl-squareFixed-sticky-dynamic_13-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
-<div id="mntl-sc-sticky-billboard-ad_38-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[300, 251],[300, 600],[300, 601],[2, 1],[160, 600],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div></div></div>
+<div id="mntl-block_4-0" class="comp mntl-block"><div id="mm-ads-squareFixed-sticky-dynamic_1-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;"><div id="mm-ads-sc-sticky-square-ad_3-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
 <div id="square-fixed" class="wrapper"
 data-timed-refresh="30000"
-data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-<div id="mntl-block_21-0" class="comp mntl-block">
-<div id="mntl-squareFixed-sticky-dynamic_14-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
-<div id="mntl-sc-sticky-billboard-ad_40-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div></div></div>
+<div id="mntl-block_5-0" class="comp mntl-block"><div id="mm-ads-squareFixed-sticky-dynamic_2-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;"><div id="mm-ads-sc-sticky-square-ad_4-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
 <div id="square-fixed" class="wrapper"
 data-timed-refresh="30000"
-data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-<div id="mntl-block_22-0" class="comp mntl-block">
-<div id="mntl-squareFixed-sticky-dynamic_15-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
-<div id="mntl-sc-sticky-billboard-ad_42-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div></div></div>
+<div id="mntl-block_6-0" class="comp mntl-block"><div id="mm-ads-squareFixed-sticky-dynamic_3-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;"><div id="mm-ads-sc-sticky-square-ad_5-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
 <div id="square-fixed" class="wrapper"
 data-timed-refresh="30000"
-data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-<div id="mntl-block_23-0" class="comp mntl-block">
-<div id="mntl-squareFixed-sticky-dynamic_16-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
-<div id="mntl-sc-sticky-billboard-ad_44-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div></div></div>
+<div id="mntl-block_7-0" class="comp mntl-block"><div id="mm-ads-squareFixed-sticky-dynamic_4-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;"><div id="mm-ads-sc-sticky-square-ad_6-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
 <div id="square-fixed" class="wrapper"
 data-timed-refresh="30000"
-data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-<div id="mntl-block_24-0" class="comp mntl-block">
-<div id="mntl-squareFixed-sticky-dynamic_17-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
-<div id="mntl-sc-sticky-billboard-ad_46-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div></div></div>
+<div id="mntl-block_8-0" class="comp mntl-block"><div id="mm-ads-squareFixed-sticky-dynamic_5-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;"><div id="mm-ads-sc-sticky-square-ad_7-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
 <div id="square-fixed" class="wrapper"
 data-timed-refresh="30000"
-data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-<div id="mntl-block_25-0" class="comp mntl-block">
-<div id="mntl-squareFixed-sticky-dynamic_18-0" class="comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard" data-height="600" style="height: 600px;">
-<div id="mntl-sc-sticky-billboard-ad_48-0" class="comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic">
+data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div></div></div>
+<div id="mntl-block_9-0" class="comp mntl-block"><div id="mm-ads-squareFixed-sticky-dynamic_6-0" class="comp mm-ads-squareFixed-sticky-dynamic mm-ads-sc-sticky-square scads-to-load right-rail__item" data-height="600" style="height: 600px;"><div id="mm-ads-sc-sticky-square-ad_8-0" class="comp mm-ads-sc-sticky-square-ad mm-ads-square mm-ads-gpt-adunit gpt square dynamic">
 <div id="square-fixed" class="wrapper"
 data-timed-refresh="30000"
-data-type="billboard" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp mntl-sc-sticky-billboard-ad mntl-billboard mntl-gpt-adunit gpt billboard dynamic -->
-</div><!-- end: comp scads-to-load right-rail__item mntl-squareFixed-sticky-dynamic mntl-sc-sticky-billboard -->
-</div><!-- end: comp mntl-block -->
-</div><!-- end: comp js-scads-inline-content recipe-billboard-group mntl-block -->
-</div><!-- end: comp mntl-right-rail mntl-block -->
-</div>
-<div class="loc article-footer">
-<div id="photo-dialog_1-0" class="comp dialog__content photo-dialog mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="photo-dialog">
-<div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
+data-type="square" data-pos="atf" data-priority="2" data-sizes="[[300, 250],[299, 251],&quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
+</div></div></div></div></div>
+</div><div class="loc article-footer">
+<div id="photo-dialog_1-0" class="comp photo-dialog mntl-dialog dialog__content dialog " data-a11y-dialog="photo-dialog" aria-hidden="true"> <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
 <div role="dialog" class="dialog__content" aria-labelledby="photo-dialog_1-0-title">
 <div class="dialog__heading">
 <span id="photo-dialog_1-0-title" class="dialog__title "></span>
 <button data-a11y-dialog-hide class="dialog__close" data-click-tracked="false" aria-label="Close this dialog window">
 <svg class="icon icon-arrow_left "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow_left" href="#icon-arrow_left"></use>
 </svg>
 </button>
-<div class="loc heading dialog__heading-content">
-<button id="mntl-button_1-0" class="comp type--rabbit-bold button--contained photo-dialog__add-photo mntl-button" data-click-tracked="false">
-Add Your Photo
-<svg class="icon icon-add-photo mntl-button__icon photo-dialog__add-photo-icon"
+</div>
+<div class="loc content dialog__main"><h2 id="photo-dialog__title_1-0" class="comp photo-dialog__title mntl-text-block type--goat-bold">Photos of Four Cheese Margherita Pizza</h2>
+<div id="photo-dialog__content_1-0" class="comp photo-dialog__content mntl-block" data-limit="10"><div id="photo-dialog__page_1-0" class="comp photo-dialog__page" data-page="1" data-active="true"><div id="photo-dialog__item_1-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_1-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">01</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:75.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F43%2F2022%2F10%2F28%2F5225433-four-cheese-margherita-pizza-Christina-4x3-1.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-1 photo-dialog__icon ugc-icon-avatar-1"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-add-photo"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-1" href="#icon-avatar-1"></use>
 </svg>
-</button><!-- end: comp type--rabbit-bold button--contained photo-dialog__add-photo mntl-button -->
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<span class="photo-dialog__profile photo-dialog__profile--textonly">Christina</span>
 </div>
 </div>
-<div class="loc content dialog__main">
-<h2 id="photo-dialog__title_1-0" class="comp type--goat-bold photo-dialog__title mntl-text-block">
-Photos of Four Cheese Margherita Pizza</h2><!-- end: comp type--goat-bold photo-dialog__title mntl-text-block -->
-<div id="photo-dialog__content_1-0" class="comp photo-dialog__content mntl-block" data-limit="10">
-<div id="photo-dialog__page_1-0" class="comp photo-dialog__page" data-active="true" data-page="1" data-defer="loadDialogContent" data-defer-params></div><!-- end: comp photo-dialog__page -->
-</div><!-- end: comp photo-dialog__content mntl-block -->
+<div id="photo-dialog__item_2-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_2-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">02</span>
+<span class="content-list-number__total type--mouse">of 107</span>
 </div>
 </div>
-</div><!-- end: comp dialog__content photo-dialog mntl-dialog dialog -->
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:191.7%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fpublic-assets.meredithcorp.io%2F7884ec3daedf375238715c3aa5111ab7%2F1708869895968IMG_0710.jpeg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
 </div>
-</article><!-- end: comp mntl-article--two-column-right-rail sc-ad-container adjusted-right-rail allrecipes-article mntl-article -->
-<div id="leaderboard-post-content_1-0" class="comp js-lazy-ad has-right-label leaderboard leaderboard-post-content mntl-leaderboardac mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-2 photo-dialog__icon ugc-icon-avatar-2"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-2" href="#icon-avatar-2"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<span class="photo-dialog__profile photo-dialog__profile--textonly">Allrecipes Member</span>
+</div>
+</div>
+<div id="photo-dialog__item_3-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_3-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">03</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:75.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fpublic-assets.meredithcorp.io%2Fd7b0d535005f8623ddabcd35289415d5%2F1659572371CF3BCC73-2FBD-4DCA-969B-493ACC39E704.jpeg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-3 photo-dialog__icon ugc-icon-avatar-3"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-3" href="#icon-avatar-3"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<span class="photo-dialog__profile photo-dialog__profile--textonly">DREGINEK</span>
+</div>
+</div>
+<div id="photo-dialog__item_4-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_4-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">04</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F9160611.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-4 photo-dialog__icon ugc-icon-avatar-4"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-4" href="#icon-avatar-4"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<a
+href="https://www.allrecipes.com/cook/923414"
+rel="nocaes"
+data-click-tracked="false"
+class="photo-dialog__profile photo-dialog__profile--linked"
+>Bobbie</a>
+</div>
+</div>
+<div id="photo-dialog__item_5-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_5-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">05</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8657339.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-5 photo-dialog__icon ugc-icon-avatar-5"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-5" href="#icon-avatar-5"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<a
+href="https://www.allrecipes.com/cook/24172151"
+rel="nocaes"
+data-click-tracked="false"
+class="photo-dialog__profile photo-dialog__profile--linked"
+>scranney</a>
+</div>
+</div>
+<div id="photo-dialog__item_6-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_6-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">06</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8613814.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-1 photo-dialog__icon ugc-icon-avatar-1"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-1" href="#icon-avatar-1"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<a
+href="https://www.allrecipes.com/cook/28149804"
+rel="nocaes"
+data-click-tracked="false"
+class="photo-dialog__profile photo-dialog__profile--linked"
+>Toni Spratt</a>
+</div>
+</div>
+<div id="photo-dialog__item_7-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_7-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">07</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8365672.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-2 photo-dialog__icon ugc-icon-avatar-2"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-2" href="#icon-avatar-2"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<a
+href="https://www.allrecipes.com/cook/9118055"
+rel="nocaes"
+data-click-tracked="false"
+class="photo-dialog__profile photo-dialog__profile--linked"
+>chazzhess</a>
+</div>
+</div>
+<div id="photo-dialog__item_8-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_8-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">08</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F4508794.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-3 photo-dialog__icon ugc-icon-avatar-3"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-3" href="#icon-avatar-3"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<a
+href="https://www.allrecipes.com/cook/3516359"
+rel="nocaes"
+data-click-tracked="false"
+class="photo-dialog__profile photo-dialog__profile--linked"
+>Elvira Silva</a>
+</div>
+</div>
+<div id="photo-dialog__item_9-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_9-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">09</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8224382.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-4 photo-dialog__icon ugc-icon-avatar-4"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-4" href="#icon-avatar-4"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<a
+href="https://www.allrecipes.com/cook/3516359"
+rel="nocaes"
+data-click-tracked="false"
+class="photo-dialog__profile photo-dialog__profile--linked"
+>Elvira Silva</a>
+</div>
+</div>
+<div id="photo-dialog__item_10-0" class="comp photo-dialog__item list-sc-item mntl-sc-list-item"><div id="mntl-list-marker_10-0" class="comp mntl-list-marker mntl-list-marker--numbers"> <div class="content-list-number">
+<span class="content-list-number__item-number type--goat">10</span>
+<span class="content-list-number__total type--mouse">of 107</span>
+</div>
+</div>
+<figure class="photo mntl-universal-image universal-image__container">
+<div class="img-placeholder" style="padding-bottom:100.0%;">
+<img
+class=" lazyload universal-image__image"
+src=""
+width="0"
+height="512"
+alt=""
+role=""
+data-expand="0"
+data-src="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fimages.media-allrecipes.com%2Fuserphotos%2F8142253.jpg&q=60&c=sc&poi=auto&orient=true&h=512"
+/>
+</div>
+</figure>
+<div class="photo-dialog__caption">
+<svg class="icon icon-avatar-5 photo-dialog__icon ugc-icon-avatar-5"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-avatar-5" href="#icon-avatar-5"></use>
+</svg>
+<span class="photo-title__photo-by">Photo by&nbsp;</span>
+<a
+href="https://www.allrecipes.com/cook/16000810"
+rel="nocaes"
+data-click-tracked="false"
+class="photo-dialog__profile photo-dialog__profile--linked"
+>Tara Flynn</a>
+</div>
+</div><ol id="photo-dialog__pagination_1-0" class="comp photo-dialog__pagination photo-dialog__pagination">
+<li class="pagination__item pagination__item--selected button--outlined-little-round type--rabbit-bold"
+data-page="1">
+<span class="button--outlined-little-round type--rabbit-bold">1</span>
+</li>
+<li class="pagination__item" data-page="2" data-click-tracked="false">
+<a class="button--outlined-little-round type--rabbit-bold" href="#">2</a>
+</li>
+<li class="pagination__item" data-page="3" data-click-tracked="false">
+<a class="button--outlined-little-round type--rabbit-bold" href="#">3</a>
+</li>
+<li class="pagination__item" data-page="4" data-click-tracked="false">
+<a class="button--outlined-little-round type--rabbit-bold" href="#">4</a>
+</li>
+<li class="pagination__item" data-page="5" data-click-tracked="false">
+<a class="button--outlined-little-round type--rabbit-bold" href="#">5</a>
+</li>
+<li class="pagination__next" data-page="2">
+<a class="type--squirrel-link" href="#" data-click-tracked="false">
+<span class="pagination__next-text">Next</span>
+<svg class="icon icon-chevron pagination__next-icon"
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-chevron" href="#icon-chevron"></use>
+</svg>
+</a>
+</li>
+</ol></div></div>
+</div> </div>
+</div>
+</div></article>
+<div id="leaderboard-post-content_1-0" class="comp leaderboard-post-content mm-ads-leaderboardac mm-ads-flexible-leaderboard-lazy mm-ads-flexible-leaderboard mm-ads-flexible-ad mm-ads-gpt-adunit js-lazy-ad has-right-label leaderboard gpt leaderboard dynamic">
 <div id="leaderboardac" class="wrapper"
 data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], &quot;fluid&quot;, [970, 250], [1, 11], [1200, 450]]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp js-lazy-ad has-right-label leaderboard leaderboard-post-content mntl-leaderboardac mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic -->
-<section id="recirc-section_1-0" class="comp recirc-section" data-tracking-container="true">
-<span class="recirc-section__header type--camel">
-You’ll Also Love
-</span>
-<div class="loc recirc-content">
-<div id="save__confirmation-dialog_1-0" class="comp save__confirmation-dialog mntl-save__confirmation-dialog mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="mntl-save__dialog">
-<div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
-<div role="dialog" class="dialog__content" aria-labelledby="save__confirmation-dialog_1-0-title">
-<div class="dialog__heading">
-<span id="save__confirmation-dialog_1-0-title" class="dialog__title "></span>
-<button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
-<svg class="icon icon-close "
+</div>
+<div id="recirc-section_1-0" class="comp recirc-section mntl-recirc-section mntl-block" data-tracking-container="true"><h2 id="mntl-recirc-section__header_1-0" class="comp mntl-recirc-section__header mntl-text-block type--camel">You’ll Also Love</h2>
+<div id="mntl-recirc-section__content_1-0" class="comp mntl-recirc-section__content mntl-block recirc-content"><div id="mntl-recirc-section__block-1_1-0" class="comp mntl-recirc-section__block-1 mntl-universal-card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36"><a id="mntl-card-list-items_1-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6597026" data-tax-levels href="https://www.allrecipes.com/recipe/223391/crispy-grilled-pizza-margherita/" data-ordinal="1">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/2HVetfn_OtnaJrOd4B2LFd33B3k=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/861455-22b49e2379dd49b7804c74995cbc4ab5.jpg"
+width="282"
+height="188"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/2HVetfn_OtnaJrOd4B2LFd33B3k=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/861455-22b49e2379dd49b7804c74995cbc4ab5.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_1-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6597026"
+data-doc-title="Crispy Grilled Pizza Margherita"
+data-doc-image="https://www.allrecipes.com/thmb/fpNaUQc91ZAS18AOrly_2tuxIWw=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/861455-22b49e2379dd49b7804c74995cbc4ab5.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
 </button>
 </div>
-<div class="loc content dialog__main">
-<svg class="icon icon-check-circle "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-check-circle"></use>
-</svg>
-<div id="mntl-save__confirmation-text_2-0" class="comp type--zebra mntl-save__confirmation-text mntl-text-block">
-Saved!</div><!-- end: comp type--zebra mntl-save__confirmation-text mntl-text-block -->
-<div id="save__confirmation-saved-items_2-0" class="comp save__confirmation-saved-items mntl-text-block">
-View <a rel="nofollow" href="/account/profile#/collections">All Saved Items</a></div><!-- end: comp save__confirmation-saved-items mntl-text-block -->
-</div>
-</div>
-</div><!-- end: comp save__confirmation-dialog mntl-save__confirmation-dialog mntl-dialog dialog -->
-<div id="recirc-section__card-list-1_1-0" class="comp recirc-section__card-list-1 card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36">
-<a id="mntl-card-list-items_1-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7971911" data-tax-levels href="https://www.allrecipes.com/french-bread-pizza-recipe-7971911" data-cta data-ordinal="1">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/s6U4fyePCNkSAwDBUMFffpauwKk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/7971911_French-Bread-Pizza_lutzflcat_4x3-342dc92f7dad4e12a422a84a0b142b7f.jpg"
-width="282"
-height="188"
-alt="pizza toppings baked on French bread on wooden board"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/s6U4fyePCNkSAwDBUMFffpauwKk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/7971911_French-Bread-Pizza_lutzflcat_4x3-342dc92f7dad4e12a422a84a0b142b7f.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="pizza toppings baked on French bread on wooden board"
-/>
-</noscript>
-</div></div>
-<div id="card__save_1-0" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_2-0" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="7971911" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
-</div>
-<div class="card__content " data-tag="Pizza Recipes">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">French Bread Pizza</span></span>
-<div id="recipe-card-meta_1-0" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_1-0" class="comp mntl-recipe-star-rating">
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-1
-<span class="recipe-card-meta__rating-count-text">
-Rating
-</span>
-</div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_1-0-1" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7255338" data-tax-levels href="https://www.allrecipes.com/puff-pastry-margherita-pizza-recipe-7255338" data-cta data-ordinal="2">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/gQ_dxC2gccwweLBsRGYaalkmMcw=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/PuffPastryMargheritaPizzafabeveryday2x1-fffdd595471e408280f6e26f6dc5ccd5.jpg"
-width="282"
-height="188"
-alt="Puff Pastry Margarita Pizza with mozzarella, tomato and basil"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/gQ_dxC2gccwweLBsRGYaalkmMcw=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/PuffPastryMargheritaPizzafabeveryday2x1-fffdd595471e408280f6e26f6dc5ccd5.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="Puff Pastry Margarita Pizza with mozzarella, tomato and basil"
-/>
-</noscript>
-</div></div>
-<div id="card__save_1-0-1" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_2-0-1" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="7255338" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
-</div>
-<div class="card__content " data-tag="Pizza Recipes">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Puff Pastry Margherita Pizza</span></span>
-<div id="recipe-card-meta_1-0-1" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_1-0-1" class="comp mntl-recipe-star-rating">
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star-half "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
-</svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-5
-<span class="recipe-card-meta__rating-count-text">
-Ratings
-</span>
-</div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_1-0-2" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6574612" data-tax-levels href="https://www.allrecipes.com/recipe/129557/goat-cheese-arugula-pizza-no-red-sauce/" data-cta data-ordinal="3">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/pHnj0EfhB_pD5SDZYdIRdBnSF10=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(479x0:481x2):format(webp)/8057567-a37e1aea3ac245aca36284865e812fc8.jpg"
-width="282"
-height="188"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/pHnj0EfhB_pD5SDZYdIRdBnSF10=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(479x0:481x2):format(webp)/8057567-a37e1aea3ac245aca36284865e812fc8.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-/>
-</noscript>
-</div></div>
-<div id="card__save_1-0-2" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_2-0-2" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6574612" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
 </div>
 <div class="card__content " data-tag="Italian">
 <div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Arugula and Goat Cheese Pizza</span></span>
-<div id="recipe-card-meta_1-0-2" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_1-0-2" class="comp mntl-recipe-star-rating">
+<span class="card__title"><span class="card__title-text ">Crispy Grilled Pizza Margherita</span></span>
+<div id="mntl-recipe-card-meta_1-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_1-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-110
-<span class="recipe-card-meta__rating-count-text">
-Ratings
-</span>
-</div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_1-0-3" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6569204" data-tax-levels href="https://www.allrecipes.com/recipe/36107/allies-mushroom-pizza/" data-cta data-ordinal="4">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/8zVGK7Emsm1RzEqLC8bQoI126F8=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/36107allies-mushroom-pizzafabeveryday4x3-005f809371b147378094d60f28daf212.jpg"
-width="282"
-height="188"
-alt="bird&#39;s eye view of cheesy mushroom pizza garnished with torn basil"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/8zVGK7Emsm1RzEqLC8bQoI126F8=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/36107allies-mushroom-pizzafabeveryday4x3-005f809371b147378094d60f28daf212.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="bird&#39;s eye view of cheesy mushroom pizza garnished with torn basil"
-/>
-</noscript>
-</div></div>
-<div id="card__save_1-0-3" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_2-0-3" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6569204" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
-</div>
-<div class="card__content " data-tag="Italian">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Allie&#39;s Mushroom Pizza</span></span>
-<div id="recipe-card-meta_1-0-3" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_1-0-3" class="comp mntl-recipe-star-rating">
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star-half "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
 </svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-162
-<span class="recipe-card-meta__rating-count-text">
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+2
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Ratings
 </span>
 </div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_1-0-4" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6737021" data-tax-levels href="https://www.allrecipes.com/gallery/best-pizza-recipes-of-all-time/" data-cta data-ordinal="5">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
+</div> </div>
+</a>
+<a id="mntl-card-list-items_2-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6567179" data-tax-levels href="https://www.allrecipes.com/recipe/279581/margherita-flatbread-pizza/" data-ordinal="2">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.allrecipes.com/thmb/O6OOIeHKDRe_AqBgAb8qQPMeAHY=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(479x0:481x2):format(webp)/3655815-04e4011577a9465ab6c1559c537bb792.jpg"
-width="282"
-height="188"
-alt="Brick-Oven Pizza (Brooklyn Style)"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/O6OOIeHKDRe_AqBgAb8qQPMeAHY=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(479x0:481x2):format(webp)/3655815-04e4011577a9465ab6c1559c537bb792.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="Brick-Oven Pizza (Brooklyn Style)"
-/>
-</noscript>
-</div></div>
-</div>
-<div class="card__content " data-tag="Pizza Recipes">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Our 15 Best Pizza Recipes of All Time Might Make You Rethink Takeout</span></span>
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_1-0-5" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6650739" data-tax-levels href="https://www.allrecipes.com/recipe/233084/naan-bread-margherita-pizza-with-prosciutto/" data-cta data-ordinal="6">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/aTS6l8DzUG3KqznwbJqt0I4QzCI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(2310x1608:2312x1610):format(webp)/233084-naan-bread-margherita-pizza-with-prosciutto-GOLDMAN-4x3_2364-897068ccbd51492da5e43f8beb74bb78.jpg"
-width="282"
-height="188"
-alt="an overhead view of three naan bread margherita pizza with prosciutto, one sliced into four pieces. "
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/aTS6l8DzUG3KqznwbJqt0I4QzCI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(2310x1608:2312x1610):format(webp)/233084-naan-bread-margherita-pizza-with-prosciutto-GOLDMAN-4x3_2364-897068ccbd51492da5e43f8beb74bb78.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="an overhead view of three naan bread margherita pizza with prosciutto, one sliced into four pieces. "
-/>
-</noscript>
-</div></div>
-<div id="card__save_1-0-4" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_2-0-4" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6650739" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
-</div>
-<div class="card__content " data-tag="Indian">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Naan Bread Margherita Pizza with Prosciutto</span></span>
-<div id="recipe-card-meta_1-0-4" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_1-0-4" class="comp mntl-recipe-star-rating">
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-27
-<span class="recipe-card-meta__rating-count-text">
-Ratings
-</span>
-</div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_1-0-6" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6567179" data-tax-levels href="https://www.allrecipes.com/recipe/279581/margherita-flatbread-pizza/" data-cta data-ordinal="7">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/4HQbealudxkEI2OvBvvjvcHvxeM=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(2185x0:2187x2):format(webp)/279581margherita-flatbread-pizzalutzflcat2x1-fa909266fb5548c191e5e86ec281cbf5.jpg"
+data-src="https://www.allrecipes.com/thmb/T0MobuAhIn7l5WPxgx_7zsNa0EI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/279581margherita-flatbread-pizzalutzflcat2x1-fa909266fb5548c191e5e86ec281cbf5.jpg"
 width="282"
 height="188"
 alt="flatbread pizza with tomatoes, mozzarella and asil"
@@ -4885,7 +3557,7 @@ data-expand="300"
 />
 <noscript>
 <img
-src="https://www.allrecipes.com/thmb/4HQbealudxkEI2OvBvvjvcHvxeM=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(2185x0:2187x2):format(webp)/279581margherita-flatbread-pizzalutzflcat2x1-fa909266fb5548c191e5e86ec281cbf5.jpg"
+src="https://www.allrecipes.com/thmb/T0MobuAhIn7l5WPxgx_7zsNa0EI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/279581margherita-flatbread-pizzalutzflcat2x1-fa909266fb5548c191e5e86ec281cbf5.jpg"
 width="282"
 height="188"
 class="img--noscript card__img universal-image__image"
@@ -4893,58 +3565,62 @@ alt="flatbread pizza with tomatoes, mozzarella and asil"
 />
 </noscript>
 </div></div>
-<div id="card__save_1-0-5" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_2-0-5" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6567179" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
+<div id="card__favorite_2-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6567179"
+data-doc-title="Margherita Flatbread Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/fMl-v_DzAcqsfZLbHjSwLfR4dPo=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/279581margherita-flatbread-pizzalutzflcat2x1-fa909266fb5548c191e5e86ec281cbf5.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
+</button>
+</div>
 </div>
 <div class="card__content " data-tag="Italian">
 <div class="card__header"></div>
 <span class="card__title"><span class="card__title-text ">Margherita Flatbread Pizza</span></span>
-<div id="recipe-card-meta_1-0-5" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_1-0-5" class="comp mntl-recipe-star-rating">
+<div id="mntl-recipe-card-meta_2-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_2-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star-empty "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty" href="#icon-star-empty"></use>
 </svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
 1
-<span class="recipe-card-meta__rating-count-text">
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Rating
 </span>
 </div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_1-0-7" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6568220" data-tax-levels href="https://www.allrecipes.com/recipe/233527/individual-greek-pita-pizzas/" data-cta data-ordinal="8">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
+</div> </div>
+</a>
+<a id="mntl-card-list-items_3-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6601340" data-tax-levels href="https://www.allrecipes.com/recipe/155498/pear-and-prosciutto-pizza/" data-ordinal="3">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.allrecipes.com/thmb/b_02ELBrh35qap-noupPfvTw-jo=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(479x0:481x2):format(webp)/1046442-50759489fc0e486d92bac0cb1cb59c34.jpg"
+data-src="https://www.allrecipes.com/thmb/hmwH1Cr3KTuPpVIZI20w7PPjKYc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/390110-51dd03bc03c64c6f8397d3c76dae62d0.jpg"
 width="282"
 height="188"
 class="lazyload card__img universal-image__image"
@@ -4952,247 +3628,427 @@ data-expand="300"
 />
 <noscript>
 <img
-src="https://www.allrecipes.com/thmb/b_02ELBrh35qap-noupPfvTw-jo=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(479x0:481x2):format(webp)/1046442-50759489fc0e486d92bac0cb1cb59c34.jpg"
+src="https://www.allrecipes.com/thmb/hmwH1Cr3KTuPpVIZI20w7PPjKYc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/390110-51dd03bc03c64c6f8397d3c76dae62d0.jpg"
 width="282"
 height="188"
 class="img--noscript card__img universal-image__image"
 />
 </noscript>
 </div></div>
-<div id="card__save_1-0-6" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_2-0-6" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6568220" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
+<div id="card__favorite_3-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6601340"
+data-doc-title="Pear and Prosciutto Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/iwTRViWul2Fk5Bq2qp35M-hkVgI=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/390110-51dd03bc03c64c6f8397d3c76dae62d0.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
+</button>
 </div>
-<div class="card__content " data-tag="Pizza Recipes">
+</div>
+<div class="card__content " data-tag="Italian">
 <div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Individual Greek Pita Pizzas</span></span>
-<div id="recipe-card-meta_1-0-6" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_1-0-6" class="comp mntl-recipe-star-rating">
+<span class="card__title"><span class="card__title-text ">Pear and Prosciutto Pizza</span></span>
+<div id="mntl-recipe-card-meta_3-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_3-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star-half "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
 </svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-41
-<span class="recipe-card-meta__rating-count-text">
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+48
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Ratings
 </span>
 </div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-</div><!-- end: comp recirc-section__card-list-1 card-list mntl-document-card-list mntl-card-list mntl-block -->
-<div id="leaderboard-deferred-footer_1-0" class="comp js-lazy-ad has-right-label leaderboard leaderboard-deferred-footer mntl-leaderboardfooter-flex-1-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
-<div id="leaderboardfooter-flex-1" class="wrapper"
-data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp js-lazy-ad has-right-label leaderboard leaderboard-deferred-footer mntl-leaderboardfooter-flex-1-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic -->
-<div id="recirc-section__card-list-2_1-0" class="comp recirc-section__card-list-2 card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36">
-<a id="mntl-card-list-items_2-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7369199" data-tax-levels href="https://www.allrecipes.com/chicken-parmesan-pizza-recipe-7369199" data-cta data-ordinal="1">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
+</div> </div>
+</a>
+<a id="mntl-card-list-items_4-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6736485" data-tax-levels href="https://www.allrecipes.com/recipe/244636/cheesy-crust-skillet-pizza/" data-ordinal="4">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.allrecipes.com/thmb/HlmIfKN0kRs0aRKPOffqvvcnsGQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/7369199chicken-parmesan-pizza-recipeJennyAlemandeBolaos4x3-593e4bdab5584f6dbe0530293e612742.jpg"
+data-src="https://www.allrecipes.com/thmb/q6Nsedb8RBjwmvtFXmL94ONYqyA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/2612551-cheesy-crust-skillet-pizza-The-Gruntled-Gourmand-1x1-1-f9a328af9dfe487a9fc408f581927696.jpg"
 width="282"
 height="188"
-alt="pizza with chicken, parmesan, and mozzarella garnished with basil"
+alt="overhead view of a Cheesy-Crust Skillet Pizza with tomatoes and basil"
 class="lazyload card__img universal-image__image"
 data-expand="300"
 />
 <noscript>
 <img
-src="https://www.allrecipes.com/thmb/HlmIfKN0kRs0aRKPOffqvvcnsGQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/7369199chicken-parmesan-pizza-recipeJennyAlemandeBolaos4x3-593e4bdab5584f6dbe0530293e612742.jpg"
+src="https://www.allrecipes.com/thmb/q6Nsedb8RBjwmvtFXmL94ONYqyA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/2612551-cheesy-crust-skillet-pizza-The-Gruntled-Gourmand-1x1-1-f9a328af9dfe487a9fc408f581927696.jpg"
 width="282"
 height="188"
 class="img--noscript card__img universal-image__image"
-alt="pizza with chicken, parmesan, and mozzarella garnished with basil"
+alt="overhead view of a Cheesy-Crust Skillet Pizza with tomatoes and basil"
 />
 </noscript>
 </div></div>
-<div id="card__save_2-0" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="7369199" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
+<div id="card__favorite_4-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6736485"
+data-doc-title="Cheesy-Crust Skillet Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/M6xz8QkiL_r-Exjry0Aa4xnx-Ao=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/2612551-cheesy-crust-skillet-pizza-The-Gruntled-Gourmand-1x1-1-f9a328af9dfe487a9fc408f581927696.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Italian">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Cheesy-Crust Skillet Pizza</span></span>
+<div id="mntl-recipe-card-meta_4-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_4-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-half "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+51
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_5-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6650739" data-tax-levels href="https://www.allrecipes.com/recipe/233084/naan-bread-margherita-pizza-with-prosciutto/" data-ordinal="5">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/qgCj6ZIoKIjo3XUXh4oIgqINJjg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/233084-naan-bread-margherita-pizza-with-prosciutto-GOLDMAN-4x3_2364-897068ccbd51492da5e43f8beb74bb78.jpg"
+width="282"
+height="188"
+alt="an overhead view of three naan bread margherita pizza with prosciutto, one sliced into four pieces. "
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/qgCj6ZIoKIjo3XUXh4oIgqINJjg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/233084-naan-bread-margherita-pizza-with-prosciutto-GOLDMAN-4x3_2364-897068ccbd51492da5e43f8beb74bb78.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="an overhead view of three naan bread margherita pizza with prosciutto, one sliced into four pieces. "
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_5-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6650739"
+data-doc-title="Naan Bread Margherita Pizza with Prosciutto"
+data-doc-image="https://www.allrecipes.com/thmb/LETADgy8fUpRkillG2agJPGp6-k=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/233084-naan-bread-margherita-pizza-with-prosciutto-GOLDMAN-4x3_2364-897068ccbd51492da5e43f8beb74bb78.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Indian">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Naan Bread Margherita Pizza with Prosciutto</span></span>
+<div id="mntl-recipe-card-meta_5-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_5-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+28
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_6-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6578682" data-tax-levels href="https://www.allrecipes.com/recipe/140955/crab-artichoke-pizza/" data-ordinal="6">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/ax8UlRGkNv8l04AajjSFf00wKtU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/2810521-769149491c234fef9c32d61538356767.jpg"
+width="282"
+height="188"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/ax8UlRGkNv8l04AajjSFf00wKtU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/2810521-769149491c234fef9c32d61538356767.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_6-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6578682"
+data-doc-title="Crab-Artichoke Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/e0SGHw1L-s33qJT5HVGr_CRMT7A=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/2810521-769149491c234fef9c32d61538356767.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Italian">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Crab-Artichoke Pizza</span></span>
+<div id="mntl-recipe-card-meta_6-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_6-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-empty "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty" href="#icon-star-empty"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+13
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_7-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6571874" data-tax-levels href="https://www.allrecipes.com/recipe/187171/red-white-and-green-pizza/" data-ordinal="7">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/qdIFcEWuvSTOdeNics_RDSoMYR0=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/1195404-71c5bffd2c7041029daef7ccf77e09bb.jpg"
+width="282"
+height="188"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/qdIFcEWuvSTOdeNics_RDSoMYR0=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/1195404-71c5bffd2c7041029daef7ccf77e09bb.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_7-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6571874"
+data-doc-title="Red, White, and Green Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/FQntrstrdUlo9qf6I-Qql-5Br5Y=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/1195404-71c5bffd2c7041029daef7ccf77e09bb.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Italian">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Red, White, and Green Pizza</span></span>
+<div id="mntl-recipe-card-meta_7-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_7-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-half "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+18
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_8-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6600809" data-tax-levels href="https://www.allrecipes.com/recipe/172070/fast-and-easy-ricotta-cheese-pizza-with-mushrooms-broccoli-and-chicken/" data-ordinal="8">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/nuXl4EW70GFrBP5EGSIqyf7oM1k=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/233904-47e71420e32642beb397743b01f7115b.jpg"
+width="282"
+height="188"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/nuXl4EW70GFrBP5EGSIqyf7oM1k=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/233904-47e71420e32642beb397743b01f7115b.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_8-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6600809"
+data-doc-title="Fast and Easy Ricotta Cheese Pizza with Mushrooms, Broccoli, and Chicken"
+data-doc-image="https://www.allrecipes.com/thmb/l3M0t4bZ_VcUDZdosPYO29omB4k=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/233904-47e71420e32642beb397743b01f7115b.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
 </div>
 <div class="card__content " data-tag="Chicken">
 <div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Chicken Parmesan Pizza</span></span>
-<div id="recipe-card-meta_2-0" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_2-0" class="comp mntl-recipe-star-rating">
+<span class="card__title"><span class="card__title-text ">Fast and Easy Ricotta Cheese Pizza with Mushrooms, Broccoli, and Chicken</span></span>
+<div id="mntl-recipe-card-meta_8-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_8-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star-half "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
 </svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-3
-<span class="recipe-card-meta__rating-count-text">
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+20
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Ratings
 </span>
 </div>
+</div> </div>
+</a></div>
+<div id="leaderboard-deferred-footer_1-0" class="comp leaderboard-deferred-footer mm-ads-leaderboardfooter-flex-1-lazy mm-ads-flexible-leaderboard-lazy mm-ads-flexible-leaderboard mm-ads-flexible-ad mm-ads-gpt-adunit js-lazy-ad has-right-label leaderboard gpt leaderboard dynamic">
+<div id="leaderboardfooter-flex-1" class="wrapper"
+data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
 </div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_2-0-1" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6650887" data-tax-levels href="https://www.allrecipes.com/recipe/213131/homemade-four-cheese-ravioli/" data-cta data-ordinal="2">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
+<div id="mntl-recirc-section__block-2_1-0" class="comp mntl-recirc-section__block-2 mntl-universal-card-list mntl-document-card-list mntl-card-list mntl-block" data-chunk="36"><a id="mntl-card-list-items_9-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6577149" data-tax-levels href="https://www.allrecipes.com/recipe/220190/ds-taco-pizza/" data-ordinal="1">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.allrecipes.com/thmb/B1UQO6vrMmAQoMrf-q8lwvMJ8qU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/8896331-homemade-four-cheese-ravioli-Carsons-Mommy-1x1-1-fff83fd883c343cc8f5f962b7af37728.jpg"
-width="282"
-height="188"
-alt="close up view of ravioli on top of parchment paper"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/B1UQO6vrMmAQoMrf-q8lwvMJ8qU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/8896331-homemade-four-cheese-ravioli-Carsons-Mommy-1x1-1-fff83fd883c343cc8f5f962b7af37728.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="close up view of ravioli on top of parchment paper"
-/>
-</noscript>
-</div></div>
-<div id="card__save_2-0-1" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0-1" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6650887" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
-</div>
-<div class="card__content " data-tag="Ravioli Recipes">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Homemade Four Cheese Ravioli</span></span>
-<div id="recipe-card-meta_2-0-1" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_2-0-1" class="comp mntl-recipe-star-rating">
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star-empty "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty"></use>
-</svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-218
-<span class="recipe-card-meta__rating-count-text">
-Ratings
-</span>
-</div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_2-0-2" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7503843" data-tax-levels href="https://www.allrecipes.com/bruschetta-pizza-recipe-7503843" data-cta data-ordinal="3">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/TQ6Kd2imUt6tFD403g_tbKev7UQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/7503843_Bruschetta-Pizza_TheDailyGourmet_4x3-b5cc56213253471db4b1b6a1287f4376.jpg"
-width="282"
-height="188"
-alt="pizza with fresh tomatoes, basil, and cheese on a board"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/TQ6Kd2imUt6tFD403g_tbKev7UQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1999x0:2001x2):format(webp)/7503843_Bruschetta-Pizza_TheDailyGourmet_4x3-b5cc56213253471db4b1b6a1287f4376.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="pizza with fresh tomatoes, basil, and cheese on a board"
-/>
-</noscript>
-</div></div>
-<div id="card__save_2-0-2" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0-2" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="7503843" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
-</div>
-<div class="card__content " data-tag="Pizza Recipes">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">This Bruschetta Pizza Recipe Is Full of Irresistible Italian Flavor</span></span>
-<div id="recipe-card-meta_2-0-2" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_2-0-3" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6600360" data-tax-levels href="https://www.allrecipes.com/recipe/37677/bubble-pizza/" data-cta data-ordinal="4">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/AanoyyvaVRBQtUKk_MXH8pqWnWQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(124x0:126x2):format(webp)/573706-9860fdedc13f47f29e522fc3b2317d9e.jpg"
+data-src="https://www.allrecipes.com/thmb/RxaJWp2xgwEfLVtt7JjmUq_IYu4=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/1014051-29eb1797884c42d8bc52869e511a9fd0.jpg"
 width="282"
 height="188"
 class="lazyload card__img universal-image__image"
@@ -5200,361 +4056,585 @@ data-expand="300"
 />
 <noscript>
 <img
-src="https://www.allrecipes.com/thmb/AanoyyvaVRBQtUKk_MXH8pqWnWQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(124x0:126x2):format(webp)/573706-9860fdedc13f47f29e522fc3b2317d9e.jpg"
+src="https://www.allrecipes.com/thmb/RxaJWp2xgwEfLVtt7JjmUq_IYu4=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/1014051-29eb1797884c42d8bc52869e511a9fd0.jpg"
 width="282"
 height="188"
 class="img--noscript card__img universal-image__image"
 />
 </noscript>
 </div></div>
-<div id="card__save_2-0-3" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0-3" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6600360" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
+<div id="card__favorite_9-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6577149"
+data-doc-title="D&#39;s Taco Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/hOGf8xqd_CViDJIjGnQRL1OvmcE=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/1014051-29eb1797884c42d8bc52869e511a9fd0.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
+</button>
+</div>
 </div>
 <div class="card__content " data-tag="Beef">
 <div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Bubble Pizza</span></span>
-<div id="recipe-card-meta_2-0-3" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_2-0-2" class="comp mntl-recipe-star-rating">
+<span class="card__title"><span class="card__title-text ">D&#39;s Taco Pizza</span></span>
+<div id="mntl-recipe-card-meta_9-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_9-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
-<svg class="icon icon-star-empty "
+<svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-empty"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-392
-<span class="recipe-card-meta__rating-count-text">
+<svg class="icon icon-star-half "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+54
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Ratings
 </span>
 </div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_2-0-4" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7496725" data-tax-levels href="https://www.allrecipes.com/tavern-pizza-recipe-7496725" data-cta data-ordinal="5">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
+</div> </div>
+</a>
+<a id="mntl-card-list-items_10-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6603087" data-tax-levels href="https://www.allrecipes.com/recipe/275384/vietnamese-spring-roll-pizza/" data-ordinal="2">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.allrecipes.com/thmb/otV43aN-KDXurWyGDkcWnWKkJGk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1965x1563:1967x1565):format(webp)/ar-tavern-the-real-chicago-pizza-DDMFS-4x3-178-d3f97ec78a0e4ff98902ddc0c669a599.jpg"
+data-src="https://www.allrecipes.com/thmb/rz_dFB_AqXHBgHgPcTYMGOJw8Uk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/6979709-f43a29cb49af40028e0fc513cac969d1.jpg"
 width="282"
 height="188"
-alt="Overhead shot of a Tavern Pizza with toppings cut into squares"
 class="lazyload card__img universal-image__image"
 data-expand="300"
 />
 <noscript>
 <img
-src="https://www.allrecipes.com/thmb/otV43aN-KDXurWyGDkcWnWKkJGk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(1965x1563:1967x1565):format(webp)/ar-tavern-the-real-chicago-pizza-DDMFS-4x3-178-d3f97ec78a0e4ff98902ddc0c669a599.jpg"
+src="https://www.allrecipes.com/thmb/rz_dFB_AqXHBgHgPcTYMGOJw8Uk=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/6979709-f43a29cb49af40028e0fc513cac969d1.jpg"
 width="282"
 height="188"
 class="img--noscript card__img universal-image__image"
-alt="Overhead shot of a Tavern Pizza with toppings cut into squares"
 />
 </noscript>
 </div></div>
-<div id="card__save_2-0-4" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0-4" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="7496725" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
+<div id="card__favorite_10-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6603087"
+data-doc-title="Vietnamese Spring Roll Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/7-P3OhzPct01yVlJhPJ3us0-YuQ=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/6979709-f43a29cb49af40028e0fc513cac969d1.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Asian">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Vietnamese Spring Roll Pizza</span></span>
+<div id="mntl-recipe-card-meta_10-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_10-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-half "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+11
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_11-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6584723" data-tax-levels href="https://www.allrecipes.com/recipe/213644/blue-cheese-and-asparagus-pizza/" data-ordinal="3">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/CU11oKGME5RUFbNssxxOQELbIxg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/417125-6b4c3dae7a1d4623b4a99e61d4727e6e.jpg"
+width="282"
+height="188"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/CU11oKGME5RUFbNssxxOQELbIxg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/417125-6b4c3dae7a1d4623b4a99e61d4727e6e.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_11-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6584723"
+data-doc-title="Blue Cheese and Asparagus Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/mv4I2_XmI9_bVbxzO4DgU_OD6sw=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/417125-6b4c3dae7a1d4623b4a99e61d4727e6e.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Italian">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Blue Cheese and Asparagus Pizza</span></span>
+<div id="mntl-recipe-card-meta_11-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_11-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-half "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+6
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_12-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6586681" data-tax-levels href="https://www.allrecipes.com/recipe/132071/calamari-in-a-creamy-white-wine-sauce/" data-ordinal="4">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/mBTfRcj45DdjgYMUifjuqPPyxpQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/4510144-8971a457bc8c4cf29d66672ed1e1cf54.jpg"
+width="282"
+height="188"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/mBTfRcj45DdjgYMUifjuqPPyxpQ=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/4510144-8971a457bc8c4cf29d66672ed1e1cf54.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_12-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6586681"
+data-doc-title="Calamari in a Creamy White Wine Sauce"
+data-doc-image="https://www.allrecipes.com/thmb/pPX3HoXgOlskSIByMaOg5nXZcdo=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/4510144-8971a457bc8c4cf29d66672ed1e1cf54.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Italian">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Calamari in a Creamy White Wine Sauce</span></span>
+<div id="mntl-recipe-card-meta_12-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_12-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-half "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+31
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_13-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6737818" data-tax-levels href="https://www.allrecipes.com/recipe/14522/pizza-on-the-grill-i/" data-ordinal="5">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/XajoDY79zQu-znnc2v5CQmo2eDc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/14522-Pizza-On-The-Grill100-4x3-cd872c310ad243c2b39917186df83d77.jpg"
+width="282"
+height="188"
+alt="Looking down at a sliced pizza on the grill, topped with various toppings. "
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/XajoDY79zQu-znnc2v5CQmo2eDc=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/14522-Pizza-On-The-Grill100-4x3-cd872c310ad243c2b39917186df83d77.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+alt="Looking down at a sliced pizza on the grill, topped with various toppings. "
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_13-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6737818"
+data-doc-title="Pizza on the Grill"
+data-doc-image="https://www.allrecipes.com/thmb/qE_lJ29TLp3JDmP0wOOpxyxv3ok=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/14522-Pizza-On-The-Grill100-4x3-cd872c310ad243c2b39917186df83d77.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
 </div>
 <div class="card__content " data-tag="Pizza Recipes">
 <div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Tavern Pizza</span></span>
-<div id="recipe-card-meta_2-0-4" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
+<span class="card__title"><span class="card__title-text ">Pizza on the Grill</span></span>
+<div id="mntl-recipe-card-meta_13-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_13-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
 </div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_2-0-5" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6664211" data-tax-levels href="https://www.allrecipes.com/recipe/239287/four-cheese-truffled-macaroni-and-cheese/" data-cta data-ordinal="6">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
-<img
-data-src="https://www.allrecipes.com/thmb/ib-H0sIxCXpl4DL9Jrute6dLluA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/5041720-four-cheese-truffled-macaroni-and-cheese-Tmac-4x3-1-642aa24d631742789714e44d9921625b.jpg"
-width="282"
-height="188"
-alt="close up view of Four-Cheese Truffled Macaroni and Cheese in a glass baking dish"
-class="lazyload card__img universal-image__image"
-data-expand="300"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/ib-H0sIxCXpl4DL9Jrute6dLluA=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/5041720-four-cheese-truffled-macaroni-and-cheese-Tmac-4x3-1-642aa24d631742789714e44d9921625b.jpg"
-width="282"
-height="188"
-class="img--noscript card__img universal-image__image"
-alt="close up view of Four-Cheese Truffled Macaroni and Cheese in a glass baking dish"
-/>
-</noscript>
-</div></div>
-<div id="card__save_2-0-5" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0-5" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6664211" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
-</svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
-</div>
-<div class="card__content " data-tag="Baked Macaroni and Cheese Recipes">
-<div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Four-Cheese Truffled Macaroni and Cheese</span></span>
-<div id="recipe-card-meta_2-0-5" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_2-0-3" class="comp mntl-recipe-star-rating">
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star-half "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
-</svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-36
-<span class="recipe-card-meta__rating-count-text">
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+442
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Ratings
 </span>
 </div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_2-0-6" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="7104308" data-tax-levels href="https://www.allrecipes.com/recipe/8527294/hawaiian-pizza/" data-cta data-ordinal="7">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
+</div> </div>
+</a>
+<a id="mntl-card-list-items_14-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6599509" data-tax-levels href="https://www.allrecipes.com/recipe/204778/eggplant-pizzas/" data-ordinal="6">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.allrecipes.com/thmb/45YB3HJh6d9dFQgfR946EGHhlfI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/hawaiian-pizza-ddmfs-3x2-132-450eff04ad924d9a9eae98ca44e3f988.jpg"
+data-src="https://www.allrecipes.com/thmb/uv6JTXlDth74RuTppByG64dY-08=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/8226717-69a5cdc22a864118b4ca97e1f9a745b9.jpg"
 width="282"
 height="188"
-alt="close up on a Hawaiian pizza on a tray with a few slices missing"
 class="lazyload card__img universal-image__image"
 data-expand="300"
 />
 <noscript>
 <img
-src="https://www.allrecipes.com/thmb/45YB3HJh6d9dFQgfR946EGHhlfI=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/hawaiian-pizza-ddmfs-3x2-132-450eff04ad924d9a9eae98ca44e3f988.jpg"
+src="https://www.allrecipes.com/thmb/uv6JTXlDth74RuTppByG64dY-08=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/8226717-69a5cdc22a864118b4ca97e1f9a745b9.jpg"
 width="282"
 height="188"
 class="img--noscript card__img universal-image__image"
-alt="close up on a Hawaiian pizza on a tray with a few slices missing"
 />
 </noscript>
 </div></div>
-<div id="card__save_2-0-6" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0-6" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="7104308" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
+<div id="card__favorite_14-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6599509"
+data-doc-title="Eggplant Pizzas"
+data-doc-image="https://www.allrecipes.com/thmb/o8bdrxa5pnYBVYQMcR2bvyLWvj0=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/8226717-69a5cdc22a864118b4ca97e1f9a745b9.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
+</button>
+</div>
+</div>
+<div class="card__content " data-tag="Eggplant">
+<div class="card__header"></div>
+<span class="card__title"><span class="card__title-text ">Eggplant Pizzas</span></span>
+<div id="mntl-recipe-card-meta_14-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_14-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+<svg class="icon icon-star-half "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+112
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
+Ratings
+</span>
+</div>
+</div> </div>
+</a>
+<a id="mntl-card-list-items_15-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6606211" data-tax-levels href="https://www.allrecipes.com/recipe/275379/greek-veggie-pizza/" data-ordinal="7">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
+<img
+data-src="https://www.allrecipes.com/thmb/zuG-HiM6Pn9f_jlx3-U3KjZyJXg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/7096990-84c4fa3f341e41c9a4b96c6aeec7496f.jpg"
+width="282"
+height="188"
+class="lazyload card__img universal-image__image"
+data-expand="300"
+/>
+<noscript>
+<img
+src="https://www.allrecipes.com/thmb/zuG-HiM6Pn9f_jlx3-U3KjZyJXg=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/7096990-84c4fa3f341e41c9a4b96c6aeec7496f.jpg"
+width="282"
+height="188"
+class="img--noscript card__img universal-image__image"
+/>
+</noscript>
+</div></div>
+<div id="card__favorite_15-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6606211"
+data-doc-title="Greek Veggie Pizza"
+data-doc-image="https://www.allrecipes.com/thmb/ye0byN4R0eaAilA5HKwc2VpWZDU=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/7096990-84c4fa3f341e41c9a4b96c6aeec7496f.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+</button>
+</div>
 </div>
 <div class="card__content " data-tag="Pizza Recipes">
 <div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Hawaiian Pizza</span></span>
-<div id="recipe-card-meta_2-0-6" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_2-0-4" class="comp mntl-recipe-star-rating">
+<span class="card__title"><span class="card__title-text ">Greek Veggie Pizza</span></span>
+<div id="mntl-recipe-card-meta_15-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_15-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
-</svg>
-<svg class="icon icon-star "
->
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
-<svg class="icon icon-star-half "
+<svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-8
-<span class="recipe-card-meta__rating-count-text">
+<svg class="icon icon-star "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
+</svg>
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+4
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Ratings
 </span>
 </div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-<a id="mntl-card-list-items_2-0-7" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6650697" data-tax-levels href="https://www.allrecipes.com/recipe/273658/keto-chicken-crust-pizza/" data-cta data-ordinal="8">
-<div class="loc card__top">
-<div class="card__media mntl-universal-image card__media universal-image__container">
-<div class="img-placeholder" style="padding-bottom:66.6%;">
+</div> </div>
+</a>
+<a id="mntl-card-list-items_16-0" class="comp mntl-card-list-items mntl-document-card mntl-card card card--no-image" data-doc-id="6593716" data-tax-levels href="https://www.allrecipes.com/recipe/257196/pizza-rustica/" data-ordinal="8">
+<div class="loc card__top"><div class="card__media mntl-universal-image card__media universal-image__container"><div class="img-placeholder" style="padding-bottom:66.6%;">
 <img
-data-src="https://www.allrecipes.com/thmb/N2STEoLLR9eEQLsv6psHT75Xaj4=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/6627572-keto-chicken-crust-pizza-Yoly-4x3-1-233f64efb4814356a0408a20d5788fd2.jpg"
+data-src="https://www.allrecipes.com/thmb/qptoRvM7Uc6vV8JwZpNmEjXXIxU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/8636669-3cd3478916a14a0d97120ba2181081a1.jpg"
 width="282"
 height="188"
-alt="close up view of Keto Chicken Crust Pizza garnished with fresh basil on top of a parchment paper lined cooling rack"
 class="lazyload card__img universal-image__image"
 data-expand="300"
 />
 <noscript>
 <img
-src="https://www.allrecipes.com/thmb/N2STEoLLR9eEQLsv6psHT75Xaj4=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():focal(999x0:1001x2):format(webp)/6627572-keto-chicken-crust-pizza-Yoly-4x3-1-233f64efb4814356a0408a20d5788fd2.jpg"
+src="https://www.allrecipes.com/thmb/qptoRvM7Uc6vV8JwZpNmEjXXIxU=/282x188/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/8636669-3cd3478916a14a0d97120ba2181081a1.jpg"
 width="282"
 height="188"
 class="img--noscript card__img universal-image__image"
-alt="close up view of Keto Chicken Crust Pizza garnished with fresh basil on top of a parchment paper lined cooling rack"
 />
 </noscript>
 </div></div>
-<div id="card__save_2-0-7" class="comp card__save mntl-save mntl-block">
-<button id="mntl-save__link_3-0-7" class="comp mntl-save__link mntl-button" data-scroll-to-save="true" data-click-tracked="false" data-check-on-load="false" data-doc-id="6650697" data-tracking-on="card" data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl=" aria-label="Save Recipe">
-<svg class="icon save-icon-favorite mntl-button__icon "
+<div id="card__favorite_16-0" class="comp card__favorite mntl-favorite"> <button class="mntl-favorite__link"
+data-click-tracked="false"
+data-check-on-load="false"
+data-scroll-to-favorite="true"
+data-doc-id="6593716"
+data-doc-title="Pizza Rustica"
+data-doc-image="https://www.allrecipes.com/thmb/OI_kZIo26KBSMnBPES51xhIlN08=/280x280/filters:no_upscale():max_bytes(150000):strip_icc()/8636669-3cd3478916a14a0d97120ba2181081a1.jpg"
+data-tracking-on="card"
+data-sign-in="/authentication/login?regSource=3833&relativeRedirectUrl="
+data-brand="alrcom"
+aria-label="Save Recipe">
+<svg class="icon save-icon-favorite "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
 </svg>
-</button><!-- end: comp mntl-save__link mntl-button -->
-</div><!-- end: comp card__save mntl-save mntl-block -->
+</button>
 </div>
-<div class="card__content " data-tag="Pizza Dough and Crust Recipes">
+</div>
+<div class="card__content " data-tag="Italian">
 <div class="card__header"></div>
-<span class="card__title"><span class="card__title-text ">Keto Chicken Crust Pizza</span></span>
-<div id="recipe-card-meta_2-0-7" class="comp recipe-card-meta">
-<div class="recipe-card-meta__rating-count">
-<div id="mntl-recipe-star-rating_2-0-5" class="comp mntl-recipe-star-rating">
+<span class="card__title"><span class="card__title-text ">Pizza Rustica</span></span>
+<div id="mntl-recipe-card-meta_16-0" class="comp mntl-recipe-card-meta mm-recipes-card-meta">
+<div id="mntl-recipe-star-rating_16-0" class="comp mntl-recipe-star-rating mm-recipes-star-rating">
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star" href="#icon-star"></use>
 </svg>
 <svg class="icon icon-star-half "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-star-half" href="#icon-star-half"></use>
 </svg>
-</div><!-- end: comp mntl-recipe-star-rating -->
-<div class="recipe-card-meta__rating-count-number">
-16
-<span class="recipe-card-meta__rating-count-text">
+</div>
+<div class="mm-recipes-card-meta__rating-count-number mntl-recipe-card-meta__rating-count-number">
+3
+<span class="mm-recipes-card-meta__rating-count-text mntl-recipe-card-meta__rating-count-text">
 Ratings
 </span>
 </div>
-</div>
-</div><!-- end: comp recipe-card-meta -->
-</div>
-</a><!-- end: comp mntl-card-list-items mntl-document-card mntl-card card card--no-image -->
-</div><!-- end: comp recirc-section__card-list-2 card-list mntl-document-card-list mntl-card-list mntl-block -->
-<div id="leaderboard2-deferred-footer_1-0" class="comp js-lazy-ad has-right-label leaderboard leaderboard2-deferred-footer mntl-leaderboardfooter-flex-2-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic">
+</div> </div>
+</a></div>
+<div id="leaderboard2-deferred-footer_1-0" class="comp leaderboard2-deferred-footer mm-ads-leaderboardfooter-flex-2-lazy mm-ads-flexible-leaderboard-lazy mm-ads-flexible-leaderboard mm-ads-flexible-ad mm-ads-gpt-adunit js-lazy-ad has-right-label leaderboard gpt leaderboard dynamic">
 <div id="leaderboardfooter-flex-2" class="wrapper"
 data-type="leaderboard" data-pos="atf" data-priority="1" data-sizes="[[728, 90], [728, 98], [970, 250], [970, 258], [1, 9], &quot;fluid&quot;]" data-rtb="true" data-wait-for-third-party="false" data-targeting="{}"></div>
-</div><!-- end: comp js-lazy-ad has-right-label leaderboard leaderboard2-deferred-footer mntl-leaderboardfooter-flex-2-lazy mntl-flexible-leaderboard-lazy mntl-flexible-leaderboard mntl-flexible-ad mntl-gpt-adunit gpt leaderboard dynamic -->
-</div>
-</section><!-- end: comp recirc-section -->
-</main>
-<footer id="footer_1-0" class="comp footer" role="contentinfo" data-tracking-container="true">
-<div class="footer__inner">
-<div class="footer__primary">
-<div class="footer__logo">
-<a id="logo_2-0" class="comp logo mntl-block" rel="home" href="/" aria-label="Home">
-<div id="mntl-text-block_2-0" class="comp is-screenreader-only mntl-text-block">
-Allrecipes</div><!-- end: comp is-screenreader-only mntl-text-block -->
+</div></div></div>
+</main><footer id="mntl-footer_1-0" class="comp mntl-footer" role="contentinfo" data-tracking-container="true"> <div class="mntl-footer__inner">
+<div class="mntl-footer__primary">
+<div class="mntl-footer__logo">
+<a
+href="/"
+rel="home nocaes"
+id="mntl-logo_1-0"
+aria-label="Visit Allrecipes&#39; homepage"
+> <div class="is-screenreader-only">Allrecipes</div>
 <svg class="icon icon-logo "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo"></use>
-</svg>
-</a><!-- end: comp logo mntl-block -->
-</div>
-<div class="loc newsletter-link-wrapper footer__newsletter">
-<a
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-logo" href="#icon-logo"></use>
+</svg></a> </div>
+<div class="loc newsletter-link-wrapper mntl-footer__newsletter"><a
 href="#"
 rel="nocaes"
 data-a11y-dialog-show="newsletter-dialog-footer"
-id="newsletter-dialog-footer-link_1-0"
+id="mntl-newsletter-dialog--footer-link_1-0"
 role="button"
-class=" newsletter-dialog-footer-link dialog-link mntl-text-link footer__newsletter-link"
+class="mntl-newsletter-dialog--footer-link dialog-link mntl-text-link mntl-footer__newsletter-link"
 data-tracking-container="true"
-><span class="link__wrapper">Newsletter</span></a><!-- end: newsletter-dialog-footer-link dialog-link mntl-text-link footer__newsletter-link -->
-</div>
-<div class="footer__magsub-wrapper">
-<a href="https://www.magazines.com/allrecipes-magazine.html?utm_source=allrecipes.com&utm_medium=owned&utm_campaign=i204arrfw2801" target="_blank">
-<div class="loc footer__magsub">
-<div class="img-placeholder" style="padding-bottom:50.0%;">
-<img
-data-src="https://www.allrecipes.com/thmb/654t4XHoQIwmjRLxb1jkXyA7xOY=/300x150/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/ar_magazine-457b736e5ed6442ea95b29d69489d496.png"
-width="300"
-height="150"
-alt="Magazine Sub Placeholder Image"
-class="lazyload universal-image__image"
-/>
-<noscript>
-<img
-src="https://www.allrecipes.com/thmb/654t4XHoQIwmjRLxb1jkXyA7xOY=/300x150/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/ar_magazine-457b736e5ed6442ea95b29d69489d496.png"
-width="300"
-height="150"
-class="img--noscript universal-image__image"
-alt="Magazine Sub Placeholder Image"
-/>
-</noscript>
-</div>
-</div>
-</a>
-</div>
-<div class="loc footer__social">
-<div id="footer__social-nav_1-0" class="comp footer__social-nav allrecipes-social-nav mntl-social-nav" data-tracking-container="true">
+><span class="link__wrapper">Newsletters</span></a>
+</div> <div class="mntl-footer__social">
+<div id="mntl-footer-social_1-0" class="comp mntl-footer-social allrecipes-social-nav mntl-social-nav" data-tracking-container="true">
 <div class="social-nav__title">Follow Us</div>
 <ul class="social-nav__list">
 <li class="social-nav__item social-nav__item--facebook">
@@ -5566,9 +4646,9 @@ class="social-nav__link social-nav__link--facebook"
 aria-label="Visit Allrecipes&#39;s Facebook"
 > <svg class="icon icon-facebook social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-facebook" href="#icon-facebook"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--facebook --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--instagram">
 <a
 href="https://www.instagram.com/allrecipes/"
@@ -5578,9 +4658,9 @@ class="social-nav__link social-nav__link--instagram"
 aria-label="Visit Allrecipes&#39;s Instagram"
 > <svg class="icon icon-instagram social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-instagram" href="#icon-instagram"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--instagram --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--pinterest">
 <a
 href="https://www.pinterest.com/allrecipes/"
@@ -5590,9 +4670,9 @@ class="social-nav__link social-nav__link--pinterest"
 aria-label="Visit Allrecipes&#39;s Pinterest"
 > <svg class="icon icon-pinterest social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-pinterest" href="#icon-pinterest"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--pinterest --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--tiktok">
 <a
 href="https://www.tiktok.com/@allrecipes"
@@ -5602,9 +4682,9 @@ class="social-nav__link social-nav__link--tiktok"
 aria-label="Visit Allrecipes&#39;s TikTok"
 > <svg class="icon icon-tiktok social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tiktok"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-tiktok" href="#icon-tiktok"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--tiktok --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--youtube">
 <a
 href="https://www.youtube.com/user/allrecipes/videos"
@@ -5614,21 +4694,21 @@ class="social-nav__link social-nav__link--youtube"
 aria-label="Visit Allrecipes&#39;s YouTube"
 > <svg class="icon icon-youtube social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-youtube" href="#icon-youtube"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--youtube --> </li>
-<li class="social-nav__item social-nav__item--twitter">
+</a> </li>
+<li class="social-nav__item social-nav__item--x">
 <a
 href="https://twitter.com/Allrecipes"
 target="_blank"
 rel="noopener nocaes"
-class="social-nav__link social-nav__link--twitter"
-aria-label="Visit Allrecipes&#39;s Twitter"
-> <svg class="icon icon-twitter social-nav__icon"
+class="social-nav__link social-nav__link--x"
+aria-label="Visit Allrecipes&#39; X"
+> <svg class="icon icon-x social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-twitter"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-x" href="#icon-x"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--twitter --> </li>
+</a> </li>
 <li class="social-nav__item social-nav__item--flipboard">
 <a
 href="https://flipboard.com/@Allrecipes"
@@ -5638,203 +4718,212 @@ class="social-nav__link social-nav__link--flipboard"
 aria-label="Visit Allrecipes&#39;s Flipboard"
 > <svg class="icon icon-flipboard social-nav__icon"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-flipboard" href="#icon-flipboard"></use>
 </svg>
-</a><!-- end: social-nav__link social-nav__link--flipboard --> </li>
+</a> </li>
 </ul>
-</div><!-- end: comp footer__social-nav allrecipes-social-nav mntl-social-nav -->
+</div> </div>
 </div>
-</div>
-<div class="footer__secondary">
-<nav id="footer-nav_1-0" class="comp footer-nav mntl-block">
-<ul id="mntl-block_1-0" class="comp footer-nav__list mntl-block">
-<li id="footer-nav__list-item_1-0" class="comp footer-nav__list-item mntl-block">
-<a
+<div class="mntl-footer__secondary">
+<nav id="mntl-footer-nav_1-0" class="comp mntl-footer-nav mntl-block" aria-label="Footer"><ul id="mntl-block_1-0" class="comp mntl-block mntl-footer-nav__list"><li id="mntl-footer-nav__list-item_1-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/recipes/17562/dinner/"
 rel="nocaes"
 id="mntl-text-link_1-0"
-class=" mntl-text-link type--squirrel-link"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">Dinners</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-<li id="footer-nav__list-item_1-0-1" class="comp footer-nav__list-item mntl-block">
-<a
+><span class="link__wrapper">Dinners</span></a></li>
+<li id="mntl-footer-nav__list-item_2-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/recipes/"
 rel="nocaes"
-id="mntl-text-link_1-0-1"
-class=" mntl-text-link type--squirrel-link"
+id="mntl-text-link_2-0"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">Meals</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-<li id="footer-nav__list-item_1-0-2" class="comp footer-nav__list-item mntl-block">
-<a
+><span class="link__wrapper">Meals</span></a></li>
+<li id="mntl-footer-nav__list-item_3-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/recipes/17567/ingredients/"
 rel="nocaes"
-id="mntl-text-link_1-0-2"
-class=" mntl-text-link type--squirrel-link"
+id="mntl-text-link_3-0"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">Ingredients</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-<li id="footer-nav__list-item_1-0-3" class="comp footer-nav__list-item mntl-block">
-<a
+><span class="link__wrapper">Ingredients</span></a></li>
+<li id="mntl-footer-nav__list-item_4-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/recipes/85/holidays-and-events/"
 rel="nocaes"
-id="mntl-text-link_1-0-3"
-class=" mntl-text-link type--squirrel-link"
+id="mntl-text-link_4-0"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">Occasions</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-<li id="footer-nav__list-item_1-0-4" class="comp footer-nav__list-item mntl-block">
-<a
+><span class="link__wrapper">Occasions</span></a></li>
+<li id="mntl-footer-nav__list-item_5-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/recipes/86/world-cuisine/"
 rel="nocaes"
-id="mntl-text-link_1-0-4"
-class=" mntl-text-link type--squirrel-link"
+id="mntl-text-link_5-0"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">Cuisines</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-<li id="footer-nav__list-item_1-0-5" class="comp footer-nav__list-item mntl-block">
-<a
+><span class="link__wrapper">Cuisines</span></a></li>
+<li id="mntl-footer-nav__list-item_6-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/kitchen-tips/"
 rel="nocaes"
-id="mntl-text-link_1-0-5"
-class=" mntl-text-link type--squirrel-link"
+id="mntl-text-link_6-0"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">Kitchen Tips</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-<li id="footer-nav__list-item_1-0-6" class="comp footer-nav__list-item mntl-block">
-<a
+><span class="link__wrapper">Kitchen Tips</span></a></li>
+<li id="mntl-footer-nav__list-item_7-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/food-news-trends/"
 rel="nocaes"
-id="mntl-text-link_1-0-6"
-class=" mntl-text-link type--squirrel-link"
+id="mntl-text-link_7-0"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">News</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-<li id="footer-nav__list-item_1-0-7" class="comp footer-nav__list-item mntl-block">
-<a
+><span class="link__wrapper">News</span></a></li>
+<li id="mntl-footer-nav__list-item_8-0" class="comp mntl-footer-nav__list-item mntl-block"><a
 href="https://www.allrecipes.com/recipes/1642/everyday-cooking/"
 rel="nocaes"
-id="mntl-text-link_1-0-7"
-class=" mntl-text-link type--squirrel-link"
+id="mntl-text-link_8-0"
+class="mntl-text-link type--squirrel-link"
 data-tracking-container="true"
-><span class="link__wrapper">Features</span></a><!-- end: mntl-text-link type--squirrel-link -->
-</li><!-- end: comp footer-nav__list-item mntl-block -->
-</ul><!-- end: comp footer-nav__list mntl-block -->
-</nav><!-- end: comp footer-nav mntl-block -->
-<ul id="footer-links_1-0" class="comp footer-links">
-<li class="footer-links__item "><a
+><span class="link__wrapper">Features</span></a></li></ul></nav><ul id="mntl-footer-links_1-0" class="comp mntl-footer-links footer-links"> <li class="mntl-footer-links__item ">
+<a
 href="/about-us-6648102"
 rel="nocaes"
 data-type="ourStory"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->About Us</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> About Us
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="/about-us-6648102#toc-editorial-guidelines"
 rel="nocaes"
-data-type="editorialProcess"
+data-type="editorialGuidelines"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Editorial Process</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> Editorial Process
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="/about-us-6648102#toc-diversity-and-inclusion"
 rel="nocaes"
 data-type="antiRacismPledge"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Anti-Racism Pledge</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> Anti-Racism Pledge
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="https://www.dotdashmeredith.com/brands-privacy"
 target="_blank"
 rel="noopener nofollow nocaes"
 data-type="privacyPolicy"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Privacy Policy</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> Privacy Policy
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="/about-us-6648102#toc-product-reviews"
 rel="nocaes"
 data-type="productVetting"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Product Vetting</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> Product Vetting
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="https://www.dotdashmeredith.com/brands-termsofservice"
 target="_blank"
 rel="noopener nofollow nocaes"
 data-type="termsOfService"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Terms of Service</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> Terms of Service
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="https://www.dotdashmeredith.com/brands/food-drink/allrecipes"
 target="_blank"
 rel="noopener nofollow nocaes"
 data-type="advertise"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Advertise</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> Advertise
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="https://www.dotdashmeredith.com/careers"
 target="_blank"
 rel="noopener nofollow nocaes"
-data-type="careers"
+data-type="careersAtDotDashMeredith"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Careers</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item "><a
+> Careers
+</a> </li>
+<li class="mntl-footer-links__item ">
+<a
 href="/about-us-6648102#toc-contact-us"
 rel="nocaes"
 data-type="contact"
 data-ordinal="1"
-class="type--rabbit-link"
+class="mntl-footer-links__link type--rabbit-link"
 data-component="footerLinks"
 data-source="footerLinks"
->Contact</a><!-- end: type--rabbit-link --></li>
-<li class="footer-links__item ot-pref-trigger">
-<a
+> Contact
+</a> </li>
+<li class="mntl-footer-links__item ot-pref-trigger">
+<button
+class="mntl-footer-links__link mntl-footer-links__privacy type--rabbit-link"
+type="button"
+data-component="footerLinks"
+data-type="cmpFooterLink"
+safelist="true"
 href="#"
-rel="nofollow nocaes"
-data-type="cmpLink"
 data-ordinal="1"
-class="type--rabbit-link"
-data-component="footerLinks"
 data-source="footerLinks"
-> Your Privacy Choices<span class="loc privacy-choices-icon">
-<svg class="icon icon-privacy-choices "
+forceNoSponsored="true"
+> <span class="link-wrapper">Your Privacy Choices</span>
+&nbsp;<span class="post-link-wrapper"> <svg class="icon icon-privacy-options "
 role="img"
 aria-label="Manage Your Privacy Choices"
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-privacy-choices"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-privacy-options" href="#icon-privacy-options"></use>
 </svg>
 </span>
-</a><!-- end: type--rabbit-link --> </li>
-</ul><!-- end: comp footer-links -->
+</button> </li>
+<li class="mntl-footer-links__item mntl-truste-badge-wrapper">
+<div class="loc truste-badge"><div id="mntl-universal-truste-badge_1-0" class="comp mntl-universal-truste-badge mntl-block"><a
+href="//privacy.truste.com/privacy-seal/validation?rid=7c04f997-515d-4179-a53b-1ccbee37bd62"
+target="_blank"
+rel="noopener nocaes"
+id="mntl-universal-truste-badge_1-0-link"
+class="mntl-truste-badge-link"
+data-tracking-container="true"
+> <img
+class="mntl-truste-badge-image lazyload"
+alt="Access TRUSTe's Enterprise Privacy Certification program"
+data-src="//privacy-policy.truste.com/privacy-seal/seal?rid=7c04f997-515d-4179-a53b-1ccbee37bd62"
+/>
+</a></div>
+</div> </li>
+</ul> </div>
 </div>
-</div>
-<div class="loc footer-bottom">
-<div id="mntl-dotdash-universal-nav_1-0" class="comp mntl-dotdash-universal-nav" data-tracking-container="true">
-<div class="mntl-dotdash-universal-nav__content">
+<div class="loc footer-bottom"><div id="mntl-dotdash-universal-nav_1-0" class="comp mntl-dotdash-universal-nav mntl-carbon-dotdash-universal-nav" data-tracking-container="true"> <div class="mntl-dotdash-universal-nav__content">
 <svg class="icon mntl-dotdash-universal-nav__logo "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mntl-dotdash-universal-nav__logo"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#mntl-dotdash-universal-nav__logo" href="#mntl-dotdash-universal-nav__logo"></use>
 </svg>
 <div class="mntl-dotdash-universal-nav__wrapper">
 <div class="mntl-dotdash-universal-nav__text">
@@ -5843,57 +4932,208 @@ href="https://www.dotdashmeredith.com"
 target="_blank"
 rel="noopener nofollow nocaes"
 class="mntl-dotdash-universal-nav__text--link"
->Dotdash Meredith</a><!-- end: mntl-dotdash-universal-nav__text--link --> publishing&nbsp;family.
-</div>
-<div class="mntl-dotdash-universal-nav__notice">
-Please review our updated <a
-href="https://www.dotdashmeredith.com/brands-termsofservice"
-target="_blank"
-rel="noopener nofollow nocaes"
-class="mntl-dotdash-universal-nav__text--link"
->Terms of Service</a><!-- end: mntl-dotdash-universal-nav__text--link -->.
+>Dotdash Meredith</a>&nbsp;publishing&nbsp;family.
 </div>
 </div>
 </div>
-</div><!-- end: comp mntl-dotdash-universal-nav -->
 </div>
-</footer><!-- end: comp footer -->
-<div id="campaign-dialog_1-0" class="comp campaign-dialog mntl-dialog--campaign mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="newsletter-dialog" data-defer="load" data-defer-params></div><!-- end: comp campaign-dialog mntl-dialog--campaign mntl-dialog dialog -->
-<div id="newsletter-dialog-header_1-0" class="comp newsletter-dialog-header mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="newsletter-dialog-header">
-<div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
+<div id="mntl-favorite__confirmation_1-0" class="comp mntl-favorite__confirmation mntl-favorite__confirmation-dialog mntl-dialog myrecipes dialog " data-a11y-dialog="mntl-favorite__dialog" aria-hidden="true"> <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
+<div role="dialog" class="dialog__content" aria-labelledby="mntl-favorite__confirmation_1-0-title">
+<div class="dialog__heading">
+<span id="mntl-favorite__confirmation_1-0-title" class="dialog__title "></span>
+<button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
+<svg class="icon icon-myr-close "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-myr-close" href="#icon-myr-close"></use>
+</svg>
+</button>
+</div>
+<div class="loc content dialog__main"><button id="mntl-favorite__confirmation-back-button_1-0" class="comp mntl-favorite__confirmation-back-button mntl-button is-hidden" aria-label="Back to add to collections">
+<svg class="icon icon-arrow mntl-button__icon "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-arrow" href="#icon-arrow"></use>
+</svg>
+</button>
+<div id="mntl-favorite__add-recipe_1-0" class="comp mntl-favorite__add-recipe mntl-myr-add-recipe" data-is-quick-view="false"> <div class="mntl-myr-add-recipe__card-preview" data-click-tracked="false">
+<div class="mntl-myr-add-recipe__logo-title">
+<svg class="icon save-icon-favorite "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#save-icon-favorite" href="#save-icon-favorite"></use>
+</svg>
+<span class="mntl-myr-add-recipe__logo-title-text">
+Added to
+<a class="mntl-myr-add-recipe__logo-title-link" href="/favorites#/">Saved Recipes</a>
+</span>
+</div>
+<div class="mntl-myr-add-recipe__recipe-card">
+<div class="mntl-myr-add-recipe__recipe-card-image"></div>
+<div class="mntl-myr-add-recipe__recipe-card-title">
+<span class="mntl-myr-add-recipe__recipe-card-title-text"></span>
+</div>
+</div>
+</div>
+<div class="mntl-myr-add-recipe__collections" data-click-tracked="false" data-brand="alrcom">
+<h2 class="mntl-myr-add-recipe__collections-title">
+Add to collections
+</h2>
+<div class="mntl-myr-add-recipe__collections-wrapper">
+<form class="mntl-myr-add-recipe__collections-form">
+<fieldset class="mntl-myr-add-recipe__collections-existing" data-click-tracked="false"></fieldset>
+<fieldset class="mntl-myr-add-recipe__collections-suggested" data-click-tracked="false" data-suggested="Keepers,Want to Try,Weeknight Ideas"></fieldset>
+</form>
+<div class="mntl-myr-add-recipe__collections-cta">
+<button class="mntl-myr-add-recipe__collections-cta-button">
+<svg class="icon icon-myr-plus-flat "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-myr-plus-flat" href="#icon-myr-plus-flat"></use>
+</svg>
+Create collection
+</button>
+</div>
+</div>
+<div class="mntl-myr-add-recipe__collections-actions">
+<button
+type="button"
+data-click-tracked="false"
+class="mntl-myr-add-recipe__collections-button--remove"
+aria-label="Remove recipe from all favorites and collections"
+>
+<svg class="icon icon-myr-delete "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-myr-delete" href="#icon-myr-delete"></use>
+</svg>
+Remove
+</button>
+<button
+type="button"
+data-a11y-dialog-hide
+data-click-tracked="false"
+class="mntl-myr-add-recipe__collections-button--done"
+aria-label="Confirm save and close this dialog window"
+>
+Done
+</button>
+</div>
+</div>
+</div>
+<div id="mntl-favorite__collection_1-0" class="comp mntl-favorite__collection mntl-myr-favorite-collection is-hidden" data-brand="alrcom" data-edit-collection="false"> <div class="mntl-myr-favorite-collection__illo" data-click-tracked="false">
+<svg class="icon icon-new-collection "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-new-collection" href="#icon-new-collection"></use>
+</svg>
+</div>
+<div class="mntl-myr-favorite-collection__content" data-click-tracked="false">
+<h2 class="mntl-myr-favorite-collection__title">
+New Collection
+</h2>
+<form class="mntl-myr-favorite-collection__form">
+<div class="mntl-myr-favorite-collection__form-input-group" data-click-tracked="false">
+<label for="favorite-collection-name" class="mntl-myr-favorite-collection__form-label">
+Collection Name
+</label>
+<input type="text" id="favorite-collection-name" name="collectionName" class="mntl-myr-favorite-collection__form-input" placeholder="Lunch, Dinner, Dessert..." maxlength="40" required data-click-tracked="false" />
+<div id="collection-name-error_1-0" class="comp collection-name-error mntl-message-banner--error mntl-message-banner is-hidden mntl-message-banner--error" data-close-class="is-hidden" role="alert"> <svg class="icon icon-error mntl-message-banner__prefix-icon mntl-message-banner__icon "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-error" href="#icon-error"></use>
+</svg>
+<span class="type--cat-bold mntl-message-banner__text ">
+</span>
+</div> </div>
+<div class="mntl-myr-favorite-collection__form-input-group" data-click-tracked="false">
+<label for="favorite-collection-description" class="mntl-myr-favorite-collection__form-label">
+Description
+<span class="mntl-myr-favorite-collection__form-label--requirement">(optional)</span>
+</label>
+<textarea id="favorite-collection-description" name="description" class="mntl-myr-favorite-collection__form-textarea" placeholder="How would you describe this collection?" rows="4" maxlength="120" data-click-tracked="false"></textarea>
+<span class="mntl-myr-favorite-collection__form-counter type-mouse"></span>
+</div>
+<div class="mntl-myr-favorite-collection__form-controls">
+<button
+type="button"
+class="mntl-myr-favorite-collection__form-button--cancel"
+data-click-tracked="false"
+aria-label="Close this dialog window"
+>
+Cancel
+</button>
+<button
+type="button"
+class="mntl-myr-favorite-collection__form-button--submit"
+data-click-tracked="false"
+disabled
+>
+Create
+</button>
+</div>
+</form>
+</div>
+</div>
+</div> </div>
+</div>
+</div></footer>
+<div id="newsletter-dialog-header_1-0" class="comp newsletter-dialog-header mntl-newsletter-dialog--header mntl-newsletter-dialog mntl-dialog dialog " data-a11y-dialog="newsletter-dialog-header" aria-hidden="true"> <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
 <div role="dialog" class="dialog__content" aria-labelledby="newsletter-dialog-header_1-0-title">
 <div class="dialog__heading">
 <span id="newsletter-dialog-header_1-0-title" class="dialog__title type--monkey-bold">Newsletter Sign Up</span>
 <button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
 <svg class="icon icon-close "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use>
 </svg>
 </button>
 </div>
-<div class="loc content dialog__main">
-<div id="newsletter_2-0" class="comp newsletter mntl-newsletter" data-defer="loadDialogContent" data-defer-params></div><!-- end: comp newsletter mntl-newsletter -->
+<div class="loc content dialog__main"><div id="mntl-newsletter_1-0" class="comp mntl-newsletter" data-defer="loadDialogContent"></div>
+</div> </div>
 </div>
-</div>
-</div><!-- end: comp newsletter-dialog-header mntl-dialog dialog -->
-<div id="newsletter-dialog-footer_1-0" class="comp newsletter-dialog-footer newsletter-dialog-header mntl-dialog dialog " aria-hidden="true" data-a11y-dialog="newsletter-dialog-footer">
-<div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
+<div id="newsletter-dialog-footer_1-0" class="comp newsletter-dialog-footer mntl-newsletter-dialog--footer mntl-newsletter-dialog mntl-dialog dialog " data-a11y-dialog="newsletter-dialog-footer" aria-hidden="true"> <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
 <div role="dialog" class="dialog__content" aria-labelledby="newsletter-dialog-footer_1-0-title">
 <div class="dialog__heading">
 <span id="newsletter-dialog-footer_1-0-title" class="dialog__title type--monkey-bold">Newsletter Sign Up</span>
 <button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
 <svg class="icon icon-close "
 >
-<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close"></use>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use>
 </svg>
 </button>
 </div>
-<div class="loc content dialog__main">
-<div id="newsletter_3-0" class="comp newsletter mntl-newsletter" data-defer="loadDialogContent" data-defer-params></div><!-- end: comp newsletter mntl-newsletter -->
+<div class="loc content dialog__main"><div id="mntl-newsletter_2-0" class="comp mntl-newsletter" data-defer="loadDialogContent"></div>
+</div> </div>
+</div>
+<div id="mntl-myr-confirmation-dialog_1-0" class="comp mntl-myr-confirmation-dialog mntl-dialog mntl-myr-confirmation-dialog__content dialog " data-a11y-dialog="mntl-myr-confirmation-dialog" aria-hidden="true"> <div class="dialog__overlay" tabindex="-1" data-a11y-dialog-hide></div>
+<div role="dialog" class="dialog__content" aria-labelledby="mntl-myr-confirmation-dialog_1-0-title">
+<div class="dialog__heading">
+<span id="mntl-myr-confirmation-dialog_1-0-title" class="dialog__title ">Remove from All Favorites</span>
+<button data-a11y-dialog-hide class="dialog__close" data-click-tracked="true" aria-label="Close this dialog window">
+<svg class="icon icon-close "
+>
+<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-close" href="#icon-close"></use>
+</svg>
+</button>
+</div>
+<div class="loc content dialog__main"><div id="mntl-myr-confirmation-dialog-overlay_1-0" class="comp mntl-myr-confirmation-dialog-overlay mntl-block"><div id="mntl-myr-confirmation-dialog-content_1-0" class="comp mntl-myr-confirmation-dialog-content">
+<div class="modal__content">
+<div class="modal__content-body-wrapper">
+<div class="modal__content-body"></div>
+</div>
+<div class="modal__button-wrapper">
+<button
+data-a11y-dialog-hide
+class="modal__button modal__button-cancel"
+aria-label="Close this dialog window"
+>
+Cancel
+</button>
+<button
+data-a11y-dialog-hide
+class="modal__button modal__button-confirm"
+aria-label="Confirm the action and close the dialog window">
+Remove
+</button>
 </div>
 </div>
-</div><!-- end: comp newsletter-dialog-footer newsletter-dialog-header mntl-dialog dialog -->
-<svg class="is-hidden">
+</div></div>
+</div> </div>
+</div><svg class="is-hidden">
 <defs>
 <symbol id="mntl-sc-block-starrating-icon">
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -5901,24 +5141,52 @@ class="mntl-dotdash-universal-nav__text--link"
 </svg>
 </symbol>
 </defs>
-</svg>		
-<script type="text/javascript" data-glb-js="bottom" src="/static/1.130.0/cache/eNqdVW2SpCAMvdCy1pxh_-4lAkZMd4TegPY4p9_4MdPq2No1VRbwAnkGeAlFypDJFQ2EzFjMiMmm4qLfvxal_1WsF-lEm4kpEyZjW-Js7pRr83R1owPTQSBmMMlJZN6ucrG5xYAhp4JCRgnARYkVyuA_DgTLAyeXpBqbJ1EsluL7xE8faJjCddzpN-MBAVSV7h7ytNII3oXyFOmTqQOyO5Ueta-RfJ3_1BA8_qWUMSjjnvGLa0ESoCOvxhgKKwilk7bRG1yMX4igoxKjuTH0014u9xlsfTci4fTb-oT56Eob8KMSPFV78YOoQV3m3rioGgi5EHR0w7kztzrmaISsjeHgZyUBRz934z3s_XJNXWIG4rSBRxoox71_iprhozdQnjgEneseGTHBA585RpZkKHhNABrNG3xOMO9KBl3ehL4OdmE5JwltVi2rxEwFbtDcGusRWOQfXO6PeasojSpqyAlgkxDE1Ru45_Yp9wZTUlUaC2FItTX8uUgFWQ-1NE5bH6U3GXw6nHz9_rAjvGuE8t3yMkmKjobzqUF2bQdECVS8Q3NSEODtrTdT-r2api-Up1XglzU-CSgpuPaW8llGW01mG0Gm5E7OcHRX87DuyWKqSvNuluC8elSM72RVSovKsVjlOVp9Bmst4uNbMHQn1X96l3stLd1yfOI1UY9Oj-GJT9Uy61OOGEa_NTy8dk-x1go7PC3lBv4HZkdHag.min.js" async defer="true"></script>
-<script type="text/javascript">Mntl.utilities.scriptsOnLoad(document.querySelectorAll('script[data-glb-js="bottom"]'), function() {var Mntl = window.Mntl || {};window.Mntl.externalizeLinks.addPlugin(window.Mntl.affiliateLinkRewriter);
-window.Mntl.externalizeLinks.addPlugin(window.Mntl.amazonAffiliateTagger);
+</svg><script type="text/javascript" data-glb-js="bottom" src="/static/2.56.0/cache/eNqVVWty4yAMvtCynp5h_-4lBMi2EhlSwEnd01fG3tZpCGVnEiN9SEJP6GKCRKabwCXGbueYdOxO8nudMSy_unsh2ZgTMSXCqPRMnNSN0qieSk9CqCs4YgYVTfDM36WMny7eoUuxI5cwOODOYo9h1c9EQFtRMjH0-fPEi4Movm326R0VkzvnSB_AigHoe4ke0iapAt4Cpc1TkZowGHwm82XV25kxH83wviioBWdpID8qiwwL2m9sRe9GdkBZR6RhTH9GcAP-pZjQibclsGJrYK-lJiOCzcrr8ineKlfuMnh5WZQlYD9UHHBwpUH2vNu7b1ECHemKcu_DFLuIEMyoVuZIV_QmjBEGVBrcmrN7tlqxNZp9yS3QFtmWrxzYF9mm2s_MMluILqvfsxUTOoCzEukS1r8y3omobLSpJA8xbd_WdLQZBmtlagxd8EC2qfZw9eu0SSzMaLbsPGJtxiQfPYUp53hv0hL2MNgHa1ey6NXpdlnnVa6JnfhhKjj-1kPEWlppkmZcZQfqS7N46A4dpJ1MmCcdj3TN7S3lUUVvJEQVRwhYBP-vKp9ETW1OSfrw8-24BHkU1IY23Hd3Hp_u-VKeinrlCJ-nKeCV8CZXQyhApVMhCCAB7Os6eXIJp117X9Rl9MmrQFpLFQtYi2sWExA_8DVVJxvXnLyNajmGQ1TkBnmoqYY3JXN9OXPVC1CLATcn6bF1Pnswz3HFoJF_mMQozHnRVHc9vs7_2s0o9uasNqRU-q2A-21yZGoHaIjZfM_4RloaBuwHVjm-xw.min.js" async defer="true"></script>
+<script type="text/javascript">
+Mntl.utilities.scriptsOnLoad(document.querySelectorAll('script[data-glb-js="bottom"]'), function() {
+var Mntl = window.Mntl || {};
+window.Mntl.externalizeLinks.addPlugin(window.Mntl.affiliateLinkRewriter);
+window.Mntl.externalizeLinks.addPlugin(window?.Trx?.amazonAffiliateTagger);
 window.Mntl.externalizeLinks.init();window.Mntl.affiliateLinkRewriter.setMappings( {
 DOC_ID: '6586301'
 ,SITE: 'allrecipes'
-,REQUEST_ID: 'nd00c11d041104581bced15ae05ed134701'
+,REQUEST_ID: 'nb0e3cd855e144c73b1a3502bbe3cd23b21'
 }
-);
+);(function (Mntl) {
+Mntl.digioh = {
+script: null,
+brandId: null,
+initialized: false,
+init() {
+if (this.initialized) return;
+const brandId = '47b4a4dd-ffd7-43db-8118-8002b7c15352';
+const digiohFastActivation = 'false';
+const lightboxJs = digiohFastActivation === 'true' ? '/lightbox_speed.js' : '/lightbox_inline.js';
+// eslint-disable-next-line prefer-template
+const script = 'https://www.lightboxcdn.com/vendor/' + brandId + lightboxJs;
+this.brandId = brandId;
+this.script = script;
+this.initialized = true;
+},
+load(callback) {
+this.init();
+if (callback) {
+Mntl.utilities.loadExternalJS({ src: this.script }, callback);
+} else {
+Mntl.utilities.loadExternalJS({ src: this.script });
+}
+}
+};
+})(window.Mntl || {});
+Mntl.digiohTimerDelay = parseFloat('0') * 1000;
 (function() {
 var article = document.getElementById('allrecipes-article_1-0');
 if (article && !article.gtmPageView) {
-article.gtmPageView = {"country":"US","description":"These delicious four cheese pizzas are bursting with flavor, and ready in under one hour.","fullUrl":"https://www.allrecipes.com/recipe/133948/four-cheese-margherita-pizza/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"internalSessionId":"n92148e470e5249bba5bf2cb02a76265801","internalRequestId":"nd00c11d041104581bced15ae05ed134701","hid":"","experienceTypeName":"","recircDocIdsFooter":"S-7971911|S-7255338|S-6574612|S-6569204|S-6737021|S-6650739|S-6567179|S-6568220","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"3.14.359","commerceVersion":"","primaryTaxonomyIds":"6502448|6651953|6651964|6653161|6653052","primaryTaxonomyNames":"Allrecipes|Recipes|Cuisine|European|Italian","title":"Four Cheese Margherita Pizza Recipe" || document.title || '',"viewType":"BROADVIDEO","templateId":"120","lastEditingAuthorId":"1015024","lastEditingUserId":"151378030080892","templateName":"RECIPESC","muid":"7c4ee15a-daa6-479b-88bb-42a5147fa732","documentId":6586301,"authorId":"1015024","contentGroup":"Other","revenueGroup":""};
+article.gtmPageView = {"country":"US","fullUrl":"https://www.allrecipes.com/recipe/133948/four-cheese-margherita-pizza/" + location.hash,"experienceType":"single page","entryType":"direct","excludeFromComscore":false,"internalSessionId":"n92fb7040bdf94a89851ddd3952fa4f9319","internalRequestId":"nb0e3cd855e144c73b1a3502bbe3cd23b21","hid":"","experienceTypeName":"","recircDocIdsFooter":"S-6597026|S-6567179|S-6601340|S-6736485|S-6650739|S-6578682|S-6571874|S-6600809","euTrafficFlag":false,"isGoogleBot":false,"mantleVersion":"4.0.432","commerceVersion":"","primaryTaxonomyIds":"6502448|6651953|6651964|6653161|6653052","primaryTaxonomyNames":"Allrecipes|Recipes|Cuisine|European|Italian","description":"These delicious four cheese pizzas are bursting with flavor, and ready in under one hour.","title":"Four Cheese Margherita Pizza Recipe" || document.title || '',"authorId":"1015024","contentGroup":"Other","viewType":"","revenueGroup":"","templateName":"RECIPESC","templateId":"120","muid":"0232beda-105c-411a-9e94-24bc972fde83","lastEditingAuthorId":"1015024","lastEditingUserId":"151378030080892","documentId":6586301};
 }
 }());
-(function() {
-const setup = {"clickToInitialize":false,"playlistUrl":"https:\/\/cdn.jwplayer.com\/v2\/playlists\/fV1m0Jmn","skin":{"name":"mantle"},"mute":true,"advertising":{"client":"googima","rules":{"frequency":1},"forceNonLinearFullSlot":true,"vpaidcontrols":true,"autoplayadsmuted":true},"autostart":true,"preload":"metadata","aspectratio":"16:9","pauseotherplayers":"true","cast":{},"recsPlaylistId":"ZBQZ5egR","width":"100%"};
+(function(Mntl) {
+const setup = {"clickToInitialize":false,"pauseotherplayers":"true","cast":{},"recsPlaylistId":"ZBQZ5egR","playlistUrl":"https:\/\/cdn.jwplayer.com\/v2\/playlists\/fV1m0Jmn","width":"100%","skin":{"name":"mantle"},"mute":true,"advertising":{"client":"googima","vpaidmode":"enabled","rules":{"frequency":1},"forceNonLinearFullSlot":true,"vpaidcontrols":true,"autoplayadsmuted":true},"autostart":true,"preload":"metadata","aspectratio":"16:9"};
 // JW player requires `playlist` to be populated for contextual playlists
 setup.playlist = setup.playlistUrl;
 const isImmediateAutoplay = false;
@@ -5934,13 +5202,12 @@ return sz.join('x');
 // Assign a randomly-generated, eight character, alpha-numeric value to this property.
 setup.advertising.adscheduleid = Math.random().toString(36).substr(2,8);
 // muid - used for audience targeting
-setup.advertising.ppid = '7c4ee15a-daa6-479b-88bb-42a5147fa732';
+setup.advertising.ppid = '0232beda-105c-411a-9e94-24bc972fde83';
 let custParams = '';
 custParams += '&' + encodeURIComponent('slot') + '=' + encodeURIComponent('broadmatch');
 const inFocus = window && window.document && window.document.hasFocus();
 const durationParams = Mntl.JWPlayer.getDurationParams(0, true);
 custParams += '&ttid=' + setup.mediaid;
-custParams += '&videomuted=' + setup.mute;
 custParams += '&play=' + Mntl.JWPlayer.getCustomPlayValue(setup.autostart, isImmediateAutoplay, playInView);
 custParams += '&in_focus=' + inFocus;
 custParams += '&videoduration=' + durationParams.duration;
@@ -5996,7 +5263,8 @@ defer: true,
 deferOnRFDS: false,
 displayMode: "none",
 divId: "mntl-jwplayer-broad__video_1-0",
-eventCategoryType: "",
+enableBiddingWithTCData: false,
+eventCategoryType: "Trending",
 intersectionMargin: "250px",
 isImmediateAutoplay: isImmediateAutoplay,
 isImmediateStickyDisabled: false,
@@ -6007,42 +5275,19 @@ isPlaylist: true,
 mediaSize: 1080,
 playerId: "aiy6MJ4O",
 playInView: playInView,
-prebidVideoConfig: {},
 showCaptions: true,
+rtbVideoConfig: {"plcmt":2},
+useGamPlcmt: true,
+usePrebidPlcmt: true,
+useDynamicVideoSizes: true,
 skipExistingMediaContent: false,
 stickyplay: false,
 useMotionThumbnails: false
 }, setup );
-}());
-(function (Mntl) {
-Mntl.digioh = {
-script: null,
-brandId: null,
-initialized: false,
-init() {
-if (this.initialized) return;
-const brandId = '47b4a4dd-ffd7-43db-8118-8002b7c15352';
-// eslint-disable-next-line prefer-template
-const script = 'https://www.lightboxcdn.com/vendor/' + brandId + '/lightbox_inline.js';
-this.brandId = brandId;
-this.script = script;
-this.initialized = true;
-},
-load(callback) {
-this.init();
-if (callback) {
-Mntl.utilities.loadExternalJS({ src: this.script }, callback);
-} else {
-Mntl.utilities.loadExternalJS({ src: this.script });
-}
-}
-};
-})(window.Mntl || {});
-Mntl.digiohTimerDelay = parseFloat('30') * 1000;
-});</script>
-<div id="mntl-sponsor-tracking-codes_1-0" class="comp mntl-sponsor-tracking-codes" data-defer="load" data-defer-params></div><!-- end: comp mntl-sponsor-tracking-codes -->
+}(window.Mntl || {}));
+});
+</script>
 <div id="onetrust-consent-sdk" class="" data-tracking-container="true">
-<div id="onetrust-banner-sdk" class="otFlat bottom ot-wo-title" tabindex="0"><div role="alertdialog" aria-describedby="onetrust-policy-text" aria-label="Privacy"><div class="ot-sdk-container"><div class="ot-sdk-row"><div id="onetrust-group-container" class="ot-sdk-eight ot-sdk-columns"><div class="banner_logo"></div><div id="onetrust-policy"><p id="onetrust-policy-text">By clicking “Accept All Cookies”, you agree to the storing of cookies on your device to enhance site navigation, analyze site usage, and assist in our marketing efforts. </p></div></div><div id="onetrust-button-group-parent" class="ot-sdk-three ot-sdk-columns"><div id="onetrust-button-group"><button id="onetrust-pc-btn-handler" class=" cookie-setting-link">Cookies Settings</button> <button id="onetrust-accept-btn-handler">Accept All Cookies</button></div></div></div></div><!-- Close Button --><div id="onetrust-close-btn-container"><button class="onetrust-close-btn-handler onetrust-close-btn-ui banner-close-button ot-close-icon" aria-label="Close"></button></div><!-- Close Button END--></div></div>
-</div>		
-</body>
-</html><!-- end: comp no-js taxlevel-4 recipeScTemplate html mntl-html -->		
+<div id="onetrust-banner-sdk" class="otFlat bottom ot-wo-title" tabindex="0"><div role="alertdialog" aria-describedby="onetrust-policy-text" aria-label="Privacy"><div class="ot-sdk-container"><div class="ot-sdk-row"><div id="onetrust-group-container" class="ot-sdk-eight ot-sdk-columns"><div class="banner_logo"></div><div id="onetrust-policy"><div id="onetrust-policy-text">By clicking “Accept All Cookies”, you agree to the storing of cookies on your device to enhance site navigation, analyze site usage, and assist in our marketing efforts. </div></div></div><div id="onetrust-button-group-parent" class="ot-sdk-three ot-sdk-columns"><div id="onetrust-button-group"><button id="onetrust-pc-btn-handler" class=" cookie-setting-link">Cookies Settings</button> <button id="onetrust-accept-btn-handler">Accept All Cookies</button></div></div></div></div><!-- Close Button --><div id="onetrust-close-btn-container"><button class="onetrust-close-btn-handler onetrust-close-btn-ui banner-close-button ot-close-icon" style="background-image: url('https://cdn.cookielaw.org/logos/static/ot_close.svg')" aria-label="Close"></button></div><!-- Close Button END--></div></div>
+</div></body>
+</html>


### PR DESCRIPTION
AllRecipes changed their HTML structure, which breaks our workaround for pulling recipe ingredients. For more information, [see the bug report](https://github.com/hhursev/recipe-scrapers/issues/1154).

Since the class seems to be generated (a few other sites use a similar class name) I added a slightly more robust class selector, in case it ever changes again.

Fixes https://github.com/hhursev/recipe-scrapers/issues/1154