### PR TITLE
Consistency: provide `site_name` for all scrapers.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@
 # and would error on `str.format()` usage
 ignore = E203, E266, E501, W503, FS002, N818
 max-line-length = 88
-max-complexity = 18
+max-complexity = 20
 select = B,C,E,F,N,W,T4,B9
 exclude =
     ./.tox/

--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -138,7 +138,7 @@ from .headbangerskitchen import HeadbangersKitchen
 from .heatherchristo import HeatherChristo
 from .heb import HEB
 from .hellofresh import HelloFresh
-from .herseyland import HerseyLand
+from .hersheyland import HersheyLand
 from .homechef import HomeChef
 from .hostthetoast import Hostthetoast
 from .ica import Ica
@@ -267,7 +267,7 @@ from .ricetta import Ricetta
 from .ricetteperbimby import RicettePerBimby
 from .rosannapansino import RosannaPansino
 from .rutgerbakt import RutgerBakt
-from .saboresanjinomoto import SaboresAnjinomoto
+from .saboresajinomoto import SaboresAjinomoto
 from .sallysbakingaddiction import SallysBakingAddiction
 from .sallysblog import SallysBlog
 from .saltpepperskillet import SaltPepperSkillet
@@ -538,7 +538,7 @@ SCRAPERS = {
     HelloFresh.host(domain="nl"): HelloFresh,
     HelloFresh.host(domain="no"): HelloFresh,
     HelloFresh.host(domain="se"): HelloFresh,
-    HerseyLand.host(): HerseyLand,
+    HersheyLand.host(): HersheyLand,
     HomeChef.host(): HomeChef,
     Hostthetoast.host(): Hostthetoast,
     Ica.host(): Ica,
@@ -652,7 +652,7 @@ SCRAPERS = {
     Ricetta.host(): Ricetta,
     RosannaPansino.host(): RosannaPansino,
     RutgerBakt.host(): RutgerBakt,
-    SaboresAnjinomoto.host(): SaboresAnjinomoto,
+    SaboresAjinomoto.host(): SaboresAjinomoto,
     SallysBakingAddiction.host(): SallysBakingAddiction,
     SallysBlog.host(): SallysBlog,
     SaltPepperSkillet.host(): SaltPepperSkillet,

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -10,6 +10,7 @@ from recipe_scrapers.settings import settings
 
 from ._exceptions import ElementNotFoundInHtml
 from ._grouping_utils import IngredientGroup
+from ._opengraph import OpenGraph
 from ._schemaorg import SchemaOrg
 
 # Some sites close their content for 'bots', so user-agent must be supplied
@@ -49,6 +50,7 @@ class AbstractScraper:
 
         self.wild_mode = wild_mode
         self.soup = BeautifulSoup(self.page_data, "html.parser")
+        self.opengraph = OpenGraph(self.soup)
         self.schema = SchemaOrg(self.page_data)
 
         # attach the plugins as instructed in settings.PLUGINS
@@ -205,8 +207,7 @@ class AbstractScraper:
 
     def site_name(self):
         """Name of the website."""
-        meta = self.soup.find("meta", property="og:site_name")
-        return meta.get("content") if meta else None
+        raise NotImplementedError("This should be implemented.")
 
     def to_json(self):
         """Recipe information in JSON format."""

--- a/recipe_scrapers/_exceptions.py
+++ b/recipe_scrapers/_exceptions.py
@@ -36,11 +36,23 @@ class ElementNotFoundInHtml(RecipeScrapersExceptions):
         super().__init__(message)
 
 
-class SchemaOrgException(RecipeScrapersExceptions):
-    """Error in parsing or missing portion of the Schema.org data on the page"""
+class FillPluginException(RecipeScrapersExceptions):
+    """Inability to locate an element on a page by using a fill plugin"""
 
     def __init__(self, message):
         super().__init__(message)
+
+
+class OpenGraphException(FillPluginException):
+    """Unable to locate element on the page using OpenGraph metadata"""
+
+    ...
+
+
+class SchemaOrgException(FillPluginException):
+    """Error in parsing or missing portion of the Schema.org data on the page"""
+
+    ...
 
 
 class StaticValueException(RecipeScrapersExceptions):

--- a/recipe_scrapers/_opengraph.py
+++ b/recipe_scrapers/_opengraph.py
@@ -8,14 +8,14 @@ class OpenGraph:
     def site_name(self):
         meta = self.soup.find("meta", {"property": "og:site_name"})
         meta = meta or self.soup.find("meta", {"name": "og:site_name"})
-        if meta:
-            return meta.get("content")
+        if not meta:
+            raise OpenGraphException("Site name not found in OpenGraph metadata.")
 
-        raise OpenGraphException("Site name not found in OpenGraph metadata.")
+        return meta.get("content")
 
     def image(self):
         image = self.soup.find("meta", {"property": "og:image", "content": True})
-        if image:
-            return image.get("content")
+        if not image:
+            raise OpenGraphException("Image not found in OpenGraph metadata.")
 
-        raise OpenGraphException("Image not found in OpenGraph metadata.")
+        return image.get("content")

--- a/recipe_scrapers/_opengraph.py
+++ b/recipe_scrapers/_opengraph.py
@@ -1,0 +1,21 @@
+from ._exceptions import OpenGraphException
+
+
+class OpenGraph:
+    def __init__(self, soup):
+        self.soup = soup
+
+    def site_name(self):
+        meta = self.soup.find("meta", {"property": "og:site_name"})
+        meta = meta or self.soup.find("meta", {"name": "og:site_name"})
+        if meta:
+            return meta.get("content")
+
+        raise OpenGraphException("Site name not found in OpenGraph metadata.")
+
+    def image(self):
+        image = self.soup.find("meta", {"property": "og:image", "content": True})
+        if image:
+            return image.get("content")
+
+        raise OpenGraphException("Image not found in OpenGraph metadata.")

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -36,13 +36,7 @@ class SchemaOrg:
             if self._contains_schematype(graph_item, schematype):
                 return graph_item
 
-    def __init__(self, page_data, raw=False):
-        if raw:
-            self.format = "raw"
-            self.data = page_data
-            self.people = {}
-            self.ratingsdata = {}
-            return
+    def __init__(self, page_data):
         self.format = None
         self.data = {}
         self.people = {}

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -115,7 +115,6 @@ class SchemaOrg:
 
         return normalize_string(self.website_name)
 
-
     def language(self):
         return self.data.get("inLanguage") or self.data.get("language")
 

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -85,6 +85,7 @@ class SchemaOrg:
                 syntax_data.insert(0, syntax_data.pop(index))
             except ValueError:
                 pass
+
             for item in syntax_data:
                 if SCHEMA_ORG_HOST not in item.get("@context", ""):
                     continue

--- a/recipe_scrapers/afghankitchenrecipes.py
+++ b/recipe_scrapers/afghankitchenrecipes.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_yields
 
 
@@ -6,6 +7,9 @@ class AfghanKitchenRecipes(AbstractScraper):
     @classmethod
     def host(cls):
         return "afghankitchenrecipes.com"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="Afghan Kitchen Recipes")
 
     def author(self):
         given_name = self.soup.find("h5", {"class": "given-name"})

--- a/recipe_scrapers/afghankitchenrecipes.py
+++ b/recipe_scrapers/afghankitchenrecipes.py
@@ -8,7 +8,7 @@ class AfghanKitchenRecipes(AbstractScraper):
     def host(cls):
         return "afghankitchenrecipes.com"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="Afghan Kitchen Recipes")
 
     def author(self):

--- a/recipe_scrapers/albertheijn.py
+++ b/recipe_scrapers/albertheijn.py
@@ -1,6 +1,7 @@
 import re
 
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 
@@ -8,6 +9,9 @@ class AlbertHeijn(AbstractScraper):
     @classmethod
     def host(cls):
         return "ah.nl"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Albert Heijn")
 
     def instructions(self):
         instructions = [

--- a/recipe_scrapers/archanaskitchen.py
+++ b/recipe_scrapers/archanaskitchen.py
@@ -7,6 +7,9 @@ class ArchanasKitchen(AbstractScraper):
     def host(cls):
         return "archanaskitchen.com"
 
+    def site_name(self):
+        return self.opengraph.site_name()
+
     def ingredient_groups(self):
         return group_ingredients(
             self.ingredients(),

--- a/recipe_scrapers/bettybossi.py
+++ b/recipe_scrapers/bettybossi.py
@@ -12,6 +12,10 @@ class BettyBossi(AbstractScraper):
     def host(cls):
         return "bettybossi.ch"
 
+    def site_name(self):
+        """ Self-titled website """
+        return self.author()
+
     def __init__(
         self,
         url: str,

--- a/recipe_scrapers/bettybossi.py
+++ b/recipe_scrapers/bettybossi.py
@@ -13,7 +13,7 @@ class BettyBossi(AbstractScraper):
         return "bettybossi.ch"
 
     def site_name(self):
-        """ Self-titled website """
+        """Self-titled website"""
         return self.author()
 
     def __init__(

--- a/recipe_scrapers/bongeats.py
+++ b/recipe_scrapers/bongeats.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 
@@ -6,6 +7,9 @@ class BongEats(AbstractScraper):
     @classmethod
     def host(cls):
         return "bongeats.com"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="Bong Eats")
 
     def ingredients(self):
         ingredients_div = self.soup.find(

--- a/recipe_scrapers/bongeats.py
+++ b/recipe_scrapers/bongeats.py
@@ -8,7 +8,7 @@ class BongEats(AbstractScraper):
     def host(cls):
         return "bongeats.com"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="Bong Eats")
 
     def ingredients(self):

--- a/recipe_scrapers/cookeatshare.py
+++ b/recipe_scrapers/cookeatshare.py
@@ -1,10 +1,14 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class CookEatShare(AbstractScraper):
     @classmethod
     def host(cls):
         return "cookeatshare.com"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="CookEatShare Cookbook")
 
     def total_time(self):
         return None

--- a/recipe_scrapers/cookeatshare.py
+++ b/recipe_scrapers/cookeatshare.py
@@ -7,7 +7,7 @@ class CookEatShare(AbstractScraper):
     def host(cls):
         return "cookeatshare.com"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="CookEatShare Cookbook")
 
     def total_time(self):

--- a/recipe_scrapers/cookpad.py
+++ b/recipe_scrapers/cookpad.py
@@ -7,5 +7,5 @@ class CookPad(AbstractScraper):
     def host(cls):
         return "cookpad.com"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="Cookpad")

--- a/recipe_scrapers/cookpad.py
+++ b/recipe_scrapers/cookpad.py
@@ -1,7 +1,11 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class CookPad(AbstractScraper):
     @classmethod
     def host(cls):
         return "cookpad.com"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="Cookpad")

--- a/recipe_scrapers/cooktalk.py
+++ b/recipe_scrapers/cooktalk.py
@@ -1,6 +1,6 @@
 from ._abstract import AbstractScraper
-from ._grouping_utils import group_ingredients
 from ._exceptions import StaticValueException
+from ._grouping_utils import group_ingredients
 
 
 class CookTalk(AbstractScraper):

--- a/recipe_scrapers/cooktalk.py
+++ b/recipe_scrapers/cooktalk.py
@@ -1,11 +1,15 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._exceptions import StaticValueException
 
 
 class CookTalk(AbstractScraper):
     @classmethod
     def host(cls):
         return "cook-talk.com"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="Cook-Talk")
 
     def author(self):
         author_element = self.soup.find("div", {"class": "article-content"}).find(

--- a/recipe_scrapers/cooktalk.py
+++ b/recipe_scrapers/cooktalk.py
@@ -8,7 +8,7 @@ class CookTalk(AbstractScraper):
     def host(cls):
         return "cook-talk.com"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="Cook-Talk")
 
     def author(self):

--- a/recipe_scrapers/costco.py
+++ b/recipe_scrapers/costco.py
@@ -11,7 +11,7 @@ class Costco(AbstractScraper):
     def author(self):
         return "Costco Connection"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="Costco")
 
     def title(self):

--- a/recipe_scrapers/costco.py
+++ b/recipe_scrapers/costco.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 
@@ -9,6 +10,9 @@ class Costco(AbstractScraper):
 
     def author(self):
         return "Costco Connection"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="Costco")
 
     def title(self):
         return self.soup.find("h1", style="font-size: 2.5em;").get_text()

--- a/recipe_scrapers/cybercook.py
+++ b/recipe_scrapers/cybercook.py
@@ -1,7 +1,11 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class Cybercook(AbstractScraper):
     @classmethod
     def host(cls):
         return "cybercook.com.br"
+
+    def site_name(self):
+        raise StaticValueException(return_value="CyberCook")

--- a/recipe_scrapers/finedininglovers.py
+++ b/recipe_scrapers/finedininglovers.py
@@ -5,3 +5,8 @@ class FineDiningLovers(AbstractScraper):
     @classmethod
     def host(cls):
         return "finedininglovers.com"
+
+    def site_name(self):
+        home_link = self.soup.find("a", {"rel": "home", "href": "/", "title": True})
+        if home_link:
+            return home_link["title"]

--- a/recipe_scrapers/food.py
+++ b/recipe_scrapers/food.py
@@ -1,7 +1,11 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class Food(AbstractScraper):
     @classmethod
     def host(cls):
         return "food.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Food.com")

--- a/recipe_scrapers/foodnetwork.py
+++ b/recipe_scrapers/foodnetwork.py
@@ -5,3 +5,9 @@ class FoodNetwork(AbstractScraper):
     @classmethod
     def host(cls, domain="co.uk"):
         return f"foodnetwork.{domain}"
+
+    def author(self):
+        return self.schema.data.get("copyrightNotice") or self.schema.author()
+
+    def site_name(self):
+        return self.schema.author()

--- a/recipe_scrapers/g750g.py
+++ b/recipe_scrapers/g750g.py
@@ -5,3 +5,6 @@ class G750g(AbstractScraper):
     @classmethod
     def host(cls):
         return "750g.com"
+
+    def site_name(self):
+        return self.opengraph.site_name()

--- a/recipe_scrapers/gesundaktiv.py
+++ b/recipe_scrapers/gesundaktiv.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 
@@ -6,6 +7,9 @@ class GesundAktiv(AbstractScraper):
     @classmethod
     def host(cls):
         return "gesund-aktiv.com"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="gesund + aktiv")
 
     def title(self):
         return self.soup.find("h1", {"class": "page-header"}).get_text()

--- a/recipe_scrapers/gesundaktiv.py
+++ b/recipe_scrapers/gesundaktiv.py
@@ -8,7 +8,7 @@ class GesundAktiv(AbstractScraper):
     def host(cls):
         return "gesund-aktiv.com"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="gesund + aktiv")
 
     def title(self):

--- a/recipe_scrapers/grouprecipes.py
+++ b/recipe_scrapers/grouprecipes.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -6,6 +7,9 @@ class GroupRecipes(AbstractScraper):
     @classmethod
     def host(cls):
         return "grouprecipes.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Group Recipes")
 
     def title(self):
         return normalize_string(self.soup.find("title").text)

--- a/recipe_scrapers/headbangerskitchen.py
+++ b/recipe_scrapers/headbangerskitchen.py
@@ -5,3 +5,6 @@ class HeadbangersKitchen(AbstractScraper):
     @classmethod
     def host(cls):
         return "headbangerskitchen.com"
+
+    def site_name(self):
+        return self.opengraph.site_name()

--- a/recipe_scrapers/hersheyland.py
+++ b/recipe_scrapers/hersheyland.py
@@ -1,14 +1,18 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_equipment
 
 
-class HerseyLand(AbstractScraper):
+class HersheyLand(AbstractScraper):
     @classmethod
     def host(cls):
         return "hersheyland.com"
 
     def author(self):
-        return "Herseyland"
+        raise StaticValueException(return_value="Hersheyland")
+
+    def site_name(self):
+        raise StaticValueException(return_value="Hersheyland")
 
     def equipment(self):
         equipment_items = [

--- a/recipe_scrapers/inbloombakery.py
+++ b/recipe_scrapers/inbloombakery.py
@@ -1,7 +1,11 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class InBloomBakery(AbstractScraper):
     @classmethod
     def host(cls):
         return "inbloombakery.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="In Bloom Bakery")

--- a/recipe_scrapers/innit.py
+++ b/recipe_scrapers/innit.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 """
     Note that innit hosts recipes for several companies.  I found it while looking at centralmarket.com
@@ -9,3 +10,6 @@ class Innit(AbstractScraper):
     @classmethod
     def host(cls, domain="com"):
         return f"innit.{domain}"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Innit")

--- a/recipe_scrapers/justbento.py
+++ b/recipe_scrapers/justbento.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_minutes, normalize_string
 
 
@@ -6,6 +7,9 @@ class JustBento(AbstractScraper):
     @classmethod
     def host(cls):
         return "justbento.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Just Bento")
 
     def title(self):
         expected_prefix = "Recipe: "

--- a/recipe_scrapers/kochbucher.py
+++ b/recipe_scrapers/kochbucher.py
@@ -1,10 +1,14 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class Kochbucher(AbstractScraper):
     @classmethod
     def host(cls):
         return "kochbucher.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Kochbucher")
 
     def title(self):
         return self.soup.find("h1", {"class": "post-title entry-title left"}).get_text()

--- a/recipe_scrapers/matprat.py
+++ b/recipe_scrapers/matprat.py
@@ -1,12 +1,16 @@
 from recipe_scrapers._grouping_utils import group_ingredients
 
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class Matprat(AbstractScraper):
     @classmethod
     def host(cls):
         return "matprat.no"
+
+    def site_name(self):
+        raise StaticValueException(return_value="MatPrat")
 
     def ingredient_groups(self):
         return group_ingredients(

--- a/recipe_scrapers/misya.py
+++ b/recipe_scrapers/misya.py
@@ -1,7 +1,11 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class Misya(AbstractScraper):
     @classmethod
     def host(cls):
         return "misya.info"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Ricette di Misya")

--- a/recipe_scrapers/mob.py
+++ b/recipe_scrapers/mob.py
@@ -1,6 +1,7 @@
 import json
 
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._grouping_utils import IngredientGroup
 
 
@@ -15,6 +16,9 @@ class Mob(AbstractScraper):
     @classmethod
     def host(cls):
         return "mob.co.uk"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Mob")
 
     def author(self):
         chefs = self.recipe_json.get("chefs", [])

--- a/recipe_scrapers/monsieurcuisine.py
+++ b/recipe_scrapers/monsieurcuisine.py
@@ -3,6 +3,7 @@ import re
 import requests
 
 from ._abstract import HEADERS, AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_yields
 
 SCRIPT_PATTERN = re.compile(r'"recipeId":(\d+)')
@@ -33,6 +34,9 @@ class MonsieurCuisine(AbstractScraper):
 
     def author(self):
         return self.data.get("data").get("recipe").get("author").get("name")
+
+    def site_name(self):
+        raise StaticValueException(return_value="Monsieur Cuisine")
 
     def cuisine(self):
         return None

--- a/recipe_scrapers/motherthyme.py
+++ b/recipe_scrapers/motherthyme.py
@@ -5,3 +5,8 @@ class MotherThyme(AbstractScraper):
     @classmethod
     def host(cls):
         return "motherthyme.com"
+
+    def site_name(self):
+        home_link = self.soup.find("a", {"rel": "home", "aria-label": True})
+        if home_link:
+            return home_link["aria-label"]

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from ._abstract import AbstractScraper
-from ._exceptions import ElementNotFoundInHtml
+from ._exceptions import ElementNotFoundInHtml, StaticValueException
 from ._grouping_utils import IngredientGroup
 from ._utils import get_minutes, get_yields, normalize_string
 
@@ -14,6 +14,9 @@ class NIHHealthyEating(AbstractScraper):
     def title(self):
         # This content must be present for all recipes on this website.
         return normalize_string(self.soup.h1.get_text())
+
+    def site_name(self):
+        raise StaticValueException(return_value="National Heart, Lung and Blood Institute")
 
     def total_time(self):
         # This content must be present for all recipes on this website.

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -16,7 +16,9 @@ class NIHHealthyEating(AbstractScraper):
         return normalize_string(self.soup.h1.get_text())
 
     def site_name(self):
-        raise StaticValueException(return_value="National Heart, Lung and Blood Institute")
+        raise StaticValueException(
+            return_value="National Heart, Lung and Blood Institute"
+        )
 
     def total_time(self):
         # This content must be present for all recipes on this website.

--- a/recipe_scrapers/paninihappy.py
+++ b/recipe_scrapers/paninihappy.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -6,6 +7,9 @@ class PaniniHappy(AbstractScraper):
     @classmethod
     def host(cls):
         return "paninihappy.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Panini Happy®")
 
     def title(self):
         return self.soup.find("h1", {"class": "entry-title"}).get_text()

--- a/recipe_scrapers/plugins/__init__.py
+++ b/recipe_scrapers/plugins/__init__.py
@@ -1,7 +1,7 @@
 from .exception_handling import ExceptionHandlingPlugin
 from .html_tags_stripper import HTMLTagStripperPlugin
 from .normalize_string import NormalizeStringPlugin
-from .opengraph_image_fetch import OpenGraphImageFetchPlugin  # NoQA
+from .opengraph_image_fetch import OpenGraphImageFetchPlugin
 from .opengraph_fill import OpenGraphFillPlugin
 from .schemaorg_fill import SchemaOrgFillPlugin
 from .static_values import StaticValueExceptionHandlingPlugin
@@ -11,6 +11,7 @@ __all__ = [
     "StaticValueExceptionHandlingPlugin",
     "HTMLTagStripperPlugin",
     "NormalizeStringPlugin",
+    "OpenGraphImageFetchPlugin",
     "OpenGraphFillPlugin",
     "SchemaOrgFillPlugin",
 ]

--- a/recipe_scrapers/plugins/__init__.py
+++ b/recipe_scrapers/plugins/__init__.py
@@ -1,8 +1,8 @@
 from .exception_handling import ExceptionHandlingPlugin
 from .html_tags_stripper import HTMLTagStripperPlugin
 from .normalize_string import NormalizeStringPlugin
-from .opengraph_image_fetch import OpenGraphImageFetchPlugin
 from .opengraph_fill import OpenGraphFillPlugin
+from .opengraph_image_fetch import OpenGraphImageFetchPlugin
 from .schemaorg_fill import SchemaOrgFillPlugin
 from .static_values import StaticValueExceptionHandlingPlugin
 

--- a/recipe_scrapers/plugins/__init__.py
+++ b/recipe_scrapers/plugins/__init__.py
@@ -1,7 +1,8 @@
 from .exception_handling import ExceptionHandlingPlugin
 from .html_tags_stripper import HTMLTagStripperPlugin
 from .normalize_string import NormalizeStringPlugin
-from .opengraph_image_fetch import OpenGraphImageFetchPlugin
+from .opengraph_image_fetch import OpenGraphImageFetchPlugin  # NoQA
+from .opengraph_fill import OpenGraphFillPlugin
 from .schemaorg_fill import SchemaOrgFillPlugin
 from .static_values import StaticValueExceptionHandlingPlugin
 
@@ -10,6 +11,6 @@ __all__ = [
     "StaticValueExceptionHandlingPlugin",
     "HTMLTagStripperPlugin",
     "NormalizeStringPlugin",
-    "OpenGraphImageFetchPlugin",
+    "OpenGraphFillPlugin",
     "SchemaOrgFillPlugin",
 ]

--- a/recipe_scrapers/plugins/opengraph_fill.py
+++ b/recipe_scrapers/plugins/opengraph_fill.py
@@ -10,37 +10,17 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-class SchemaOrgFillPlugin(PluginInterface):
+class OpenGraphFillPlugin(PluginInterface):
     """
     If any of the methods listed is invoked on a scraper class
-    that happens not to be implement and Schema.org is available
-    attempt to return the results from the schema available.
+    that happens not to be implemented, attempt to return results
+    by checking for OpenGraph metadata.
     """
 
     run_on_hosts = ("*",)
     run_on_methods = (
-        "author",
         "site_name",
-        "title",
-        "category",
-        "total_time",
-        "yields",
         "image",
-        "ingredients",
-        "instructions",
-        "ratings",
-        "reviews",
-        "links",
-        "language",
-        "nutrients",
-        "cooking_method",
-        "cuisine",
-        "description",
-        "cook_time",
-        "prep_time",
-        "keywords",
-        "ratings_count",
-        "dietary_restrictions",
     )
 
     @classmethod
@@ -51,15 +31,16 @@ class SchemaOrgFillPlugin(PluginInterface):
             class_name = self.__class__.__name__
             method_name = decorated.__name__
             logger.debug(
-                f"Decorating: {class_name}.{method_name}() with SchemaOrgFillPlugin"
+                f"Decorating: {class_name}.{method_name}() with OpenGraphFillPlugin"
             )
+
             try:
                 return decorated(self, *args, **kwargs)
             except (FillPluginException, NotImplementedError) as e:
-                function = getattr(self.schema, decorated.__name__)
-                if self.schema.data and function:
+                function = getattr(self.opengraph, decorated.__name__)
+                if self.opengraph.soup and function:
                     logger.info(
-                        f"{class_name}.{method_name}() seems to not be implemented but .schema is available! Attempting to return result from SchemaOrg."
+                        f"{class_name}.{method_name}() seems not to be implemented but OpenGraph metadata may be available. Attempting to return result from OpenGraph."
                     )
                     return function(*args, **kwargs)
                 else:

--- a/recipe_scrapers/przepisy.py
+++ b/recipe_scrapers/przepisy.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_yields, normalize_string
 
 
@@ -6,6 +7,9 @@ class Przepisy(AbstractScraper):
     @classmethod
     def host(cls):
         return "przepisy.pl"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Przepisy.pl")
 
     def yields(self):
         return get_yields(self.soup.find("div", {"class": "person-count"}))

--- a/recipe_scrapers/purplecarrot.py
+++ b/recipe_scrapers/purplecarrot.py
@@ -6,5 +6,10 @@ class PurpleCarrot(AbstractScraper):
     def host(cls):
         return "purplecarrot.com"
 
+    def site_name(self):
+        home_link = self.soup.find("a", {"href": "/", "title": True})
+        if home_link:
+            return home_link["title"]
+
     def nutrients(self):
         return self.schema.nutrients()

--- a/recipe_scrapers/rezeptwelt.py
+++ b/recipe_scrapers/rezeptwelt.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._exceptions import SchemaOrgException
+from ._exceptions import SchemaOrgException, StaticValueException
 from ._utils import normalize_string
 
 
@@ -7,6 +7,9 @@ class Rezeptwelt(AbstractScraper):
     @classmethod
     def host(cls):
         return "rezeptwelt.de"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Rezeptwelt")
 
     def author(self):
         return normalize_string(self.soup.find("span", {"id": "viewRecipeAuthor"}).text)

--- a/recipe_scrapers/ricetta.py
+++ b/recipe_scrapers/ricetta.py
@@ -1,10 +1,14 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class Ricetta(AbstractScraper):
     @classmethod
     def host(cls):
         return "ricetta.it"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Ricetta.it")
 
     def instructions(self):
         instructions_list = []

--- a/recipe_scrapers/saboresajinomoto.py
+++ b/recipe_scrapers/saboresajinomoto.py
@@ -1,12 +1,16 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._grouping_utils import group_ingredients
 from ._utils import normalize_string
 
 
-class SaboresAnjinomoto(AbstractScraper):
+class SaboresAjinomoto(AbstractScraper):
     @classmethod
     def host(cls):
         return "saboresajinomoto.com.br"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Sabores Ajinomoto")
 
     def title(self):
         return self.schema.title().capitalize()

--- a/recipe_scrapers/sallysblog.py
+++ b/recipe_scrapers/sallysblog.py
@@ -1,6 +1,7 @@
 from urllib.parse import unquote
 
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_minutes, normalize_string
 
 
@@ -8,6 +9,9 @@ class SallysBlog(AbstractScraper):
     @classmethod
     def host(cls):
         return "sallys-blog.de"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Sallys Blog")
 
     def title(self):
         return normalize_string(self.soup.head.find("title").get_text())

--- a/recipe_scrapers/settings/default.py
+++ b/recipe_scrapers/settings/default.py
@@ -2,7 +2,7 @@ from recipe_scrapers.plugins import (
     ExceptionHandlingPlugin,
     HTMLTagStripperPlugin,
     NormalizeStringPlugin,
-    OpenGraphImageFetchPlugin,
+    OpenGraphFillPlugin,
     SchemaOrgFillPlugin,
     StaticValueExceptionHandlingPlugin,
 )
@@ -15,7 +15,7 @@ PLUGINS = (
     StaticValueExceptionHandlingPlugin,
     HTMLTagStripperPlugin,
     NormalizeStringPlugin,
-    OpenGraphImageFetchPlugin,
+    OpenGraphFillPlugin,
     SchemaOrgFillPlugin,
 )
 

--- a/recipe_scrapers/settings/default.py
+++ b/recipe_scrapers/settings/default.py
@@ -2,6 +2,7 @@ from recipe_scrapers.plugins import (
     ExceptionHandlingPlugin,
     HTMLTagStripperPlugin,
     NormalizeStringPlugin,
+    OpenGraphImageFetchPlugin,
     OpenGraphFillPlugin,
     SchemaOrgFillPlugin,
     StaticValueExceptionHandlingPlugin,
@@ -15,6 +16,7 @@ PLUGINS = (
     StaticValueExceptionHandlingPlugin,
     HTMLTagStripperPlugin,
     NormalizeStringPlugin,
+    OpenGraphImageFetchPlugin,
     OpenGraphFillPlugin,
     SchemaOrgFillPlugin,
 )

--- a/recipe_scrapers/settings/default.py
+++ b/recipe_scrapers/settings/default.py
@@ -2,8 +2,8 @@ from recipe_scrapers.plugins import (
     ExceptionHandlingPlugin,
     HTMLTagStripperPlugin,
     NormalizeStringPlugin,
-    OpenGraphImageFetchPlugin,
     OpenGraphFillPlugin,
+    OpenGraphImageFetchPlugin,
     SchemaOrgFillPlugin,
     StaticValueExceptionHandlingPlugin,
 )

--- a/recipe_scrapers/simplycookit.py
+++ b/recipe_scrapers/simplycookit.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 
@@ -6,6 +7,9 @@ class SimplyCookit(AbstractScraper):
     @classmethod
     def host(cls):
         return "simply-cookit.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Simply Cookit")
 
     def ingredients(self):
         ingredients = []

--- a/recipe_scrapers/sunbasket.py
+++ b/recipe_scrapers/sunbasket.py
@@ -7,6 +7,9 @@ class SunBasket(AbstractScraper):
     def host(cls, domain="com"):
         return f"sunbasket.{domain}"
 
+    def site_name(self):
+        return self.author()
+
     def _instructions_list(self):
         instructions_container = self.soup.find(
             "div", {"class": "instructions-container"}

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -10,6 +10,12 @@ class TastyKitchen(AbstractScraper):
     def title(self):
         return self.soup.find("h1", {"itemprop": "name"}).get_text()
 
+    def site_name(self):
+        current_selection = next(iter(self.soup.select("div.tpw-network a.selected")), None)
+        if not current_selection:
+            raise StaticValueException(return_value="Tasty Kitchen")
+        return current_selection.text
+
     def ingredients(self):
         ingredients = self.soup.find("ul", {"class": "ingredients"}).findAll("li")
 

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 

--- a/recipe_scrapers/tastykitchen.py
+++ b/recipe_scrapers/tastykitchen.py
@@ -12,7 +12,9 @@ class TastyKitchen(AbstractScraper):
         return self.soup.find("h1", {"itemprop": "name"}).get_text()
 
     def site_name(self):
-        current_selection = next(iter(self.soup.select("div.tpw-network a.selected")), None)
+        current_selection = next(
+            iter(self.soup.select("div.tpw-network a.selected")), None
+        )
         if not current_selection:
             raise StaticValueException(return_value="Tasty Kitchen")
         return current_selection.text

--- a/recipe_scrapers/thevintagemixer.py
+++ b/recipe_scrapers/thevintagemixer.py
@@ -1,7 +1,11 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class TheVintageMixer(AbstractScraper):
     @classmethod
     def host(cls):
         return "thevintagemixer.com"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="Vintage Mixer")

--- a/recipe_scrapers/thevintagemixer.py
+++ b/recipe_scrapers/thevintagemixer.py
@@ -7,5 +7,5 @@ class TheVintageMixer(AbstractScraper):
     def host(cls):
         return "thevintagemixer.com"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="Vintage Mixer")

--- a/recipe_scrapers/timesofindia.py
+++ b/recipe_scrapers/timesofindia.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 
@@ -6,6 +7,9 @@ class TimesOfIndia(AbstractScraper):
     @classmethod
     def host(cls):
         return "recipes.timesofindia.com"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Times of India - Recipes")
 
     def ingredients(self):
         ingredients = self.soup.find_all("label", attrs={"class": "clearfix"})

--- a/recipe_scrapers/usdamyplate.py
+++ b/recipe_scrapers/usdamyplate.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -6,6 +7,9 @@ class USDAMyPlate(AbstractScraper):
     @classmethod
     def host(cls):
         return "myplate.gov"
+
+    def site_name(self):
+        raise StaticValueException(return_value="MyPlate")
 
     def title(self):
         return self.soup.h1.get_text().strip()

--- a/recipe_scrapers/vegetarbloggen.py
+++ b/recipe_scrapers/vegetarbloggen.py
@@ -1,10 +1,14 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 
 
 class Vegetarbloggen(AbstractScraper):
     @classmethod
     def host(cls):
         return "vegetarbloggen.no"
+
+    def site_name(self):
+        raise StaticValueException(return_value="Vegetarbloggen")
 
     def instructions(self):
         return self.schema.instructions().strip()

--- a/recipe_scrapers/waitrose.py
+++ b/recipe_scrapers/waitrose.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 
@@ -8,7 +9,14 @@ class Waitrose(AbstractScraper):
         return "waitrose.com"
 
     def author(self):
-        return "waitrose.com"
+        raise StaticValueException(return_value="Waitrose")
+
+    def site_name(self):
+        logo = next(iter(self.soup.select("div.logo")), None)
+        if not logo:
+            raise StaticValueException(return_value="Waitrose")
+        if home_link := logo.find("a", {"href": "/"}):
+            return home_link.text
 
     def image(self):
         img_tag = self.soup.find("img", {"itemprop": "image"})

--- a/recipe_scrapers/weightwatcherspublic.py
+++ b/recipe_scrapers/weightwatcherspublic.py
@@ -1,3 +1,4 @@
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 from .weightwatchers import WeightWatchers
 
@@ -14,7 +15,6 @@ class WeightWatchersPublic(WeightWatchers):
             raise StaticValueException(return_value="WeightWatchers")
         _recipe, _delimiter, site_name = title.text.rpartition("|")
         return site_name.lstrip()
-
 
     def _find_data_container(self):
         return self.soup.find("div", {"class": "HorizontalList_list__GESs0"})

--- a/recipe_scrapers/weightwatcherspublic.py
+++ b/recipe_scrapers/weightwatcherspublic.py
@@ -8,6 +8,14 @@ class WeightWatchersPublic(WeightWatchers):
     def host(cls):
         return "weightwatchers.com"
 
+    def site_name(self):
+        title = self.soup.find("title")
+        if not title:
+            raise StaticValueException(return_value="WeightWatchers")
+        _recipe, _delimiter, site_name = title.text.rpartition("|")
+        return site_name.lstrip()
+
+
     def _find_data_container(self):
         return self.soup.find("div", {"class": "HorizontalList_list__GESs0"})
 

--- a/recipe_scrapers/wikicookbook.py
+++ b/recipe_scrapers/wikicookbook.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import get_minutes, get_yields, normalize_string
 
 
@@ -6,6 +7,9 @@ class WikiCookbook(AbstractScraper):
     @classmethod
     def host(cls):
         return "en.wikibooks.org"
+
+    def site_name(cls):
+        raise StaticValueException(return_value="Wikibooks")
 
     def title(self):
         return self.soup.find("h1").get_text().replace("Cookbook:", "")

--- a/recipe_scrapers/wikicookbook.py
+++ b/recipe_scrapers/wikicookbook.py
@@ -8,7 +8,7 @@ class WikiCookbook(AbstractScraper):
     def host(cls):
         return "en.wikibooks.org"
 
-    def site_name(cls):
+    def site_name(self):
         raise StaticValueException(return_value="Wikibooks")
 
     def title(self):

--- a/recipe_scrapers/woolworths.py
+++ b/recipe_scrapers/woolworths.py
@@ -1,7 +1,6 @@
 import requests
 
 from ._abstract import HEADERS, AbstractScraper
-from ._schemaorg import SchemaOrg
 from ._utils import url_path_to_dict
 
 
@@ -12,7 +11,7 @@ class Woolworths(AbstractScraper):
         target = url_path_to_dict(url)["path"].split("/")[-1]
         data_url = f"https://foodhub.woolworths.com.au/content/woolworths-foodhub/en/{target}.model.json"
 
-        self.page_data = (
+        self.schema.data = (
             requests.get(
                 data_url,
                 headers=HEADERS,
@@ -25,7 +24,6 @@ class Woolworths(AbstractScraper):
             .get(":items")
             .get("recipe_seo_data")
         )
-        self.schema = SchemaOrg(self.page_data, raw=True)
 
     @classmethod
     def host(cls):

--- a/recipe_scrapers/yummly.py
+++ b/recipe_scrapers/yummly.py
@@ -10,6 +10,13 @@ class Yummly(AbstractScraper):
     def author(self):
         return self.soup.find("a", {"class": "markdown-link"}).get_text()
 
+    def site_name(self):
+        title = self.soup.find("title")
+        if not title:
+            raise StaticValueException(return_value="Yummly")
+        _recipe, _delimiter, site_name = title.text.rpartition("|")
+        return site_name.lstrip()
+
     def ingredients(self):
         ingredients = self.soup.findAll("li", {"class": "IngredientLine"})
 

--- a/recipe_scrapers/yummly.py
+++ b/recipe_scrapers/yummly.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._exceptions import StaticValueException
 from ._utils import normalize_string
 
 

--- a/tests/legacy/test_monsieurcuisine.py
+++ b/tests/legacy/test_monsieurcuisine.py
@@ -96,7 +96,7 @@ class TestMonsieurCuisineScraper(ScraperTest):
         self.assertEqual(None, self.harvester_class.cuisine())
 
     def test_site_name(self):
-        self.assertEqual(None, self.harvester_class.site_name())
+        self.assertEqual("Monsieur Cuisine", self.harvester_class.site_name())
 
     def test_category(self):
         self.assertEqual(

--- a/tests/test_data/afghankitchenrecipes.com/afghankitchenrecipes.json
+++ b/tests/test_data/afghankitchenrecipes.com/afghankitchenrecipes.json
@@ -1,7 +1,7 @@
 {
   "author": "nash",
   "canonical_url": "http://www.afghankitchenrecipes.com/recipe/mantu-beef-dumplings/",
-  "site_name": null,
+  "site_name": "Afghan Kitchen Recipes",
   "host": "afghankitchenrecipes.com",
   "language": "en-US",
   "title": "Mantu (Beef Dumplings)",

--- a/tests/test_data/ah.nl/albertheijn.json
+++ b/tests/test_data/ah.nl/albertheijn.json
@@ -1,7 +1,7 @@
 {
   "author": "Albert Heijn",
   "canonical_url": "ah.nl",
-  "site_name": null,
+  "site_name": "Albert Heijn",
   "host": "ah.nl",
   "language": "nl",
   "title": "Rijkgevulde vegan pastasalade",

--- a/tests/test_data/bbcgoodfood.com/bbcgoodfood.json
+++ b/tests/test_data/bbcgoodfood.com/bbcgoodfood.json
@@ -1,7 +1,7 @@
 {
   "author": "Elena Silcock",
   "canonical_url": "https://www.bbcgoodfood.com/recipes/summer-meatballs-spaghetti",
-  "site_name": null,
+  "site_name": "BBC Good Food",
   "host": "bbcgoodfood.com",
   "language": "en",
   "title": "Summer meatballs & spaghetti",

--- a/tests/test_data/bbcgoodfood.com/bbcgoodfood_groups.json
+++ b/tests/test_data/bbcgoodfood.com/bbcgoodfood_groups.json
@@ -1,7 +1,7 @@
 {
   "author": "Good Food team",
   "canonical_url": "https://www.bbcgoodfood.com/recipes/monster-cupcakes",
-  "site_name": null,
+  "site_name": "BBC Good Food",
   "host": "bbcgoodfood.com",
   "language": "en",
   "title": "Monster cupcakes",

--- a/tests/test_data/bettybossi.ch/bettybossi.json
+++ b/tests/test_data/bettybossi.ch/bettybossi.json
@@ -1,7 +1,7 @@
 {
   "author": "Betty Bossi",
   "canonical_url": "bettybossi.ch",
-  "site_name": null,
+  "site_name": "Betty Bossi",
   "host": "bettybossi.ch",
   "language": "fr",
   "title": "Minicheesecakes",

--- a/tests/test_data/bongeats.com/bongeats.json
+++ b/tests/test_data/bongeats.com/bongeats.json
@@ -1,7 +1,7 @@
 {
   "author": "Bong Eats",
   "canonical_url": "bongeats.com",
-  "site_name": null,
+  "site_name": "Bong Eats",
   "host": "bongeats.com",
   "language": "en",
   "title": "Lau Chingri",

--- a/tests/test_data/chefkoch.de/chefkoch.json
+++ b/tests/test_data/chefkoch.de/chefkoch.json
@@ -1,7 +1,7 @@
 {
   "author": "Delphinella",
   "canonical_url": "https://www.chefkoch.de/rezepte/1170311223132029/Hackbraten-supersaftig.html",
-  "site_name": "Chefkoch.de",
+  "site_name": "Chefkoch",
   "host": "chefkoch.de",
   "language": "de",
   "title": "Saftiger Hackbraten im Ofen",

--- a/tests/test_data/cook-talk.com/cooktalk_1.json
+++ b/tests/test_data/cook-talk.com/cooktalk_1.json
@@ -1,7 +1,7 @@
 {
   "author": "Лариса Ивановна",
   "canonical_url": "https://cook-talk.com/?p=3163",
-  "site_name": null,
+  "site_name": "Cook-Talk",
   "host": "cook-talk.com",
   "language": "ru-RU",
   "title": "Курица с сыром пармезан",

--- a/tests/test_data/cook-talk.com/cooktalk_2.json
+++ b/tests/test_data/cook-talk.com/cooktalk_2.json
@@ -1,7 +1,7 @@
 {
   "author": "Гаспадыня",
   "canonical_url": "https://cook-talk.com/?p=10440",
-  "site_name": null,
+  "site_name": "Cook-Talk",
   "host": "cook-talk.com",
   "language": "ru-RU",
   "title": "Шоколадные маффины с крим-чизом",

--- a/tests/test_data/cookeatshare.com/cookeatshare.json
+++ b/tests/test_data/cookeatshare.com/cookeatshare.json
@@ -1,7 +1,7 @@
 {
   "author": "CookEatShare Cookbook",
   "canonical_url": "cookeatshare.com",
-  "site_name": null,
+  "site_name": "CookEatShare Cookbook",
   "host": "cookeatshare.com",
   "title": "Pork Steak Vegetable Bake",
   "ingredients": [

--- a/tests/test_data/cookpad.com/cookpad.json
+++ b/tests/test_data/cookpad.com/cookpad.json
@@ -1,7 +1,7 @@
 {
   "author": "reoririna",
   "canonical_url": "https://cookpad.com/recipe/4610651",
-  "site_name": null,
+  "site_name": "Cookpad",
   "host": "cookpad.com",
   "language": "ja",
   "title": "30分で簡単♡本格バターチキンカレー♡",

--- a/tests/test_data/costco.com/costco.json
+++ b/tests/test_data/costco.com/costco.json
@@ -1,7 +1,7 @@
 {
   "author": "Costco Connection",
   "canonical_url": "costco.com",
-  "site_name": null,
+  "site_name": "Costco",
   "host": "costco.com",
   "language": "en-us",
   "title": "Chicken Salad with Red Grapes, Walnuts and Blue Cheese",

--- a/tests/test_data/cybercook.com.br/cybercook.json
+++ b/tests/test_data/cybercook.com.br/cybercook.json
@@ -1,7 +1,7 @@
 {
   "author": "Leticia Obo Andreghetti",
   "canonical_url": "https://cybercook.com.br/receitas/aves/strogonoff-de-frango-16644",
-  "site_name": null,
+  "site_name": "CyberCook",
   "host": "cybercook.com.br",
   "language": "pt-BR",
   "title": "Strogonoff de Frango",

--- a/tests/test_data/eatwhattonight.com/eatwhattonight.json
+++ b/tests/test_data/eatwhattonight.com/eatwhattonight.json
@@ -1,7 +1,7 @@
 {
   "author": "Eat What Tonight",
   "canonical_url": "https://eatwhattonight.com/2020/08/ginger-soya-chicken/",
-  "site_name": "Eat What Tonight - Singapore Food & Lifestyle Blog",
+  "site_name": "Eat What Tonight",
   "host": "eatwhattonight.com",
   "language": "en-US",
   "title": "Ginger Soya Chicken",

--- a/tests/test_data/en.wikibooks.org/wikicookbook.json
+++ b/tests/test_data/en.wikibooks.org/wikicookbook.json
@@ -1,6 +1,6 @@
 {
   "canonical_url": "https://en.wikibooks.org/wiki/Cookbook:Pumpkin_Pie",
-  "site_name": null,
+  "site_name": "Wikibooks",
   "host": "en.wikibooks.org",
   "language": "en",
   "title": "Pumpkin Pie",

--- a/tests/test_data/finedininglovers.com/finedininglovers.json
+++ b/tests/test_data/finedininglovers.com/finedininglovers.json
@@ -1,7 +1,7 @@
 {
   "author": "<a href=\"/people/uno-cookbook\" hreflang=\"en\">Uno Cookbook</a>",
   "canonical_url": "https://www.finedininglovers.com/recipes/main-course/zucchini-raw-vegan-lasagna",
-  "site_name": null,
+  "site_name": "Fine Dining Lovers",
   "host": "finedininglovers.com",
   "language": "en",
   "title": "Zucchini Raw Vegan Lasagna",

--- a/tests/test_data/food.com/food.json
+++ b/tests/test_data/food.com/food.json
@@ -1,7 +1,7 @@
 {
   "author": "JackieOhNo!",
   "canonical_url": "https://www.food.com/recipe/chicken-noodle-soup-with-carrots-parsnips-and-dill-454415",
-  "site_name": null,
+  "site_name": "Food.com",
   "host": "food.com",
   "language": "en",
   "title": "Chicken Noodle Soup With Carrots, Parsnips and Dill",

--- a/tests/test_data/foodnetwork.co.uk/foodnetwork.json
+++ b/tests/test_data/foodnetwork.co.uk/foodnetwork.json
@@ -1,7 +1,7 @@
 {
-  "author": "Food Network UK",
+  "author": "Recipe courtesy Giada De Laurentiis",
   "canonical_url": "https://foodnetwork.co.uk/recipes/tuscan-mushrooms-5389",
-  "site_name": null,
+  "site_name": "Food Network UK",
   "host": "foodnetwork.co.uk",
   "language": "en",
   "title": "Tuscan mushrooms",

--- a/tests/test_data/gesund-aktiv.com/gesundaktiv.json
+++ b/tests/test_data/gesund-aktiv.com/gesundaktiv.json
@@ -1,6 +1,6 @@
 {
   "canonical_url": "https://www.gesund-aktiv.com/rezepte/fruehstueck/suesse-spinat-pancakes",
-  "site_name": null,
+  "site_name": "gesund + aktiv",
   "host": "gesund-aktiv.com",
   "language": "de",
   "title": "Süße Spinat-Pancakes",

--- a/tests/test_data/grouprecipes.com/grouprecipes.json
+++ b/tests/test_data/grouprecipes.com/grouprecipes.json
@@ -1,7 +1,7 @@
 {
   "author": "MountainMamas",
   "canonical_url": "grouprecipes.com",
-  "site_name": null,
+  "site_name": "Group Recipes",
   "host": "grouprecipes.com",
   "language": "en",
   "title": "Slow Cooker Chicken & Biscuits Recipe",

--- a/tests/test_data/healthyeating.nhlbi.nih.gov/nihhealthyeating_3.json
+++ b/tests/test_data/healthyeating.nhlbi.nih.gov/nihhealthyeating_3.json
@@ -1,6 +1,6 @@
 {
   "canonical_url": "healthyeating.nhlbi.nih.gov",
-  "site_name": null,
+  "site_name": "National Heart, Lung and Blood Institute",
   "host": "healthyeating.nhlbi.nih.gov",
   "title": "Fruit Skewers With Yogurt Dip",
   "ingredients": [

--- a/tests/test_data/hersheyland.com/herseyland.json
+++ b/tests/test_data/hersheyland.com/herseyland.json
@@ -1,7 +1,7 @@
 {
-  "author": "Herseyland",
+  "author": "Hersheyland",
   "canonical_url": "hersheyland.com",
-  "site_name": null,
+  "site_name": "Hersheyland",
   "host": "hersheyland.com",
   "language": "en-US",
   "title": "HERSHEY'S \"Perfectly Chocolate\" Chocolate Cake Recipe | Hersheyland",

--- a/tests/test_data/inbloombakery.com/inbloombakery.json
+++ b/tests/test_data/inbloombakery.com/inbloombakery.json
@@ -1,7 +1,7 @@
 {
   "author": "Ginny Dyer",
   "canonical_url": "https://inbloombakery.com/the-best-cinnamon-rolls-ever/",
-  "site_name": "In Bloom Bakery -",
+  "site_name": "In Bloom Bakery",
   "host": "inbloombakery.com",
   "language": "en-US",
   "title": "The Best Cinnamon Rolls Ever",

--- a/tests/test_data/innit.com/innit.json
+++ b/tests/test_data/innit.com/innit.json
@@ -1,7 +1,7 @@
 {
   "author": "Innit Inc",
   "canonical_url": "innit.com",
-  "site_name": null,
+  "site_name": "Innit",
   "host": "innit.com",
   "language": "en",
   "title": "Tofu Mixed Greens Salad with Broccoli Beet Mix & Carrot Ginger Dressing",

--- a/tests/test_data/justbento.com/justbento.json
+++ b/tests/test_data/justbento.com/justbento.json
@@ -1,6 +1,6 @@
 {
   "canonical_url": "https://justbento.com/handbook/recipes-sides-and-fillers/bento-filler-orange-juice-carrots",
-  "site_name": null,
+  "site_name": "Just Bento",
   "host": "justbento.com",
   "language": "en",
   "title": "Bento Filler: Orange Juice Carrots",

--- a/tests/test_data/kochbucher.com/kochbucher.json
+++ b/tests/test_data/kochbucher.com/kochbucher.json
@@ -1,7 +1,7 @@
 {
   "author": "Kochbucher",
   "canonical_url": "https://kochbucher.com/putengeschnetzeltes-mit-reis-und-blattsalat/",
-  "site_name": null,
+  "site_name": "Kochbucher",
   "host": "kochbucher.com",
   "language": "en-US",
   "title": "Putengeschnetzeltes mit Reis und Blattsalat",

--- a/tests/test_data/madsvin.com/madsvin.json
+++ b/tests/test_data/madsvin.com/madsvin.json
@@ -1,7 +1,7 @@
 {
   "author": "Mads Vindfeld Andersen",
   "canonical_url": "https://madsvin.com/pandekager/",
-  "site_name": "madsvin.com",
+  "site_name": "Madsvin.com",
   "host": "madsvin.com",
   "language": "da-DK",
   "title": "Pandekager",

--- a/tests/test_data/matprat.no/matprat_1.json
+++ b/tests/test_data/matprat.no/matprat_1.json
@@ -1,7 +1,7 @@
 {
   "author": "MatPrat",
   "canonical_url": "https://www.matprat.no/oppskrifter/gjester/butter-chicken---indisk-smorkylling/",
-  "site_name": null,
+  "site_name": "MatPrat",
   "host": "matprat.no",
   "language": "no",
   "title": "Butter chicken - indisk smørkylling",

--- a/tests/test_data/matprat.no/matprat_2.json
+++ b/tests/test_data/matprat.no/matprat_2.json
@@ -1,7 +1,7 @@
 {
   "author": "MatPrat",
   "canonical_url": "https://www.matprat.no/oppskrifter/sunn/mangosalat/",
-  "site_name": null,
+  "site_name": "MatPrat",
   "host": "matprat.no",
   "language": "no",
   "title": "Mangosalat",

--- a/tests/test_data/misya.info/misya.json
+++ b/tests/test_data/misya.info/misya.json
@@ -1,7 +1,7 @@
 {
   "author": "Flavia Imperatore",
   "canonical_url": "https://www.misya.info/ricetta/tortino-cuore-caldo.htm",
-  "site_name": null,
+  "site_name": "Ricette di Misya",
   "host": "misya.info",
   "language": "it",
   "title": "Tortino cuore caldo",

--- a/tests/test_data/mob.co.uk/mob_2.json
+++ b/tests/test_data/mob.co.uk/mob_2.json
@@ -1,7 +1,7 @@
 {
   "author": "Christina Soteriou",
   "canonical_url": "mob.co.uk",
-  "site_name": null,
+  "site_name": "Mob",
   "host": "mob.co.uk",
   "language": "en",
   "title": "Speedy Udon Miso Noodle Soup",

--- a/tests/test_data/motherthyme.com/motherthyme.json
+++ b/tests/test_data/motherthyme.com/motherthyme.json
@@ -1,7 +1,7 @@
 {
   "author": "Jenn (Mother Thyme)",
   "canonical_url": "https://www.motherthyme.com/2014/01/cinnamon-roll-oatmeal.html",
-  "site_name": null,
+  "site_name": "Mother Thyme",
   "host": "motherthyme.com",
   "language": "en-US",
   "title": "Cinnamon Roll Oatmeal",

--- a/tests/test_data/myplate.gov/usdamyplate.json
+++ b/tests/test_data/myplate.gov/usdamyplate.json
@@ -1,7 +1,7 @@
 {
   "author": "MyPlate",
   "canonical_url": "https://www.myplate.gov/recipes/supplemental-nutrition-assistance-program-snap/fabulous-fig-bars",
-  "site_name": null,
+  "site_name": "MyPlate",
   "host": "myplate.gov",
   "language": "en",
   "title": "Fabulous Fig Bars",

--- a/tests/test_data/nutritionfacts.org/nutritionfacts_1.json
+++ b/tests/test_data/nutritionfacts.org/nutritionfacts_1.json
@@ -1,7 +1,7 @@
 {
   "author": "Michael Greger M.D. FACLM",
   "canonical_url": "https://nutritionfacts.org/recipe/sweet-potato-taquitos/",
-  "site_name": null,
+  "site_name": "NutritionFacts.org",
   "host": "nutritionfacts.org",
   "language": "en-US",
   "title": "Sweet Potato Taquitos",

--- a/tests/test_data/nutritionfacts.org/nutritionfacts_2.json
+++ b/tests/test_data/nutritionfacts.org/nutritionfacts_2.json
@@ -1,7 +1,7 @@
 {
   "author": "Jill Dalton from the Whole Food Plant Based Cooking Show",
   "canonical_url": "https://nutritionfacts.org/recipe/cinnamon-roll-oatmeal/",
-  "site_name": null,
+  "site_name": "NutritionFacts.org",
   "host": "nutritionfacts.org",
   "language": "en-US",
   "title": "Cinnamon Roll Oatmeal",

--- a/tests/test_data/paninihappy.com/paninihappy.json
+++ b/tests/test_data/paninihappy.com/paninihappy.json
@@ -1,6 +1,6 @@
 {
   "canonical_url": "https://paninihappy.com/grilled-mac-cheese-with-bbq-pulled-pork/",
-  "site_name": null,
+  "site_name": "Panini Happy®",
   "host": "paninihappy.com",
   "language": "en-US",
   "title": "Grilled Mac & Cheese with BBQ Pulled Pork",

--- a/tests/test_data/przepisy.pl/przepisy.json
+++ b/tests/test_data/przepisy.pl/przepisy.json
@@ -1,7 +1,7 @@
 {
   "author": "przepisy.pl",
   "canonical_url": "https://www.przepisy.pl/przepis/placki-ziemniaczane",
-  "site_name": null,
+  "site_name": "Przepisy.pl",
   "host": "przepisy.pl",
   "language": "pl-PL",
   "title": "Placki ziemniaczane",

--- a/tests/test_data/purplecarrot.com/purplecarrot.json
+++ b/tests/test_data/purplecarrot.com/purplecarrot.json
@@ -1,7 +1,7 @@
 {
   "author": "Purple Carrot",
   "canonical_url": "https://www.purplecarrot.com/recipe/roasted-cauliflower-lentil-bowl-with-avocado-curried-balsamic-vinaigrette",
-  "site_name": null,
+  "site_name": "Purple Carrot",
   "host": "purplecarrot.com",
   "language": "en",
   "title": "Roasted Cauliflower Lentil Bowl with Avocado & Curried Balsamic Vinaigrette",

--- a/tests/test_data/recipes.timesofindia.com/timesofindia.json
+++ b/tests/test_data/recipes.timesofindia.com/timesofindia.json
@@ -1,7 +1,7 @@
 {
   "author": "TNN",
   "canonical_url": "https://recipes.timesofindia.com/us/recipes/stuffed-tortellini/rs71330969.cms",
-  "site_name": null,
+  "site_name": "Times of India - Recipes",
   "host": "recipes.timesofindia.com",
   "language": "en",
   "title": "Stuffed Tortellini Recipe",

--- a/tests/test_data/reishunger.de/reishunger_1.json
+++ b/tests/test_data/reishunger.de/reishunger_1.json
@@ -1,7 +1,7 @@
 {
   "author": "pommesherz",
   "canonical_url": "https://www.reishunger.de/rezepte/rezept/2743/crispy-tofu-bowl",
-  "site_name": "https://www.reishunger.de",
+  "site_name": "Reishunger",
   "host": "reishunger.de",
   "language": "de",
   "title": "Crispy Tofu Bowl",

--- a/tests/test_data/reishunger.de/reishunger_2.json
+++ b/tests/test_data/reishunger.de/reishunger_2.json
@@ -1,7 +1,7 @@
 {
   "author": "snackicat",
   "canonical_url": "https://www.reishunger.de/rezepte/rezept/2835/susskartoffel-kichererbsen-curry",
-  "site_name": "https://www.reishunger.de",
+  "site_name": "Reishunger",
   "host": "reishunger.de",
   "language": "de",
   "title": "Süßkartoffel-Kichererbsen-Curry",

--- a/tests/test_data/rezeptwelt.de/rezeptwelt.json
+++ b/tests/test_data/rezeptwelt.de/rezeptwelt.json
@@ -1,7 +1,7 @@
 {
   "author": "Kräuterwiese",
   "canonical_url": "rezeptwelt.de",
-  "site_name": null,
+  "site_name": "Rezeptwelt",
   "host": "rezeptwelt.de",
   "language": "de_DE",
   "title": "Italienischer Nudelsalat",

--- a/tests/test_data/ricetta.it/ricetta.json
+++ b/tests/test_data/ricetta.it/ricetta.json
@@ -1,7 +1,7 @@
 {
   "author": "Luca Gatti",
   "canonical_url": "https://ricetta.it/lasagne-al-radicchio-e-formaggio",
-  "site_name": null,
+  "site_name": "Ricetta.it",
   "host": "ricetta.it",
   "language": "it",
   "title": "Lasagne al radicchio e formaggio",

--- a/tests/test_data/saboresajinomoto.com.br/saboresanjinomoto_1.json
+++ b/tests/test_data/saboresajinomoto.com.br/saboresanjinomoto_1.json
@@ -1,7 +1,7 @@
 {
   "author": "sabores ajinomoto",
   "canonical_url": "https://www.saboresajinomoto.com.br/receita/pure-de-batata-com-frango",
-  "site_name": null,
+  "site_name": "Sabores Ajinomoto",
   "host": "saboresajinomoto.com.br",
   "language": "pt-br",
   "title": "Purê de batata com frango",

--- a/tests/test_data/saboresajinomoto.com.br/saboresanjinomoto_2.json
+++ b/tests/test_data/saboresajinomoto.com.br/saboresanjinomoto_2.json
@@ -1,7 +1,7 @@
 {
   "author": "sabores ajinomoto",
   "canonical_url": "https://www.saboresajinomoto.com.br/receita/crepioca-com-brocolis-e-frango",
-  "site_name": null,
+  "site_name": "Sabores Ajinomoto",
   "host": "saboresajinomoto.com.br",
   "language": "pt-br",
   "title": "Crepioca com brócolis e frango",

--- a/tests/test_data/sallys-blog.de/sallysblog.json
+++ b/tests/test_data/sallys-blog.de/sallysblog.json
@@ -1,6 +1,6 @@
 {
   "canonical_url": "https://sallys-blog.de/rezepte/20-minuten-pasta-brokkoli-schinken-nudeln",
-  "site_name": null,
+  "site_name": "Sallys Blog",
   "host": "sallys-blog.de",
   "language": "de",
   "title": "20 Minuten Pasta / Brokkoli-Schinken-Nudeln / Sally und Murat kochen",

--- a/tests/test_data/simply-cookit.com/simplycookit.json
+++ b/tests/test_data/simply-cookit.com/simplycookit.json
@@ -1,7 +1,7 @@
 {
   "author": "simply-cookit.com",
   "canonical_url": "https://",
-  "site_name": null,
+  "site_name": "Simply Cookit",
   "host": "simply-cookit.com",
   "language": "de",
   "title": "Gnocchi mit Zuckerschoten und getrockneten Tomaten in Parmesansauce",

--- a/tests/test_data/sobors.hu/sobors.json
+++ b/tests/test_data/sobors.hu/sobors.json
@@ -1,7 +1,7 @@
 {
   "author": "Botos Claudia",
   "canonical_url": "https://sobors.hu/receptek/piskotatekercs-parizsi-kremmel-recept/",
-  "site_name": null,
+  "site_name": "SóBors",
   "host": "sobors.hu",
   "language": "hu",
   "title": "Piskótatekercs párizsi krémmel",

--- a/tests/test_data/sunbasket.com/sunbasket.json
+++ b/tests/test_data/sunbasket.com/sunbasket.json
@@ -1,7 +1,7 @@
 {
   "author": "Sunbasket",
   "canonical_url": "sunbasket.com",
-  "site_name": null,
+  "site_name": "Sunbasket",
   "host": "sunbasket.com",
   "language": "en",
   "title": "Lemongrass-turkey salad with rice noodles and pear",

--- a/tests/test_data/tastykitchen.com/tastykitchen.json
+++ b/tests/test_data/tastykitchen.com/tastykitchen.json
@@ -1,7 +1,7 @@
 {
   "author": "Ree | The Pioneer Woman",
   "canonical_url": "https://www.thepioneerwoman.com/food-cooking/recipes/a11059/restaurant-style-salsa/",
-  "site_name": null,
+  "site_name": "Tasty Kitchen",
   "host": "tastykitchen.com",
   "language": "en-US",
   "title": "Restaurant Style Salsa",

--- a/tests/test_data/thevintagemixer.com/thevintagemixer.json
+++ b/tests/test_data/thevintagemixer.com/thevintagemixer.json
@@ -1,7 +1,7 @@
 {
   "author": "Becky",
   "canonical_url": "https://www.thevintagemixer.com/cherry-baby-birthday-cake-party/",
-  "site_name": null,
+  "site_name": "Vintage Mixer",
   "host": "thevintagemixer.com",
   "language": "en-US",
   "title": "Gluten Free and Sugar Free Cherry Baby Smash Cake",

--- a/tests/test_data/vegetarbloggen.no/vegetarbloggen.json
+++ b/tests/test_data/vegetarbloggen.no/vegetarbloggen.json
@@ -1,7 +1,7 @@
 {
   "author": "Mari Hult",
   "canonical_url": "https://www.vegetarbloggen.no/2021/11/25/pasta-i-gresskarsaus-2/",
-  "site_name": null,
+  "site_name": "Vegetarbloggen",
   "host": "vegetarbloggen.no",
   "language": "en-US",
   "title": "Pasta i gresskarsaus",

--- a/tests/test_data/waitrose.com/waitrose.json
+++ b/tests/test_data/waitrose.com/waitrose.json
@@ -1,5 +1,5 @@
 {
-  "author": "waitrose.com",
+  "author": "Waitrose",
   "canonical_url": "waitrose.com",
   "site_name": "Waitrose",
   "host": "waitrose.com",

--- a/tests/test_data/waitrose.com/waitrose.json
+++ b/tests/test_data/waitrose.com/waitrose.json
@@ -1,7 +1,7 @@
 {
   "author": "waitrose.com",
   "canonical_url": "waitrose.com",
-  "site_name": null,
+  "site_name": "Waitrose",
   "host": "waitrose.com",
   "language": "en",
   "title": "Banana, chocolate and oatmeal tea bread",

--- a/tests/test_data/weightwatchers.com/weightwatcherspublic.json
+++ b/tests/test_data/weightwatchers.com/weightwatcherspublic.json
@@ -1,7 +1,7 @@
 {
   "author": "WeightWatchers",
   "canonical_url": "https://www.weightwatchers.com/de/rezept/kartoffelgulasch/562a9b02873e1afb2a3c4c13",
-  "site_name": null,
+  "site_name": "WW Deutschland",
   "host": "weightwatchers.com",
   "language": "en",
   "title": "Kartoffelgulasch",

--- a/tests/test_data/yummly.com/yummly.json
+++ b/tests/test_data/yummly.com/yummly.json
@@ -1,7 +1,7 @@
 {
   "author": "Sara Mellas",
   "canonical_url": "https://www.yummly.com/recipe/Easy-White-Cheese-_-Garlic-Pizzas-9351327",
-  "site_name": null,
+  "site_name": "Yummly",
   "host": "yummly.com",
   "language": "en",
   "title": "Easy White Cheese & Garlic Pizzas",


### PR DESCRIPTION
* Refactor the `OpenGraph` fill plugin to handle site names in addition to images.
* Allow both `OpenGraph` and `SchemaOrg` fill plugins to complement each other.
* Fill-in all previously-null-valued `site_name` JSON test expectations.
* Nitpicks: fix the names of a couple of scrapers.

Many sites are handled by the presence of OpenGraph `og:site_name` meta tags -- and a few are handled by `schema.org` `WebSite` metadata.  In the remaining cases, I've used authoritative-appearing hyperlinks (usually back to the homepage, with the brandname attached) to retrieve the site names dynamically, or added static values (using `StaticValueException` to help track those) when that seemed like the best path forward.

Resolves #1173.