### PR TITLE
README: Adopt v15-style list for HTTP client hyperlinks.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,13 @@ Notes:
 
 - ``scraper.links()`` returns a list of dictionaries containing all of the <a> tag attributes. The attribute names are the dictionary keys.
 
-Some Python HTTP clients that you can use to retrieve HTML include `requests <https://pypi.org/project/requests/>`_, `httpx <https://pypi.org/project/httpx/>`_, and the `urllib.request module <https://docs.python.org/3/library/urllib.request.html>`_ included in Python's standard library.  Please refer to their documentation to find out what options (timeout configuration, proxy support, etc) are available.
+Some Python HTTP clients that you can use to retrieve HTML include `requests`_, `httpx`_, and the `urllib.request module`_ included in Python's standard library.  Please refer to their documentation to find out what options (timeout configuration, proxy support, etc) are available.
+
+.. _requests: https://pypi.org/project/requests/
+
+.. _httpx: https://pypi.org/project/httpx/
+
+.. _urllib.request module: https://docs.python.org/3/library/urllib.request.html
 
 
 Scrapers available for:

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ In the example above, we asked the library to scrape a web address (a.k.a. URL).
 
 Behind the scenes, the library made a web request to download the HTML from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
 
-In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python ``requests`` library to perform the download:
+In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python `requests`_ library to perform the download:
 
 .. code:: python
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ In the example above, we asked the library to scrape a web address (a.k.a. URL).
 
 Behind the scenes, the library made a web request to download the HTML from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
 
-In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we use the Python `requests`_ library to perform the download:
+In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we adapt the code above to explicitly use the Python `requests`_ library to perform the download:
 
 .. code:: python
 
@@ -76,7 +76,8 @@ In situations where the HTML for a recipe webpage is already available to us, or
     from recipe_scrapers import scrape_html
 
     url = "https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/"
-    html = requests.get(url).content
+    name = input('What is your name, burger seeker?\n')
+    html = requests.get(url, headers={"User-Agent": f"Burger Seeker {name}"}).content
 
     scraper = scrape_html(html=html, org_url=url)
 

--- a/README.rst
+++ b/README.rst
@@ -64,27 +64,6 @@ To learn what the library can do, you can open a `Python interpreter session <ht
     >>> scraper = scrape_html(html, org_url=url)
     >>> help(scraper)
 
-In the example above, we asked the library to scrape a web address (a.k.a. URL).
-
-Behind the scenes, the library made a web request to download the HTML from the URL, `parsed <https://en.wikipedia.org/wiki/Parsing>`_ the server's response with the assistance of other Python libraries, and then returned a `class instance <https://docs.python.org/3/tutorial/classes.html>`_ that we can use to access information about the recipe.
-
-In situations where the HTML for a recipe webpage is already available to us, or will be retrieved using some other mechanism, we can ask the library to skip the download step -- but for accurate scraping it does need to know the URL that the HTML was retrieved from.  Here's an example where we adapt the code above to explicitly use the Python `requests`_ library to perform the download:
-
-.. code:: python
-
-    import requests
-    from recipe_scrapers import scrape_html
-
-    url = "https://www.allrecipes.com/recipe/158968/spinach-and-feta-turkey-burgers/"
-    name = input('What is your name, burger seeker?\n')
-    html = requests.get(url, headers={"User-Agent": f"Burger Seeker {name}"}).content
-
-    scraper = scrape_html(html=html, org_url=url)
-
-    scraper.title()
-    scraper.total_time()
-    # etc...
-
 Notes:
 
 - ``scraper.links()`` returns a list of dictionaries containing all of the <a> tag attributes. The attribute names are the dictionary keys.


### PR DESCRIPTION
* Provide the list of HTTP client options as a list, as currently drafted in the V15 branch (f768a3ef4b873821061e88e03c105f2ba5c961df / #746).
* Remove some duplicative / incorrect code since the initial introductory examples now refer to `scrape_html` and use an HTTP client explicitly.