### PR TITLE
internals: add identifying library-plus-version string to `HEADERS`

### DIFF
--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -15,7 +15,7 @@ from ._schemaorg import SchemaOrg
 
 # Some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {
-    "User-Agent": f"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 recipe-scrapers/{__version__} Firefox/123.0"
+    "User-Agent": f"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:{__version__}) recipe-scrapers/{__version__}"
 }
 
 

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -12,7 +12,6 @@ from ._exceptions import ElementNotFoundInHtml
 from ._grouping_utils import IngredientGroup
 from ._opengraph import OpenGraph
 from ._schemaorg import SchemaOrg
-from .__version__ import __version__
 
 # Some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 
+from recipe_scrapers.__version__ import __version__
 from recipe_scrapers.settings import settings
 
 from ._exceptions import ElementNotFoundInHtml
@@ -14,7 +15,7 @@ from ._schemaorg import SchemaOrg
 
 # Some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0"
+    "User-Agent": f"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 recipe-scrapers/{__version__} Firefox/123.0"
 }
 
 

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -12,6 +12,7 @@ from ._exceptions import ElementNotFoundInHtml
 from ._grouping_utils import IngredientGroup
 from ._opengraph import OpenGraph
 from ._schemaorg import SchemaOrg
+from .__version__ import __version__
 
 # Some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {

--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -16,7 +16,7 @@ from .__version__ import __version__
 
 # Some sites close their content for 'bots', so user-agent must be supplied
 HEADERS = {
-    "User-Agent": f"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:{__version__}) recipe-scrapers/{__version__}"
+    "User-Agent": f"Mozilla/5.0 (compatible; Windows NT 10.0; Win64; x64; rv:{__version__}) recipe-scrapers/{__version__}"
 }
 
 


### PR DESCRIPTION
Adds the version of the `recipe-scrapers` library to the `HEADERS` user-agent field.  The format suggested here follows the [user-agent spec from RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3) (HTTP 1.1) -- there may be a better and/or more-recent alternative that I'm not aware of!

Resolves #1219 