### PR TITLE
v14: make `wild_mode` opt-in (as usual) when using `scrape_html` interface.

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -820,6 +820,10 @@ def scrape_html(
             scraper = SCRAPERS[host_name]
 
     if not scraper:
+        if not options.get("wild_mode", False):
+            raise WebsiteNotImplementedError(host_name)
+
+        options.pop("wild_mode")
         wild_scraper = SchemaScraperFactory.generate(url=org_url, html=html, **options)
 
         if not wild_scraper.schema.data:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -84,11 +84,11 @@ def test_func_factory(
                 for group in expect.get("ingredient_groups", [])
             ]
 
-        wild_mode = host not in SCRAPERS
-        actual = scrape_html(testhtml.read_text(encoding="utf-8"), host, wild_mode=wild_mode)
-        if wild_mode:
-            self.assertFalse(RecipeTestCase.been_wild, "Only one wild mode test should occur.")
-            RecipeTestCase.been_wild = True
+        kwargs = {"wild_mode": True} if host not in SCRAPERS else {}
+        actual = scrape_html(testhtml.read_text(encoding="utf-8"), host, **kwargs)
+        if kwargs.get("wild_mode"):
+            self.assertFalse(self.been_wild, "Only one wild mode test should occur.")
+            type(self).been_wild = True
 
         # Mandatory tests
         # If the key isn't present, check an assertion is raised

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ import pathlib
 import unittest
 from typing import Callable
 
-from recipe_scrapers import scrape_html
+from recipe_scrapers import SCRAPERS, scrape_html
 from recipe_scrapers._exceptions import StaticValueException
 from recipe_scrapers._grouping_utils import IngredientGroup
 
@@ -42,6 +42,7 @@ OPTIONAL_TESTS = [
 
 class RecipeTestCase(unittest.TestCase):
     maxDiff = None
+    been_wild = False
 
 
 def test_func_factory(
@@ -82,7 +83,12 @@ def test_func_factory(
                 IngredientGroup(**group)
                 for group in expect.get("ingredient_groups", [])
             ]
-        actual = scrape_html(testhtml.read_text(encoding="utf-8"), host)
+
+        wild_mode = host not in SCRAPERS
+        actual = scrape_html(testhtml.read_text(encoding="utf-8"), host, wild_mode=wild_mode)
+        if wild_mode:
+            self.assertFalse(RecipeTestCase.been_wild, "Only one wild mode test should occur.")
+            RecipeTestCase.been_wild = True
 
         # Mandatory tests
         # If the key isn't present, check an assertion is raised

--- a/tests/library/test_exceptions.py
+++ b/tests/library/test_exceptions.py
@@ -3,14 +3,19 @@ import unittest
 from recipe_scrapers import (
     NoSchemaFoundInWildMode,
     WebsiteNotImplementedError,
+    scrape_html,
     scrape_me,
 )
 
 
 class TestExceptions(unittest.TestCase):
-    def test_website_not_implemented_error(self):
+    def test_website_not_implemented_error_legacy(self):
         with self.assertRaises(WebsiteNotImplementedError):
             scrape_me("https://example.com/recipe")
+
+    def test_website_not_implemented_error(self):
+        with self.assertRaises(WebsiteNotImplementedError):
+            scrape_html(html="<html></html>", org_url="http://example.com/recipe")
 
     def test_no_schema_found_in_wild_mode_error(self):
         exception = NoSchemaFoundInWildMode("example.com")


### PR DESCRIPTION
Resolves #1186.