### PR TITLE
Remove `mypy: allow untyped defs`

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 # generate.py generates a new recipe scraper.
 import ast
 import json

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,9 +3,6 @@
 [mypy-recipe_scrapers.*]
 disable_error_code = union-attr
 
-[mypy-tests.*]
-disallow_untyped_defs = false
-
 # Third-party libraries
 
 [mypy-isodate]

--- a/recipe_scrapers/aberlehome.py
+++ b/recipe_scrapers/aberlehome.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/abuelascounter.py
+++ b/recipe_scrapers/abuelascounter.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/addapinch.py
+++ b/recipe_scrapers/addapinch.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/aflavorjournal.py
+++ b/recipe_scrapers/aflavorjournal.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import get_equipment

--- a/recipe_scrapers/aldi.py
+++ b/recipe_scrapers/aldi.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/alexandracooks.py
+++ b/recipe_scrapers/alexandracooks.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/alittlebityummy.py
+++ b/recipe_scrapers/alittlebityummy.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/allthehealthythings.py
+++ b/recipe_scrapers/allthehealthythings.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/bakels.py
+++ b/recipe_scrapers/bakels.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/barefeetinthekitchen.py
+++ b/recipe_scrapers/barefeetinthekitchen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/barefootcontessa.py
+++ b/recipe_scrapers/barefootcontessa.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/bestrecipes.py
+++ b/recipe_scrapers/bestrecipes.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._exceptions import StaticValueException
 

--- a/recipe_scrapers/bluejeanchef.py
+++ b/recipe_scrapers/bluejeanchef.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/breadtopia.py
+++ b/recipe_scrapers/breadtopia.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/briceletbaklava.py
+++ b/recipe_scrapers/briceletbaklava.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/cafedelites.py
+++ b/recipe_scrapers/cafedelites.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/carlsbadcravings.py
+++ b/recipe_scrapers/carlsbadcravings.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/chefnini.py
+++ b/recipe_scrapers/chefnini.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/chefsavvy.py
+++ b/recipe_scrapers/chefsavvy.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/cooktalk.py
+++ b/recipe_scrapers/cooktalk.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/coopse.py
+++ b/recipe_scrapers/coopse.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import json
 import re
 

--- a/recipe_scrapers/costco.py
+++ b/recipe_scrapers/costco.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/countryliving.py
+++ b/recipe_scrapers/countryliving.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/creativecanning.py
+++ b/recipe_scrapers/creativecanning.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/damndelicious.py
+++ b/recipe_scrapers/damndelicious.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/dinneratthezoo.py
+++ b/recipe_scrapers/dinneratthezoo.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/dinnerthendessert.py
+++ b/recipe_scrapers/dinnerthendessert.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/eatingwell.py
+++ b/recipe_scrapers/eatingwell.py
@@ -1,6 +1,3 @@
-# mypy: allow-untyped-defs
-
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/eatliverun.py
+++ b/recipe_scrapers/eatliverun.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/eatwell101.py
+++ b/recipe_scrapers/eatwell101.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import html
 import re
 

--- a/recipe_scrapers/elavegan.py
+++ b/recipe_scrapers/elavegan.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import get_equipment

--- a/recipe_scrapers/emmikochteinfach.py
+++ b/recipe_scrapers/emmikochteinfach.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/epicurious.py
+++ b/recipe_scrapers/epicurious.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/errenskitchen.py
+++ b/recipe_scrapers/errenskitchen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/evolvingtable.py
+++ b/recipe_scrapers/evolvingtable.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/familyfoodonthetable.py
+++ b/recipe_scrapers/familyfoodonthetable.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/fattoincasadabenedetta.py
+++ b/recipe_scrapers/fattoincasadabenedetta.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/felixkitchen.py
+++ b/recipe_scrapers/felixkitchen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._exceptions import FieldNotProvidedByWebsiteException
 from ._utils import normalize_string

--- a/recipe_scrapers/fifteengram.py
+++ b/recipe_scrapers/fifteengram.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/finedininglovers.py
+++ b/recipe_scrapers/finedininglovers.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/fitslowcookerqueen.py
+++ b/recipe_scrapers/fitslowcookerqueen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/foodfidelity.py
+++ b/recipe_scrapers/foodfidelity.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/forktospoon.py
+++ b/recipe_scrapers/forktospoon.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/gesundaktiv.py
+++ b/recipe_scrapers/gesundaktiv.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/goodfooddiscoveries.py
+++ b/recipe_scrapers/goodfooddiscoveries.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/goodhousekeeping.py
+++ b/recipe_scrapers/goodhousekeeping.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/gourmettraveller.py
+++ b/recipe_scrapers/gourmettraveller.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/grandfrais.py
+++ b/recipe_scrapers/grandfrais.py
@@ -1,6 +1,3 @@
-# mypy: allow-untyped-defs
-
-
 import re
 from urllib.parse import urlparse
 

--- a/recipe_scrapers/grimgrains.py
+++ b/recipe_scrapers/grimgrains.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from itertools import chain
 from urllib.parse import urljoin
 

--- a/recipe_scrapers/grouprecipes.py
+++ b/recipe_scrapers/grouprecipes.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import get_minutes, get_yields, normalize_string
 

--- a/recipe_scrapers/hassanchef.py
+++ b/recipe_scrapers/hassanchef.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/heatherchristo.py
+++ b/recipe_scrapers/heatherchristo.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/herseyland.py
+++ b/recipe_scrapers/herseyland.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import get_equipment
 

--- a/recipe_scrapers/ig.py
+++ b/recipe_scrapers/ig.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import get_yields, normalize_string
 

--- a/recipe_scrapers/inbloombakery.py
+++ b/recipe_scrapers/inbloombakery.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/insanelygoodrecipes.py
+++ b/recipe_scrapers/insanelygoodrecipes.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/inspiralized.py
+++ b/recipe_scrapers/inspiralized.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/izzycooking.py
+++ b/recipe_scrapers/izzycooking.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/jocooks.py
+++ b/recipe_scrapers/jocooks.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import get_equipment

--- a/recipe_scrapers/joshuaweissman.py
+++ b/recipe_scrapers/joshuaweissman.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 # from pprint import pprint
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients

--- a/recipe_scrapers/joythebaker.py
+++ b/recipe_scrapers/joythebaker.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from __future__ import annotations
 
 from recipe_scrapers._exceptions import ElementNotFoundInHtml

--- a/recipe_scrapers/justonecookbook.py
+++ b/recipe_scrapers/justonecookbook.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/keukenliefdenl.py
+++ b/recipe_scrapers/keukenliefdenl.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 from ._abstract import AbstractScraper
 from ._exceptions import ElementNotFoundInHtml
 from ._utils import get_minutes, get_yields, normalize_string

--- a/recipe_scrapers/kitchenaidaustralia.py
+++ b/recipe_scrapers/kitchenaidaustralia.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 from typing import List
 

--- a/recipe_scrapers/kitchensanctuary.py
+++ b/recipe_scrapers/kitchensanctuary.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from recipe_scrapers._grouping_utils import IngredientGroup
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/kochbucher.py
+++ b/recipe_scrapers/kochbucher.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/kristineskitchenblog.py
+++ b/recipe_scrapers/kristineskitchenblog.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/kuchynalidla.py
+++ b/recipe_scrapers/kuchynalidla.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 from itertools import zip_longest
 

--- a/recipe_scrapers/leanandgreenrecipes.py
+++ b/recipe_scrapers/leanandgreenrecipes.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from bs4 import BeautifulSoup
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/lifestyleofafoodie.py
+++ b/recipe_scrapers/lifestyleofafoodie.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/maangchi.py
+++ b/recipe_scrapers/maangchi.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/madsvin.py
+++ b/recipe_scrapers/madsvin.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/mccormick.py
+++ b/recipe_scrapers/mccormick.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/ministryofcurry.py
+++ b/recipe_scrapers/ministryofcurry.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/mobkitchen.py
+++ b/recipe_scrapers/mobkitchen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from .mob import Mob
 
 

--- a/recipe_scrapers/modernhoney.py
+++ b/recipe_scrapers/modernhoney.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import get_equipment
 

--- a/recipe_scrapers/momontimeout.py
+++ b/recipe_scrapers/momontimeout.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/moulinex.py
+++ b/recipe_scrapers/moulinex.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import re
 

--- a/recipe_scrapers/mundodereceitasbimby.py
+++ b/recipe_scrapers/mundodereceitasbimby.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/myjewishlearning.py
+++ b/recipe_scrapers/myjewishlearning.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/mykoreankitchen.py
+++ b/recipe_scrapers/mykoreankitchen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from recipe_scrapers._grouping_utils import IngredientGroup
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/norecipes.py
+++ b/recipe_scrapers/norecipes.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/notenoughcinnamon.py
+++ b/recipe_scrapers/notenoughcinnamon.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/nrkmat.py
+++ b/recipe_scrapers/nrkmat.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._exceptions import SchemaOrgException
 from ._grouping_utils import group_ingredients

--- a/recipe_scrapers/number2pencil.py
+++ b/recipe_scrapers/number2pencil.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/nutritionfacts.py
+++ b/recipe_scrapers/nutritionfacts.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/omnivorescookbook.py
+++ b/recipe_scrapers/omnivorescookbook.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/onceuponachef.py
+++ b/recipe_scrapers/onceuponachef.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/onesweetappetite.py
+++ b/recipe_scrapers/onesweetappetite.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import get_equipment, normalize_string
 

--- a/recipe_scrapers/persnicketyplates.py
+++ b/recipe_scrapers/persnicketyplates.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/pickuplimes.py
+++ b/recipe_scrapers/pickuplimes.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/pinchofyum.py
+++ b/recipe_scrapers/pinchofyum.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/pinkowlkitchen.py
+++ b/recipe_scrapers/pinkowlkitchen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/platingpixels.py
+++ b/recipe_scrapers/platingpixels.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/plowingthroughlife.py
+++ b/recipe_scrapers/plowingthroughlife.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/plugins/static_values.py
+++ b/recipe_scrapers/plugins/static_values.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import functools
 import warnings
 

--- a/recipe_scrapers/potatorolls.py
+++ b/recipe_scrapers/potatorolls.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._exceptions import StaticValueException
 from ._grouping_utils import group_ingredients

--- a/recipe_scrapers/practicalselfreliance.py
+++ b/recipe_scrapers/practicalselfreliance.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from .creativecanning import CreativeCanning
 
 

--- a/recipe_scrapers/pressureluckcooking.py
+++ b/recipe_scrapers/pressureluckcooking.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/projectgezond.py
+++ b/recipe_scrapers/projectgezond.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/przepisy.py
+++ b/recipe_scrapers/przepisy.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import get_yields, normalize_string
 

--- a/recipe_scrapers/receitasnestlebr.py
+++ b/recipe_scrapers/receitasnestlebr.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/recept.py
+++ b/recipe_scrapers/recept.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/recipegirl.py
+++ b/recipe_scrapers/recipegirl.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/ricetta.py
+++ b/recipe_scrapers/ricetta.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/ricetteperbimby.py
+++ b/recipe_scrapers/ricetteperbimby.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/rosannapansino.py
+++ b/recipe_scrapers/rosannapansino.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._exceptions import FieldNotProvidedByWebsiteException
 from ._utils import normalize_string

--- a/recipe_scrapers/rutgerbakt.py
+++ b/recipe_scrapers/rutgerbakt.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/saboresanjinomoto.py
+++ b/recipe_scrapers/saboresanjinomoto.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/savorynothings.py
+++ b/recipe_scrapers/savorynothings.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import get_equipment

--- a/recipe_scrapers/simpleveganista.py
+++ b/recipe_scrapers/simpleveganista.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/smulweb.py
+++ b/recipe_scrapers/smulweb.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/spendwithpennies.py
+++ b/recipe_scrapers/spendwithpennies.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/staysnatched.py
+++ b/recipe_scrapers/staysnatched.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/strongrfastr.py
+++ b/recipe_scrapers/strongrfastr.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/tasteatlas.py
+++ b/recipe_scrapers/tasteatlas.py
@@ -1,6 +1,3 @@
-# mypy: allow-untyped-defs
-
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/tasteau.py
+++ b/recipe_scrapers/tasteau.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/theclevercarrot.py
+++ b/recipe_scrapers/theclevercarrot.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/thecookierookie.py
+++ b/recipe_scrapers/thecookierookie.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/thecookingguy.py
+++ b/recipe_scrapers/thecookingguy.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._exceptions import ElementNotFoundInHtml, FieldNotProvidedByWebsiteException
 from ._grouping_utils import IngredientGroup

--- a/recipe_scrapers/thekitchencommunity.py
+++ b/recipe_scrapers/thekitchencommunity.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/themagicalslowcooker.py
+++ b/recipe_scrapers/themagicalslowcooker.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/themodernproper.py
+++ b/recipe_scrapers/themodernproper.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/thepalatablelife.py
+++ b/recipe_scrapers/thepalatablelife.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/therecipecritic.py
+++ b/recipe_scrapers/therecipecritic.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/thesaltymarshmallow.py
+++ b/recipe_scrapers/thesaltymarshmallow.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/tidymom.py
+++ b/recipe_scrapers/tidymom.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/tofoo.py
+++ b/recipe_scrapers/tofoo.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/tudogostoso.py
+++ b/recipe_scrapers/tudogostoso.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/uitpaulineskeukennl.py
+++ b/recipe_scrapers/uitpaulineskeukennl.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string

--- a/recipe_scrapers/unsophisticook.py
+++ b/recipe_scrapers/unsophisticook.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 from ._utils import get_equipment, normalize_string

--- a/recipe_scrapers/usapears.py
+++ b/recipe_scrapers/usapears.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import get_minutes, normalize_string
 

--- a/recipe_scrapers/vegetarbloggen.py
+++ b/recipe_scrapers/vegetarbloggen.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/vegolosi.py
+++ b/recipe_scrapers/vegolosi.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/waitrose.py
+++ b/recipe_scrapers/waitrose.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/wearenotmartha.py
+++ b/recipe_scrapers/wearenotmartha.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/weightwatchers.py
+++ b/recipe_scrapers/weightwatchers.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/weightwatcherspublic.py
+++ b/recipe_scrapers/weightwatcherspublic.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._utils import normalize_string
 from .weightwatchers import WeightWatchers
 

--- a/recipe_scrapers/wellplated.py
+++ b/recipe_scrapers/wellplated.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/recipe_scrapers/whole30.py
+++ b/recipe_scrapers/whole30.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/williamssonoma.py
+++ b/recipe_scrapers/williamssonoma.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
 

--- a/recipe_scrapers/womensweeklyfood.py
+++ b/recipe_scrapers/womensweeklyfood.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import re
 
 from ._abstract import AbstractScraper

--- a/recipe_scrapers/yummly.py
+++ b/recipe_scrapers/yummly.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/zaubertopf.py
+++ b/recipe_scrapers/zaubertopf.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 

--- a/recipe_scrapers/zeitwochenmarkt.py
+++ b/recipe_scrapers/zeitwochenmarkt.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 import extruct
 
 from ._abstract import AbstractScraper

--- a/templates/scraper.py
+++ b/templates/scraper.py
@@ -1,5 +1,3 @@
-# mypy: allow-untyped-defs
-
 from ._abstract import AbstractScraper
 
 

--- a/tests/legacy/test_coopse.py
+++ b/tests/legacy/test_coopse.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import responses
 
 from recipe_scrapers.coopse import CoopSE

--- a/tests/legacy/test_coopse_groups.py
+++ b/tests/legacy/test_coopse_groups.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import responses
 
 from recipe_scrapers._grouping_utils import IngredientGroup

--- a/tests/legacy/test_monsieurcuisine.py
+++ b/tests/legacy/test_monsieurcuisine.py
@@ -1,4 +1,3 @@
-# mypy: allow-untyped-defs
 import responses
 
 from recipe_scrapers.monsieurcuisine import MonsieurCuisine


### PR DESCRIPTION
As suggested in the review on https://github.com/hhursev/recipe-scrapers/pull/1171.

I did this with a couple iterations of `sed` (`gsed`) as follows, along with manual deleting in a few places.

```sh
$ # Delete a blank line after a pattern (https://stackoverflow.com/a/31962251/3330552)
$ sed -i '/allow-untyped-defs/{N;s/\n$//}' recipe_scrapers/*.py

$ # Delete the line containing a matching pattern
$ sed -i '/allow-untyped-defs/d' recipe_scrapers/*.py
```