### PR TITLE
schema.org-fill: raise a `RecipeSchemaNotFound` when no recipe metadata is found

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -5,6 +5,7 @@ __all__ = (
     "ElementNotFoundInHtml",
     "FieldNotProvidedByWebsiteException",
     "NoSchemaFoundInWildMode",
+    "RecipeSchemaNotFound",
     "StaticValueException",
     "WebsiteNotImplementedError",
     "scrape_html",
@@ -26,6 +27,7 @@ from ._exceptions import (
     ElementNotFoundInHtml,
     FieldNotProvidedByWebsiteException,
     NoSchemaFoundInWildMode,
+    RecipeSchemaNotFound,
     StaticValueException,
     WebsiteNotImplementedError,
 )

--- a/recipe_scrapers/_exceptions.py
+++ b/recipe_scrapers/_exceptions.py
@@ -55,6 +55,15 @@ class SchemaOrgException(FillPluginException):
     ...
 
 
+class RecipeSchemaNotFound(SchemaOrgException):
+    """No recipe schema metadata found on the page"""
+
+    def __init__(self, url):
+        self.url = url
+        message = f"No Recipe Schema found at {self.url}."
+        super().__init__(message)
+
+
 class StaticValueException(RecipeScrapersExceptions):
     """Error to communicate that the scraper is returning a fixed/static value."""
 

--- a/recipe_scrapers/plugins/schemaorg_fill.py
+++ b/recipe_scrapers/plugins/schemaorg_fill.py
@@ -1,7 +1,7 @@
 import functools
 import logging
 
-from recipe_scrapers._exceptions import FillPluginException
+from recipe_scrapers._exceptions import FillPluginException, RecipeSchemaNotFound
 from recipe_scrapers.settings import settings
 
 from ._interface import PluginInterface
@@ -57,7 +57,9 @@ class SchemaOrgFillPlugin(PluginInterface):
                 return decorated(self, *args, **kwargs)
             except (FillPluginException, NotImplementedError) as e:
                 function = getattr(self.schema, decorated.__name__)
-                if self.schema.data and function:
+                if not self.schema.data:
+                    raise RecipeSchemaNotFound(url=self.url)
+                if function:
                     logger.info(
                         f"{class_name}.{method_name}() seems to not be implemented but .schema is available! Attempting to return result from SchemaOrg."
                     )

--- a/tests/library/test_exceptions.py
+++ b/tests/library/test_exceptions.py
@@ -1,7 +1,9 @@
 import unittest
 
 from recipe_scrapers import (
+    AbstractScraper,
     NoSchemaFoundInWildMode,
+    RecipeSchemaNotFound,
     WebsiteNotImplementedError,
     scrape_html,
 )
@@ -17,3 +19,13 @@ class TestExceptions(unittest.TestCase):
 
         self.assertEqual(exception.url, "example.com")
         self.assertEqual(exception.message, "No Recipe Schema found at example.com.")
+
+    def test_no_schema_found_for_fill_plugin(self):
+        class TestScraper(AbstractScraper):
+            @classmethod
+            def host(self):
+                return "example.com"
+
+        scraper = TestScraper(html="<html></html>", url="http://example.com/recipe")
+        with self.assertRaises(RecipeSchemaNotFound):
+            scraper.category()

--- a/tests/library/test_exceptions.py
+++ b/tests/library/test_exceptions.py
@@ -23,7 +23,7 @@ class TestExceptions(unittest.TestCase):
     def test_no_schema_found_for_fill_plugin(self):
         class TestScraper(AbstractScraper):
             @classmethod
-            def host(self):
+            def host(cls):
                 return "example.com"
 
         scraper = TestScraper(html="<html></html>", url="http://example.com/recipe")


### PR DESCRIPTION
Supports / unblocks #1228.
Resolves #1229.