### PR TITLE
Fix ratings_count to return integer values

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -302,7 +302,7 @@ class SchemaOrg:
                 ratings = self.ratingsdata.get(rating_id, ratings)
             ratings = ratings.get("ratingCount") or ratings.get("reviewCount")
         if ratings:
-            return round(float(ratings), 2) if float(ratings) != 0 else None
+            return int(float(ratings)) if float(ratings) != 0 else None
         raise SchemaOrgException("No ratingCount in SchemaOrg.")
 
     def cuisine(self):

--- a/tests/test_data/aflavorjournal.com/aflavorjournal_1.json
+++ b/tests/test_data/aflavorjournal.com/aflavorjournal_1.json
@@ -50,7 +50,7 @@
   "prep_time": 5,
   "cuisine": "American",
   "ratings": 4.87,
-  "ratings_count": 499.0,
+  "ratings_count": 499,
   "equipment": [
     "1 Medium Bowl",
     "1 whisk",

--- a/tests/test_data/aflavorjournal.com/aflavorjournal_2.json
+++ b/tests/test_data/aflavorjournal.com/aflavorjournal_2.json
@@ -92,7 +92,7 @@
   "prep_time": 20,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 1.0,
+  "ratings_count": 1,
   "nutrients": {
     "servingSize": "1 salad",
     "calories": "665 kcal",

--- a/tests/test_data/alexandracooks.com/alexandracooks_1.json
+++ b/tests/test_data/alexandracooks.com/alexandracooks_1.json
@@ -46,7 +46,7 @@
   "cuisine": "American",
   "cooking_method": "blender",
   "ratings": 5.0,
-  "ratings_count": 4.0,
+  "ratings_count": 4,
   "image": "https://alexandracooks.com/wp-content/uploads/2022/03/veganranchdressing-225x225.jpg",
   "keywords": [
     "cashew",

--- a/tests/test_data/alexandracooks.com/alexandracooks_2.json
+++ b/tests/test_data/alexandracooks.com/alexandracooks_2.json
@@ -59,7 +59,7 @@
   "cuisine": "American",
   "cooking_method": "Baking",
   "ratings": 5.0,
-  "ratings_count": 16.0,
+  "ratings_count": 16,
   "image": "https://alexandracooks.com/wp-content/uploads/2021/03/haminoven_alexandraskitchen-225x225.jpg",
   "keywords": [
     "baked",

--- a/tests/test_data/barefeetinthekitchen.com/barefeetinthekitchen_1.json
+++ b/tests/test_data/barefeetinthekitchen.com/barefeetinthekitchen_1.json
@@ -48,7 +48,7 @@
   "prep_time": 10,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 5.0,
+  "ratings_count": 5,
   "nutrients": {
     "calories": "518 kcal",
     "carbohydrateContent": "25 g",

--- a/tests/test_data/barefeetinthekitchen.com/barefeetinthekitchen_2.json
+++ b/tests/test_data/barefeetinthekitchen.com/barefeetinthekitchen_2.json
@@ -58,7 +58,7 @@
   "prep_time": 5,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 17.0,
+  "ratings_count": 17,
   "nutrients": {
     "calories": "415 kcal",
     "carbohydrateContent": "43 g",

--- a/tests/test_data/cafedelites.com/cafedelites_1.json
+++ b/tests/test_data/cafedelites.com/cafedelites_1.json
@@ -65,7 +65,7 @@
   "prep_time": 15,
   "cuisine": "Spanish",
   "ratings": 5.0,
-  "ratings_count": 4.0,
+  "ratings_count": 4,
   "nutrients": {
     "calories": "121 kcal",
     "carbohydrateContent": "17 g",

--- a/tests/test_data/cafedelites.com/cafedelites_2.json
+++ b/tests/test_data/cafedelites.com/cafedelites_2.json
@@ -49,7 +49,7 @@
   "prep_time": 15,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 19.0,
+  "ratings_count": 19,
   "nutrients": {
     "calories": "284 kcal",
     "carbohydrateContent": "17 g",

--- a/tests/test_data/damndelicious.net/damndelicious_1.json
+++ b/tests/test_data/damndelicious.net/damndelicious_1.json
@@ -55,6 +55,6 @@
   "cook_time": 15,
   "prep_time": 15,
   "ratings": 5.0,
-  "ratings_count": 31.0,
+  "ratings_count": 31,
   "image": "https://s23209.pcdn.co/wp-content/uploads/2021/06/Salmon-with-Garlic-Cream-SauceIMG_1398.jpg"
 }

--- a/tests/test_data/damndelicious.net/damndelicious_2.json
+++ b/tests/test_data/damndelicious.net/damndelicious_2.json
@@ -93,6 +93,6 @@
   "cook_time": 10,
   "prep_time": 140,
   "ratings": 5.0,
-  "ratings_count": 21.0,
+  "ratings_count": 21,
   "image": "https://s23209.pcdn.co/wp-content/uploads/2023/01/220905_DD_Chx-Caesar-Salad_051.jpg"
 }

--- a/tests/test_data/familyfoodonthetable.com/familyfoodonthetable_1.json
+++ b/tests/test_data/familyfoodonthetable.com/familyfoodonthetable_1.json
@@ -52,7 +52,7 @@
   "prep_time": 5,
   "cuisine": "Asian",
   "ratings": 4.4,
-  "ratings_count": 2879.0,
+  "ratings_count": 2879,
   "nutrients": {
     "calories": "360 calories",
     "carbohydrateContent": "15 grams carbohydrates",

--- a/tests/test_data/familyfoodonthetable.com/familyfoodonthetable_2.json
+++ b/tests/test_data/familyfoodonthetable.com/familyfoodonthetable_2.json
@@ -59,7 +59,7 @@
   "prep_time": 5,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 2.0,
+  "ratings_count": 2,
   "nutrients": {
     "calories": "766 calories",
     "carbohydrateContent": "14 grams carbohydrates",

--- a/tests/test_data/modernhoney.com/modernhoney_1.json
+++ b/tests/test_data/modernhoney.com/modernhoney_1.json
@@ -45,7 +45,7 @@
   "prep_time": 3,
   "cuisine": "Asian",
   "ratings": 4.96,
-  "ratings_count": 21.0,
+  "ratings_count": 21,
   "equipment": [
     "12 inch cast iron skillet"
   ],

--- a/tests/test_data/momontimeout.com/momontimeout_1.json
+++ b/tests/test_data/momontimeout.com/momontimeout_1.json
@@ -89,7 +89,7 @@
   "prep_time": 25,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 2.0,
+  "ratings_count": 2,
   "nutrients": {
     "calories": "709 kcal",
     "carbohydrateContent": "91 g",

--- a/tests/test_data/momontimeout.com/momontimeout_2.json
+++ b/tests/test_data/momontimeout.com/momontimeout_2.json
@@ -43,7 +43,7 @@
   "prep_time": 20,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 2.0,
+  "ratings_count": 2,
   "nutrients": {
     "calories": "193 kcal",
     "carbohydrateContent": "29 g",

--- a/tests/test_data/recipegirl.com/recipegirl_1.json
+++ b/tests/test_data/recipegirl.com/recipegirl_1.json
@@ -54,7 +54,7 @@
   "prep_time": 30,
   "cuisine": "American",
   "ratings": 4.6,
-  "ratings_count": 5.0,
+  "ratings_count": 5,
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "770 kcal",

--- a/tests/test_data/recipegirl.com/recipegirl_2.json
+++ b/tests/test_data/recipegirl.com/recipegirl_2.json
@@ -70,7 +70,7 @@
   "prep_time": 30,
   "cuisine": "American",
   "ratings": 4.34,
-  "ratings_count": 3.0,
+  "ratings_count": 3,
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "642 kcal",

--- a/tests/test_data/savorynothings.com/savorynothings_1.json
+++ b/tests/test_data/savorynothings.com/savorynothings_1.json
@@ -52,7 +52,7 @@
   "prep_time": 15,
   "cuisine": "American",
   "ratings": 4.8,
-  "ratings_count": 387.0,
+  "ratings_count": 387,
   "equipment": [
     "Cookie Scoop",
     "Baking Sheet"

--- a/tests/test_data/savorynothings.com/savorynothings_2.json
+++ b/tests/test_data/savorynothings.com/savorynothings_2.json
@@ -69,7 +69,7 @@
   "prep_time": 15,
   "cuisine": "American",
   "ratings": 4.58,
-  "ratings_count": 203.0,
+  "ratings_count": 203,
   "equipment": [
     "5×9 inch loaf pan",
     "Baking Parchment",

--- a/tests/test_data/thecookierookie.com/thecookierookie_1.json
+++ b/tests/test_data/thecookierookie.com/thecookierookie_1.json
@@ -58,7 +58,7 @@
   "cook_time": 150,
   "cuisine": "American",
   "ratings": 4.64,
-  "ratings_count": 33.0,
+  "ratings_count": 33,
   "nutrients": {
     "servingSize": "0.75 pounds",
     "calories": "565 kcal",

--- a/tests/test_data/thecookierookie.com/thecookierookie_2.json
+++ b/tests/test_data/thecookierookie.com/thecookierookie_2.json
@@ -62,7 +62,7 @@
   "prep_time": 5,
   "cuisine": "American",
   "ratings": 4.68,
-  "ratings_count": 331.0,
+  "ratings_count": 331,
   "nutrients": {
     "calories": "456 kcal",
     "carbohydrateContent": "10 g",

--- a/tests/test_data/thesaltymarshmallow.com/thesaltymarshmallow_1.json
+++ b/tests/test_data/thesaltymarshmallow.com/thesaltymarshmallow_1.json
@@ -50,7 +50,7 @@
   "prep_time": 15,
   "cuisine": "American",
   "ratings": 5.0,
-  "ratings_count": 4.0,
+  "ratings_count": 4,
   "image": "https://thesaltymarshmallow.com/wp-content/uploads/2022/12/cream-cheese-cookies-featured.jpg",
   "keywords": [
     "cream cheese cookies"


### PR DESCRIPTION
Resolves #1175 

Modifies `ratings_count` to return integer values instead of floating-point & updates existing test cases