### PR TITLE
README: Update introductory section.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Start by using `Python's built-in package installer <https://docs.python.org/3/i
 
 This should produce output about the installation process, and the final line should read: ``Successfully installed recipe-scrapers-<version-number>``.
 
-To learn what the library can do, you can run ``python`` at the command-line to open an `interpreter session <https://docs.python.org/3/tutorial/interpreter.html>`_, and then begin typing -- and/or modifying -- the code below:
+To learn what the library can do, you can run ``python`` at the command-line to open an `interpreter session <https://docs.python.org/3/tutorial/interpreter.html>`_, and then begin typing -- and/or modifying -- the statements below (on the lines containing the ``>>>`` prompt):
 
 .. code:: pycon
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ To get started, use `Python's built-in package installer <https://docs.python.or
 
 This should produce output to inform you of any dependencies that were installed, and the final line of output should read ``Successfully installed recipe-scrapers-<version-number>``.
 
-Now that we have the library installed, we can type ``python`` and press 'enter' to open an interactive interpreter session, and then begin typing -- and/or modifying -- some of the code shown below to scrape some recipes!
+Once the library is installed, we can type ``python`` and press 'enter' to open an interactive interpreter session, and then begin typing -- and/or modifying -- some of the code shown below to scrape some recipes!
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,11 @@
 
 A simple scraping tool for recipe webpages.
 
-To get started, use `Python's built-in package installer <https://docs.python.org/3/installing/index.html>`_, named ``pip``:
+
+Getting Started
+---------------
+
+First of all, use `Python's built-in package installer <https://docs.python.org/3/installing/index.html>`_, named ``pip`` to install the library:
 
 .. code:: shell
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Start by using `Python's built-in package installer <https://docs.python.org/3/i
 
     python -m pip install recipe-scrapers
 
-This should produce output about the installation process, and the final line should read: ``Successfully installed recipe-scrapers-<version-number>``.
+This should produce output about the installation process, with the final line reading: ``Successfully installed recipe-scrapers-<version-number>``.
 
 To learn what the library can do, you can run ``python`` at the command-line to open an `interpreter session <https://docs.python.org/3/tutorial/interpreter.html>`_, and then begin typing -- and/or modifying -- the statements below (on the lines containing the ``>>>`` prompt):
 

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,16 @@
 A simple scraping tool for recipe webpages.
 
 
+Netiquette
+----------
+
+If you're using this library to collect large numbers of recipes from the web, please use the software responsibly and try to avoid creating high volumes of network traffic.
+
+Python's standard library provides a ``robots.txt`` `parser <https://docs.python.org/3/library/urllib.robotparser.html>`_ that may be helpful to automatically follow common instructions specified by websites for web crawlers.
+
+Another parser option -- particularly if you find that many web requests from ``urllib.robotparser`` are blocked -- is the `robotexclusionrulesparser <https://pypi.org/project/robotexclusionrulesparser/>`_ library.
+
+
 Getting Started
 ---------------
 
@@ -76,16 +86,6 @@ Notes:
 - ``scraper.links()`` returns a list of dictionaries containing all of the <a> tag attributes. The attribute names are the dictionary keys.
 
 Some Python HTTP clients that you can use to retrieve HTML include `requests <https://pypi.org/project/requests/>`_ and `httpx <https://pypi.org/project/httpx/>`_.  Please refer to their documentation to find out what options (timeout configuration, proxy support, etc) are available.
-
-
-Netiquette
-----------
-
-If you're using this library to collect large numbers of recipes from the web, please use the software responsibly and try to avoid creating high volumes of network traffic.
-
-Python's standard library provides a ``robots.txt`` `parser <https://docs.python.org/3/library/urllib.robotparser.html>`_ that may be helpful to automatically follow common instructions specified by websites for web crawlers.
-
-Another parser option -- particularly if you find that many web requests from ``urllib.robotparser`` are blocked -- is the `robotexclusionrulesparser <https://pypi.org/project/robotexclusionrulesparser/>`_ library.
 
 
 Scrapers available for:

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ In the example above, we asked the library to scrape a web address (a.k.a. URL).
 
 Behind the scenes, the library made a web request to download the HTML from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
 
-In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
+In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to perform the download:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,9 @@ To learn what the library can do, you can run ``python`` at the command-line to 
     >>> scraper = scrape_me('https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/')
     >>> help(scraper)
 
-In the example above, we asked the library to scrape a web address (also known as a Universal Resource Location -- a URL).
+In the example above, we asked the library to scrape a web address (a.k.a. URL).
 
-Behind the scenes, the library made a web request to download the HTML (HyperText Markup Language -- a way of structuring information for a web browser to display it) from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
+Behind the scenes, the library made a web request to download the HTML from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
 
 In situations where recipe webpage HTML is already available, or is retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ To learn what the library can do, you can run ``python`` at the command-line to 
     Type "help", "copyright", "credits" or "license" for more information.
     >>> from recipe_scrapers import scrape_me
     >>> scraper = scrape_me('https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/')
+    >>> help(scraper)
 
 You also have an option to scrape html-like content
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ To get started, use `Python's built-in package installer <https://docs.python.or
 
 This should produce output to inform you of any dependencies that were installed, and the final line of output should read ``Successfully installed recipe-scrapers-<version-number>``.
 
-Now that we have the library installed, we can type ``python`` and press 'enter' to open an interactive interpreter session, and then try typing in -- and/or modifying -- some of the code shown below to scrape some recipes:
+Now that we have the library installed, we can type ``python`` and press 'enter' to open an interactive interpreter session, and then begin typing -- and/or modifying -- some of the code shown below to scrape some recipes!
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Start by using `Python's built-in package installer <https://docs.python.org/3/i
 
 This should produce output about the installation process, and the final line should read: ``Successfully installed recipe-scrapers-<version-number>``.
 
-Once the library is installed, run ``python`` at the command-line to open an interpreter session, and then begin typing -- and/or modifying -- the code below to scrape some recipes!
+To learn what the library can do, you can run ``python`` at the command-line to open an `interpreter session <https://docs.python.org/3/tutorial/interpreter.html>`_, and then begin typing -- and/or modifying -- the code below:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ In the example above, we asked the library to scrape a web address (also known a
 
 Behind the scenes, the library made a web request to download the HTML (HyperText Markup Language -- a way of structuring information for a web browser to display it) from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
 
-In situations where recipe webpage HTML is already available, or is retrieved using some other mechanism, this library can still help, but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
+In situations where recipe webpage HTML is already available, or is retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ To learn what the library can do, you can run ``python`` at the command-line to 
     >>> scraper = scrape_me('https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/')
     >>> help(scraper)
 
-In the previous example, we asked the library to scrape a web address (also known as a Universal Resource Location -- a URL).
+In the example above, we asked the library to scrape a web address (also known as a Universal Resource Location -- a URL).
 
 Behind the scenes, it made a web request to download the HTML (HyperText Markup Language -- a way of structuring information for a web browser to display it) from that URL.
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ To learn what the library can do, you can run ``python`` at the command-line to 
 
 In the example above, we asked the library to scrape a web address (also known as a Universal Resource Location -- a URL).
 
-Behind the scenes, it made a web request to download the HTML (HyperText Markup Language -- a way of structuring information for a web browser to display it) from that URL.
+Behind the scenes, the library made a web request to download the HTML (HyperText Markup Language -- a way of structuring information for a web browser to display it) from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
 
 In situations where recipe webpage HTML is already available, or is retrieved using some other mechanism, this library can still help, but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
 

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,13 @@
 
 A simple scraping tool for recipe webpages.
 
+To get started, use `Python's built-in package installer <https://docs.python.org/3/installing/index.html>`_, named ``pip``:
+
 .. code:: shell
 
-    pip install recipe-scrapers
+    python -m pip install recipe-scrapers
+
+This should produce output to inform you of any dependencies that were installed, and the final line of output should read ``Successfully installed recipe-scrapers-<version-number>``.
 
 then:
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@
 ------
 
 
-A simple web scraping tool for recipe sites.
+A simple scraping tool for recipe webpages.
 
 .. code:: shell
 

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ In the previous example, we asked the library to scrape a web address (also know
 
 Behind the scenes, it made a web request to download the HTML (HyperText Markup Language -- a way of structuring information for a web browser to display it) from that URL.
 
-In some situations, we may have a copy of the recipe webpage HTML already -- or we might prefer to use other tools to download it.  This library can help in these cases too, but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
+In situations where recipe webpage HTML is already available, or is retrieved using some other mechanism, this library can still help, but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -30,16 +30,6 @@
 A simple scraping tool for recipe webpages.
 
 
-Netiquette
-----------
-
-If you're using this library to collect large numbers of recipes from the web, please use the software responsibly and try to avoid creating high volumes of network traffic.
-
-Python's standard library provides a ``robots.txt`` `parser <https://docs.python.org/3/library/urllib.robotparser.html>`_ that may be helpful to automatically follow common instructions specified by websites for web crawlers.
-
-Another parser option -- particularly if you find that many web requests from ``urllib.robotparser`` are blocked -- is the `robotexclusionrulesparser <https://pypi.org/project/robotexclusionrulesparser/>`_ library.
-
-
 Getting Started
 ---------------
 
@@ -102,6 +92,16 @@ Notes:
 - ``scraper.links()`` returns a list of dictionaries containing all of the <a> tag attributes. The attribute names are the dictionary keys.
 
 Some Python HTTP clients that you can use to retrieve HTML include `requests <https://pypi.org/project/requests/>`_ and `httpx <https://pypi.org/project/httpx/>`_.  Please refer to their documentation to find out what options (timeout configuration, proxy support, etc) are available.
+
+
+Netiquette
+----------
+
+If you're using this library to collect large numbers of recipes from the web, please use the software responsibly and try to avoid creating high volumes of network traffic.
+
+Python's standard library provides a ``robots.txt`` `parser <https://docs.python.org/3/library/urllib.robotparser.html>`_ that may be helpful to automatically follow common instructions specified by websites for web crawlers.
+
+Another parser option -- particularly if you find that many web requests from ``urllib.robotparser`` are blocked -- is the `robotexclusionrulesparser <https://pypi.org/project/robotexclusionrulesparser/>`_ library.
 
 
 Scrapers available for:

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,16 @@
 A simple scraping tool for recipe webpages.
 
 
+Netiquette
+----------
+
+If you're using this library to collect large numbers of recipes from the web, please use the software responsibly and try to avoid creating high volumes of network traffic.
+
+Python's standard library provides a ``robots.txt`` `parser <https://docs.python.org/3/library/urllib.robotparser.html>`_ that may be helpful to automatically follow common instructions specified by websites for web crawlers.
+
+Another parser option -- particularly if you find that many web requests from ``urllib.robotparser`` are blocked -- is the `robotexclusionrulesparser <https://pypi.org/project/robotexclusionrulesparser/>`_ library.
+
+
 Getting Started
 ---------------
 
@@ -520,15 +530,6 @@ FAQ
     # if no error is raised - there's schema available:
     scraper.title()
     scraper.instructions()  # etc.
-
-Netiquette
-----------
-
-If you're using this library to collect large numbers of recipes from the web, please use the software responsibly and try to avoid creating high volumes of network traffic.
-
-Python's standard library provides a ``robots.txt`` `parser <https://docs.python.org/3/library/urllib.robotparser.html>`_ that may be helpful to automatically follow common instructions specified by websites for web crawlers.
-
-Another parser option -- particularly if you find that many web requests from ``urllib.robotparser`` are blocked -- is the `robotexclusionrulesparser <https://pypi.org/project/robotexclusionrulesparser/>`_ library.
 
 
 Special thanks to:

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ To get started, use `Python's built-in package installer <https://docs.python.or
 
 This should produce output to inform you of any dependencies that were installed, and the final line of output should read ``Successfully installed recipe-scrapers-<version-number>``.
 
-then:
+Now that we have the library installed, we can type ``python`` and press 'enter' to open an interactive interpreter session, and then try typing in -- and/or modifying -- some of the code shown below to scrape some recipes:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Start by using `Python's built-in package installer <https://docs.python.org/3/i
 
 This should produce output about the installation process, with the final line reading: ``Successfully installed recipe-scrapers-<version-number>``.
 
-To learn what the library can do, you can run ``python`` at the command-line to open an `interpreter session <https://docs.python.org/3/tutorial/interpreter.html>`_, and then begin typing -- and/or modifying -- the statements below (on the lines containing the ``>>>`` prompt):
+To learn what the library can do, you can open a `Python interpreter session <https://docs.python.org/3/tutorial/interpreter.html>`_, and then begin typing -- and/or modifying -- the statements below (on the lines containing the ``>>>`` prompt):
 
 .. code:: pycon
 

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,11 @@ To learn what the library can do, you can run ``python`` at the command-line to 
     >>> scraper = scrape_me('https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/')
     >>> help(scraper)
 
-You also have an option to scrape html-like content
+In the previous example, we asked the library to scrape a web address (also known as a Universal Resource Location -- a URL).
+
+Behind the scenes, it made a web request to download the HTML (HyperText Markup Language -- a way of structuring information for a web browser to display it) from that URL.
+
+In some situations, we may have a copy of the recipe webpage HTML already -- or we might prefer to use other tools to download it.  This library can help in these cases too, but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ In the example above, we asked the library to scrape a web address (a.k.a. URL).
 
 Behind the scenes, the library made a web request to download the HTML from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
 
-In situations where recipe webpage HTML is already available, or is retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
+In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to retrieve HTML:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -43,33 +43,12 @@ This should produce output about the installation process, and the final line sh
 
 To learn what the library can do, you can run ``python`` at the command-line to open an `interpreter session <https://docs.python.org/3/tutorial/interpreter.html>`_, and then begin typing -- and/or modifying -- the code below:
 
-.. code:: python
+.. code:: pycon
 
-    from recipe_scrapers import scrape_me
-
-    scraper = scrape_me('https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/')
-
-    # Q: What if the recipe site I want to extract information from is not listed below?
-    # A: You can give it a try with the wild_mode option! If there is Schema/Recipe available it will work just fine.
-    scraper = scrape_me('https://www.feastingathome.com/tomato-risotto/', wild_mode=True)
-
-    scraper.host()
-    scraper.title()
-    scraper.total_time()
-    scraper.image()
-    scraper.ingredients()
-    scraper.ingredient_groups()
-    scraper.instructions()
-    scraper.instructions_list()
-    scraper.yields()
-    scraper.to_json()
-    scraper.links()
-    scraper.nutrients()  # not always available
-    scraper.canonical_url()  # not always available
-    scraper.equipment()  # not always available
-    scraper.cooking_method()  # not always available
-    scraper.keywords()  # not always available
-    scraper.dietary_restrictions() # not always available
+    Python 4.0.4 (main, Oct 26 1985, 09:00:32) [GCC 22.3.4] on linux
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> from recipe_scrapers import scrape_me
+    >>> scraper = scrape_me('https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/')
 
 You also have an option to scrape html-like content
 
@@ -521,15 +500,48 @@ In case you want to run a single unittest for a newly developed scraper
 
 FAQ
 ---
-- **How do I know if a website has a Recipe Schema?** Run in python shell:
+**What if the recipe site I want to extract information from is not listed above?**
+
+You can give it a try with the ``wild_mode`` option!
+
+If there is Schema/Recipe available it will work just fine.
 
 .. code:: python
 
-    from recipe_scrapers import scrape_me
-    scraper = scrape_me('<url of a recipe from the site>', wild_mode=True)
-    # if no error is raised - there's schema available:
+    scraper = scrape_me('https://www.feastingathome.com/tomato-risotto/', wild_mode=True)
+
+    scraper.host()
     scraper.title()
-    scraper.instructions()  # etc.
+    scraper.total_time()
+    scraper.image()
+    scraper.ingredients()
+    scraper.ingredient_groups()
+    scraper.instructions()
+    scraper.instructions_list()
+    scraper.yields()
+    scraper.to_json()
+    scraper.links()
+    scraper.nutrients()  # not always available
+    scraper.canonical_url()  # not always available
+    scraper.equipment()  # not always available
+    scraper.cooking_method()  # not always available
+    scraper.keywords()  # not always available
+    scraper.dietary_restrictions() # not always available
+
+
+**How do I know if a website has a Recipe Schema?**
+
+Run in python shell:
+
+.. code:: pycon
+
+    Python 4.0.4 (main, Oct 26 1985, 09:00:32) [GCC 22.3.4] on linux
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> from recipe_scrapers import scrape_me
+    >>> scraper = scrape_me('<url of a recipe from the site>', wild_mode=True)
+    >>> # if no error is raised - there's schema available:
+    >>> scraper.title()
+    >>> scraper.instructions()  # etc.
 
 
 Special thanks to:

--- a/README.rst
+++ b/README.rst
@@ -33,15 +33,15 @@ A simple scraping tool for recipe webpages.
 Getting Started
 ---------------
 
-First of all, use `Python's built-in package installer <https://docs.python.org/3/installing/index.html>`_, named ``pip`` to install the library:
+Start by using `Python's built-in package installer <https://docs.python.org/3/installing/index.html>`_, ``pip``, to install the library:
 
 .. code:: shell
 
     python -m pip install recipe-scrapers
 
-This should produce output to inform you of any dependencies that were installed, and the final line of output should read ``Successfully installed recipe-scrapers-<version-number>``.
+This should produce output about the installation process, and the final line should read: ``Successfully installed recipe-scrapers-<version-number>``.
 
-Once the library is installed, we can type ``python`` and press 'enter' to open an interactive interpreter session, and then begin typing -- and/or modifying -- some of the code shown below to scrape some recipes!
+Once the library is installed, run ``python`` at the command-line to open an interpreter session, and then begin typing -- and/or modifying -- the code below to scrape some recipes!
 
 .. code:: python
 


### PR DESCRIPTION
* Move netiquette guidance to the top of the document.
* Clarification in terminology: refer to the ability to scrape webpages instead of sites.
* Place introductory instructions under their own dedicated section heading.
* Add a reference link to, and re-use, Python's recommended `pip` installation command-line.
* Fill in a missing step about opening a Python interpreter session.

Inspired-by / resolves #1180.