### PR TITLE
ci: enable GitHub Actions workflows on the v14 branch

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v14
   pull_request:
     branches:
       - main
+      - v14
 
 jobs:
   coverage:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v14
   pull_request:
     branches:
       - main
+      - v14
 
 jobs:
   linters:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v14
   pull_request:
     branches:
       - main
+      - v14
 
 jobs:
   test:


### PR DESCRIPTION
Allows continuous integration to run for both the development mainline (`main` branch) and the maintained v14 (`v14` branch) branches.

If merged, this change will be merged into `v14` so that both branches contain identical workflow configurations.