### PR TITLE
Tests: add package description metadata retrieval for Python 3.9 and earlier

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -e .
 coverage>=7.4.4
 types-beautifulsoup4>=4.12.0
+importlib-metadata>=4.6 ; python_version < "3.10"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -e .
 coverage>=7.4.4
 types-beautifulsoup4>=4.12.0
-importlib-metadata>=4.6 ; python_version < "3.10"
+importlib-metadata>=4.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -e .
 coverage>=7.4.4
 types-beautifulsoup4>=4.12.0
-importlib-metadata>=4.6
+importlib-metadata>=4.6 ; python_version < "3.10"

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -1,6 +1,7 @@
 import re
 import unittest
 from collections import defaultdict
+
 try:
     from importlib.metadata import PackageNotFoundError, metadata
 except ImportError:

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -1,12 +1,7 @@
 import re
 import unittest
 from collections import defaultdict
-
-try:
-    from importlib.metadata import PackageNotFoundError, metadata
-except ImportError:
-    # Python 3.9 and earlier
-    from importlib_metadata import PackageNotFoundError, metadata  # type: ignore[assignment,no-redef]
+from importlib_metadata import PackageNotFoundError, metadata
 
 from typing import Dict, List, Optional, Tuple
 

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -1,8 +1,12 @@
 import re
-import sys
 import unittest
 from collections import defaultdict
-from importlib.metadata import PackageNotFoundError, metadata
+try:
+    from importlib.metadata import PackageNotFoundError, metadata
+except ImportError:
+    # Python 3.9 and earlier
+    from importlib_resources import PackageNotFoundError, metadata
+
 from typing import Dict, List, Optional, Tuple
 
 from recipe_scrapers import SCRAPERS, AbstractScraper
@@ -120,13 +124,6 @@ class TestReadme(unittest.TestCase):
     def test_includes(self):
         scraper_index = get_scraper_index()
         primary_domains = sorted(scraper_index.keys())
-
-        # TODO: Remove this skip-branch once py3.10 is our minimum baseline;
-        # package description metadata (that we rely on for this test) is only
-        # available in importlib.metadata from py3.10 onwards
-        if sys.version_info < (3, 10):
-            msg = "Python 3.10+ is required for importlib.metadata to read package 'description' metadata."
-            self.skipTest(msg)
 
         try:
             lines = get_list_lines()

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -1,7 +1,12 @@
 import re
 import unittest
 from collections import defaultdict
-from importlib_metadata import PackageNotFoundError, metadata
+
+try:
+    from importlib.metadata import PackageNotFoundError, metadata
+except ImportError:
+    # Python 3.9 and earlier
+    from importlib_metadata import PackageNotFoundError, metadata  # type: ignore[assignment,no-redef]
 
 from typing import Dict, List, Optional, Tuple
 

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -6,6 +6,9 @@ from collections import defaultdict
 if sys.version_info >= (3, 10):
     from importlib.metadata import PackageNotFoundError, metadata
 else:
+    # TODO: Remove this branch once py3.10 is our minimum baseline;
+    # package description metadata (that we rely on for 'test_includes') is
+    # only available in importlib.metadata from py3.10 onwards
     from importlib_metadata import PackageNotFoundError, metadata
 
 from typing import Dict, List, Optional, Tuple

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -1,12 +1,12 @@
 import re
+import sys
 import unittest
 from collections import defaultdict
 
-try:
+if sys.version_info >= (3, 10):
     from importlib.metadata import PackageNotFoundError, metadata
-except ImportError:
-    # Python 3.9 and earlier
-    from importlib_metadata import PackageNotFoundError, metadata  # type: ignore[assignment,no-redef]
+else:
+    from importlib_metadata import PackageNotFoundError, metadata
 
 from typing import Dict, List, Optional, Tuple
 

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -5,7 +5,7 @@ try:
     from importlib.metadata import PackageNotFoundError, metadata
 except ImportError:
     # Python 3.9 and earlier
-    from importlib_resources import PackageNotFoundError, metadata
+    from importlib_metadata import PackageNotFoundError, metadata
 
 from typing import Dict, List, Optional, Tuple
 

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -5,7 +5,7 @@ try:
     from importlib.metadata import PackageNotFoundError, metadata
 except ImportError:
     # Python 3.9 and earlier
-    from importlib_metadata import PackageNotFoundError, metadata
+    from importlib_metadata import PackageNotFoundError, metadata  # type: ignore[assignment,no-redef]
 
 from typing import Dict, List, Optional, Tuple
 


### PR DESCRIPTION
Enables the unit test added in #1162 to run on all of the versions of Python supported by the library.