### PR TITLE
Add Support for Instrupix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,7 @@ Scrapers available for:
 - `https://www.innit.com/ <https://www.innit.com/>`_
 - `https://insanelygoodrecipes.com <https://insanelygoodrecipes.com/>`_
 - `https://inspiralized.com/ <https://inspiralized.com>`_
+- `https://www.instrupix.com <https://www.instrupix.com>`_
 - `https://izzycooking.com/ <https://izzycooking.com/>`_
 - `https://jamieoliver.com/ <https://jamieoliver.com>`_
 - `https://jimcooksfoodgood.com/ <https://jimcooksfoodgood.com/>`_

--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -178,6 +178,7 @@ from .ingoodflavor import InGoodFlavor
 from .innit import Innit
 from .insanelygoodrecipes import InsanelyGoodRecipes
 from .inspiralized import Inspiralized
+from .instrupix import Instrupix
 from .izzycooking import IzzyCooking
 from .jamieoliver import JamieOliver
 from .jimcooksfoodgood import JimCooksFoodGood
@@ -480,6 +481,7 @@ SCRAPERS = {
     HeatherChristo.host(): HeatherChristo,
     InBloomBakery.host(): InBloomBakery,
     InGoodFlavor.host(): InGoodFlavor,
+    Instrupix.host(): Instrupix,
     JoCooks.host(): JoCooks,
     JoshuaWeissman.host(): JoshuaWeissman,
     JoyTheBaker.host(): JoyTheBaker,

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -342,3 +342,30 @@ def get_nutrition_keys():
         "fiberContent",
         "cholesterolContent",
     ]
+
+
+def get_max_res_src(img):
+    # Prefer data src set for higher image resolution
+    srcset_str = img.get("data-srcset", None)
+    if not srcset_str:
+        # Fallback to regular img source
+        return img.get("src", None)
+    # Convert source set string to cleaner list
+    srcset = srcset_str.split(",")
+    # Find image with the best resolution
+    max_res = None
+    max_res_src = None
+    res_pattern = re.compile(r"(\d+)w")
+    for src_str in srcset:
+        src = src_str.strip().split(" ")
+        res_match = res_pattern.findall(src[1])
+        res = None
+        if res_match:
+            try:
+                res = int(res_match[0])
+            except ValueError:
+                pass
+        if max_res is None or res > max_res:
+            max_res = res
+            max_res_src = src[0]
+    return max_res_src

--- a/recipe_scrapers/instrupix.py
+++ b/recipe_scrapers/instrupix.py
@@ -1,0 +1,84 @@
+from ._abstract import AbstractScraper
+from ._utils import get_minutes, normalize_string
+
+
+class Instrupix(AbstractScraper):
+    @classmethod
+    def host(cls):
+        return "instrupix.com"
+
+    def site_name(self):
+        return "Instrupix"
+
+    def author(self):
+        return "Instrupix"
+
+    def title(self):
+        return self.soup.find("h1", {"class": "entry-title"}).get_text()
+
+    def category(self):
+        return self.soup.find("span", {"class": "wprm-recipe-course"}).get_text()
+
+    def total_time(self):
+        return (self.cook_time() | 0) + (self.prep_time() | 0)
+
+    def yields(self):
+        return self.soup.find("span", {"class": "wprm-recipe-servings"}).get_text()
+
+    def image(self):
+        container = self.soup.find("div", {"class": "acme_featured_image"})
+        if not container:
+            return None
+        image = container.find("img", {"src": True})
+        return image["src"] if image else None
+
+    def ingredients(self):
+        ingredient_tags = self.soup.findAll("li", {"class": "wprm-recipe-ingredient"})
+        return [
+            normalize_string(ingredient_tag.get_text())
+            for ingredient_tag in ingredient_tags
+        ]
+
+    def instructions(self):
+        return "\n".join(self.instructions_list())
+
+    def instructions_list(self):
+        instruction_tags = self.soup.findAll("li", {"class": "wprm-recipe-instruction"})
+        return [
+            normalize_string(instruction_tag.get_text())
+            for instruction_tag in instruction_tags
+        ]
+
+    def ratings(self):
+        return None
+
+    def cuisine(self):
+        keywords_tag = self.soup.find("span", {"class": "wprm-recipe-cuisine"})
+        return keywords_tag.get_text() if keywords_tag else None
+
+    def description(self):
+        return self.soup.find("meta", {"name": "description"})["content"]
+
+    def cook_time(self):
+        cook_time_tag = self.soup.find(
+            "div", {"class": "wprm-recipe-cook-time-container"}
+        )
+
+        return get_minutes(cook_time_tag) if cook_time_tag else None
+
+    def prep_time(self):
+        prep_time = self.soup.find("div", {"class": "wprm-recipe-prep-time-container"})
+        return get_minutes(prep_time) if prep_time else None
+
+    def equipment(self):
+        equipment_tags = self.soup.findAll(
+            "li", {"class": "wprm-recipe-equipment-item"}
+        )
+        return [
+            normalize_string(equipment_tag.get_text())
+            for equipment_tag in equipment_tags
+        ]
+
+    def keywords(self):
+        keywords_tag = self.soup.find("span", {"class": "wprm-recipe-keyword"})
+        return keywords_tag.get_text().split(", ") if keywords_tag else None

--- a/recipe_scrapers/instrupix.py
+++ b/recipe_scrapers/instrupix.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_minutes, normalize_string
+from ._utils import get_max_res_src, get_minutes, normalize_string
 
 
 class Instrupix(AbstractScraper):
@@ -30,7 +30,7 @@ class Instrupix(AbstractScraper):
         if not container:
             return None
         image = container.find("img", {"src": True})
-        return image["src"] if image else None
+        return get_max_res_src(image) if image else None
 
     def ingredients(self):
         ingredient_tags = self.soup.findAll("li", {"class": "wprm-recipe-ingredient"})

--- a/recipe_scrapers/tineno.py
+++ b/recipe_scrapers/tineno.py
@@ -1,7 +1,5 @@
-import re
-
 from ._abstract import AbstractScraper
-from ._utils import change_keys
+from ._utils import change_keys, get_max_res_src
 
 
 def fix_json_ld_property_keys(k):
@@ -22,33 +20,7 @@ class TineNo(AbstractScraper):
 
     def image(self):
         image = self.soup.find("img", {"id": "HeaderMediaContent"})
-        if not image:
-            # No image available
-            return None
-        # Prefer data src set for higher image resolution
-        srcset_str = image.get("data-srcset", None)
-        if not srcset_str:
-            # Fallback to regular img source
-            return image.get("src", None)
-        # Convert source set string to cleaner list
-        srcset = srcset_str.split(",")
-        # Find image with the best resolution
-        max_res = None
-        max_res_src = None
-        res_pattern = re.compile(r"(\d+)w")
-        for src_str in srcset:
-            src = src_str.strip().split(" ")
-            res_match = res_pattern.findall(src[1])
-            res = None
-            if res_match:
-                try:
-                    res = int(res_match[0])
-                except ValueError:
-                    pass
-            if max_res is None or res > max_res:
-                max_res = res
-                max_res_src = src[0]
-        return max_res_src
+        return get_max_res_src(image) if image else None
 
     def instructions(self):
         """

--- a/tests/test_data/instrupix.com/instrupix_1.json
+++ b/tests/test_data/instrupix.com/instrupix_1.json
@@ -1,0 +1,34 @@
+{
+  "author": "Instrupix",
+  "canonical_url": "https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/",
+  "site_name": "Instrupix",
+  "host": "instrupix.com",
+  "language": "en-US",
+  "title": "The Best Slow Cooker Pot Roast Recipe",
+  "ingredients": [
+    "1 3-5lb beef roast (any kind)",
+    "1½ cups water",
+    "1 packet brown gravy mix",
+    "1 packet ranch dressing mix",
+    "1 packet Italian dressing mix",
+    "vegetables of your choice (potatoes, carrots, celery, etc.)"
+  ],
+  "instructions_list": [
+    "Place your beef roast into your slow cooker with 1½ cups of water.",
+    "Sprinkle all of the seasoning packets over the roast.",
+    "Cover and cook on low for about 4 hours and then add your veggies.",
+    "Cook for an additional 2-4 hours or until the beef easily pulls apart. The time needed will greatly depend on your cut of meat and the brand of your slow cooker."
+  ],
+  "category": "Main Course",
+  "yields": "6",
+  "description": "Looking for fast and easy pot roast recipes made in your crockpot? This basic pot roast is easy to make with simple ingredients: a beef roast, ranch seasoning, brown gravy mix and a packet of Italian salad dressing mix. The BEST recipe with potatoes and carrots! A dinner recipe the entire family will love. Some serious comfort food!",
+  "total_time": 490,
+  "cook_time": 480,
+  "prep_time": 10,
+  "image": "https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe.jpg",
+  "keywords": [
+    "comfort food",
+    "easy dinner idea",
+    "slow cooker meals"
+  ]
+}

--- a/tests/test_data/instrupix.com/instrupix_1.testhtml
+++ b/tests/test_data/instrupix.com/instrupix_1.testhtml
@@ -1,0 +1,2439 @@
+<html class="js cssanimations flexbox no-flexboxtweener" lang="en-US"><!--<![endif]--><head><script type="text/javascript" async="" src="https://cdn.id5-sync.com/api/1.0/id5PrebidModule.js"></script>
+	<meta charset="UTF-8">
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+	<link rel="pingback" href="https://www.instrupix.com/xmlrpc.php">
+	<meta property="fb:app_id" content="1060721147363596">
+	<script async="" src="https://cdn.opecloud.com/ope-dmplite.js"></script><script src="https://pghub.io/js/pandg-sdk.js" type="text/javascript"></script><script src="https://oa.openxcdn.net/esp.js" type="text/javascript" data-ox-ats="1"></script><script async="" src="//c.amazon-adsystem.com/aax2/apstag.js"></script><script src="https://scripts.grow.me/main.js" type="text/javascript"></script><script src="https://keywords.mediavine.com/keyword/web.keywords.js?pageUrl=https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/" type="text/javascript"></script><script src="https://exchange.mediavine.com/usersync.min.js?s2sVersion=production" type="text/javascript"></script><script src="https://scripts.mediavine.com/tags/3.6.17/wrapper.min.js?bust=1504223161" type="text/javascript"></script><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-0Q9V5TYVSH&amp;cx=c&amp;_slc=1" nonce="HMTAA31x"></script><script src="https://privacy-center.fides.mediavine.com/fides.js?property_id=FDS-F0G1B3&amp;gpp=true&amp;initialize=false" type="text/javascript"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script><script src="https://connect.facebook.net/en_US/sdk.js?hash=20be3e641648c86c61b32d42e0ec23c8" async="" crossorigin="anonymous"></script><script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.mediavine.com/tags/instrupix.js"></script>
+	<script>var clicky_site_ids = clicky_site_ids || []; clicky_site_ids.push(100964726);		</script>
+<script async="" src="//static.getclicky.com/js"></script>
+	
+	<!-- Google tag (gtag.js) -->
+<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-0Q9V5TYVSH"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-0Q9V5TYVSH');
+</script>
+
+
+	<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+
+<meta name="viewport" content="initial-scale=1.0, width=device-width">
+
+	<!-- This site is optimized with the Yoast SEO plugin v23.4 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>The BEST Easy Slow Cooker Pot Roast (Made with Ranch, Brown Gravy &amp; Italian Dressing Mix)</title>
+	<meta name="description" content="Looking for fast and easy pot roast recipes made in your crockpot? This basic pot roast is easy to make with simple ingredients: a beef roast, ranch seasoning, brown gravy mix and a packet of Italian salad dressing mix. The BEST recipe with potatoes and carrots! A dinner recipe the entire family will love. Some serious comfort food!">
+	<link rel="canonical" href="https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/">
+	<meta property="og:locale" content="en_US">
+	<meta property="og:type" content="recipe">
+	<meta property="og:title" content="The BEST Easy Slow Cooker Pot Roast (Made with Ranch, Brown Gravy &amp; Italian Dressing Mix)">
+	<meta property="og:description" content="Looking for fast and easy pot roast recipes made in your crockpot? This basic pot roast is easy to make with simple ingredients: a beef roast, ranch seasoning, brown gravy mix and a packet of Italian salad dressing mix. The BEST recipe with potatoes and carrots! A dinner recipe the entire family will love. Some serious comfort food!">
+	<meta property="og:url" content="https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/">
+	<meta property="og:site_name" content="Instrupix">
+	<meta property="article:publisher" content="https://www.facebook.com/instrupix">
+	<meta property="article:published_time" content="2019-11-01T20:06:40+00:00">
+	<meta property="article:modified_time" content="2024-06-29T15:41:12+00:00">
+	<meta property="og:image" content="https://www.instrupix.com/wp-content/uploads/2019/11/best-easy-pot-roast-made-with-3-seasoning-packets.jpg">
+	<meta property="og:image:width" content="1496">
+	<meta property="og:image:height" content="784">
+	<meta property="og:image:type" content="image/jpeg">
+	<meta name="author" content="Lilly">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:label1" content="Written by">
+	<meta name="twitter:data1" content="Lilly">
+	<meta name="twitter:label2" content="Est. reading time">
+	<meta name="twitter:data2" content="4 minutes">
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/","url":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/","name":"The BEST Easy Slow Cooker Pot Roast (Made with Ranch, Brown Gravy & Italian Dressing Mix)","isPartOf":{"@id":"https://www.instrupix.com/#website"},"primaryImageOfPage":{"@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#primaryimage"},"image":{"@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#primaryimage"},"thumbnailUrl":"https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-with-potatoes-and-carrots.jpg","datePublished":"2019-11-01T20:06:40+00:00","dateModified":"2024-06-29T15:41:12+00:00","author":{"@id":"https://www.instrupix.com/#/schema/person/8cee678a0fd4037cdf113bf130a4c54d"},"description":"Looking for fast and easy pot roast recipes made in your crockpot? This basic pot roast is easy to make with simple ingredients: a beef roast, ranch seasoning, brown gravy mix and a packet of Italian salad dressing mix. The BEST recipe with potatoes and carrots! A dinner recipe the entire family will love. Some serious comfort food!","breadcrumb":{"@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#primaryimage","url":"https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-with-potatoes-and-carrots.jpg","contentUrl":"https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-with-potatoes-and-carrots.jpg","width":725,"height":907},{"@type":"BreadcrumbList","@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.instrupix.com/"},{"@type":"ListItem","position":2,"name":"The Best Slow Cooker Pot Roast Recipe"}]},{"@type":"WebSite","@id":"https://www.instrupix.com/#website","url":"https://www.instrupix.com/","name":"Instrupix","description":"Instructional Pictures","potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.instrupix.com/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-US"},{"@type":"Person","@id":"https://www.instrupix.com/#/schema/person/8cee678a0fd4037cdf113bf130a4c54d","name":"Lilly","image":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.instrupix.com/#/schema/person/image/","url":"https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=96&d=mm&r=g","contentUrl":"https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=96&d=mm&r=g","caption":"Lilly"},"url":"https://www.instrupix.com/author/lilly/"},{"@type":"Recipe","name":"Easy Slow Cooker Pot Roast Recipe With Vegetables","author":{"@id":"https://www.instrupix.com/#/schema/person/8cee678a0fd4037cdf113bf130a4c54d"},"description":"Are you looking for easy crockpot dinner recipes for your family? This simple pot roast is absolutely incredible and requires just 4 ingredients: beef roast, ranch seasoning, Italian seasoning, and brown gravy mix. I also like to make it with potatoes, carrots, and celery but you can add any veggies that you&#39;d prefer.","datePublished":"2019-11-01T20:06:40+00:00","image":["https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker.jpg","https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-500x500.jpg","https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-500x375.jpg","https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-480x270.jpg"],"recipeYield":["6"],"prepTime":"PT10M","cookTime":"PT480M","recipeIngredient":["1 3-5lb  beef roast ((any kind))","1½ cups water","1  packet brown gravy mix","1  packet ranch dressing mix","1  packet Italian dressing mix","vegetables of your choice ((potatoes, carrots, celery, etc.))"],"recipeInstructions":[{"@type":"HowToStep","text":"Place your beef roast into your slow cooker with 1½ cups of water.","name":"Place your beef roast into your slow cooker with 1½ cups of water.","url":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#wprm-recipe-4819-step-0-0"},{"@type":"HowToStep","text":"Sprinkle all of the seasoning packets over the roast.","name":"Sprinkle all of the seasoning packets over the roast.","url":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#wprm-recipe-4819-step-0-1"},{"@type":"HowToStep","text":"Cover and cook on low for about 4 hours and then add your veggies.","name":"Cover and cook on low for about 4 hours and then add your veggies.","url":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#wprm-recipe-4819-step-0-2"},{"@type":"HowToStep","text":"Cook for an additional 2-4 hours or until the beef easily pulls apart. The time needed will greatly depend on your cut of meat and the brand of your slow cooker.","name":"Cook for an additional 2-4 hours or until the beef easily pulls apart. The time needed will greatly depend on your cut of meat and the brand of your slow cooker.","url":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#wprm-recipe-4819-step-0-3"}],"recipeCategory":["Main Course"],"keywords":"comfort food, easy dinner idea, slow cooker meals","@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/#recipe","isPartOf":{"@id":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/"},"mainEntityOfPage":"https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/"}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel="dns-prefetch" href="//fonts.googleapis.com">
+<link rel="alternate" type="application/rss+xml" title="Instrupix » Feed" href="https://www.instrupix.com/feed/">
+<link rel="alternate" type="application/rss+xml" title="Instrupix » Comments Feed" href="https://www.instrupix.com/comments/feed/">
+<link rel="alternate" type="application/rss+xml" title="Instrupix » The Best Slow Cooker Pot Roast Recipe Comments Feed" href="https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/feed/">
+<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.instrupix.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.6.1"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83d\udc26\u200d\u2b1b","\ud83d\udc26\u200b\u2b1b")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+<style id="wp-emoji-styles-inline-css" type="text/css">
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel="stylesheet" id="adace-style-css" href="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/css/style.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="shoppable-images-css-css" href="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/css/shoppable-images-front.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-crestafont-css" href="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/css/csscfont.min.css?ver=2.9.9.5" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-wp-style-css" href="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/css/cresta-wp-css.min.css?ver=2.9.9.5" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-googlefonts-css" href="//fonts.googleapis.com/css?family=Noto+Sans:400,700&amp;display=swap" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-hover-css" href="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/css/cresta-hover.min.css?ver=2.9.9.5" type="text/css" media="all">
+<link rel="stylesheet" id="mace-lazy-load-youtube-css" href="https://www.instrupix.com/wp-content/plugins/media-ace/includes/lazy-load/css/youtube.css?ver=1.2.3" type="text/css" media="all">
+<link rel="stylesheet" id="mediaelement-css" href="https://www.instrupix.com/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.17" type="text/css" media="all">
+<link rel="stylesheet" id="wp-mediaelement-css" href="https://www.instrupix.com/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="mace-vp-style-css" href="https://www.instrupix.com/wp-content/plugins/media-ace/includes/video-playlist/css/video-playlist.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="mace-gallery-css" href="https://www.instrupix.com/wp-content/plugins/media-ace/includes/gallery/css/gallery.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="g1-main-css" href="https://www.instrupix.com/wp-content/themes/starmile/css/1.2.2/styles/food-blogger/all-light.min.css?ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-iconfont-css" href="https://www.instrupix.com/wp-content/themes/starmile/css/1.2.2/fonts/styles.css?ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-google-fonts-css" href="//fonts.googleapis.com/css?family=Merriweather%3A400%2C400i%2C700%2C700i%7CMerriweather+Sans%3A400%2C400i%2C700%2C700i&amp;subset=latin%2Clatin-ext&amp;ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="font-awesome-css" href="https://www.instrupix.com/wp-content/themes/starmile/css/1.2.2/fonts/font-awesome/css/font-awesome.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-dynamic-style-css" href="https://www.instrupix.com/wp-content/uploads/dynamic-style.css?respondjs=no&amp;ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-style-css" href="https://www.instrupix.com/wp-content/themes/starmile-child-theme/style.css?ver=6.6.1" type="text/css" media="screen">
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/js/slideup.js?ver=0.1" id="adace-slideup-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/ad-ace/includes/shoppable-images/assets/js/shoppable-images-front.js?ver=0.1" id="shoppable-images-js-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/js/coupons.js?ver=0.1" id="adace-coupons-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/modernizr/modernizr-custom.min.js?ver=3.3.0" id="modernizr-js"></script>
+<link rel="https://api.w.org/" href="https://www.instrupix.com/wp-json/"><link rel="alternate" title="JSON" type="application/json" href="https://www.instrupix.com/wp-json/wp/v2/posts/4801"><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.instrupix.com/xmlrpc.php?rsd">
+<link rel="shortlink" href="https://www.instrupix.com/?p=4801">
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.instrupix.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F">
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.instrupix.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F&amp;format=xml">
+	<style type="text/css">
+		.adace-slot-wrapper-mobile{
+			display:none;
+		}
+		.adace-slot-wrapper-tablet{
+			display:none;
+		}
+		@media only screen and (max-width: 600px ) {
+			.adace-hide-on-mobile{
+				display:none;
+			}
+			.adace-slot-wrapper-mobile{
+				display:block;
+			}
+		}
+		@media only screen and (min-width: 601px  ) and  (max-width: 960px ){
+			.adace-hide-on-tablet{
+				display:none;
+			}
+			.adace-slot-wrapper-tablet{
+				display:block;
+			}
+		}
+	</style>
+	<style id="cresta-social-share-counter-pro-inline-css">.cresta-share-icon .sbutton, .cresta-share-icon .sbutton-total {font-family: 'Noto Sans', sans-serif;}#crestashareiconincontent {float: left;}
+			.cresta-share-icon .cresta-the-count-content, #crestashareiconincontent .sbutton a[data-name]:hover:before {color:#ffffff!important;} 
+			.cresta-share-icon .cresta-the-total-count, .cresta-share-icon .cresta-the-total-text {color:#000000!important;} 
+			#crestashareiconincontent .sbutton-total {border-right: 2px solid #000000!important;} 
+			
+				.cresta-share-icon .cresta-the-count-content, #crestashareiconincontent .sbutton a[data-name]:hover:before {background: #D60000!important;}
+				#crestashareiconincontent .sbutton a[data-name]:hover:after, #crestashareicon .sbutton a[data-name]:hover:after {border-color: #D60000 transparent !important;} 
+				
+					.cresta-share-icon i.c-icon-cresta-facebook {background: #666699;}
+					.cresta-share-icon i.c-icon-cresta-facebook:hover {border: 2px solid #666699!important; color: #666699; }
+					
+					.cresta-share-icon i.c-icon-cresta-pinterest {background: #cc6666;}
+					.cresta-share-icon i.c-icon-cresta-pinterest:hover {border: 2px solid #cc6666!important; color: #cc6666; }
+					
+					.cresta-share-icon i.c-icon-cresta-mail {background: #ffcc66;}
+					.cresta-share-icon i.c-icon-cresta-mail:hover {border: 2px solid #ffcc66!important; color: #ffcc66; }
+					</style>		<style>
+			:root {
+				--mv-create-radius: 0;
+			}
+		</style>
+		<style type="text/css"> .tippy-box[data-theme~="wprm"] { background-color: #333333; color: #FFFFFF; } .tippy-box[data-theme~="wprm"][data-placement^="top"] > .tippy-arrow::before { border-top-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="bottom"] > .tippy-arrow::before { border-bottom-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="left"] > .tippy-arrow::before { border-left-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="right"] > .tippy-arrow::before { border-right-color: #333333; } .tippy-box[data-theme~="wprm"] a { color: #FFFFFF; } .wprm-comment-rating svg { width: 18px !important; height: 18px !important; } img.wprm-comment-rating { width: 90px !important; height: 18px !important; } body { --comment-rating-star-color: #343434; } body { --wprm-popup-font-size: 16px; } body { --wprm-popup-background: #ffffff; } body { --wprm-popup-title: #000000; } body { --wprm-popup-content: #444444; } body { --wprm-popup-button-background: #444444; } body { --wprm-popup-button-text: #ffffff; }</style><style type="text/css">.wprm-glossary-term {color: #5A822B;text-decoration: underline;cursor: help;}</style><link rel="icon" href="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-32x32.jpg" sizes="32x32">
+<link rel="icon" href="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-192x192.jpg" sizes="192x192">
+<link rel="apple-touch-icon" href="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-180x180.jpg">
+<meta name="msapplication-TileImage" content="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-270x270.jpg">
+		<style type="text/css" id="wp-custom-css">
+			blockquote:before {
+content: "";
+}
+
+blockquote {
+border-top: 2px solid #aeac4a;
+border-bottom: 2px solid #aeac4a;
+padding: 5px 5px;
+margin: 5px 5px 5px 5px;
+}
+
+blockquote h3 {
+margin: 2rem 0;
+padding: 5px 5px;
+text-align: center;
+color: #aeac4a !important;
+font-size: 2rem;
+}
+
+mashicon-pinterest mash-large mash-center mashsb-noshadow a {
+color: #2d5f9a;
+}
+
+.acme-related-posts {
+	border-bottom: 1px solid #ccc;
+	border-top: 1px solid #ccc;
+	font-size: 16px;
+	font-size: 1.6rem;
+	min-height: 180px;
+	position: relative;
+	line-height: 1.5;
+}
+
+.acme-related-posts p {
+	line-height: 1.5;
+}
+
+.acme-related-posts strong,
+.acme-related-posts strong a{
+	color: #b4c246;
+}
+
+.acme-related-posts a:hover {
+	text-decoration: none
+}
+
+.acme-related-posts a {
+	color: #534640;
+	font-family: Arial, Helvetica, Tahoma, sans-serif;
+	font-size: 18px;
+	font-weight: normal;
+	line-height: 1.5;
+	margin: 0;
+	padding: 0;
+	text-decoration: none;
+}
+
+.acme-related-posts h5 {
+	color: #b3b3b3;
+	font-family: 'Tahoma', sans-serif;
+	font-size: 2rem !important;
+	font-weight: normal;
+	margin: -13px 0 0;
+	text-align: center;
+	text-transform: uppercase
+}
+
+.acme-related-posts h5 span {
+	background: #fff;
+	padding: 0 15px
+}
+.related-thumbnail { 
+	float:left;
+	display:inline;
+	margin: 0 12px 0 0;
+}
+
+a {
+	color: #b4c246;
+}
+
+.hiddenimage {
+	display: none
+}
+
+.g1-socials-section .g1-socials-item-tooltip-inner {
+	font-size: 24px;
+}
+
+[type="submit"],
+[type="reset"],
+[type="button"],
+button,
+.g1-button-solid,
+.g1-button-solid:hover,
+.g1-arrow-solid,
+.author-link,
+.author-info .author-link {
+border-color: #b6bc72;
+background-color: #b6bc72;
+color: #000000;
+}
+
+.button_89 {
+  border-radius: 4px;
+  background-color: #f4511e;
+  border: none;
+  color: #FFFFFF;
+  text-align: center;
+  font-size: 28px;
+  padding: 20px;
+  width: 500px;
+  transition: all 0.5s;
+  cursor: pointer;
+  margin: 5px;
+}
+
+.button_89 span {
+  cursor: pointer;
+  display: inline-block;
+  position: relative;
+  transition: 0.5s;
+}
+
+.button_89 span:after {
+  content: '\00bb';
+  position: absolute;
+  opacity: 0;
+  top: 0;
+  right: -20px;
+  transition: 0.5s;
+}
+
+.button_89:hover span {
+  padding-right: 25px;
+}
+
+.button_89:hover span:after {
+  opacity: 1;
+  right: 0;
+}
+
+hr:before {
+    content: "\2605\2605\2605\2605\2605"
+}
+
+/* Style all font awesome icons */
+.fa {
+    padding: 10px;
+    font-size: 20px;
+    width: 20px;
+    text-align: center;
+    text-decoration: none;
+    border-radius: 50%;
+}
+/* Add a hover effect if you want */
+.fa:hover {
+    opacity: 0.7;
+}
+
+/* Set a specific color for each brand */
+
+/* Facebook */
+.fa-facebook {
+    background: #3B5998;
+    color: white;
+}
+
+/* Twitter */
+.fa-pinterest {
+    background:  #c8232c;
+    color: white;
+}
+
+.g1-socials-item-icon-facebook {
+color: #3b5998 !important;
+}
+
+.g1-socials-item-icon-pinterest {
+color: #cb2027 !important;
+}
+
+.g1-socials-item-icon-instagram {
+color: purple !important;
+}
+
+
+.starmile-search {
+	color: #000 !important;
+}
+
+.wp-caption-text a {
+-webkit-box-shadow: none;
+-moz-box-shadow: none;
+box-shadow: none;
+font-size: 12px;
+font-family: 'Tahoma';
+font-weight: 700;
+font-style: normal;
+text-transform: none;
+letter-spacing: .1em;
+color: #b4c246;
+}
+
+.hideimage {
+	display: none
+}
+
+.g1-bin-1 .g1-hb-search-form, .g1-bin-1 .g1-id, .g1-bin-1 .g1-mobile-logo-wrapper, .g1-bin-1 .g1-primary-nav, .g1-bin-1 .g1-small-logo-wrapper, .g1-bin-1 .g1-socials-hb-list, .g1-bin-1 .wpml-ls {
+	margin-right: 5px;
+}
+.g1-bin-3 .g1-hb-search-form, .g1-bin-3 .g1-id, .g1-bin-3 .g1-mobile-logo-wrapper, .g1-bin-3 .g1-primary-nav, .g1-bin-3 .g1-small-logo-wrapper, .g1-bin-3 .g1-socials-hb-list, .g1-bin-3 .wpml-ls {
+	margin-left: 5px;
+}
+
+.g1-socials-item-icon.g1-socials-item-icon-28 {
+	padding: 0 5px;
+}
+
+.g1-bin .g1-socials-items .g1-socials-item-icon.g1-socials-item-icon-28 {
+	font-size: 20px;
+}
+.g1-hb-row .sub-menu .menu-item > a {
+	color: #000;
+}
+.g1-canvas-content, .g1-canvas-toggle, .g1-canvas-content .menu-item > a, .g1-canvas-content .g1-menu-v .menu-item>a, .g1-canvas-content .g1-hamburger, .g1-canvas-content .g1-drop-toggle, .g1-canvas-content .g1-socials-item-link {
+	color: #000;
+}
+.relatedposts2 {
+	padding-top: 10px;
+}
+
+.fb-root {
+	width:100%
+}
+
+.fb_iframe_widget_fluid_desktop iframe {
+min-width: 100%;
+position: relative;
+}
+g1-alpha g1-alpha-2nd page-title archive-title .page-title {
+	margin-bottom: 50px;
+}
+
+.instructional_picutures body {
+	margin-bottom: .5rem;
+	color: #999
+}
+
+h88 {
+	color: #999;
+}
+
+.wp-caption-text a {
+	margin-top: 1em;
+	font-size: 18px;
+	letter-spacing: 0em;
+	font-weight: 550;
+}
+
+.wp-caption-text {
+	margin-top: 1em;
+	font-size: 18px;
+	letter-spacing: 0em;
+	font-weight: 550;
+	line-height: normal;
+
+}
+
+.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] [data-style="minimal"] {
+	padding: 20px !important;
+}
+
+.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="dark"], .formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="light"] {
+	display: none;
+}
+
+.formkit-form[data-uid="ae3b256f6f"] .formkit-header {
+	margin: 0 0 0 0; 
+}
+
+
+.g1-delta, h4 {
+	font-size: 18px !important;
+}
+
+.acme-helpful-tips-margin-top {
+	margin-top:30px;
+	margin-bottom: 30px;
+}
+
+.acme-helpful-tips {
+	border-bottom: 1px solid #ccc;
+	border-top: 1px solid #ccc;
+	border-left: 1px solid #ccc;
+	border-right: 1px solid #ccc;
+	font-size: 16px;
+	font-size: 1.6rem;
+	min-height: 180px;
+	position: relative;
+	line-height: 1.5;
+}
+
+.acme-helpful-tips p {
+	line-height: 1.5;
+}
+
+.acme-helpful-tips strong,
+.acme-helpful-tips strong a{
+	color: #b4c246;
+	font-size: 2rem;
+}
+
+.acme-helpful-tips a:hover {
+	text-decoration: none
+}
+
+
+.acme-helpful-tips ul,
+.acme-helpful-tips li {
+	color: #797979;
+	margin-left: 30px;
+	font-size: 15px;
+	padding-right: 20px;
+	
+}
+
+
+.acme-helpful-tips p {
+	color: #797979;
+	margin-left: 30px;
+	font-size: 15px;
+	padding-right: 20px;
+	
+}
+
+.acme-helpful-tips a {
+	color: #999a34;
+	font-family: Arial, Helvetica, Tahoma, sans-serif;
+	line-height: 1.5;
+	margin: 0;
+	padding: 0;
+	text-decoration: underline;
+}
+
+.acme-helpful-tips h5 {
+	color: #454545;
+	font-family: 'Merriweather', sans-serif;
+	font-size: 2rem !important;
+	font-weight: normal;
+	margin: -13px 0 0;
+	text-align: center;
+	text-transform: uppercase
+}
+
+.acme-helpful-tips h5 span {
+	background: #fff;
+	padding: 0 15px;
+	font-size: 2.2rem;
+}
+
+.fb_iframe_widget_fluid_desktop iframe {
+	min-width: 100% !important;
+}
+.acme_featured_image {
+	padding-bottom: 5px;
+}
+
+
+.grey_bg {
+				padding: 25px;
+        background-color: #f3f3f3;
+	margin-top: 20px;
+	margin-bottom: 20px;
+    }
+
+ul {
+list-style-type: disc;
+}
+
+
+
+
+.g1-alpha-3rd, .g1-beta-3rd, .g1-delta-3rd, .g1-epsilon-3rd, .g1-gamma-3rd, .g1-giga-3rd, .g1-mega-3rd, .g1-zeta-3rd {
+	
+	color: #666666;
+}		</style>
+		<link rel="preload" href="https://securepubads.g.doubleclick.net/tag/js/gpt.js" as="script"><style type="text/css">:root{--fides-overlay-primary-color:#8243f2;--fides-overlay-background-color:#f7fafc;--fides-overlay-embed-background-color:transparent;--fides-overlay-font-color:#4a5568;--fides-overlay-font-color-dark:#2d3748;--fides-overlay-hover-color:#edf2f7;--fides-overlay-gpc-applied-background-color:#38a169;--fides-overlay-gpc-applied-text-color:#fff;--fides-overlay-gpc-overridden-background-color:#e53e3e;--fides-overlay-gpc-overridden-text-color:#fff;--fides-overlay-background-dark-color:#e2e8f0;--fides-overlay-width:680px;--fides-overlay-primary-button-background-color:var(
+    --fides-overlay-primary-color
+  );--fides-overlay-primary-button-background-hover-color:#9569f4;--fides-overlay-primary-button-text-color:#fff;--fides-overlay-primary-button-border-color:transparent;--fides-overlay-secondary-button-background-color:var(
+    --fides-overlay-background-color
+  );--fides-overlay-secondary-button-background-hover-color:var(
+    --fides-overlay-hover-color
+  );--fides-overlay-secondary-button-text-color:#2d3748;--fides-overlay-secondary-button-border-color:var(
+    --fides-overlay-primary-color
+  );--fides-overlay-title-font-color:var(--fides-overlay-font-color);--fides-overlay-body-font-color:var(--fides-overlay-font-color);--fides-overlay-link-font-color:var(--fides-overlay-font-color-dark);--fides-overlay-primary-active-color:var(--fides-overlay-primary-color);--fides-overlay-inactive-color:#e2e8f0;--fides-overlay-inactive-font-color:#a0aec0;--fides-overlay-disabled-color:#e1e7ee;--fides-overlay-row-divider-color:#e2e8f0;--fides-overlay-row-hover-color:var(--fides-overlay-hover-color);--fides-overlay-badge-background-color:#718096;--fides-overlay-badge-border-radius:4px;--fides-overlay-select-border-color:#e2e8f0;--fides-overlay-language-button-border-radius:4px;--fides-overlay-font-family:Inter,sans-serif;--12px:0.75rem;--14px:0.875rem;--15px:0.9375rem;--16px:1rem;--fides-overlay-font-size-body-small:var(--12px);--fides-overlay-font-size-body:var(--14px);--fides-overlay-font-size-title:var(--16px);--fides-overlay-font-size-buttons:var(--14px);--fides-overlay-padding:24px;--fides-overlay-padding-tcf:40px;--fides-overlay-button-border-radius:6px;--fides-overlay-button-padding:8px 16px;--fides-overlay-link-v-padding:4px;--fides-overlay-link-h-padding:4px;--fides-overlay-link-padding:var(--fides-overlay-link-v-padding) var(--fides-overlay-link-h-padding);--fides-overlay-container-border-radius:12px;--fides-overlay-container-border-width:1px;--fides-overlay-component-border-radius:4px;--fides-overlay-banner-offset:48px;--fides-banner-font-size-title:var(--16px);--fides-overlay-language-loading-indicator-speed:5s}@keyframes spin{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}div.fides-overlay{position:fixed;z-index:1000}div#fides-overlay-wrapper *{box-sizing:border-box}.fides-banner,.fides-modal-container{-webkit-font-smoothing:antialiased;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-body);line-height:calc(1em + .4rem);white-space:pre-line}#fides-modal-link{cursor:pointer;display:none}#fides-modal-link.fides-modal-link-shown{display:inline}div#fides-banner-container:not(.fides-embedded){display:flex;justify-content:center;position:fixed;transform:translateY(0);transition:transform 1s,visibility 1s;visibility:visible;width:100%;z-index:1}div#fides-banner{align-items:center;background:var(--fides-overlay-background-color);border-top:var(--fides-overlay-container-border-width) solid var(--fides-overlay-primary-color);color:var(--fides-overlay-body-font-color);display:flex;flex-direction:row;flex-wrap:wrap;font-size:var(--fides-overlay-font-size-body);justify-content:space-between;overflow-y:hidden;padding:24px;position:relative}.fides-embedded div#fides-banner{border:none}div#fides-banner-inner{width:100%}div#fides-banner-container.fides-banner-bottom{bottom:0;left:0}div#fides-banner-container.fides-banner-hidden{visibility:hidden}div#fides-banner-container.fides-banner-hidden.fides-embedded{display:none}div#fides-banner-container.fides-banner-bottom.fides-banner-hidden{transform:translateY(150%)}div#fides-banner-container.fides-banner-top{left:0;top:0}div#fides-banner-container.fides-banner-top.fides-banner-hidden{transform:translateY(-150%)}div#fides-banner-inner div#fides-button-group{align-items:center;flex-direction:row-reverse;margin-bottom:0;margin-top:0;padding-bottom:0;padding-top:0;width:100%}.fides-modal-footer div#fides-button-group{align-items:center;flex-direction:column;gap:12px;margin-inline:var(--fides-overlay-padding)}div#fides-banner-inner-container{grid-column-gap:60px;display:grid;grid-template-columns:1fr 1fr}div#fides-banner-inner-description{grid-column:1;grid-row:1}div#fides-tcf-banner-inner{grid-column:2;grid-row:1/3;height:0;margin-top:40px;min-height:100%;overflow-y:auto;scrollbar-gutter:stable}div#fides-banner-heading{align-items:center;display:flex;margin-right:13px}div#fides-banner-title{color:var(--fides-overlay-title-font-color);flex:1;font-size:var(--fides-banner-font-size-title);font-weight:600;line-height:1.5em;min-width:33%}div#fides-banner-description{flex:1;font-size:var(--fides-overlay-font-size-body);margin-bottom:24px;margin-top:16px}div#fides-banner-notices{margin-top:16px}div#fides-button-group{background-color:var(--fides-overlay-background-color);display:flex;justify-content:space-between;margin-bottom:var(--fides-overlay-padding);margin-top:8px;z-index:5}button.fides-banner-button{background:var(--fides-overlay-primary-button-background-color);border:1px solid;border-radius:var(--fides-overlay-button-border-radius);color:var(--fides-overlay-primary-button-text-color);cursor:pointer;display:inline-block;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-buttons);font-weight:600;margin:4px 0 0;padding:var(--fides-overlay-button-padding);text-align:center;text-decoration:none}button.fides-banner-button:hover{background:var(--fides-overlay-primary-button-background-hover-color)}button.fides-banner-button.fides-banner-button-primary{background:var(--fides-overlay-primary-button-background-color);border:none;color:var(--fides-overlay-primary-button-text-color)}button.fides-banner-button.fides-banner-button-primary:hover{background:var(--fides-overlay-primary-button-background-hover-color)}button.fides-banner-button.fides-banner-button-secondary{background:var(--fides-overlay-secondary-button-background-color);border:1px solid var(--fides-overlay-primary-button-background-color);color:var(--fides-overlay-secondary-button-text-color)}button.fides-banner-button.fides-banner-button-secondary:hover{background:var(--fides-overlay-secondary-button-background-hover-color)}button.fides-banner-button.fides-banner-button-tertiary{background:none;border:none;color:var(--fides-overlay-link-font-color);cursor:pointer;font-size:var(--fides-overlay-font-size-body);font-weight:500;line-height:1.25em;padding:0;text-decoration:underline}button.fides-banner-button.fides-acknowledge-button{min-width:160px}div.fides-modal-content{background-color:var(--fides-overlay-background-color);border:var(--fides-overlay-container-border-width) solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-container-border-radius);color:var(--fides-overlay-body-font-color);display:flex;flex-direction:column;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-body);left:50%;max-height:680px;overflow:hidden;padding:0;position:fixed;top:50%;transform:translate(-50%,-50%);width:var(--fides-overlay-width);z-index:2}.fides-modal-container,.fides-modal-overlay{background-color:rgba(0,0,0,.25);bottom:0;left:0;position:fixed;right:0;top:0}div#fides-embed-container div#fides-consent-content .fides-modal-footer{position:inherit}div#fides-embed-container .fides-modal-body{padding-top:16px}div#fides-embed-container div#fides-consent-content{background-color:var(--fides-overlay-background-color);border:none;border-radius:var(--fides-overlay-container-border-radius);border-bottom-left-radius:0;border-bottom-right-radius:0;color:var(--fides-overlay-body-font-color);display:flex;flex-direction:column;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-body);left:50%;max-height:none;overflow:hidden;padding:0;position:static;top:50%;transform:none;width:var(--fides-overlay-width)}.fides-modal-container{display:flex;z-index:2}.fides-modal-container[aria-hidden=true]{display:none}div#fides-modal .fides-modal-header{display:flex;justify-content:end}div#fides-consent-content{overflow:auto;scrollbar-gutter:stable}div#fides-consent-content .fides-modal-title{color:var(--fides-overlay-title-font-color);font-size:var(--fides-overlay-font-size-title);font-weight:600;margin:0;text-align:center}div#fides-consent-content .fides-modal-body{height:100%;overflow-y:auto;padding-inline:var(--fides-overlay-padding)}.fides-modal-footer{background-color:var(--fides-overlay-background-color);border-bottom-left-radius:var(--fides-overlay-component-border-radius);border-bottom-right-radius:var(--fides-overlay-component-border-radius);bottom:0;display:flex;flex-direction:column;max-width:var(--fides-overlay-width);position:relative;width:100%;z-index:5}div#fides-consent-content .fides-modal-description{margin:8px 0 24px}.fides-banner-button-group{align-items:center;display:flex;gap:12px}.fides-modal-button-group{display:flex;flex-direction:row;gap:12px;margin-inline:var(--fides-overlay-padding);width:100%}.fides-modal-primary-actions .fides-banner-button{flex:1}.fides-banner-secondary-actions{justify-content:space-between}.fides-modal-secondary-actions{justify-content:center}.fides-banner-secondary-actions{gap:36px}.fides-tcf-banner-container div#fides-banner div#fides-banner-inner div#fides-button-group{gap:12px}.fides-no-scroll{overflow-y:hidden}@media (max-width:768px){div#fides-consent-content,div.fides-modal-content{width:100%!important}.fides-modal-button-group{flex-direction:column}button.fides-banner-button{margin:0 8px 12px 0}}div#fides-banner .fides-close-button{background:none;border:none;cursor:pointer;display:flex;position:absolute;right:3px;top:8px}.fides-modal-header .fides-close-button{background:none;border:none;cursor:pointer;padding-right:8px;padding-top:8px}.fides-close-button:hover{background:var(--fides-overlay-hover-color)}.fides-embedded .fides-close-button{display:none!important}.fides-modal-notices{margin-bottom:16px}.fides-privacy-policy,div#fides-banner-inner .fides-privacy-policy{color:var(--fides-overlay-primary-color);display:block;text-align:center}.fides-privacy-policy{font-family:var(--fides-overlay-font-family)}button.fides-banner-button.fides-banner-button-tertiary,div#fides-banner-inner .fides-privacy-policy,div.fides-i18n-pseudo-button{line-height:1;margin:0;padding:var(--fides-overlay-link-padding)}@media (prefers-reduced-motion:reduce){.fides-toggle-display{transition-duration:0ms}}.fides-toggle{align-items:center;display:inline-flex;flex-wrap:wrap;gap:1ch;position:relative}.fides-toggle .fides-toggle-input{cursor:pointer;height:100%;opacity:0;position:absolute;width:100%;z-index:4}.fides-toggle .fides-toggle-display{--offset:4px;--diameter:16px;align-items:center;background-color:var(--fides-overlay-inactive-color);border-radius:100vw;box-sizing:content-box;color:var(--fides-overlay-inactive-font-color);display:inline-flex!important;height:24px;justify-content:space-around;justify-content:end;padding-inline:8px;position:relative;transition:.25s;width:34px}div#fides-overlay-wrapper .fides-toggle .fides-toggle-display{box-sizing:content-box}.fides-toggle .fides-toggle-display:before{background-color:#fff;border-radius:50%;box-shadow:0 1.3px 2.7px rgba(0,0,0,.25);box-sizing:border-box;content:"";height:var(--diameter);left:var(--offset);position:absolute;top:50%;transform:translateY(-50%);transition:inherit;width:var(--diameter);z-index:3}.fides-toggle .fides-toggle-input:checked+.fides-toggle-display{background-color:var(--fides-overlay-primary-active-color);color:var(--fides-overlay-primary-button-text-color);justify-content:start}.fides-toggle .fides-toggle-input:checked+.fides-toggle-display:before{transform:translate(26px,-50%)}.fides-toggle .fides-toggle-input:disabled{cursor:not-allowed}.fides-toggle .fides-toggle-input:disabled+.fides-toggle-display,.fides-toggle .fides-toggle-input:disabled:checked+.fides-toggle-display{background-color:var(--fides-overlay-disabled-color)}.fides-toggle .fides-toggle-input:focus+.fides-toggle-display{outline:1px auto Highlight;outline:1px auto -webkit-focus-ring-color}.fides-toggle .fides-toggle-input:focus:not(:focus-visible)+.fides-toggle-display{outline:0}.fides-divider{border-color:var(--fides-overlay-row-divider-color);border-width:0 0 1px;margin:0}.fides-disclosure-hidden{display:flex;height:0;margin-bottom:0;margin-top:0;overflow:hidden;visibility:hidden}.fides-notice-toggle .fides-notice-toggle-title{align-items:center;border-bottom:1px solid var(--fides-overlay-row-divider-color);display:flex;justify-content:space-between;padding-inline:12px 12px}.fides-notice-toggle .fides-notice-toggle-trigger{align-items:center;display:flex;justify-content:flex-end;min-height:40px}.fides-notice-toggle .fides-notice-toggle-trigger svg{flex-shrink:0}.fides-notice-toggle .fides-notice-toggle-title:hover{background-color:var(--fides-overlay-row-hover-color);cursor:pointer}.fides-notice-toggle .fides-notice-toggle-trigger:before{border-style:solid;border-width:2px 2px 0 0;content:"";display:inline-block;height:8px;margin-right:calc(.5rem + 2px);min-width:8px;transform:translateY(-2px) rotate(135deg);transition:transform .12s ease-in-out}.fides-notice-toggle.fides-notice-toggle-expanded .fides-notice-toggle-trigger:before{transform:translateY(2px) rotate(-45deg)}#fides-tcf-banner-inner .fides-disclosure-visible{padding:12px}.fides-notice-toggle .fides-disclosure-visible{display:flex;flex-direction:column;gap:12px;overflow:auto;padding:12px}.fides-notice-toggle p{margin:0 0 18px}.fides-notice-toggle p:last-child{margin:0}.fides-notice-toggle-title .fides-flex-center{align-items:center;display:flex;white-space:wrap;width:100%}.fides-notice-toggle-expanded{background-color:var(--fides-overlay-row-hover-color)}.fides-notice-toggle-header{font-weight:600}.fides-record-header{border-bottom:1px solid var(--fides-overlay-row-divider-color);font-weight:600;padding:12px}.fides-gpc-banner{border:1px solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-component-border-radius);display:flex;margin-bottom:16px;padding:18px}.fides-gpc-banner p{margin:0}.fides-gpc-warning{color:var(--fides-overlay-primary-color);margin-right:8px}.fides-gpc-header{font-weight:700}.fides-gpc-label{display:inline-flex;font-size:var(--fides-overlay-font-size-body);font-weight:600;padding:0 8px;white-space:nowrap}.fides-gpc-badge{border-radius:var(--fides-overlay-badge-border-radius);display:inline-flex;font-weight:700;margin-left:4px;padding:0 4px;text-transform:uppercase}.fides-gpc-badge-applied,.fides-gpc-badge-detected{background:var(--fides-overlay-gpc-applied-background-color);color:var(--fides-overlay-gpc-applied-text-color)}.fides-gpc-badge-overridden{background:var(--fides-overlay-gpc-overridden-background-color);color:var(--fides-overlay-gpc-overridden-text-color)}.fides-tab-list{display:flex;list-style-type:none;padding:0}.fides-tab-list>li{width:100%}.fides-tab-button{background:none;border-width:0 0 1px;border-bottom:1px solid var(--fides-overlay-row-divider-color);color:var(--fides-overlay-body-font-color);cursor:pointer;font-weight:500;padding:10px 20px;width:100%}.fides-tab-button[aria-selected=true]{border-bottom-width:2px;border-color:var(--fides-overlay-primary-active-color);color:var(--fides-overlay-primary-active-color);font-weight:600}.fides-tab-button::focus-visible{outline:1px auto Highlight;outline:1px auto -webkit-focus-ring-color}.fides-tab-button:focus:not(:focus-visible){outline:0}.fides-notice-badge{align-items:center;background:var(--fides-overlay-badge-background-color);border-radius:var(--fides-overlay-badge-border-radius);color:#fff;display:inline-flex;font-size:var(--fides-overlay-font-size-body-small);font-weight:600;height:18px;margin-left:4px;margin-right:8px;padding:0 4px;text-transform:uppercase}.fides-background-dark{background-color:var(--fides-overlay-background-dark-color)}.fides-radio-button-group{background-color:var(
+    --fides-overlay-secondary-button-background-hover-color
+  );border:1px solid var(--fides-overlay-row-divider-color);display:flex;margin-bottom:22px;padding:4px}.fides-radio-button{background-color:transparent;border:none;cursor:pointer;flex:1;padding:5px 16px}.fides-radio-button[aria-checked=true]{background-color:var(--fides-overlay-primary-button-background-color);color:var(--fides-overlay-primary-button-text-color)}.fides-flex-center{align-items:center;display:flex}.fides-margin-right{margin-right:3px}.fides-justify-space-between{justify-content:space-between}.fides-tcf-toggle-content{font-size:var(--fides-overlay-font-size-body-small);font-weight:400;margin-right:60px}.fides-tcf-purpose-vendor-title{display:flex;font-weight:600;justify-content:space-between}.fides-tcf-illustration{font-size:var(--fides-overlay-font-size-body-small);padding:13px 60px 13px 13px}.fides-tcf-illustration,.fides-tcf-purpose-vendor{border-radius:var(--fides-overlay-component-border-radius)}.fides-tcf-purpose-vendor{padding:13px}.fides-tcf-purpose-vendor-list{font-weight:400;list-style:none;margin-bottom:0;margin-left:0;padding-left:0}.fides-tcf-vendor-toggles{display:flex}.fides-vendor-details-table{width:100%}.fides-vendor-details-table td,.fides-vendor-details-table th{font-size:var(--fides-overlay-font-size-body-small);text-align:left}.fides-vendor-details-table td{border-bottom:1px solid var(--fides-overlay-row-divider-color)}.fides-link-button{background:none;border:none;color:var(--fides-overlay-body-font-color);cursor:pointer;padding:0;text-decoration:underline}.fides-external-link,.fides-primary-text-color{color:var(--fides-overlay-primary-color)}.fides-external-link{font-size:var(--fides-overlay-font-size-body-small);font-weight:500;margin-right:16px}.fides-vendor-info-banner{border-radius:var(--fides-overlay-component-border-radius);display:flex;flex-direction:row;gap:30px;justify-content:space-around;margin-bottom:16px;padding:16px 12px;position:sticky;top:0}.fides-vendor-info-label{font-size:var(--fides-overlay-font-size-body-small);font-weight:600;margin-right:4px}.fides-info-box{background-color:var(--fides-overlay-hover-color);border-radius:var(--fides-overlay-component-border-radius);margin:10px 0;padding:16px}.fides-info-box p{margin:0}.fides-tabs .tabpanel-container{overflow:hidden}.tabpanel-container section[hidden]{display:none}@media screen and (min-width:768px){div#fides-banner{border:1px solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-component-border-radius);width:75%}div#fides-banner-container.fides-banner-bottom{bottom:var(--fides-overlay-banner-offset)}}@media only screen and (min-width:1280px){div#fides-banner{border:1px solid var(--fides-overlay-primary-color);width:60%}}@media screen and (max-width:992px){.fides-vendor-info-banner{flex-direction:column;gap:16px}}@media screen and (max-width:768px){div#fides-banner{padding:24px;width:100%}div#fides-banner-description{margin-bottom:0}div#fides-banner-inner div#fides-button-group{align-items:flex-start;flex-direction:column;gap:12px;padding-top:24px}.fides-banner-button-group{flex-direction:column;width:100%}button.fides-banner-button{margin:0;width:100%}div#fides-tcf-banner-inner{margin-top:24px;min-height:revert;overflow-y:revert}div#fides-banner-inner-container{display:flex;flex-direction:column;max-height:50vh;overflow-y:auto;scrollbar-gutter:stable}div#fides-privacy-policy-link{order:1;width:100%}.fides-modal-footer{max-width:100%}.fides-tcf-banner-container div#fides-banner div#fides-banner-inner div#fides-button-group .fides-banner-button-group{padding-left:0}.fides-banner-secondary-actions{gap:12px}.fides-banner-secondary-actions .fides-manage-preferences-button{order:0}.fides-banner-secondary-actions #fides-privacy-policy-link{order:1}.fides-banner-secondary-actions .fides-i18n-menu{order:2}}.fides-tcf-banner-container{bottom:0!important}.fides-tcf-banner-container #fides-banner{border-radius:0;border-width:1px 0 0;padding:var(--fides-overlay-padding) var(--fides-overlay-padding-tcf) var(--fides-overlay-padding-tcf) var(--fides-overlay-padding-tcf);width:100%}.fides-tcf-banner-container #fides-privacy-policy-link{margin:auto}@media screen and (max-width:768px){.fides-tcf-banner-container #fides-banner{padding:var(--fides-overlay-padding)}}.fides-paging-buttons{display:flex;gap:8px;justify-content:center}.fides-paging-info{color:var(--fides-overlay-font-color-dark);font-size:var(--fides-overlay-font-size-body-small);font-weight:600;padding:8px}.fides-paging-previous-button{margin-right:8px}.fides-paging-next-button,.fides-paging-previous-button{background-color:transparent;border:none;cursor:pointer;padding:6px}.fides-paging-next-button:disabled,.fides-paging-previous-button:disabled{cursor:default}.fides-i18n-menu{position:relative}.fides-modal-container .fides-i18n-menu{bottom:var(--fides-overlay-padding);left:var(--fides-overlay-padding);position:absolute}.fides-modal-container .fides-button-group-i18n{min-height:calc(var(--fides-overlay-font-size-body) + var(--fides-overlay-link-v-padding)*2)}@media screen and (max-width:768px){.fides-banner-button-group.fides-button-group-i18n{min-height:68px}.fides-i18n-menu{bottom:var(--fides-overlay-padding);left:var(--fides-overlay-padding);position:absolute}}div.fides-i18n-pseudo-button{align-items:center;cursor:pointer;display:flex;flex-direction:row;gap:2px;height:var(--fides-overlay-font-size-body);text-transform:uppercase;white-space:nowrap}#fides-i18n-icon{animation-duration:var(--fides-overlay-language-loading-indicator-speed);animation-iteration-count:infinite;animation-timing-function:linear;transform-origin:50% 50%}div#fides-overlay-wrapper .fides-i18n-pseudo-button{box-sizing:content-box}.fides-i18n-popover{bottom:100%;display:flex;flex-direction:column;gap:1px;height:0;left:0;max-height:7rem;overflow:hidden;position:absolute;transition:height .5s}.fides-i18n-menu:hover .fides-i18n-pseudo-button{background-color:var(--fides-overlay-hover-color);border-radius:var(--fides-overlay-language-button-border-radius)}.fides-i18n-menu:hover .fides-i18n-pseudo-button .fides-i18n-caret{transform:rotate(180deg)}.fides-i18n-menu:focus-within .fides-i18n-popover,.fides-i18n-menu:hover .fides-i18n-popover{background-color:var(--fides-overlay-background-dark-color);border:1px solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-component-border-radius);height:auto;min-width:9rem;overflow:scroll}button.fides-banner-button.fides-menu-item{background:var(--fides-overlay-secondary-button-background-color);border:none;border-radius:0;color:var(--fides-overlay-secondary-button-text-color);margin:0;padding-left:1.5rem;text-align:left;width:100%}button.fides-banner-button.fides-menu-item[aria-pressed=true]{background:var(--fides-overlay-primary-button-background-color);color:var(--fides-overlay-primary-button-text-color)}button.fides-banner-button.fides-menu-item[aria-pressed=true]:before{content:"\2713";display:inline-block;margin-left:-1rem;margin-right:.25rem}button.fides-banner-button.fides-menu-item:not([aria-pressed=true]):hover{background:var(--fides-overlay-secondary-button-background-hover-color)}</style><style type="text/css">
+  :root {
+    --adhesion-background-color: rgba(0, 0, 0, 0.9);
+  }
+
+  .mv-empty-wrapper {	
+    margin: 0 !important;	
+    height: 0px !important;	
+    min-height: unset !important;	
+  } 
+  .adunitwrapper {
+    overflow: visible;
+    position: relative;
+    /* Typical height + padding for adunitlabels */
+    height: 264px;
+    /* Typical Width */
+    width: 300px;
+    /* try transition in separate a/b test */
+    /* transition: all 0.5s; */
+    white-space: normal !important;
+  }
+
+  div#fixed_container_bottom {
+    -webkit-transform: translate3d(0,0,0);
+    position: fixed;
+    bottom: 0;
+    width: 100vw;
+    height: 400px;
+    gap: 15px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    z-index: 2147483535;
+    pointer-events: none;
+    left: 0px !important;
+  }
+
+  div#fixed_container_bottom > * {
+    pointer-events: auto;
+    transition: all .3s ease-in;
+    transition-delay: 500ms;
+  }
+
+  div#fixed_container_bottom.highImpact_adhesion .adhesion_wrapper {
+    min-height: 150px !important;
+  }
+
+  div#fixed_container_bottom .adhesion_wrapper[data-slot-wrapper-hidden] {
+    visibility: hidden !important;
+  }
+
+  div#fixed_container_bottom[data-position=right] .universalPlayer__bottom {
+    transform: translateY(150px) !important;
+    align-self: start !important;
+  }
+
+  div#fixed_container_bottom[data-position=left] .universalPlayer__bottom {
+    transform: translateY(150px) !important;
+    align-self: end !important;
+  }
+
+  body .adunitwrapper[style*='display: block']>.adunit:before {
+    content: "Loading Ad...";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    -webkit-align-content: center;
+    align-content: center;
+    justify-content: center;
+    font-size: 14px;
+    color: #999;
+    display: -webkit-box;
+    -webkit-box-pack: center;
+    -webkit-box-align: center;
+    box-sizing: border-box;
+  }
+
+  div.mv_slot_target[data-slot] {
+    height: 264px;
+  }
+
+  div.mv_slot_target[data-hint-slot-inserted="true"],
+  div.mv_slot_target[data-hint-slot-inserted="blocked"] {
+    height: revert;
+  }
+
+  .mv-outstream-container + .adunit:before { 
+    display: none!important;
+  }
+
+  .mv-outstream-container + .adunitwrapper>.adunit:before {
+    display: none!important;
+  }
+
+  body .adunitwrapper[style*='display: block']>.adunit {
+    position: relative;
+  }
+
+  body .adunitwrapper[style*='display: block']>.adunit>div {
+    position: relative;
+  }
+
+  .adhesion_wrapper {
+    display: none;
+    max-height: 90px!important;
+  }
+
+  body.adhesion.highImpact_adhesion .adhesion_wrapper {
+    max-height: 150px!important;
+  }
+
+  .mv-native-size {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: initial;
+    overflow: hidden !important;
+  }
+
+  .mv-native-size.sidebar_atf_wrapper,
+  .mv-native-size.sidebar_btf_wrapper {
+    padding-left: 0px;
+    padding-bottom: 19px;
+  }
+
+  .mv-native-size div[id^='google_ads'] {
+    min-height: 100%!important;
+    height: 100%!important;
+    width: 100%!important;
+  }
+
+  .mv-dynamic-size div[id^='google_ads'] {
+    height: initial!important;
+    width: initial!important;
+  }
+
+  mv-ad-reporter {
+    display: none;
+    position: absolute;
+    height: 20px;
+    width: 20px;
+    z-index: 10;
+    line-height: 1.0;
+  }
+
+  .adunitwrapper mv-ad-reporter {
+    bottom: 0px;
+    right: -22px;
+  }
+  
+  .adunitwrapper.sidebar_atf_wrapper mv-ad-reporter,
+  .adunitwrapper.sidebar_btf_wrapper mv-ad-reporter,
+  .adunitwrapper.gutter_atf_wrapper mv-ad-reporter {
+    bottom: -20px;
+    right: 1px;
+  }
+
+  /* Hide Gutter Ad Reporters until the slot is filled with an ad.*/
+  .ad_gutter_middle .adunitwrapper.sidebar_btf_wrapper.mv-empty-wrapper mv-ad-reporter {
+    display: none;
+  }
+
+  #adhesion_mobile_wrapper mv-ad-reporter,
+  #adhesion_desktop_wrapper mv-ad-reporter,
+  #adhesion_tablet_wrapper mv-ad-reporter {
+    position: relative;
+    left: 3px;
+  }
+
+  @media (max-width: 391px) {
+    .adunitwrapper mv-ad-reporter {
+      bottom: -20px;
+      right: 1px;
+    }
+  }
+
+  .adunitwrapper.mv-native-size mv-ad-reporter {
+    right: 1px;
+    bottom: 0px;
+  }
+
+  .mv-ad-box mv-ad-reporter {
+    bottom: 1px;
+    right: 1px;
+  }
+
+  .mv-outstream-container {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+  }
+
+  .mv-outstream-container.active {
+    z-index: 1000;
+  }
+
+  .mv-outstream-container.inactive {
+    z-index: -1;
+  }
+
+  .adhesion_wrapper .mv-outstream-container {
+    top: -51px;
+    left: 5%;
+    width: auto;
+  }
+  
+  .mv-outstream-mute {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    width: 30px;
+    height: 30px;
+    z-index: 999;
+  }
+
+  .mv-mute-button {
+    pointer-events: none;
+  }
+
+  .mv-mute-button img {
+    width: 32px;
+  }
+
+  #arrival_wrapper {
+    margin: 10px auto 20px auto!important;
+  }
+
+  .mv-arrival-continue-button {
+    margin: 0 auto;
+    display: block;
+    width: 300px;
+    text-align: center;
+    border-top: 1px solid #efefef;
+    padding: 15px 0px;
+    z-index: 1001;
+  }
+
+  body.adhesion {
+    padding-bottom: 90px!important;
+  }
+
+  body.adhesion.highImpact_adhesion {
+    padding-bottom: 150px!important;
+  }
+
+  .mediavine img {
+    margin : 0 !important;
+    padding : 0 !important;
+    border : 0 !important;
+    box-shadow: none !important;
+  }
+
+  .sidebar_btf_wrapper {
+    margin : 0 auto 0 auto;
+    width : 300px;
+  }
+
+  /* This is a fix for trellis */
+  .mv-sticky-slot #sidebar_btf_sticky_wrapper.mv-stuck {
+    position: static;
+  }
+
+  .recipe_mobile_wrapper,
+  .content_mobile_wrapper,
+  .comments_mobile_wrapper {
+    margin-bottom : 10px;
+  }
+
+  [data-recipe-ads-inserted] .recipe_btf_wrapper,
+  [data-recipe-ads-inserted] .recipe_mobile_wrapper {
+    margin: 0 auto;
+  }
+
+  .wprm-recipe-ingredients-container .recipe_btf_wrapper{
+    float: right;
+  }
+
+  .tasty-recipes-ingredients .recipe_btf_wrapper{
+    float: right;
+  }
+
+  @media (max-width: 1023px) {
+    #sidebar_btf_sticky_wrapper, .sidebar_btf_wrapper, .sidebarBtfStacked, .sidebarBtfStackedSpacer {
+      display : none !important;
+    }
+  }
+
+
+  .mv-create-target { 
+    max-width: 300px !important;
+  }
+
+  .adunit a,
+  .adunit object,
+  .adunit embed,
+  .adunit img,
+  .adunit div,
+  .adunit iframe {
+    margin: 0 auto !important;
+    text-align: center;
+  }
+
+  .content_btf_wrapper.native,
+  .content_mobile_wrapper.native {
+    max-width : 600px;
+  }
+
+  .content_float_right {
+    margin : 0 0 10px 20px;
+    float : right;
+  }
+
+  .content_mobile_wrapper,
+  .comments_mobile_wrapper,
+  .comments_btf_wrapper,
+  .comments_mobile_wrapper,
+  .content_btf_wrapper,
+  .feed_mobile_wrapper,
+  .feed_btf_wrapper {
+    margin : 10px auto 20px auto;
+    text-align : center;
+  }
+
+  
+
+  .content_btf_wrapper,
+  .content_mobile_wrapper {
+    clear: both;
+  }
+  .sidebar_atf_wrapper,
+  .leaderboard_btf_wrapper {
+    margin : 0px auto 20px auto;
+    text-align : center;
+  }
+  .leaderboard_btf_wrapper {
+    margin-top : 20px;
+  }
+
+  @media (max-width : 727px) {
+    .leaderboard_atf_wrapper {
+      display : none !important;
+    }
+  }
+
+  .leaderboard_atf_wrapper {
+    margin: 0px auto 0px auto;
+  }
+
+  .leaderboard_atf_wrapper.adunitwrapper {
+    height: 250px;
+  }
+
+
+  .adhesion_wrapper.adhesion_container {
+    position: relative;
+    text-align: center;
+    width: 100% !important;
+    z-index: 2147483535;
+    order: 2;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--adhesion-background-color, 
+      rgba(0, 0, 0, 0.9))
+  }
+
+  .adhesion_wrapper>.adunit>div {
+    position: sticky;
+  }
+
+  .adhesion_wrapper div {
+    margin: 0px;
+  }
+
+  .gumgumAdhesion .adhesion_wrapper {
+    min-height: 100px !important;
+    visibility: hidden;
+  }
+
+  #skin_desktop_wrapper {
+    position: fixed;
+    top: 0;
+  }
+
+  .adhesion_wrapper .adhesion_buttons {
+    height: 80px;
+    width: 48px;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: space-around;
+    margin-left: 3px;
+  }
+
+  .adhesion_wrapper .mv_close_button {
+    width: 24px;
+    height: 24px;
+    display: block;
+    position: relative;
+    cursor: pointer; 
+  }
+
+  .adhesion_wrapper .mv_unbutton {
+    padding: unset;
+    border: unset;
+    background-color: transparent;
+  }
+
+  .adhesion_wrapper .mv_close_button img {
+    width: 24px;
+    height: 24px;
+    pointer-events: none;
+    /* Position it 50% from the top-left corner. */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    /* Then move it back half its width and height for perfect centering. */
+    transform: translate(-50%, -50%);
+  }
+
+  .universalPlayer_wrapper.uvp_fadeout {
+    opacity: 0%;
+    transition: all 0.5s linear 3s;
+  }
+
+  .universalPlayer_wrapper.uvp_hidden {
+    visibility: hidden !important;
+  }
+
+  .universalPlayer_wrapper {
+    display: block;
+    position: fixed;
+    background: none;
+    box-shadow: rgb(0 0 0 / 15%) 0px 2px 10px;
+    z-index: 1100;
+    overflow: visible;
+    right: 20px;
+    bottom: 20px;
+    transition: all .3s ease-in;
+    transition-delay: 500ms;
+  }
+
+  div#fixed_container_bottom .universalPlayer_wrapper {
+    position: relative;
+    order: 1;
+    align-self: end;
+  }
+
+  .universalPlayer_wrapper:after {
+    content: "\00B7\00B7\00B7";
+    position: absolute;
+    top: 0px;
+    display: flex!important;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+    color: #C4C4C4;
+    font-size: 62px;
+    letter-spacing: 2px;
+    z-index: 999;
+    animation: fadeOut 1s linear 0s infinite;
+    animation-direction: alternate;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-container {
+    border-radius: 10px;
+    overflow: hidden;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-mute {
+    top: unset;
+    bottom: 4px;
+    left: 30px;
+    width: unset;
+    opacity: 0.75;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-mute:after {
+    content: "Ad";
+    position: absolute;
+    top: 6px;
+    color: whitesmoke;
+    text-shadow: 0px 0px 8px black;
+    font-weight: lighter;
+    font-size: 12px;
+    width: fit-content;
+    word-break: normal;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-mute img {
+    width: 29px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu-backdrop {
+    display: none;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+
+    background: rgb(0,0,0, 40%);
+    border-radius: 10px;
+    z-index: 1002;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu {
+    position: absolute;
+    z-index: 1003;
+    display: flex;
+    flex-direction: column;
+    width: 55%;
+    height: 60%;
+    background: white;
+    border-radius: 5px;
+    align-items: center;
+    justify-content: space-around;
+    font-weight: 300;
+    font-size: 15px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item {
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;       
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item a {
+    text-decoration: none;
+    color: inherit;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item a:hover {
+    text-decoration: underline;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu #iconReportSvg {
+    margin-right: 3px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item:not(:last-child) {
+    border-bottom: solid lightgrey 1px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item.mv-ad-report-button > * {
+    pointer-events: none;
+  }
+
+  .universalPlayer_report {
+    position: absolute;
+    left: 3px;
+    bottom: 5px;
+    z-index: 1001;
+    height: 26px;
+    width: 26px;
+
+    display: flex;
+    align-items: center;
+
+    background: rgba(30, 30, 30, 0.5);
+    border-radius: 15px;
+  }
+
+  .universalPlayer_report img {
+    opacity: 100%;
+    width: 20px;
+    height: 20px;
+    pointer-events: none;
+    margin: 0 auto !important;
+  }
+
+  .universalPlayer_close {
+    position: absolute;
+    top: 7px;
+    z-index: 3000;
+    padding: 0px 10px;
+    line-height: 35px;
+    cursor: pointer;
+    filter: drop-shadow(0px 0px 6px black);
+  }
+
+  .universalPlayer_close img {
+    width: 15px;
+    height: 15px;
+    pointer-events: none;
+    margin: 0 auto !important;
+  }
+
+  .universalPlayer_close.outside_player_display {
+    transform: translateY(-45px);
+    padding-top: 10px;
+    padding-bottom: 10px;
+    border-radius: 18px;
+    background: rgba(30, 30, 30, 0.5);
+  }
+
+  .adunit#universalPlayer {
+    background: black;
+    border-radius: 10px;
+    width: 100%;
+    height: 100%;
+    visibility: hidden;
+  }
+
+  .universalPlayer__top {
+    top: 0;
+  }
+
+  .universalPlayer__bottom {
+    bottom: 0;
+  }
+
+  .universalPlayer__right {
+    right: 15px;
+  }
+
+  .universalPlayer__left {
+    left: 15px;
+  }
+
+  /* Note: this rule and others that specifically target '.universalPlayer__bottom.universalPlayer__left'
+    are specifically to fix a conflict with Slipstream.  Adding an extra rule makes it more specific than Slipstream's
+    and force it to have higher priority.
+    https://mediavine.atlassian.net/browse/SUP-565 */
+    div#fixed_container_bottom .universalPlayer__bottom.universalPlayer__left{
+    transform: translateX(0);
+    align-self: start;
+  }
+
+  body.adhesion div#fixed_container_bottom .universalPlayer__bottom {
+    transform: translateX(0);
+  }
+
+  /* make grow me inserted content typically used with dynamic sidebars sticky */
+  body.grow-me-scroll-carousel-active .growInsertedContent {
+    top: 60px;
+  }
+  .growInsertedContent {
+    position: sticky;
+    top: 0;
+  }
+
+
+  body.adhesion.gumgumAdhesion div#fixed_container_bottom .universalPlayer__bottom.universalPlayer__left {
+    align-self: start;
+    transform: translateX(0);
+  }
+
+  /*Keep Close Button on screen for small devices*/
+  @media(min-width: 350px) {
+    .adhesion_wrapper .mv_close_small {
+      display: none;
+    }
+
+  }
+
+  /*Push Logo Up*/
+  @media (max-width: 350px) {
+    .adhesion_wrapper .mv_unbutton {
+      display: none;
+    }
+
+    .adhesion_wrapper .adhesion_buttons {
+      position: absolute;
+      bottom: 51px;
+      right: 0px;
+      z-index: 11;
+      width: 20px;
+      height: 20px !important;
+    }
+
+    #adhesion_mobile_wrapper mv-ad-reporter {
+      display: none !important;
+    }
+  }
+
+  @media (min-width: 728px) and (max-width: 840px) {
+    
+  }
+
+  @media (max-width: 727px) {
+    body.adhesion {
+      padding-bottom : 50px;
+    }
+
+    body.adhesion.highImpact_adhesion {
+      padding-bottom: 150px!important;
+    }
+
+    .adhesion_wrapper.adhesion_container {
+      justify-content: center;
+    }
+
+    /* Provides centered padding for Mediavine logo and Report Button */
+    .mv-native-size .adunitlabel {
+      max-width: calc(100vw - 15px) !important;
+    }
+  }
+
+  @media (min-width: 728px) {
+    body.adhesion {
+      padding-bottom : 90px;
+    }
+
+    body.adhesion.highImpact_adhesion {
+      padding-bottom: 150px!important;
+    }
+  }
+
+  
+  #recipe_btf_wrapper {
+    float : right;
+  }
+  
+
+  @media print {
+    .adunit,
+    .adunitwrapper,
+    .adhesion_wrapper,
+    .mv-ad-box, 
+    mv-ad-reporter {
+      display : none !important;
+    }
+  }
+
+  #sovrn_beacon {
+    position: absolute
+  }
+
+  
+    .triplelift {
+      margin-bottom : 5px !important;
+    }
+
+    .triplelift .entry-title {
+      background : none !important;
+      font-size : 18px;
+      line-height : 22px;
+      clear : none !important;
+    }
+    .triplelift .entry-content {
+      clear : none !important;
+      background : none !important;
+    }
+    .triplelift .entry-meta {
+      display : block !important;
+      background : none !important;
+      clear : none !important;
+      border : none !important;
+      float : none !important;
+    }
+    .triplelift .entry-title a {
+      line-height: inherit !important;
+      float: none !important;
+      width: auto !important;
+      height: auto !important;
+      background: none !important;
+      color: inherit !important;
+      font-size: inherit !important;
+      line-height: inherit !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+    
+
+  
+.mv-native-ad {
+  text-align: left;
+  position: relative;
+  margin: 0 auto;
+	width: fit-content;
+}
+
+.mv-native-ad div {
+  box-sizing: border-box !important;
+}
+
+.mv-native-ad + .adunit {
+  height: 0px;
+  width: 0px;
+}
+
+.mv-native-ad-icon {
+	height: 16px;
+	width: 16px;
+	color: #FFF;
+	background: #919191;
+	font-size: 10px;
+	text-align: center;
+  align-items: center;
+	justify-content: center;
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+</style><style type="text/css">
+  body .adunitwrapper[style*='display: block']>.adunit:before {
+    display: none!important;
+  }
+  .mv-ad-box {
+    justify-content: center;
+    position: relative;
+    margin-bottom: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: #fafafa;
+    overflow: clip;
+    padding-top: 0px;
+  }
+
+  @media (min-width: 320px) and (max-width: 360px) {
+    .mv-ad-box {
+      overflow: visible;
+    }
+
+    .adunitwrapper {
+      max-width: 100vw;
+    }
+  }
+
+  
+
+  .sidebarBtfStacked .mv-ad-box {
+    background-color: unset;
+  }
+
+  .mv-ad-box .remove_padding {
+    /* 
+      This trick is incompatible with ad box when overflow 
+      is applied. 
+    */
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
+  .mv-ad-box > div {
+    z-index: 1;
+  }
+
+  @keyframes fadeOut {
+    0% { opacity: 1;}
+    100% { opacity: 0.01 }
+  }
+
+  .mv-ad-box:before {
+    content: "ADVERTISEMENT";
+    position: absolute;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    height: 20px;
+    width: 100%;
+    text-align: center;
+    color: #a5a5a5;
+    font-size: 11px;
+    letter-spacing: 2px;
+    top: 2px
+  }
+
+  .mv-ad-box:after {
+    content: "\00B7\00B7\00B7";
+    position: absolute;
+    display: flex!important;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+    color: #C4C4C4;
+    font-size: 62px;
+    letter-spacing: 2px;
+    z-index: 0;
+    animation: fadeOut 1s linear 0s infinite;
+    animation-direction: alternate;
+  }
+  .sidebarBtfStacked .mv-ad-box:after {
+    content: "";
+  }
+
+  .mv-ad-box .adunitlabel {
+    width: 100%!important;
+    left: 0; 
+    bottom: 0;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 5px;
+  }
+
+  .mv-ad-box .adunitwrapper {
+    position: relative;
+    margin: 0 !important;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mv-ad-box[data-slotid="recipe_btf"] {
+    float: right;
+  }
+
+  .mv-ad-box .adunitwrapper.mv-native-size {
+    margin-bottom: 0px;
+    background-color: #fafafa;
+    padding: 12px;
+  }
+  .mv-ad-box [data-wrapper=recipe_btf].adunitwrapper.mv-native-size,
+  .mv-ad-box [data-wrapper=recipe_mobile].adunitwrapper.mv-native-size {
+    padding: unset;
+  }
+
+  .mv-ad-box .mv-outstream-container {
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mv-pre-create-target[style*=height] {
+    min-height: 379px !important;
+  }
+</style><script type="text/javascript" src="https://scripts.grow.me/app.1.8.33.js" defer="" data-grow-headless-beta-name="1.8.33" data-grow-headless-beta-version="1.8.33" data-grow-mediavine-site-id="119d89d8-e3eb-43cf-89ab-65f8b2bca672"></script><script src="https://securepubads.g.doubleclick.net/tag/js/gpt.js" async=""></script><meta http-equiv="origin-trial" content="AlK2UR5SkAlj8jjdEc9p3F3xuFYlF6LYjAML3EOqw1g26eCwWPjdmecULvBH5MVPoqKYrOfPhYVL71xAXI1IBQoAAAB8eyJvcmlnaW4iOiJodHRwczovL2RvdWJsZWNsaWNrLm5ldDo0NDMiLCJmZWF0dXJlIjoiV2ViVmlld1hSZXF1ZXN0ZWRXaXRoRGVwcmVjYXRpb24iLCJleHBpcnkiOjE3NTgwNjcxOTksImlzU3ViZG9tYWluIjp0cnVlfQ=="><meta http-equiv="origin-trial" content="Amm8/NmvvQfhwCib6I7ZsmUxiSCfOxWxHayJwyU1r3gRIItzr7bNQid6O8ZYaE1GSQTa69WwhPC9flq/oYkRBwsAAACCeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZXN5bmRpY2F0aW9uLmNvbTo0NDMiLCJmZWF0dXJlIjoiV2ViVmlld1hSZXF1ZXN0ZWRXaXRoRGVwcmVjYXRpb24iLCJleHBpcnkiOjE3NTgwNjcxOTksImlzU3ViZG9tYWluIjp0cnVlfQ=="><meta http-equiv="origin-trial" content="A9uiHDzQFAhqALUhTgTYJcz9XrGH2y0/9AORwCSapUO/f7Uh7ysIzyszNkuWDLqNYg8446Uj48XIstBW1qv/wAQAAACNeyJvcmlnaW4iOiJodHRwczovL2RvdWJsZWNsaWNrLm5ldDo0NDMiLCJmZWF0dXJlIjoiRmxlZGdlQmlkZGluZ0FuZEF1Y3Rpb25TZXJ2ZXIiLCJleHBpcnkiOjE3Mjc4MjcxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"><meta http-equiv="origin-trial" content="A9R+gkZL3TWq+Z7RJ2L0c7ZN7FZD5z4mHmVvjrPitg/EMz9P3j5d3W7Vw5ZR9jtJGmWKltM4BO3smNzpCgwYuwwAAACTeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZXN5bmRpY2F0aW9uLmNvbTo0NDMiLCJmZWF0dXJlIjoiRmxlZGdlQmlkZGluZ0FuZEF1Y3Rpb25TZXJ2ZXIiLCJleHBpcnkiOjE3Mjc4MjcxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"><script src="https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202408290101/pubads_impl.js" nonce="HMTAA31x" async=""></script><script src="https://sb.scorecardresearch.com/cs/27053452/beacon.js" async=""></script><style type="text/css">
+      #sidebar_btf_sticky_wrapper.mv-stuck {
+        position : fixed;
+        top : 155px;
+      }
+    </style><script src="https://config.aps.amazon-adsystem.com/configs/38918095-8e45-4332-88bf-226b3514cb64" type="text/javascript" async="async"></script><style type="text/css" data-fbcssmodules="css:fb.css.base css:fb.css.dialog css:fb.css.iframewidget css:fb.css.customer_chat_plugin_iframe">.fb_hidden{position:absolute;top:-10000px;z-index:10001}.fb_reposition{overflow:hidden;position:relative}.fb_invisible{display:none}.fb_reset{background:none;border:0;border-spacing:0;color:#000;cursor:auto;direction:ltr;font-family:'lucida grande', tahoma, verdana, arial, sans-serif;font-size:11px;font-style:normal;font-variant:normal;font-weight:normal;letter-spacing:normal;line-height:1;margin:0;overflow:visible;padding:0;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;visibility:visible;white-space:normal;word-spacing:normal}.fb_reset>div{overflow:hidden}@keyframes fb_transform{from{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}}.fb_animate{animation:fb_transform .3s forwards}
+.fb_hidden{position:absolute;top:-10000px;z-index:10001}.fb_reposition{overflow:hidden;position:relative}.fb_invisible{display:none}.fb_reset{background:none;border:0;border-spacing:0;color:#000;cursor:auto;direction:ltr;font-family:'lucida grande', tahoma, verdana, arial, sans-serif;font-size:11px;font-style:normal;font-variant:normal;font-weight:normal;letter-spacing:normal;line-height:1;margin:0;overflow:visible;padding:0;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;visibility:visible;white-space:normal;word-spacing:normal}.fb_reset>div{overflow:hidden}@keyframes fb_transform{from{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}}.fb_animate{animation:fb_transform .3s forwards}
+.fb_dialog{background:rgba(82, 82, 82, .7);position:absolute;top:-10000px;z-index:10001}.fb_dialog_advanced{border-radius:8px;padding:10px}.fb_dialog_content{background:#fff;color:#373737}.fb_dialog_close_icon{background:url(https://connect.facebook.net/rsrc.php/v3/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 0 transparent;cursor:pointer;display:block;height:15px;position:absolute;right:18px;top:17px;width:15px}.fb_dialog_mobile .fb_dialog_close_icon{left:5px;right:auto;top:5px}.fb_dialog_padding{background-color:transparent;position:absolute;width:1px;z-index:-1}.fb_dialog_close_icon:hover{background:url(https://connect.facebook.net/rsrc.php/v3/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -15px transparent}.fb_dialog_close_icon:active{background:url(https://connect.facebook.net/rsrc.php/v3/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -30px transparent}.fb_dialog_iframe{line-height:0}.fb_dialog_content .dialog_title{background:#6d84b4;border:1px solid #365899;color:#fff;font-size:14px;font-weight:bold;margin:0}.fb_dialog_content .dialog_title>span{background:url(https://connect.facebook.net/rsrc.php/v3/yd/r/Cou7n-nqK52.gif) no-repeat 5px 50%;float:left;padding:5px 0 7px 26px}body.fb_hidden{height:100%;left:0;margin:0;overflow:visible;position:absolute;top:-10000px;transform:none;width:100%}.fb_dialog.fb_dialog_mobile.loading{background:url(https://connect.facebook.net/rsrc.php/v3/ya/r/3rhSv5V8j3o.gif) white no-repeat 50% 50%;min-height:100%;min-width:100%;overflow:hidden;position:absolute;top:0;z-index:10001}.fb_dialog.fb_dialog_mobile.loading.centered{background:none;height:auto;min-height:initial;min-width:initial;width:auto}.fb_dialog.fb_dialog_mobile.loading.centered #fb_dialog_loader_spinner{width:100%}.fb_dialog.fb_dialog_mobile.loading.centered .fb_dialog_content{background:none}.loading.centered #fb_dialog_loader_close{clear:both;color:#fff;display:block;font-size:18px;padding-top:20px}#fb-root #fb_dialog_ipad_overlay{background:rgba(0, 0, 0, .4);bottom:0;left:0;min-height:100%;position:absolute;right:0;top:0;width:100%;z-index:10000}#fb-root #fb_dialog_ipad_overlay.hidden{display:none}.fb_dialog.fb_dialog_mobile.loading iframe{visibility:hidden}.fb_dialog_mobile .fb_dialog_iframe{position:sticky;top:0}.fb_dialog_content .dialog_header{background:linear-gradient(from(#738aba), to(#2c4987));border-bottom:1px solid;border-color:#043b87;box-shadow:white 0 1px 1px -1px inset;color:#fff;font:bold 14px Helvetica, sans-serif;text-overflow:ellipsis;text-shadow:rgba(0, 30, 84, .296875) 0 -1px 0;vertical-align:middle;white-space:nowrap}.fb_dialog_content .dialog_header table{height:43px;width:100%}.fb_dialog_content .dialog_header td.header_left{font-size:12px;padding-left:5px;vertical-align:middle;width:60px}.fb_dialog_content .dialog_header td.header_right{font-size:12px;padding-right:5px;vertical-align:middle;width:60px}.fb_dialog_content .touchable_button{background:linear-gradient(from(#4267B2), to(#2a4887));background-clip:padding-box;border:1px solid #29487d;border-radius:3px;display:inline-block;line-height:18px;margin-top:3px;max-width:85px;padding:4px 12px;position:relative}.fb_dialog_content .dialog_header .touchable_button input{background:none;border:none;color:#fff;font:bold 12px Helvetica, sans-serif;margin:2px -12px;padding:2px 6px 3px 6px;text-shadow:rgba(0, 30, 84, .296875) 0 -1px 0}.fb_dialog_content .dialog_header .header_center{color:#fff;font-size:16px;font-weight:bold;line-height:18px;text-align:center;vertical-align:middle}.fb_dialog_content .dialog_content{background:url(https://connect.facebook.net/rsrc.php/v3/y9/r/jKEcVPZFk-2.gif) no-repeat 50% 50%;border:1px solid #4a4a4a;border-bottom:0;border-top:0;height:150px}.fb_dialog_content .dialog_footer{background:#f5f6f7;border:1px solid #4a4a4a;border-top-color:#ccc;height:40px}#fb_dialog_loader_close{float:left}.fb_dialog.fb_dialog_mobile .fb_dialog_close_icon{visibility:hidden}#fb_dialog_loader_spinner{animation:rotateSpinner 1.2s linear infinite;background-color:transparent;background-image:url(https://connect.facebook.net/rsrc.php/v3/yD/r/t-wz8gw1xG1.png);background-position:50% 50%;background-repeat:no-repeat;height:24px;width:24px}@keyframes rotateSpinner{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+.fb_iframe_widget{display:inline-block;position:relative}.fb_iframe_widget span{display:inline-block;position:relative;text-align:justify}.fb_iframe_widget iframe{position:absolute}.fb_iframe_widget_fluid_desktop,.fb_iframe_widget_fluid_desktop span,.fb_iframe_widget_fluid_desktop iframe{max-width:100%}.fb_iframe_widget_fluid_desktop iframe{min-width:220px;position:relative}.fb_iframe_widget_lift{z-index:1}.fb_iframe_widget_fluid{display:inline}.fb_iframe_widget_fluid span{width:100%}
+.fb_mpn_mobile_landing_page_slide_out{animation-duration:200ms;animation-name:fb_mpn_landing_page_slide_out;transition-timing-function:ease-in}.fb_mpn_mobile_landing_page_slide_out_from_left{animation-duration:200ms;animation-name:fb_mpn_landing_page_slide_out_from_left;transition-timing-function:ease-in}.fb_mpn_mobile_landing_page_slide_up{animation-duration:500ms;animation-name:fb_mpn_landing_page_slide_up;transition-timing-function:ease-in}.fb_mpn_mobile_bounce_in{animation-duration:300ms;animation-name:fb_mpn_bounce_in;transition-timing-function:ease-in}.fb_mpn_mobile_bounce_out{animation-duration:300ms;animation-name:fb_mpn_bounce_out;transition-timing-function:ease-in}.fb_mpn_mobile_bounce_out_v2{animation-duration:300ms;animation-name:fb_mpn_fade_out;transition-timing-function:ease-in}.fb_customer_chat_bounce_in_v2{animation-duration:300ms;animation-name:fb_bounce_in_v2;transition-timing-function:ease-in}.fb_customer_chat_bounce_in_from_left{animation-duration:300ms;animation-name:fb_bounce_in_from_left;transition-timing-function:ease-in}.fb_customer_chat_bounce_out_v2{animation-duration:300ms;animation-name:fb_bounce_out_v2;transition-timing-function:ease-in}.fb_customer_chat_bounce_out_from_left{animation-duration:300ms;animation-name:fb_bounce_out_from_left;transition-timing-function:ease-in}.fb_invisible_flow{display:inherit;height:0;overflow-x:hidden;width:0}@keyframes fb_mpn_landing_page_slide_out{0%{margin:0 12px;width:100% - 24px}60%{border-radius:18px}100%{border-radius:50%;margin:0 24px;width:60px}}@keyframes fb_mpn_landing_page_slide_out_from_left{0%{left:12px;width:100% - 24px}60%{border-radius:18px}100%{border-radius:50%;left:12px;width:60px}}@keyframes fb_mpn_landing_page_slide_up{0%{bottom:0;opacity:0}100%{bottom:24px;opacity:1}}@keyframes fb_mpn_bounce_in{0%{opacity:.5;top:100%}100%{opacity:1;top:0}}@keyframes fb_mpn_fade_out{0%{bottom:30px;opacity:1}100%{bottom:0;opacity:0}}@keyframes fb_mpn_bounce_out{0%{opacity:1;top:0}100%{opacity:.5;top:100%}}@keyframes fb_bounce_in_v2{0%{opacity:0;transform:scale(0, 0);transform-origin:bottom right}50%{transform:scale(1.03, 1.03);transform-origin:bottom right}100%{opacity:1;transform:scale(1, 1);transform-origin:bottom right}}@keyframes fb_bounce_in_from_left{0%{opacity:0;transform:scale(0, 0);transform-origin:bottom left}50%{transform:scale(1.03, 1.03);transform-origin:bottom left}100%{opacity:1;transform:scale(1, 1);transform-origin:bottom left}}@keyframes fb_bounce_out_v2{0%{opacity:1;transform:scale(1, 1);transform-origin:bottom right}100%{opacity:0;transform:scale(0, 0);transform-origin:bottom right}}@keyframes fb_bounce_out_from_left{0%{opacity:1;transform:scale(1, 1);transform-origin:bottom left}100%{opacity:0;transform:scale(0, 0);transform-origin:bottom left}}@keyframes slideInFromBottom{0%{opacity:.1;transform:translateY(100%)}100%{opacity:1;transform:translateY(0)}}@keyframes slideInFromBottomDelay{0%{opacity:0;transform:translateY(100%)}97%{opacity:0;transform:translateY(100%)}100%{opacity:1;transform:translateY(0)}}</style></head>
+	<body class="post-template-default single single-post postid-4801 single-format-standard g1-layout-boxed g1-hoverable g1-has-mobile-logo mv-loaded mv-device-desktop highImpact_adhesion adhesion" itemscope="" itemtype="http://schema.org/WebPage"><div id="fb-root" class=" fb_reset"><div style="position: absolute; top: -10000px; width: 0px; height: 0px;"><div></div></div></div>
+<script async="" defer="" crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v8.0&amp;appId=1060721147363596&amp;autoLogAppEvents=1" nonce="HMTAA31x"></script>
+
+<div class="g1-body-inner">
+	<div id="page">
+
+	<aside class="g1-row g1-sharebar g1-sharebar-off">
+		<div class="g1-row-inner">
+			<div class="g1-column g1-sharebar-inner">
+			</div>
+		</div>
+		<div class="g1-row-background">
+		</div>
+	</aside>
+					<div class="g1-sticky-top-wrapper g1-hb-row-1 g1-loaded">
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-normal g1-hb-row-a g1-hb-row-1 g1-hb-boxed g1-hb-sticky-on g1-hb-shadow-on">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+																<a class="g1-small-logo-wrapper" href="https://www.instrupix.com/">
+		<img class="g1-small-logo" width="241" height="70" src="https://www.instrupix.com/wp-content/uploads/2019/06/Instrupix-copy.png" alt="">	</a>
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+																<!-- BEGIN .g1-primary-nav -->
+	<nav id="g1-primary-nav" class="g1-primary-nav"><ul id="g1-primary-nav-menu" class="g1-primary-nav-menu g1-menu-h"><li id="menu-item-2670" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-has-children menu-item-g1-standard menu-item-2670"><a href="https://www.instrupix.com/category/recipes/">Recipes<span class="g1-link-toggle"></span></a>
+<ul class="sub-menu">
+	<li id="menu-item-5847" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-5847"><a href="https://www.instrupix.com/category/dinner/">Dinner</a></li>
+	<li id="menu-item-5848" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5848"><a href="https://www.instrupix.com/category/dessert/">Dessert</a></li>
+	<li id="menu-item-5846" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5846"><a href="https://www.instrupix.com/category/low-carb/">Low Carb</a></li>
+	<li id="menu-item-5849" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5849"><a href="https://www.instrupix.com/category/party-food/">Party Food</a></li>
+</ul>
+</li>
+<li id="menu-item-2671" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-g1-standard menu-item-2671"><a href="https://www.instrupix.com/category/diy/">DIY</a></li>
+</ul></nav>	<!-- END .g1-primary-nav -->
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+															<ul id="g1-social-icons-1" class="g1-socials-items g1-socials-items-tpl-grid g1-socials-hb-list ">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+															<div class="g1-drop g1-drop-before g1-drop-the-search  g1-drop-l">
+	<a class="g1-drop-toggle" href="https://www.instrupix.com/?s=">
+		<i class="starmile-iconfont starmile-search"></i>Search		<span class="g1-drop-toggle-arrow"></span>
+	</a>
+	<div class="g1-drop-content">
+		
+
+<div role="search" class="search-form-wrapper">
+	<form method="get" class="g1-searchform-tpl-default search-form" action="https://www.instrupix.com/">
+		<label>
+			<span class="screen-reader-text">Search for:</span>
+			<input type="search" class="search-field" placeholder="Search …" value="" name="s" title="Search for:">
+		</label>
+		<button class="search-submit">Search</button>
+	</form>
+</div>
+	</div>
+</div>
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				</div>
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-normal g1-hb-row-b g1-hb-row-2 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+			<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-normal g1-hb-row-c g1-hb-row-3 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-mobile g1-hb-row-a g1-hb-row-1 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				<div class="g1-sticky-top-wrapper g1-hb-row-2 g1-loaded">
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-mobile g1-hb-row-b g1-hb-row-2 g1-hb-boxed g1-hb-sticky-on g1-hb-shadow-on">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+																<a class="g1-mobile-logo-wrapper" href="https://www.instrupix.com/">
+		<img class="g1-mobile-logo" width="241" height="70" src="https://www.instrupix.com/wp-content/uploads/2019/06/Instrupix-copy.png" alt="">	</a>
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-left g1-bin-grow-on">
+																<a class="g1-hamburger g1-hamburger-show  " href="#">
+		<span class="g1-hamburger-icon"></span>
+		<span class="g1-hamburger-label">Menu</span>
+	</a>
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+															<ul id="g1-social-icons-2" class="g1-socials-items g1-socials-items-tpl-grid g1-socials-hb-list ">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				</div>
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-mobile g1-hb-row-c g1-hb-row-3 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+		
+	<div class="g1-row g1-row-layout-page g1-row-padding-m">
+		<div class="g1-row-background">
+		</div>
+		<div class="g1-row-inner">
+
+			<div class="g1-column g1-column-2of3" id="primary">
+				<div id="content" role="main">
+
+
+					
+
+
+<article id="post-4801" class="entry-tpl-classic entry-single post-4801 post type-post status-publish format-standard has-post-thumbnail category-beef category-dinner category-food category-main-dish category-recipes category-slow-cooker tag-beef tag-carrots tag-celery tag-crockpot tag-dinner tag-pot-roast tag-potatoes tag-slow-cooker tag-veggies" itemscope="" itemtype="http://schema.org/Article">
+	<header class="entry-header entry-single-header entry-header-01">
+					<div class="entry-before-title">
+								
+				
+				
+			</div>
+						
+		<div class="acme_featured_image"><div><img width="800" height="566" src="https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe.jpg" class="attachment-full size-full" alt="Easy to make slow cooker pot roast made with 3 seasoning packets." decoding="async" fetchpriority="high" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe.jpg 800w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-300x212.jpg 300w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-768x543.jpg 768w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-344x243.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-688x487.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-728x515.jpg 728w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-516x365.jpg 516w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-68x48.jpg 68w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-3-packet-pot-roast-slow-cooker-recipe-136x96.jpg 136w" sizes="(max-width: 800px) 100vw, 800px" nopin="nopin"></div></div>
+		<h1 class="g1-giga g1-giga-1st entry-title" itemprop="headline">The Best Slow Cooker Pot Roast Recipe</h1>
+		<h2 class="entry-subtitle g1-beta g1-beta-3rd">How to make an incredibly tender, juicy and flavorful pot roast in your slow cooker with just 3 seasoning packets.</h2>		
+							<div class="g1-meta entry-meta entry-meta-byline entry-meta-with-avatar">
+									<span class="entry-author" itemscope="" itemprop="author" itemtype="http://schema.org/Person">
+				<span class="entry-meta-label">by</span>
+			<a href="https://www.instrupix.com/author/lilly/" title="Posts by Lilly" rel="author">			<img alt="" src="https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=30&amp;d=mm&amp;r=g" srcset="https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=60&amp;d=mm&amp;r=g 2x" class="avatar avatar-30 photo" height="30" width="30" decoding="async">							<span itemprop="name">Lilly</span>
+					</a>
+	</span>
+	<time class="entry-date" datetime="2019-11-01T20:06:40" itemprop="datePublished" title="November 1, 2019, 8:06 pm">5 years ago</time>					</div>
+				
+		<div class="entry-after-title">
+								</div>
+	</header>
+
+	
+		<div class="g1-content-narrow g1-typography-xl entry-content" itemprop="articleBody" data-content-ads-inserted="true">
+		<div class="wprm-recipe wprm-recipe-snippet wprm-recipe-template-acme-jump-to-with-arrows"><a href="#recipe" data-recipe="4819" style="color: #000000;background-color: #ffffff;border-color: #929313;border-radius: 3px;padding: 3px 9px;" class="wprm-recipe-jump wprm-recipe-link wprm-jump-to-recipe-shortcode wprm-block-text-uppercase wprm-jump-smooth-scroll wprm-recipe-jump-inline-button wprm-recipe-link-inline-button wprm-color-accent" data-smooth-scroll="500">Jump to Recipe</a></div><!--www.crestaproject.com Cresta Social Share Counter Content Start--><div id="crestashareiconincontent" class="cresta-share-icon   fifteenth_style" data-slot-rendered-content="true"><div class="sbutton-total" id="total-shares-content" data-twittershares="0" data-facebookshares="1060" data-vkshares="0" data-buffershares="0" data-redditshares="0" data-okshares="0" data-xingshares="0" data-tumblrshares="0" data-pinterestshares="730479"><span class="cresta-the-total-count" id="total-count-content">731.5K</span><span class="cresta-the-total-text">Shares</span></div><div class="sbutton  facebook-cresta-share cresta-no-animation" id="facebook-cresta-c"><a rel="nofollow" href="https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F&amp;t=The+Best+Slow+Cooker+Pot+Roast+Recipe" data-name="Share to Facebook" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-facebook"></i></a><span class="cresta-the-count-content" id="facebook-count-content">1.1K</span></div><div class="sbutton  pinterest-cresta-share cresta-no-animation" id="pinterest-cresta-c"><a rel="nofollow" href="javascript:void((function()%7Bvar%20e=document.createElement('script');e.setAttribute('type','text/javascript');e.setAttribute('charset','UTF-8');e.setAttribute('src','https://assets.pinterest.com/js/pinmarklet.js?r='+Math.random()*99999999);document.body.appendChild(e)%7D)());" data-name="Share to Pinterest"><i class="cs c-icon-cresta-pinterest"></i></a><span class="cresta-the-count-content" id="pinterest-count-content">730.5K</span></div><div class="sbutton  email-cresta-share cresta-no-animation" id="email-cresta-c"><a rel="nofollow" href="mailto:?subject=The%20Best%20Slow%20Cooker%20Pot%20Roast%20Recipe&amp;body=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F" data-name="Share via Email" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-mail"></i></a></div><div style="clear: both;"></div></div>
+<div class="mv-ad-box" data-slotid="content_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="content_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+          <div id="content_btf" class="content_btf adunit" data-google-query-id="CMGJqrHOq4gDFU51DwId0LE0Yg">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_0__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://d1ca067a0e94280420aadf658583f338.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/content_0" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="9" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+<div style="clear: both;"></div><!--www.crestaproject.com Cresta Social Share Counter Content End--><h1>An easy crockpot dinner recipe for your picky family!</h1>
+<p>This <strong>easy slow cooker pot roast</strong> is made with just a few simple ingredients: beef roast, ranch seasoning mix, brown gravy mix, and a packet of dry Italian salad dressing. Simply throw everything into your crockpot and cook on low for about 5 hours. Add your optional vegetables (potatoes, carrots, celery, mushrooms, etc.) and then continue cooking for a few more hours. Easy peasy!</p>
+<p>I absolutely love <strong>slow cooker dinner recipes</strong> that just require a handful of ingredients. They are perfect for busy moms and dads on a budget! It’s so convenient to toss everything in the crockpot in the morning, and then when dinner time arrives, that’s all you have to do is eat. I honestly don’t know how I’d survive without this miracle appliance.</p>
+<p class="g1-content-img-wrap" data-slot-rendered-content="true"><img decoding="async" class="aligncenter size-full wp-image-14855" src="https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients.jpg" alt="Simple Slow Cooker Pot Roast Recipe With Vegetables (potatoes, carrots and celery)." width="725" height="994" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients.jpg 725w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-219x300.jpg 219w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-344x472.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-688x943.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-516x707.jpg 516w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-35x48.jpg 35w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-70x96.jpg 70w" sizes="(max-width: 725px) 100vw, 725px"></p>
+<div class="mv-ad-box" data-slotid="content_2_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_2_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="content_2_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+          <div id="content_2_btf" class="content_btf adunit" data-google-query-id="CNW74ODLq4gDFdiL6QUdVJQUkA">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_1__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://d1ca067a0e94280420aadf658583f338.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/content_1" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="8" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_2_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<p>This is an effortless dinner recipe that you really can’t mess up. As long as you cook the pot roast slow and low, it turns out tender every time, and the combination of these 3 seasoning packets creates outstanding flavor.&nbsp;</p>
+<p>Onion soup mix is also a popular seasoning for pot roast, so you can definitely use that in place of the ranch seasoning mix if you’d like.</p>
+<p class="g1-content-img-wrap" data-slot-rendered-content="true"><img loading="lazy" decoding="async" class="aligncenter wp-image-4803 size-full" src="https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning.jpg" alt="Easy Crockpot Pot Roast Recipe made with brown gravy mix, ranch seasoning mix and dry Italian dressing. " width="725" height="1062" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning.jpg 725w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning-205x300.jpg 205w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning-699x1024.jpg 699w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning-344x504.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning-688x1008.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning-516x756.jpg 516w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning-33x48.jpg 33w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-pot-roast-recipe-brown-gravy-ranch-seasoning-66x96.jpg 66w" sizes="(max-width: 725px) 100vw, 725px"></p>
+<div class="mv-ad-box" data-slotid="content_3_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_3_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-468x280" data-wrapper="content_3_btf" data-nosnippet="" style="visibility: visible; height: 280px; min-height: 280px; width: 468px;">
+          <div id="content_3_btf" class="content_btf adunit" data-google-query-id="CMXp057Oq4gDFXFWDwIdwZcBuQ">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_2__container__" style="border: 0pt none;"><iframe id="google_ads_iframe_/1030006,16030400/instrupix/content_2" name="google_ads_iframe_/1030006,16030400/instrupix/content_2" title="3rd party ad content" width="468" height="280" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="attribution-reporting" data-load-complete="true" style="border: 0px; vertical-align: bottom;" data-google-container-id="c" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_3_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<p><b style="font-size: 30px; float: left; font-family: Merriweather; padding: 15px 20px 5px 0px; margin:auto;">Step 1</b>Start off by placing a 3-5 pound beef chuck roast into your slow cooker with about 1.5 cups of water (you can also add in a little red wine if you happen to have a bottle open).</p>
+<p><b style="font-size: 30px; float: left; font-family: Merriweather; padding: 15px 20px 5px 0px; margin:auto;">Step 2</b>Open up all of your seasoning packets and evenly sprinkle them over your roast.&nbsp;</p>
+<p class="g1-content-img-wrap" data-slot-rendered-content="true"><img loading="lazy" decoding="async" class="aligncenter wp-image-4804 size-full" src="https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe.jpg" alt="Easy 4 Ingredient Slow Cooker Pot Roast Recipe -- a delicious crockpot dinner idea! Fabulous comfort food for cold winter nights." width="725" height="1458" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe.jpg 725w, https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe-149x300.jpg 149w, https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe-509x1024.jpg 509w, https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe-344x692.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe-688x1384.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe-516x1038.jpg 516w, https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe-24x48.jpg 24w, https://www.instrupix.com/wp-content/uploads/2019/11/the-best-easy-slow-cooker-pot-roast-recipe-48x96.jpg 48w" sizes="(max-width: 725px) 100vw, 725px"></p>
+<div class="mv-ad-box" data-slotid="content_4_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_4_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-468x280" data-wrapper="content_4_btf" data-nosnippet="" style="visibility: visible; height: 280px; min-height: 280px; width: 468px;">
+          <div id="content_4_btf" class="content_btf adunit" data-google-query-id="CLHw_J3Oq4gDFWBrDwIdwHY1eA">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_3__container__" style="border: 0pt none;"><iframe id="google_ads_iframe_/1030006,16030400/instrupix/content_3" name="google_ads_iframe_/1030006,16030400/instrupix/content_3" title="3rd party ad content" width="468" height="280" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="attribution-reporting" data-load-complete="true" style="border: 0px; vertical-align: bottom;" data-google-container-id="b" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_4_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<p><b style="font-size: 30px; float: left; font-family: Merriweather; padding: 15px 20px 5px 0px; margin:auto;">Step 3</b>Cook on low for 5-6 hours and then add optional veggies such as chopped potatoes, carrots, and celery.&nbsp;</p>
+<p><b style="font-size: 30px; float: left; font-family: Merriweather; padding: 15px 20px 5px 0px; margin:auto;">Step 4</b>Continue cooking for an additional 2-3 hours or until the meat easily falls apart with a few forks and the veggies are tender.&nbsp;</p>
+<p class="g1-content-img-wrap" data-slot-rendered-content="true"><img loading="lazy" decoding="async" class="aligncenter wp-image-4805 size-full" src="https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots.jpg" alt="How to make pot roast in your slow cooker. Easy recipe!" width="725" height="552" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots.jpg 725w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots-300x228.jpg 300w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots-344x262.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots-688x524.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots-516x393.jpg 516w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots-63x48.jpg 63w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-with-potatoes-and-carrots-126x96.jpg 126w" sizes="(max-width: 725px) 100vw, 725px"></p>
+<div class="mv-ad-box" data-slotid="content_5_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_5_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-300x250" data-wrapper="content_5_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+          <div id="content_5_btf" class="content_btf adunit" data-google-query-id="CIfE9Z3Oq4gDFRKI6QUdTYIk6w">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_4__container__" style="border: 0pt none;"><iframe id="google_ads_iframe_/1030006,16030400/instrupix/content_4" name="google_ads_iframe_/1030006,16030400/instrupix/content_4" title="3rd party ad content" width="300" height="250" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="attribution-reporting" data-load-complete="true" style="border: 0px; vertical-align: bottom;" data-google-container-id="a" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_5_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<p>That’s it! This easy pot roast is absolutely delicious. Everything just melts in your mouth! I usually serve this amazing comfort food with buttery dinner rolls, and then a few glasses of wine for myself. Hehe. It’s heavenly in the cold winter months when you’re craving a hot meal.</p>
+<p class="g1-content-img-wrap" data-slot-rendered-content="true"><img decoding="async" class="aligncenter size-full wp-image-14855" src="https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients.jpg" alt="Simple Slow Cooker Pot Roast Recipe With Vegetables (potatoes, carrots and celery)." width="725" height="994" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients.jpg 725w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-219x300.jpg 219w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-344x472.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-688x943.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-516x707.jpg 516w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-35x48.jpg 35w, https://www.instrupix.com/wp-content/uploads/2019/11/yummy-slow-cooker-pot-roast-easy-to-make-with-few-ingredients-70x96.jpg 70w" sizes="(max-width: 725px) 100vw, 725px"></p>
+<div class="mv-ad-box" data-slotid="content_6_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_6_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="content_6_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+          <div id="content_6_btf" class="content_btf adunit" data-google-query-id="CNa4853Oq4gDFUeG6QUdYAwAAQ">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_5__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://d1ca067a0e94280420aadf658583f338.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/content_5" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="4" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_6_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<div id="recipe"></div><div id="wprm-recipe-container-4819" class="wprm-recipe-container" data-recipe-id="4819" data-servings="6"><div class="wprm-recipe wprm-recipe-template-acme-compact-custom"><div class="wprm-container-float-right">
+	<div class="wprm-recipe-image wprm-block-image-rounded"><img loading="lazy" decoding="async" style="border-width: 0px;border-style: solid;border-color: #666666;border-radius: 5px;" width="150" height="150" src="https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-150x150.jpg" class="attachment-150x150 size-150x150" alt="" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-150x150.jpg 150w, https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-135x135.jpg 135w, https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-500x500.jpg 500w, https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-318x318.jpg 318w, https://www.instrupix.com/wp-content/uploads/2019/11/simple-pot-roast-recipe-slow-cooker-636x636.jpg 636w" sizes="(max-width: 150px) 100vw, 150px"></div>
+	<div class="wprm-spacer" style="height: 5px"></div>
+	<a href="https://www.instrupix.com/wprm_print/easy-slow-cooker-pot-roast-recipe-with-vegetables" style="color: #444444;background-color: #ffffff;border-color: #777777;border-radius: 0px;padding: 5px 5px;" class="wprm-recipe-print wprm-recipe-link wprm-print-recipe-shortcode wprm-block-text-bold wprm-recipe-print-wide-button wprm-recipe-link-wide-button wprm-color-accent" data-recipe-id="4819" data-template="" target="_blank" rel="nofollow"><span class="wprm-recipe-icon wprm-recipe-print-icon"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="16px" height="16px" viewBox="0 0 24 24"><g><path fill="#444444" d="M19,5.09V1c0-0.552-0.448-1-1-1H6C5.448,0,5,0.448,5,1v4.09C2.167,5.569,0,8.033,0,11v7c0,0.552,0.448,1,1,1h4v4c0,0.552,0.448,1,1,1h12c0.552,0,1-0.448,1-1v-4h4c0.552,0,1-0.448,1-1v-7C24,8.033,21.833,5.569,19,5.09z M7,2h10v3H7V2z M17,22H7v-9h10V22z M18,10c-0.552,0-1-0.448-1-1c0-0.552,0.448-1,1-1s1,0.448,1,1C19,9.552,18.552,10,18,10z"></path></g></svg></span> Print Recipe</a>
+	
+	
+</div>
+<h2 class="wprm-recipe-name wprm-block-text-bold">Easy Slow Cooker Pot Roast Recipe With Vegetables</h2>
+<div class="wprm-spacer" style="height: 5px"></div>
+<div class="wprm-recipe-summary wprm-block-text-faded"><span style="display: block;">Are you looking for easy crockpot dinner recipes for your family? This simple pot roast is absolutely incredible and requires just 4 ingredients: beef roast, ranch seasoning, Italian seasoning, and brown gravy mix. I also like to make it with potatoes, carrots, and celery but you can add any veggies that you'd prefer.</span></div>
+<div class="wprm-spacer"></div>
+<div class="wprm-recipe-meta-container wprm-recipe-times-container wprm-recipe-details-container wprm-recipe-details-container-table wprm-block-text-normal wprm-recipe-table-borders-top-bottom wprm-recipe-table-borders-inside" style="border-width: 1px;border-style: solid;border-color: #777777;"><div class="wprm-recipe-block-container wprm-recipe-block-container-table wprm-block-text-normal wprm-recipe-time-container wprm-recipe-prep-time-container" style="border-width: 1px;border-style: solid;border-color: #777777;"><span class="wprm-recipe-details-label wprm-block-text-faded wprm-recipe-time-label wprm-recipe-prep-time-label">Prep Time</span><span class="wprm-recipe-time wprm-block-text-normal"><span class="wprm-recipe-details wprm-recipe-details-minutes wprm-recipe-prep_time wprm-recipe-prep_time-minutes">10<span class="sr-only screen-reader-text wprm-screen-reader-text"> minutes</span></span> <span class="wprm-recipe-details-unit wprm-recipe-details-minutes wprm-recipe-prep_time-unit wprm-recipe-prep_timeunit-minutes" aria-hidden="true">mins</span></span></div><div class="wprm-recipe-block-container wprm-recipe-block-container-table wprm-block-text-normal wprm-recipe-time-container wprm-recipe-cook-time-container" style="border-width: 1px;border-style: solid;border-color: #777777;"><span class="wprm-recipe-details-label wprm-block-text-faded wprm-recipe-time-label wprm-recipe-cook-time-label">Cook Time</span><span class="wprm-recipe-time wprm-block-text-normal"><span class="wprm-recipe-details wprm-recipe-details-hours wprm-recipe-cook_time wprm-recipe-cook_time-hours">8<span class="sr-only screen-reader-text wprm-screen-reader-text"> hours</span></span> <span class="wprm-recipe-details-unit wprm-recipe-details-unit-hours wprm-recipe-cook_time-unit wprm-recipe-cook_timeunit-hours" aria-hidden="true">hrs</span></span></div></div>
+<div class="wprm-spacer" style="height: 5px"></div>
+<div class="wprm-recipe-meta-container wprm-recipe-tags-container wprm-recipe-details-container wprm-recipe-details-container-inline wprm-block-text-normal" style=""><div class="wprm-recipe-block-container wprm-recipe-block-container-inline wprm-block-text-normal wprm-recipe-tag-container wprm-recipe-course-container" style=""><span class="wprm-recipe-details-label wprm-block-text-faded wprm-recipe-tag-label wprm-recipe-course-label">Course: </span><span class="wprm-recipe-course wprm-block-text-normal">Main Course</span></div><div class="wprm-recipe-block-container wprm-recipe-block-container-inline wprm-block-text-normal wprm-recipe-tag-container wprm-recipe-keyword-container" style=""><span class="wprm-recipe-details-label wprm-block-text-faded wprm-recipe-tag-label wprm-recipe-keyword-label">Keyword: </span><span class="wprm-recipe-keyword wprm-block-text-normal">comfort food, easy dinner idea, slow cooker meals</span></div></div>
+<div class="wprm-recipe-block-container wprm-recipe-block-container-inline wprm-block-text-normal wprm-recipe-servings-container" style=""><span class="wprm-recipe-details-label wprm-block-text-faded wprm-recipe-servings-label">Servings: </span><span class="wprm-recipe-servings wprm-recipe-details wprm-block-text-normal">6</span></div>
+
+
+
+
+<div class="wprm-recipe-ingredients-container wprm-recipe-4819-ingredients-container wprm-block-text-normal wprm-ingredient-style-regular wprm-recipe-images-before" data-recipe="4819" data-servings="6" data-slot-rendered-recipe="true">
+<div class="mv-ad-box" data-slotid="recipe_btf" style="height: 320px; width: 300px;">
+  
+      <div id="recipe_btf_wrapper" class="adunitwrapper recipe_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="recipe_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+        <div id="recipe_btf" class="adunit" data-google-query-id="COfCp4TMq4gDFc5SDwIdk0gZrw">
+        
+        <div id="google_ads_iframe_/1030006,16030400/instrupix/recipe_0__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://d1ca067a0e94280420aadf658583f338.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/recipe_0" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="5" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+      </div>
+    
+<mv-ad-reporter data-slot-id="recipe_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+<h3 class="wprm-recipe-header wprm-recipe-ingredients-header wprm-block-text-bold wprm-align-left wprm-header-decoration-icon" style="">Ingredients</h3><div class="wprm-recipe-ingredient-group"><ul class="wprm-recipe-ingredients"><li class="wprm-recipe-ingredient" style="list-style-type: disc;" data-uid="0"><span class="wprm-recipe-ingredient-amount">1</span> <span class="wprm-recipe-ingredient-unit">3-5lb </span> <span class="wprm-recipe-ingredient-name">beef roast</span> <span class="wprm-recipe-ingredient-notes wprm-recipe-ingredient-notes-faded">(any kind)</span></li><li class="wprm-recipe-ingredient" style="list-style-type: disc;" data-uid="1"><span class="wprm-recipe-ingredient-amount">1½</span> <span class="wprm-recipe-ingredient-unit">cups</span> <span class="wprm-recipe-ingredient-name">water</span></li><li class="wprm-recipe-ingredient" style="list-style-type: disc;" data-uid="2"><span class="wprm-recipe-ingredient-amount">1</span> <span class="wprm-recipe-ingredient-name">packet brown gravy mix</span></li><li class="wprm-recipe-ingredient" style="list-style-type: disc;" data-uid="3"><span class="wprm-recipe-ingredient-amount">1</span> <span class="wprm-recipe-ingredient-name">packet ranch dressing mix</span></li><li class="wprm-recipe-ingredient" style="list-style-type: disc;" data-uid="4"><span class="wprm-recipe-ingredient-amount">1</span> <span class="wprm-recipe-ingredient-name">packet Italian dressing mix</span></li><li class="wprm-recipe-ingredient" style="list-style-type: disc;" data-uid="5"><span class="wprm-recipe-ingredient-name">vegetables of your choice</span> <span class="wprm-recipe-ingredient-notes wprm-recipe-ingredient-notes-faded">(potatoes, carrots, celery, etc.)</span></li></ul></div></div>
+<div class="wprm-recipe-instructions-container wprm-recipe-4819-instructions-container wprm-block-text-normal" data-recipe="4819" data-recipe-ads-inserted="true"><h3 class="wprm-recipe-header wprm-recipe-instructions-header wprm-block-text-bold wprm-align-left wprm-header-decoration-none" style="">Instructions</h3><div class="wprm-recipe-instruction-group" data-slot-rendered-recipe="true"><ul class="wprm-recipe-instructions"><li id="wprm-recipe-4819-step-0-0" class="wprm-recipe-instruction" style="list-style-type: decimal;"><div class="wprm-recipe-instruction-text" style="margin-bottom: 5px;"><span style="display: block;">Place your beef roast into your slow cooker with 1½ cups of water. </span></div></li><li id="wprm-recipe-4819-step-0-1" class="wprm-recipe-instruction" style="list-style-type: decimal;"><div class="wprm-recipe-instruction-text" style="margin-bottom: 5px;"><span style="display: block;">Sprinkle all of the seasoning packets over the roast.</span></div></li><li id="wprm-recipe-4819-step-0-2" class="wprm-recipe-instruction" style="list-style-type: decimal;"><div class="wprm-recipe-instruction-text" style="margin-bottom: 5px;"><span style="display: block;">Cover and cook on low for about 4 hours and then add your veggies.</span></div></li><li id="wprm-recipe-4819-step-0-3" class="wprm-recipe-instruction" style="list-style-type: decimal;"><div class="wprm-recipe-instruction-text" style="margin-bottom: 5px;"><span style="display: block;">Cook for an additional 2-4 hours or until the beef easily pulls apart. The time needed will greatly depend on your cut of meat and the brand of your slow cooker.  </span></div></li></ul></div>
+<div class="mv-ad-box" data-slotid="recipe_2_btf" style="height: 320px; width: 300px;">
+  
+      <div id="recipe_2_btf_wrapper" class="adunitwrapper recipe_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="recipe_2_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+        <div id="recipe_2_btf" class="adunit" data-google-query-id="CO-K4pzOq4gDFXtSDwIdp6IQmQ">
+        
+        <div id="google_ads_iframe_/1030006,16030400/instrupix/recipe_1__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://d1ca067a0e94280420aadf658583f338.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/recipe_1" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="6" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+      </div>
+    
+<mv-ad-reporter data-slot-id="recipe_2_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+</div>
+
+<div class="wprm-recipe-notes-container wprm-block-text-normal"><h3 class="wprm-recipe-header wprm-recipe-notes-header wprm-block-text-bold wprm-align-left wprm-header-decoration-none" style="">Notes</h3><div class="wprm-recipe-notes"><ul>
+<li>The size of the seasoning packets are about 1 ounce. Some of them are just over an ounce, and some of them are just under (depending on the brand).</li>
+<li>You can also replace half of the water with red wine if you happen to have a bottle open.</li>
+<li>French onion soup mix is also a popular seasoning for pot roast and can be used in place of the ranch.</li>
+<li>If you're on a low carb diet, try this roast with mashed cauliflower!</li>
+</ul>
+<span style="display: block;"><div data-post-id="12062" class="insert-page insert-page-12062 "><div id="list_post_wrapper">
+      <div class="acme-related-posts relatedposts2">
+    		
+     			<a href="https://www.instrupix.com/easy-creamy-garlic-mashed-cauliflower/"> 
+     			   <img loading="lazy" decoding="async" width="200" height="135" src="https://www.instrupix.com/wp-content/uploads/2021/05/keto-low-carb-side-dish-recipes-for-dinner-mashed-cauliflower-200x135.jpg" class="related-thumbnail wp-post-image" alt="" nopin="nopin" srcset="https://www.instrupix.com/wp-content/uploads/2021/05/keto-low-carb-side-dish-recipes-for-dinner-mashed-cauliflower-200x135.jpg 200w, https://www.instrupix.com/wp-content/uploads/2021/05/keto-low-carb-side-dish-recipes-for-dinner-mashed-cauliflower-72x48.jpg 72w, https://www.instrupix.com/wp-content/uploads/2021/05/keto-low-carb-side-dish-recipes-for-dinner-mashed-cauliflower-144x96.jpg 144w" sizes="(max-width: 200px) 100vw, 200px">     			 
+		<p><strong>Creamy Garlic Mashed Cauliflower</strong><br>
+<span style="color: #000000;">If you miss the creamy texture of mashed potatoes, you’ve got to try making this low carb version of those tasty spuds using fresh or frozen cauliflower.</span></p>
+</a>
+    </div>
+  </div></div></span><div class="wprm-spacer"></div>
+<span style="display: block;"><a href="https://www.instagram.com/instrupix/" target="_blank" rel="noopener"><img loading="lazy" decoding="async" class="aligncenter size-full wp-image-9478" src="https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow.jpg" alt="" width="444" height="240" srcset="https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow.jpg 444w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-300x162.jpg 300w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-344x186.jpg 344w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-89x48.jpg 89w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-178x96.jpg 178w" sizes="(max-width: 444px) 100vw, 444px"></a></span><div class="wprm-spacer"></div>
+<span style="display: block;"><div data-post-id="12117" class="insert-page insert-page-12117 "><div id="list_post_wrapper">
+  	<hr>
+	<div class="adace-slot-wrapper adace-shortcode-9988">
+	<div class="adace-disclaimer">
+		</div>
+	<div class="adace-slot"><style scoped="">@media(max-width: 600px) {.adace_ad_66d97b22bc112 {display:block !important;}}
+@media(min-width: 601px) {.adace_ad_66d97b22bc112 {display:block !important;}}
+@media(min-width: 801px) {.adace_ad_66d97b22bc112 {display:block !important;}}
+@media(min-width: 961px) {.adace_ad_66d97b22bc112 {display:block !important;}}
+</style>		<div class="adace_ad_66d97b22bc112">
+	<script src="https://f.convertkit.com/ckjs/ck.5.js"></script>
+      <form action="https://app.convertkit.com/forms/2246692/subscriptions" style="background-color: rgb(237, 237, 237); border-top-left-radius: 6px; border-top-right-radius: 6px; border-bottom-right-radius: 6px; border-bottom-left-radius: 6px;" class="seva-form formkit-form" method="post" data-sv-form="2246692" data-uid="ae3b256f6f" data-format="inline" data-version="5" data-options="{&quot;settings&quot;:{&quot;after_subscribe&quot;:{&quot;action&quot;:&quot;message&quot;,&quot;success_message&quot;:&quot;Check your inbox and confirm your subscription for super awesome stuff. &quot;,&quot;redirect_url&quot;:&quot;&quot;},&quot;analytics&quot;:{&quot;google&quot;:null,&quot;facebook&quot;:null,&quot;segment&quot;:null,&quot;pinterest&quot;:null,&quot;sparkloop&quot;:null,&quot;googletagmanager&quot;:null},&quot;modal&quot;:{&quot;trigger&quot;:&quot;timer&quot;,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:5,&quot;devices&quot;:&quot;all&quot;,&quot;show_once_every&quot;:15},&quot;powered_by&quot;:{&quot;show&quot;:true,&quot;url&quot;:&quot;https://convertkit.com/?utm_campaign=poweredby&amp;utm_content=form&amp;utm_medium=referral&amp;utm_source=dynamic&quot;},&quot;recaptcha&quot;:{&quot;enabled&quot;:false},&quot;return_visitor&quot;:{&quot;action&quot;:&quot;show&quot;,&quot;custom_content&quot;:&quot;&quot;},&quot;slide_in&quot;:{&quot;display_in&quot;:&quot;bottom_right&quot;,&quot;trigger&quot;:&quot;timer&quot;,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:5,&quot;devices&quot;:&quot;all&quot;,&quot;show_once_every&quot;:15},&quot;sticky_bar&quot;:{&quot;display_in&quot;:&quot;top&quot;,&quot;trigger&quot;:&quot;timer&quot;,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:5,&quot;devices&quot;:&quot;all&quot;,&quot;show_once_every&quot;:15}},&quot;version&quot;:&quot;5&quot;}" min-width="400 500 600"><div style="opacity: 0;" class="formkit-background"></div><div data-style="minimal"><div class="formkit-header" style="color: rgb(48, 48, 48); font-size: 25px; font-weight: 700;" data-element="header"><h2>Newsletter</h2></div><div class="formkit-subheader" style="color: rgb(142, 132, 132); font-size: 15px;" data-element="subheader"><p>Recipes &amp; other inspiration in your inbox. </p></div><ul class="formkit-alert formkit-alert-error" data-element="errors" data-group="alert"></ul><div data-element="fields" data-stacked="true" class="seva-fields formkit-fields"><div class="formkit-field"><input class="formkit-input" aria-label="Name" style="color: rgb(0, 0, 0); border-color: rgb(227, 227, 227); border-top-left-radius: 4px; border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; font-weight: 400;" name="fields[first_name]" placeholder="Name" type="text"></div><div class="formkit-field"><input class="formkit-input" name="email_address" style="color: rgb(0, 0, 0); border-color: rgb(227, 227, 227); border-top-left-radius: 4px; border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; font-weight: 400;" aria-label="Email address" placeholder="Email address" required="" type="email"></div><button data-element="submit" class="formkit-submit formkit-submit" style="color: rgb(255, 255, 255); background-color: rgb(102, 102, 102); border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; font-weight: 700;"><div class="formkit-spinner"><div></div><div></div><div></div></div><span class="">Signup</span></button></div><div class="formkit-guarantee" style="color: rgb(77, 77, 77); font-size: 13px; font-weight: 400;" data-element="guarantee"><p>We won't send you spam or anything crappy. Unsubscribe at any time.</p></div><div class="formkit-powered-by-convertkit-container"><a href="https://convertkit.com/?utm_campaign=poweredby&amp;utm_content=form&amp;utm_medium=referral&amp;utm_source=dynamic" data-element="powered-by" class="formkit-powered-by-convertkit" data-variant="dark" target="_blank" rel="noopener noreferrer">Built with ConvertKit</a></div></div><style>.formkit-form[data-uid="ae3b256f6f"] *{box-sizing:border-box;}.formkit-form[data-uid="ae3b256f6f"]{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}.formkit-form[data-uid="ae3b256f6f"] legend{border:none;font-size:inherit;margin-bottom:10px;padding:0;position:relative;display:table;}.formkit-form[data-uid="ae3b256f6f"] fieldset{border:0;padding:0.01em 0 0 0;margin:0;min-width:0;}.formkit-form[data-uid="ae3b256f6f"] body:not(:-moz-handler-blocked) fieldset{display:table-cell;}.formkit-form[data-uid="ae3b256f6f"] h1,.formkit-form[data-uid="ae3b256f6f"] h2,.formkit-form[data-uid="ae3b256f6f"] h3,.formkit-form[data-uid="ae3b256f6f"] h4,.formkit-form[data-uid="ae3b256f6f"] h5,.formkit-form[data-uid="ae3b256f6f"] h6{color:inherit;font-size:inherit;font-weight:inherit;}.formkit-form[data-uid="ae3b256f6f"] p{color:inherit;font-size:inherit;font-weight:inherit;}.formkit-form[data-uid="ae3b256f6f"] ol:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] ul:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] blockquote:not([template-default]){text-align:left;}.formkit-form[data-uid="ae3b256f6f"] p:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] hr:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] blockquote:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] ol:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] ul:not([template-default]){color:inherit;font-style:initial;}.formkit-form[data-uid="ae3b256f6f"] .ordered-list,.formkit-form[data-uid="ae3b256f6f"] .unordered-list{list-style-position:outside !important;padding-left:1em;}.formkit-form[data-uid="ae3b256f6f"] .list-item{padding-left:0;}.formkit-form[data-uid="ae3b256f6f"][data-format="modal"]{display:none;}.formkit-form[data-uid="ae3b256f6f"][data-format="slide in"]{display:none;}.formkit-form[data-uid="ae3b256f6f"][data-format="sticky bar"]{display:none;}.formkit-sticky-bar .formkit-form[data-uid="ae3b256f6f"][data-format="sticky bar"]{display:block;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input,.formkit-form[data-uid="ae3b256f6f"] .formkit-select,.formkit-form[data-uid="ae3b256f6f"] .formkit-checkboxes{width:100%;}.formkit-form[data-uid="ae3b256f6f"] .formkit-button,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit{border:0;border-radius:5px;color:#ffffff;cursor:pointer;display:inline-block;text-align:center;font-size:15px;font-weight:500;cursor:pointer;margin-bottom:15px;overflow:hidden;padding:0;position:relative;vertical-align:middle;}.formkit-form[data-uid="ae3b256f6f"] .formkit-button:hover,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:hover,.formkit-form[data-uid="ae3b256f6f"] .formkit-button:focus,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:focus{outline:none;}.formkit-form[data-uid="ae3b256f6f"] .formkit-button:hover > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:hover > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-button:focus > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:focus > span{background-color:rgba(0,0,0,0.1);}.formkit-form[data-uid="ae3b256f6f"] .formkit-button > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit > span{display:block;-webkit-transition:all 300ms ease-in-out;transition:all 300ms ease-in-out;padding:12px 24px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input{background:#ffffff;font-size:15px;padding:12px;border:1px solid #e3e3e3;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;line-height:1.4;margin:0;-webkit-transition:border-color ease-out 300ms;transition:border-color ease-out 300ms;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input:focus{outline:none;border-color:#1677be;-webkit-transition:border-color ease 300ms;transition:border-color ease 300ms;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input::-webkit-input-placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input::-moz-placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input:-ms-input-placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input::placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"]{position:relative;display:inline-block;width:100%;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"]::before{content:"";top:calc(50% - 2.5px);right:10px;position:absolute;pointer-events:none;border-color:#4f4f4f transparent transparent transparent;border-style:solid;border-width:6px 6px 0 6px;height:0;width:0;z-index:999;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"] select{height:auto;width:100%;cursor:pointer;color:#333333;line-height:1.4;margin-bottom:0;padding:0 6px;-webkit-appearance:none;-moz-appearance:none;appearance:none;font-size:15px;padding:12px;padding-right:25px;border:1px solid #e3e3e3;background:#ffffff;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"] select:focus{outline:none;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"]{text-align:left;margin:0;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"]{margin-bottom:10px;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] *{cursor:pointer;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"]:last-of-type{margin-bottom:0;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"]{display:none;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"] + label::after{content:none;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"]:checked + label::after{border-color:#ffffff;content:"";}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"]:checked + label::before{background:#10bf7a;border-color:#10bf7a;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label{position:relative;display:inline-block;padding-left:28px;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::before,.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::after{position:absolute;content:"";display:inline-block;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::before{height:16px;width:16px;border:1px solid #e3e3e3;background:#ffffff;left:0px;top:3px;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::after{height:4px;width:8px;border-left:2px solid #4d4d4d;border-bottom:2px solid #4d4d4d;-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg);left:4px;top:8px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert{background:#f9fafb;border:1px solid #e3e3e3;border-radius:5px;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;list-style:none;margin:25px auto;padding:12px;text-align:center;width:100%;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert:empty{display:none;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert-success{background:#d3fbeb;border-color:#10bf7a;color:#0c905c;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert-error{background:#fde8e2;border-color:#f2643b;color:#ea4110;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;height:0px;width:0px;margin:0 auto;position:absolute;top:0;left:0;right:0;width:0px;overflow:hidden;text-align:center;-webkit-transition:all 300ms ease-in-out;transition:all 300ms ease-in-out;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner > div{margin:auto;width:12px;height:12px;background-color:#fff;opacity:0.3;border-radius:100%;display:inline-block;-webkit-animation:formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f- 1.4s infinite ease-in-out both;animation:formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f- 1.4s infinite ease-in-out both;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner > div:nth-child(1){-webkit-animation-delay:-0.32s;animation-delay:-0.32s;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner > div:nth-child(2){-webkit-animation-delay:-0.16s;animation-delay:-0.16s;}.formkit-form[data-uid="ae3b256f6f"] .formkit-submit[data-active] .formkit-spinner{opacity:1;height:100%;width:50px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-submit[data-active] .formkit-spinner ~ span{opacity:0;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by[data-active="false"]{opacity:0.35;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit-container{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;width:100%;z-index:5;margin:10px 0;position:relative;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit-container[data-active="false"]{opacity:0.35;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;background-color:#ffffff;border:1px solid #dce1e5;border-radius:4px;color:#373f45;cursor:pointer;display:block;height:36px;margin:0 auto;opacity:0.95;padding:0;-webkit-text-decoration:none;text-decoration:none;text-indent:100%;-webkit-transition:ease-in-out all 200ms;transition:ease-in-out all 200ms;white-space:nowrap;overflow:hidden;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;width:190px;background-repeat:no-repeat;background-position:center;background-image:url("data:image/svg+xml;charset=utf8,%3Csvg width='162' height='20' viewBox='0 0 162 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M83.0561 15.2457C86.675 15.2457 89.4722 12.5154 89.4722 9.14749C89.4722 5.99211 86.8443 4.06563 85.1038 4.06563C82.6801 4.06563 80.7373 5.76407 80.4605 8.28551C80.4092 8.75244 80.0387 9.14403 79.5686 9.14069C78.7871 9.13509 77.6507 9.12841 76.9314 9.13092C76.6217 9.13199 76.3658 8.88106 76.381 8.57196C76.4895 6.38513 77.2218 4.3404 78.618 2.76974C80.1695 1.02445 82.4289 0 85.1038 0C89.5979 0 93.8406 4.07791 93.8406 9.14749C93.8406 14.7608 89.1832 19.3113 83.1517 19.3113C78.8502 19.3113 74.5179 16.5041 73.0053 12.5795C72.9999 12.565 72.9986 12.5492 73.0015 12.534C73.0218 12.4179 73.0617 12.3118 73.1011 12.2074C73.1583 12.0555 73.2143 11.907 73.2062 11.7359L73.18 11.1892C73.174 11.0569 73.2075 10.9258 73.2764 10.8127C73.3452 10.6995 73.4463 10.6094 73.5666 10.554L73.7852 10.4523C73.9077 10.3957 74.0148 10.3105 74.0976 10.204C74.1803 10.0974 74.2363 9.97252 74.2608 9.83983C74.3341 9.43894 74.6865 9.14749 75.0979 9.14749C75.7404 9.14749 76.299 9.57412 76.5088 10.1806C77.5188 13.1 79.1245 15.2457 83.0561 15.2457Z' fill='%23373F45'/%3E%3Cpath d='M155.758 6.91365C155.028 6.91365 154.804 6.47916 154.804 5.98857C154.804 5.46997 154.986 5.06348 155.758 5.06348C156.53 5.06348 156.712 5.46997 156.712 5.98857C156.712 6.47905 156.516 6.91365 155.758 6.91365ZM142.441 12.9304V9.32833L141.415 9.32323V8.90392C141.415 8.44719 141.786 8.07758 142.244 8.07986L142.441 8.08095V6.55306L144.082 6.09057V8.08073H145.569V8.50416C145.569 8.61242 145.548 8.71961 145.506 8.81961C145.465 8.91961 145.404 9.01047 145.328 9.08699C145.251 9.16351 145.16 9.2242 145.06 9.26559C144.96 9.30698 144.853 9.32826 144.745 9.32822H144.082V12.7201C144.082 13.2423 144.378 13.4256 144.76 13.4887C145.209 13.5629 145.583 13.888 145.583 14.343V14.9626C144.029 14.9626 142.441 14.8942 142.441 12.9304Z' fill='%23373F45'/%3E%3Cpath d='M110.058 7.92554C108.417 7.88344 106.396 8.92062 106.396 11.5137C106.396 14.0646 108.417 15.0738 110.058 15.0318C111.742 15.0738 113.748 14.0646 113.748 11.5137C113.748 8.92062 111.742 7.88344 110.058 7.92554ZM110.07 13.7586C108.878 13.7586 108.032 12.8905 108.032 11.461C108.032 10.1013 108.878 9.20569 110.071 9.20569C111.263 9.20569 112.101 10.0995 112.101 11.459C112.101 12.8887 111.263 13.7586 110.07 13.7586Z' fill='%23373F45'/%3E%3Cpath d='M118.06 7.94098C119.491 7.94098 120.978 8.33337 120.978 11.1366V14.893H120.063C119.608 14.893 119.238 14.524 119.238 14.0689V10.9965C119.238 9.66506 118.747 9.16047 117.891 9.16047C117.414 9.16047 116.797 9.52486 116.502 9.81915V14.069C116.502 14.1773 116.481 14.2845 116.44 14.3845C116.398 14.4845 116.337 14.5753 116.261 14.6519C116.184 14.7284 116.093 14.7891 115.993 14.8305C115.893 14.8719 115.786 14.8931 115.678 14.8931H114.847V8.10918H115.773C115.932 8.10914 116.087 8.16315 116.212 8.26242C116.337 8.36168 116.424 8.50033 116.46 8.65577C116.881 8.19328 117.428 7.94098 118.06 7.94098ZM122.854 8.09713C123.024 8.09708 123.19 8.1496 123.329 8.2475C123.468 8.34541 123.574 8.48391 123.631 8.64405L125.133 12.8486L126.635 8.64415C126.692 8.48402 126.798 8.34551 126.937 8.2476C127.076 8.1497 127.242 8.09718 127.412 8.09724H128.598L126.152 14.3567C126.091 14.5112 125.986 14.6439 125.849 14.7374C125.711 14.831 125.549 14.881 125.383 14.8809H124.333L121.668 8.09713H122.854Z' fill='%23373F45'/%3E%3Cpath d='M135.085 14.5514C134.566 14.7616 133.513 15.0416 132.418 15.0416C130.496 15.0416 129.024 13.9345 129.024 11.4396C129.024 9.19701 130.451 7.99792 132.191 7.99792C134.338 7.99792 135.254 9.4378 135.158 11.3979C135.139 11.8029 134.786 12.0983 134.38 12.0983H130.679C130.763 13.1916 131.562 13.7662 132.615 13.7662C133.028 13.7662 133.462 13.7452 133.983 13.6481C134.535 13.545 135.085 13.9375 135.085 14.4985V14.5514ZM133.673 10.949C133.785 9.87621 133.061 9.28752 132.191 9.28752C131.321 9.28752 130.734 9.93979 130.679 10.9489L133.673 10.949Z' fill='%23373F45'/%3E%3Cpath d='M137.345 8.11122C137.497 8.11118 137.645 8.16229 137.765 8.25635C137.884 8.35041 137.969 8.48197 138.005 8.62993C138.566 8.20932 139.268 7.94303 139.759 7.94303C139.801 7.94303 140.068 7.94303 140.489 7.99913V8.7265C140.489 9.11748 140.15 9.4147 139.759 9.4147C139.31 9.4147 138.651 9.5829 138.131 9.8773V14.8951H136.462V8.11112L137.345 8.11122ZM156.6 14.0508V8.09104H155.769C155.314 8.09104 154.944 8.45999 154.944 8.9151V14.8748H155.775C156.23 14.8748 156.6 14.5058 156.6 14.0508ZM158.857 12.9447V9.34254H157.749V8.91912C157.749 8.46401 158.118 8.09506 158.574 8.09506H158.857V6.56739L160.499 6.10479V8.09506H161.986V8.51848C161.986 8.97359 161.617 9.34254 161.161 9.34254H160.499V12.7345C160.499 13.2566 160.795 13.44 161.177 13.503C161.626 13.5774 162 13.9024 162 14.3574V14.977C160.446 14.977 158.857 14.9086 158.857 12.9447ZM98.1929 10.1124C98.2033 6.94046 100.598 5.16809 102.895 5.16809C104.171 5.16809 105.342 5.44285 106.304 6.12953L105.914 6.6631C105.654 7.02011 105.16 7.16194 104.749 6.99949C104.169 6.7702 103.622 6.7218 103.215 6.7218C101.335 6.7218 99.9169 7.92849 99.9068 10.1123C99.9169 12.2959 101.335 13.5201 103.215 13.5201C103.622 13.5201 104.169 13.4717 104.749 13.2424C105.16 13.0799 105.654 13.2046 105.914 13.5615L106.304 14.0952C105.342 14.7819 104.171 15.0566 102.895 15.0566C100.598 15.0566 98.2033 13.2842 98.1929 10.1124ZM147.619 5.21768C148.074 5.21768 148.444 5.58663 148.444 6.04174V9.81968L151.82 5.58131C151.897 5.47733 151.997 5.39282 152.112 5.3346C152.227 5.27638 152.355 5.24607 152.484 5.24611H153.984L150.166 10.0615L153.984 14.8749H152.484C152.355 14.8749 152.227 14.8446 152.112 14.7864C151.997 14.7281 151.897 14.6436 151.82 14.5397L148.444 10.3025V14.0508C148.444 14.5059 148.074 14.8749 147.619 14.8749H146.746V5.21768H147.619Z' fill='%23373F45'/%3E%3Cpath d='M0.773438 6.5752H2.68066C3.56543 6.5752 4.2041 6.7041 4.59668 6.96191C4.99219 7.21973 5.18994 7.62695 5.18994 8.18359C5.18994 8.55859 5.09326 8.87061 4.8999 9.11963C4.70654 9.36865 4.42822 9.52539 4.06494 9.58984V9.63379C4.51611 9.71875 4.84717 9.88721 5.05811 10.1392C5.27197 10.3882 5.37891 10.7266 5.37891 11.1543C5.37891 11.7314 5.17676 12.1841 4.77246 12.5122C4.37109 12.8374 3.81152 13 3.09375 13H0.773438V6.5752ZM1.82373 9.22949H2.83447C3.27393 9.22949 3.59473 9.16064 3.79688 9.02295C3.99902 8.88232 4.1001 8.64502 4.1001 8.31104C4.1001 8.00928 3.99023 7.79102 3.77051 7.65625C3.55371 7.52148 3.20801 7.4541 2.7334 7.4541H1.82373V9.22949ZM1.82373 10.082V12.1167H2.93994C3.37939 12.1167 3.71045 12.0332 3.93311 11.8662C4.15869 11.6963 4.27148 11.4297 4.27148 11.0664C4.27148 10.7324 4.15723 10.4849 3.92871 10.3237C3.7002 10.1626 3.35303 10.082 2.88721 10.082H1.82373Z' fill='%23373F45'/%3E%3Cpath d='M13.011 6.5752V10.7324C13.011 11.207 12.9084 11.623 12.7034 11.9805C12.5012 12.335 12.2068 12.6089 11.8201 12.8022C11.4363 12.9927 10.9763 13.0879 10.4402 13.0879C9.6433 13.0879 9.02368 12.877 8.5813 12.4551C8.13892 12.0332 7.91772 11.4531 7.91772 10.7148V6.5752H8.9724V10.6401C8.9724 11.1704 9.09546 11.5615 9.34155 11.8135C9.58765 12.0654 9.96557 12.1914 10.4753 12.1914C11.4656 12.1914 11.9607 11.6714 11.9607 10.6313V6.5752H13.011Z' fill='%23373F45'/%3E%3Cpath d='M15.9146 13V6.5752H16.9649V13H15.9146Z' fill='%23373F45'/%3E%3Cpath d='M19.9255 13V6.5752H20.9758V12.0991H23.696V13H19.9255Z' fill='%23373F45'/%3E%3Cpath d='M28.2828 13H27.2325V7.47607H25.3428V6.5752H30.1724V7.47607H28.2828V13Z' fill='%23373F45'/%3E%3Cpath d='M41.9472 13H40.8046L39.7148 9.16796C39.6679 9.00097 39.6093 8.76074 39.539 8.44727C39.4687 8.13086 39.4262 7.91113 39.4116 7.78809C39.3823 7.97559 39.3339 8.21875 39.2665 8.51758C39.2021 8.81641 39.1479 9.03905 39.1039 9.18554L38.0405 13H36.8979L36.0673 9.7832L35.2236 6.5752H36.2958L37.2143 10.3193C37.3578 10.9199 37.4604 11.4502 37.5219 11.9102C37.5541 11.6611 37.6025 11.3828 37.6669 11.0752C37.7314 10.7676 37.79 10.5186 37.8427 10.3281L38.8886 6.5752H39.9301L41.0024 10.3457C41.1049 10.6943 41.2133 11.2158 41.3276 11.9102C41.3715 11.4912 41.477 10.958 41.644 10.3105L42.558 6.5752H43.6215L41.9472 13Z' fill='%23373F45'/%3E%3Cpath d='M45.7957 13V6.5752H46.846V13H45.7957Z' fill='%23373F45'/%3E%3Cpath d='M52.0258 13H50.9755V7.47607H49.0859V6.5752H53.9155V7.47607H52.0258V13Z' fill='%23373F45'/%3E%3Cpath d='M61.2312 13H60.1765V10.104H57.2146V13H56.1643V6.5752H57.2146V9.20312H60.1765V6.5752H61.2312V13Z' fill='%23373F45'/%3E%3C/svg%3E");}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit:hover,.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit:focus{background-color:#ffffff;-webkit-transform:scale(1.025) perspective(1px);-ms-transform:scale(1.025) perspective(1px);transform:scale(1.025) perspective(1px);opacity:1;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="dark"],.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="light"]{background-color:transparent;border-color:transparent;width:166px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="light"]{color:#ffffff;background-image:url("data:image/svg+xml;charset=utf8,%3Csvg width='162' height='20' viewBox='0 0 162 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M83.0561 15.2457C86.675 15.2457 89.4722 12.5154 89.4722 9.14749C89.4722 5.99211 86.8443 4.06563 85.1038 4.06563C82.6801 4.06563 80.7373 5.76407 80.4605 8.28551C80.4092 8.75244 80.0387 9.14403 79.5686 9.14069C78.7871 9.13509 77.6507 9.12841 76.9314 9.13092C76.6217 9.13199 76.3658 8.88106 76.381 8.57196C76.4895 6.38513 77.2218 4.3404 78.618 2.76974C80.1695 1.02445 82.4289 0 85.1038 0C89.5979 0 93.8406 4.07791 93.8406 9.14749C93.8406 14.7608 89.1832 19.3113 83.1517 19.3113C78.8502 19.3113 74.5179 16.5041 73.0053 12.5795C72.9999 12.565 72.9986 12.5492 73.0015 12.534C73.0218 12.4179 73.0617 12.3118 73.1011 12.2074C73.1583 12.0555 73.2143 11.907 73.2062 11.7359L73.18 11.1892C73.174 11.0569 73.2075 10.9258 73.2764 10.8127C73.3452 10.6995 73.4463 10.6094 73.5666 10.554L73.7852 10.4523C73.9077 10.3957 74.0148 10.3105 74.0976 10.204C74.1803 10.0974 74.2363 9.97252 74.2608 9.83983C74.3341 9.43894 74.6865 9.14749 75.0979 9.14749C75.7404 9.14749 76.299 9.57412 76.5088 10.1806C77.5188 13.1 79.1245 15.2457 83.0561 15.2457Z' fill='white'/%3E%3Cpath d='M155.758 6.91365C155.028 6.91365 154.804 6.47916 154.804 5.98857C154.804 5.46997 154.986 5.06348 155.758 5.06348C156.53 5.06348 156.712 5.46997 156.712 5.98857C156.712 6.47905 156.516 6.91365 155.758 6.91365ZM142.441 12.9304V9.32833L141.415 9.32323V8.90392C141.415 8.44719 141.786 8.07758 142.244 8.07986L142.441 8.08095V6.55306L144.082 6.09057V8.08073H145.569V8.50416C145.569 8.61242 145.548 8.71961 145.506 8.81961C145.465 8.91961 145.404 9.01047 145.328 9.08699C145.251 9.16351 145.16 9.2242 145.06 9.26559C144.96 9.30698 144.853 9.32826 144.745 9.32822H144.082V12.7201C144.082 13.2423 144.378 13.4256 144.76 13.4887C145.209 13.5629 145.583 13.888 145.583 14.343V14.9626C144.029 14.9626 142.441 14.8942 142.441 12.9304Z' fill='white'/%3E%3Cpath d='M110.058 7.92554C108.417 7.88344 106.396 8.92062 106.396 11.5137C106.396 14.0646 108.417 15.0738 110.058 15.0318C111.742 15.0738 113.748 14.0646 113.748 11.5137C113.748 8.92062 111.742 7.88344 110.058 7.92554ZM110.07 13.7586C108.878 13.7586 108.032 12.8905 108.032 11.461C108.032 10.1013 108.878 9.20569 110.071 9.20569C111.263 9.20569 112.101 10.0995 112.101 11.459C112.101 12.8887 111.263 13.7586 110.07 13.7586Z' fill='white'/%3E%3Cpath d='M118.06 7.94098C119.491 7.94098 120.978 8.33337 120.978 11.1366V14.893H120.063C119.608 14.893 119.238 14.524 119.238 14.0689V10.9965C119.238 9.66506 118.747 9.16047 117.891 9.16047C117.414 9.16047 116.797 9.52486 116.502 9.81915V14.069C116.502 14.1773 116.481 14.2845 116.44 14.3845C116.398 14.4845 116.337 14.5753 116.261 14.6519C116.184 14.7284 116.093 14.7891 115.993 14.8305C115.893 14.8719 115.786 14.8931 115.678 14.8931H114.847V8.10918H115.773C115.932 8.10914 116.087 8.16315 116.212 8.26242C116.337 8.36168 116.424 8.50033 116.46 8.65577C116.881 8.19328 117.428 7.94098 118.06 7.94098ZM122.854 8.09713C123.024 8.09708 123.19 8.1496 123.329 8.2475C123.468 8.34541 123.574 8.48391 123.631 8.64405L125.133 12.8486L126.635 8.64415C126.692 8.48402 126.798 8.34551 126.937 8.2476C127.076 8.1497 127.242 8.09718 127.412 8.09724H128.598L126.152 14.3567C126.091 14.5112 125.986 14.6439 125.849 14.7374C125.711 14.831 125.549 14.881 125.383 14.8809H124.333L121.668 8.09713H122.854Z' fill='white'/%3E%3Cpath d='M135.085 14.5514C134.566 14.7616 133.513 15.0416 132.418 15.0416C130.496 15.0416 129.024 13.9345 129.024 11.4396C129.024 9.19701 130.451 7.99792 132.191 7.99792C134.338 7.99792 135.254 9.4378 135.158 11.3979C135.139 11.8029 134.786 12.0983 134.38 12.0983H130.679C130.763 13.1916 131.562 13.7662 132.615 13.7662C133.028 13.7662 133.462 13.7452 133.983 13.6481C134.535 13.545 135.085 13.9375 135.085 14.4985V14.5514ZM133.673 10.949C133.785 9.87621 133.061 9.28752 132.191 9.28752C131.321 9.28752 130.734 9.93979 130.679 10.9489L133.673 10.949Z' fill='white'/%3E%3Cpath d='M137.345 8.11122C137.497 8.11118 137.645 8.16229 137.765 8.25635C137.884 8.35041 137.969 8.48197 138.005 8.62993C138.566 8.20932 139.268 7.94303 139.759 7.94303C139.801 7.94303 140.068 7.94303 140.489 7.99913V8.7265C140.489 9.11748 140.15 9.4147 139.759 9.4147C139.31 9.4147 138.651 9.5829 138.131 9.8773V14.8951H136.462V8.11112L137.345 8.11122ZM156.6 14.0508V8.09104H155.769C155.314 8.09104 154.944 8.45999 154.944 8.9151V14.8748H155.775C156.23 14.8748 156.6 14.5058 156.6 14.0508ZM158.857 12.9447V9.34254H157.749V8.91912C157.749 8.46401 158.118 8.09506 158.574 8.09506H158.857V6.56739L160.499 6.10479V8.09506H161.986V8.51848C161.986 8.97359 161.617 9.34254 161.161 9.34254H160.499V12.7345C160.499 13.2566 160.795 13.44 161.177 13.503C161.626 13.5774 162 13.9024 162 14.3574V14.977C160.446 14.977 158.857 14.9086 158.857 12.9447ZM98.1929 10.1124C98.2033 6.94046 100.598 5.16809 102.895 5.16809C104.171 5.16809 105.342 5.44285 106.304 6.12953L105.914 6.6631C105.654 7.02011 105.16 7.16194 104.749 6.99949C104.169 6.7702 103.622 6.7218 103.215 6.7218C101.335 6.7218 99.9169 7.92849 99.9068 10.1123C99.9169 12.2959 101.335 13.5201 103.215 13.5201C103.622 13.5201 104.169 13.4717 104.749 13.2424C105.16 13.0799 105.654 13.2046 105.914 13.5615L106.304 14.0952C105.342 14.7819 104.171 15.0566 102.895 15.0566C100.598 15.0566 98.2033 13.2842 98.1929 10.1124ZM147.619 5.21768C148.074 5.21768 148.444 5.58663 148.444 6.04174V9.81968L151.82 5.58131C151.897 5.47733 151.997 5.39282 152.112 5.3346C152.227 5.27638 152.355 5.24607 152.484 5.24611H153.984L150.166 10.0615L153.984 14.8749H152.484C152.355 14.8749 152.227 14.8446 152.112 14.7864C151.997 14.7281 151.897 14.6436 151.82 14.5397L148.444 10.3025V14.0508C148.444 14.5059 148.074 14.8749 147.619 14.8749H146.746V5.21768H147.619Z' fill='white'/%3E%3Cpath d='M0.773438 6.5752H2.68066C3.56543 6.5752 4.2041 6.7041 4.59668 6.96191C4.99219 7.21973 5.18994 7.62695 5.18994 8.18359C5.18994 8.55859 5.09326 8.87061 4.8999 9.11963C4.70654 9.36865 4.42822 9.52539 4.06494 9.58984V9.63379C4.51611 9.71875 4.84717 9.88721 5.05811 10.1392C5.27197 10.3882 5.37891 10.7266 5.37891 11.1543C5.37891 11.7314 5.17676 12.1841 4.77246 12.5122C4.37109 12.8374 3.81152 13 3.09375 13H0.773438V6.5752ZM1.82373 9.22949H2.83447C3.27393 9.22949 3.59473 9.16064 3.79688 9.02295C3.99902 8.88232 4.1001 8.64502 4.1001 8.31104C4.1001 8.00928 3.99023 7.79102 3.77051 7.65625C3.55371 7.52148 3.20801 7.4541 2.7334 7.4541H1.82373V9.22949ZM1.82373 10.082V12.1167H2.93994C3.37939 12.1167 3.71045 12.0332 3.93311 11.8662C4.15869 11.6963 4.27148 11.4297 4.27148 11.0664C4.27148 10.7324 4.15723 10.4849 3.92871 10.3237C3.7002 10.1626 3.35303 10.082 2.88721 10.082H1.82373Z' fill='white'/%3E%3Cpath d='M13.011 6.5752V10.7324C13.011 11.207 12.9084 11.623 12.7034 11.9805C12.5012 12.335 12.2068 12.6089 11.8201 12.8022C11.4363 12.9927 10.9763 13.0879 10.4402 13.0879C9.6433 13.0879 9.02368 12.877 8.5813 12.4551C8.13892 12.0332 7.91772 11.4531 7.91772 10.7148V6.5752H8.9724V10.6401C8.9724 11.1704 9.09546 11.5615 9.34155 11.8135C9.58765 12.0654 9.96557 12.1914 10.4753 12.1914C11.4656 12.1914 11.9607 11.6714 11.9607 10.6313V6.5752H13.011Z' fill='white'/%3E%3Cpath d='M15.9146 13V6.5752H16.9649V13H15.9146Z' fill='white'/%3E%3Cpath d='M19.9255 13V6.5752H20.9758V12.0991H23.696V13H19.9255Z' fill='white'/%3E%3Cpath d='M28.2828 13H27.2325V7.47607H25.3428V6.5752H30.1724V7.47607H28.2828V13Z' fill='white'/%3E%3Cpath d='M41.9472 13H40.8046L39.7148 9.16796C39.6679 9.00097 39.6093 8.76074 39.539 8.44727C39.4687 8.13086 39.4262 7.91113 39.4116 7.78809C39.3823 7.97559 39.3339 8.21875 39.2665 8.51758C39.2021 8.81641 39.1479 9.03905 39.1039 9.18554L38.0405 13H36.8979L36.0673 9.7832L35.2236 6.5752H36.2958L37.2143 10.3193C37.3578 10.9199 37.4604 11.4502 37.5219 11.9102C37.5541 11.6611 37.6025 11.3828 37.6669 11.0752C37.7314 10.7676 37.79 10.5186 37.8427 10.3281L38.8886 6.5752H39.9301L41.0024 10.3457C41.1049 10.6943 41.2133 11.2158 41.3276 11.9102C41.3715 11.4912 41.477 10.958 41.644 10.3105L42.558 6.5752H43.6215L41.9472 13Z' fill='white'/%3E%3Cpath d='M45.7957 13V6.5752H46.846V13H45.7957Z' fill='white'/%3E%3Cpath d='M52.0258 13H50.9755V7.47607H49.0859V6.5752H53.9155V7.47607H52.0258V13Z' fill='white'/%3E%3Cpath d='M61.2312 13H60.1765V10.104H57.2146V13H56.1643V6.5752H57.2146V9.20312H60.1765V6.5752H61.2312V13Z' fill='white'/%3E%3C/svg%3E");}@-webkit-keyframes formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f-{0%,80%,100%{-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);}40%{-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}}@keyframes formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f-{0%,80%,100%{-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);}40%{-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}}.formkit-form[data-uid="ae3b256f6f"] blockquote{padding:10px 20px;margin:0 0 20px;border-left:5px solid #e1e1e1;} .formkit-form[data-uid="ae3b256f6f"]{border:1px solid #e3e3e3;max-width:700px;position:relative;overflow:hidden;}.formkit-form[data-uid="ae3b256f6f"] .formkit-background{width:100%;height:100%;position:absolute;top:0;left:0;background-size:cover;background-position:center;opacity:0.3;}.formkit-form[data-uid="ae3b256f6f"] [data-style="minimal"]{padding:20px;width:100%;position:relative;}.formkit-form[data-uid="ae3b256f6f"] .formkit-header{margin:0 0 27px 0;text-align:center;}.formkit-form[data-uid="ae3b256f6f"] .formkit-subheader{margin:18px 0;text-align:center;}.formkit-form[data-uid="ae3b256f6f"] .formkit-guarantee{font-size:13px;margin:10px 0 15px 0;text-align:center;}.formkit-form[data-uid="ae3b256f6f"] .formkit-guarantee > p{margin:0;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit-container{margin-bottom:0;}.formkit-form[data-uid="ae3b256f6f"] .formkit-fields{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;margin:25px auto 0 auto;}.formkit-form[data-uid="ae3b256f6f"] .formkit-field{min-width:220px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-field,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit{margin:0 0 15px 0;-webkit-flex:1 0 100%;-ms-flex:1 0 100%;flex:1 0 100%;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] [data-style="minimal"]{padding:40px;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"]{margin-left:-5px;margin-right:-5px;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-field,.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-submit{margin:0 5px 15px 5px;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-field{-webkit-flex:100 1 auto;-ms-flex:100 1 auto;flex:100 1 auto;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-submit{-webkit-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;} </style></form><br>		</div>
+		</div>
+</div>
+    <div class="acme-related-posts">
+				
+
+    		<h5>
+				<span>You Might Also Like</span>
+			</h5>
+     			<a href="https://www.instrupix.com/easy-slow-cooker-salsa-pot-roast-dinner/"> 
+     			   <img loading="lazy" decoding="async" width="200" height="135" src="https://www.instrupix.com/wp-content/uploads/2022/02/salsa-pot-roast-dinner-recipe-easy-meals-200x135.jpg" class="related-thumbnail wp-post-image" alt="" nopin="nopin">     			 
+		<p><strong>2 Ingredient Salsa Pot Roast</strong><br>
+<span style="color: #000000;">If you like cheap and easy dinner recipes as much as I do, your entire family is going to absolutely love this amazing beef pot roast! It’s tender, juicy, and full of flavor.&nbsp;</span></p>
+</a>
+    </div>
+  </div></div></span><div class="wprm-spacer"></div>
+<span style="display: block;"><div data-post-id="6364" class="insert-page insert-page-6364 "><div id="list_post_wrapper">
+      <div class="acme-related-posts relatedposts2">
+    		
+     			<a href="https://www.instrupix.com/easy-hamburger-casserole-recipe-4-ingredients/"> 
+     			   <img loading="lazy" decoding="async" width="200" height="135" src="https://www.instrupix.com/wp-content/uploads/2019/12/4-ingredient-hamburger-casserole-recipe-200x135.jpg" class="related-thumbnail wp-post-image" alt="" nopin="nopin">     			 
+		<p><strong>4 Ingredient Easy Hamburger Casserole&nbsp;</strong><br>
+<span style="color: #000000;">This quick &amp; easy casserole is a family hit! It’s made with just pasta shells, ground beef, tomato soup, and lots of cheese. Even your picky eaters will love this recipe!</span></p>
+</a>
+    </div>
+  </div></div></span><div class="wprm-spacer"></div>
+<span style="display: block;"><div data-post-id="7260" class="insert-page insert-page-7260 "><div id="list_post_wrapper">
+      <div class="acme-related-posts relatedposts2">
+    		
+     			<a href="https://www.instrupix.com/slow-cooker-creamy-sausage-tortellini-soup/"> 
+     			   <img loading="lazy" decoding="async" width="200" height="135" src="https://www.instrupix.com/wp-content/uploads/2019/12/crockpot-soup-with-tortellini-sausage-and-spinach-200x135.jpg" class="related-thumbnail wp-post-image" alt="" nopin="nopin">     			 
+		<p><strong>Slow Cooker Tortellini &amp; Sausage Soup</strong><br>
+<span style="color: #000000;">Creamy, dreamy and delish! This family friendly crockpot dinner is quick and easy to make with just 6 simple ingredients.</span></p>
+</a>
+    </div>
+  </div></div></span><div class="wprm-spacer"></div>
+<span style="display: block;"><div data-post-id="12038" class="insert-page insert-page-12038 "><div id="list_post_wrapper">
+      <div class="acme-related-posts relatedposts2">
+    		
+     			<a href="https://www.instrupix.com/garlic-butter-steak-bites-skillet-dinner/"> 
+     			   <img loading="lazy" decoding="async" width="200" height="135" src="https://www.instrupix.com/wp-content/uploads/2022/02/juicy-skillet-steak-bites-over-cauliflower-rice-200x135.jpg" class="related-thumbnail wp-post-image" alt="" nopin="nopin">     			 
+		<p><strong>Garlic Butter Steak Bites</strong></p>
+<p class="entry-subtitle g1-beta g1-beta-3rd"><span style="color: #000000;">An easy skillet steak dinner recipe made with loads of butter and chopped garlic served over a bed of cauliflower rice.&nbsp;</span></p>
+</a>
+    </div>
+  </div></div></span></div></div>
+</div></div>
+<blockquote data-slot-rendered-content="true">
+<h2 style="text-align: center;">Don’t forget to pin and save for later! 🙂</h2>
+</blockquote>
+<div class="mv-ad-box" data-slotid="content_7_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_7_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="content_7_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+          <div id="content_7_btf" class="content_btf adunit" data-google-query-id="CNS74ODLq4gDFdiL6QUdVJQUkA">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_6__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://d1ca067a0e94280420aadf658583f338.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/content_6" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="7" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_7_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<p><img loading="lazy" decoding="async" class="aligncenter size-full wp-image-5803" src="https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning.jpg" alt="Looking for easy crockpot dinner recipes for the family? This simple pot roast is made with a rump roast, ranch seasoning, Italian seasoning and brown gravy mix. It's always a hit! Add in the veggies of your choice like potatoes carrots and celery. This beef slow cooker meal is great for busy weeknight meals. Break out your crockpot and lets get started! #crockpot #slowcooker #instrupix" width="724" height="1505" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning.jpg 724w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning-144x300.jpg 144w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning-493x1024.jpg 493w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning-344x715.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning-688x1430.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning-516x1073.jpg 516w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning-23x48.jpg 23w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-recipe-ranch-and-italian-seasoning-46x96.jpg 46w" sizes="(max-width: 724px) 100vw, 724px"><br>
+<img loading="lazy" decoding="async" class="hideimage aligncenter wp-image-4808 size-full" src="https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-recipe-4-ingredients-.jpg" alt="Looking for easy crockpot dinner recipes for the family? This simple slow cooker pot roast with vegetables is THE BEST! It's super easy to make with just 4 ingredients (plus the veggies of your choice). Made with gravy mix, ranch seasoning mix and dry Italian dressing, plus potatoes, carrots and celery. My favorite beef recipe for dinner!" width="500" height="1252" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-recipe-4-ingredients-.jpg 500w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-recipe-4-ingredients--120x300.jpg 120w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-recipe-4-ingredients--409x1024.jpg 409w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-recipe-4-ingredients--344x861.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-recipe-4-ingredients--19x48.jpg 19w, https://www.instrupix.com/wp-content/uploads/2019/11/easy-slow-cooker-pot-roast-recipe-4-ingredients--38x96.jpg 38w" sizes="(max-width: 500px) 100vw, 500px"><img loading="lazy" decoding="async" class="hideimage aligncenter size-full wp-image-6792" src="https://www.instrupix.com/wp-content/uploads/2019/11/best-slow-cooker-pot-roast-made-with-ranch-seasoning-easy-crockpot-recipe.jpg" alt="Looking for easy crockpot dinner recipes for the family? This beef pot roast is absolutely incredible and mixed with just 3 ingredients: Ranch seasoning, brown gravy mix and a packet of Italian salad dressing. It's perfect with carrots and potatoes. The entire family (including the picky eaters) will low this simple slow cooker meal idea. It's cheap and perfect for large families and busy weeknights. Calling all busy moms and dads! Some serious comfort food especially on cold winter nights." width="492" height="995" srcset="https://www.instrupix.com/wp-content/uploads/2019/11/best-slow-cooker-pot-roast-made-with-ranch-seasoning-easy-crockpot-recipe.jpg 492w, https://www.instrupix.com/wp-content/uploads/2019/11/best-slow-cooker-pot-roast-made-with-ranch-seasoning-easy-crockpot-recipe-148x300.jpg 148w, https://www.instrupix.com/wp-content/uploads/2019/11/best-slow-cooker-pot-roast-made-with-ranch-seasoning-easy-crockpot-recipe-344x696.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/11/best-slow-cooker-pot-roast-made-with-ranch-seasoning-easy-crockpot-recipe-24x48.jpg 24w, https://www.instrupix.com/wp-content/uploads/2019/11/best-slow-cooker-pot-roast-made-with-ranch-seasoning-easy-crockpot-recipe-47x96.jpg 47w" sizes="(max-width: 492px) 100vw, 492px"></p>
+<!--www.crestaproject.com Cresta Social Share Counter Content Start--><div id="crestashareiconincontent" class="cresta-share-icon   fifteenth_style" data-slot-rendered-content="true"><div class="sbutton-total" id="total-shares-content" data-twittershares="0" data-facebookshares="1060" data-vkshares="0" data-buffershares="0" data-redditshares="0" data-okshares="0" data-xingshares="0" data-tumblrshares="0" data-pinterestshares="730479"><span class="cresta-the-total-count" id="total-count-content">731.5K</span><span class="cresta-the-total-text">Shares</span></div><div class="sbutton  facebook-cresta-share cresta-no-animation" id="facebook-cresta-c"><a rel="nofollow" href="https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F&amp;t=The+Best+Slow+Cooker+Pot+Roast+Recipe" data-name="Share to Facebook" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-facebook"></i></a><span class="cresta-the-count-content" id="facebook-count-content">1.1K</span></div><div class="sbutton  pinterest-cresta-share cresta-no-animation" id="pinterest-cresta-c"><a rel="nofollow" href="javascript:void((function()%7Bvar%20e=document.createElement('script');e.setAttribute('type','text/javascript');e.setAttribute('charset','UTF-8');e.setAttribute('src','https://assets.pinterest.com/js/pinmarklet.js?r='+Math.random()*99999999);document.body.appendChild(e)%7D)());" data-name="Share to Pinterest"><i class="cs c-icon-cresta-pinterest"></i></a><span class="cresta-the-count-content" id="pinterest-count-content">730.5K</span></div><div class="sbutton  email-cresta-share cresta-no-animation" id="email-cresta-c"><a rel="nofollow" href="mailto:?subject=The%20Best%20Slow%20Cooker%20Pot%20Roast%20Recipe&amp;body=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F" data-name="Share via Email" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-mail"></i></a></div><div style="clear: both;"></div></div>
+<div class="mv-ad-box" data-slotid="content_8_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_8_btf_wrapper" class="adunitwrapper content_btf_wrapper" data-wrapper="content_8_btf" data-nosnippet="">
+          <div id="content_8_btf" class="content_btf adunit">
+            
+          </div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_8_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com"></mv-ad-reporter></div>
+<div style="clear: both;"></div><!--www.crestaproject.com Cresta Social Share Counter Content End--><div><h3>Leave a comment...</h3><div class="fb-comments fb_iframe_widget fb_iframe_widget_fluid_desktop" data-href="https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/" data-numposts="5" data-width="100%" fb-xfbml-state="rendered" fb-iframe-plugin-query="app_id=1060721147363596&amp;container_width=662&amp;height=100&amp;href=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F&amp;locale=en_US&amp;numposts=5&amp;sdk=joey&amp;version=v8.0&amp;width=" style="width: 100%;"><span style="vertical-align: bottom; width: 100%; height: 761px;"><iframe name="faf445f056d54f952" width="1000px" height="100px" data-testid="fb:comments Facebook Social Plugin" title="fb:comments Facebook Social Plugin" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" src="https://www.facebook.com/v8.0/plugins/comments.php?app_id=1060721147363596&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fx%2Fconnect%2Fxd_arbiter%2F%3Fversion%3D46%23cb%3Df30b78064e82f3e3d%26domain%3Dwww.instrupix.com%26is_canvas%3Dfalse%26origin%3Dhttps%253A%252F%252Fwww.instrupix.com%252Ff6088ccc5aba4af6a%26relation%3Dparent.parent&amp;container_width=662&amp;height=100&amp;href=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F&amp;locale=en_US&amp;numposts=5&amp;sdk=joey&amp;version=v8.0&amp;width=" style="border: none; visibility: visible; width: 100%; height: 761px;" class=""></iframe></span></div>
+</div>	</div>
+
+		
+	<aside class="g1-related-entries">
+
+		
+		<h2 class="g1-gamma g1-gamma-2nd">You may also like</h2>
+
+		<div class="g1-collection g1-collection-columns-2">
+			<div class="g1-collection-viewport">
+				<ul class="g1-collection-items  ">
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-12052 post type-post status-publish format-standard has-post-thumbnail category-2-ingredient category-3-ingredient category-beef category-dinner category-food category-low-carb category-main-dish category-recipes category-slow-cooker tag-2-ingredients tag-beef tag-crockpot tag-easy-meals tag-keto tag-low-carb tag-pot-roast tag-salsa tag-slow-cooker">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-slow-cooker-salsa-pot-roast-dinner/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2022/02/slow-cooker-salsa-pot-roast-easy-meals-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2022/02/slow-cooker-salsa-pot-roast-easy-meals-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2022/02/slow-cooker-salsa-pot-roast-easy-meals-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2022/02/slow-cooker-salsa-pot-roast-easy-meals-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2022/02/slow-cooker-salsa-pot-roast-easy-meals-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2022/02/slow-cooker-salsa-pot-roast-easy-meals-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2022/02/slow-cooker-salsa-pot-roast-easy-meals-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-slow-cooker-salsa-pot-roast-dinner/" rel="bookmark">Fiesta Pot Roast Dinner</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-8334 post type-post status-publish format-standard has-post-thumbnail category-beef category-dinner category-food category-lunch category-main-dish category-recipes category-sandwiches category-slow-cooker tag-beef tag-butter tag-crockpot tag-mississippi tag-peppers tag-pot-roast tag-sandwiches tag-slow-cooker">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-mississippi-pot-roast-sandwiches/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2020/10/easy-pot-roast-recipe-with-butter-and-peppers-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2020/10/easy-pot-roast-recipe-with-butter-and-peppers-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/10/easy-pot-roast-recipe-with-butter-and-peppers-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2020/10/easy-pot-roast-recipe-with-butter-and-peppers-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/10/easy-pot-roast-recipe-with-butter-and-peppers-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2020/10/easy-pot-roast-recipe-with-butter-and-peppers-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2020/10/easy-pot-roast-recipe-with-butter-and-peppers-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-mississippi-pot-roast-sandwiches/" rel="bookmark">Mississippi Pot Roast</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-7391 post type-post status-publish format-standard has-post-thumbnail category-chicken category-dinner category-recipes category-slow-cooker tag-beans tag-chicken tag-chili tag-cream-cheese tag-creamy tag-crockpot tag-dinner tag-slow-cooker">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-slow-cooker-creamy-chicken-chili/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2020/03/slow-cooker-chicken-chili-recipe-cream-cheese-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2020/03/slow-cooker-chicken-chili-recipe-cream-cheese-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/03/slow-cooker-chicken-chili-recipe-cream-cheese-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2020/03/slow-cooker-chicken-chili-recipe-cream-cheese-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/03/slow-cooker-chicken-chili-recipe-cream-cheese-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2020/03/slow-cooker-chicken-chili-recipe-cream-cheese-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2020/03/slow-cooker-chicken-chili-recipe-cream-cheese-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-slow-cooker-creamy-chicken-chili/" rel="bookmark">Slow Cooker Creamy Chicken Chili</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-8637 post type-post status-publish format-standard has-post-thumbnail category-chicken category-dinner category-food category-home-page-feature category-main-dish category-recipes category-sandwiches category-slow-cooker tag-bacon tag-chicken tag-crockpot tag-ranch tag-sandwiches tag-slow-cooker">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-crockpot-shredded-chicken-bacon-ranch-sandwiches/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2020/12/crack-chicken-sandwiches-easy-slow-cooker-family-dinner-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2020/12/crack-chicken-sandwiches-easy-slow-cooker-family-dinner-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/12/crack-chicken-sandwiches-easy-slow-cooker-family-dinner-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2020/12/crack-chicken-sandwiches-easy-slow-cooker-family-dinner-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/12/crack-chicken-sandwiches-easy-slow-cooker-family-dinner-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2020/12/crack-chicken-sandwiches-easy-slow-cooker-family-dinner-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2020/12/crack-chicken-sandwiches-easy-slow-cooker-family-dinner-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-crockpot-shredded-chicken-bacon-ranch-sandwiches/" rel="bookmark">Crockpot Crack Chicken Sandwiches</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-5098 post type-post status-publish format-standard has-post-thumbnail category-dinner category-food category-main-dish category-recipes category-slow-cooker tag-cream-cheese tag-creamy tag-crock-pot tag-crockpot tag-pasta tag-sausage tag-slow-cooker tag-soup tag-spinach tag-tortellini">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/slow-cooker-creamy-sausage-tortellini-soup/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2019/12/easy-crockpot-soup-recipes-for-families-sausage-tortellini-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2019/12/easy-crockpot-soup-recipes-for-families-sausage-tortellini-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/12/easy-crockpot-soup-recipes-for-families-sausage-tortellini-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2019/12/easy-crockpot-soup-recipes-for-families-sausage-tortellini-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/12/easy-crockpot-soup-recipes-for-families-sausage-tortellini-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2019/12/easy-crockpot-soup-recipes-for-families-sausage-tortellini-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2019/12/easy-crockpot-soup-recipes-for-families-sausage-tortellini-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/slow-cooker-creamy-sausage-tortellini-soup/" rel="bookmark">Slow Cooker Creamy Tortellini &amp; Sausage Soup</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-4322 post type-post status-publish format-standard has-post-thumbnail category-chicken category-dinner category-food category-lunch category-main-dish category-recipes category-sandwiches category-slow-cooker tag-bbq tag-chicken tag-crockpot tag-sandwiches tag-slow-cooker">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/the-best-crockpot-bbq-chicken-sandwiches/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2019/09/the-best-shredded-bbq-chicken-sandwiches--344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2019/09/the-best-shredded-bbq-chicken-sandwiches--344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/09/the-best-shredded-bbq-chicken-sandwiches--500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2019/09/the-best-shredded-bbq-chicken-sandwiches--688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/09/the-best-shredded-bbq-chicken-sandwiches--536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2019/09/the-best-shredded-bbq-chicken-sandwiches--120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2019/09/the-best-shredded-bbq-chicken-sandwiches--240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/the-best-crockpot-bbq-chicken-sandwiches/" rel="bookmark">Zesty Slow Cooker BBQ Chicken Sandwiches</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-2784 post type-post status-publish format-standard has-post-thumbnail category-dinner category-food category-main-dish category-recipes tag-crockpot tag-dinner tag-italian tag-lasagna tag-vegetarian">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-crockpot-lasagna/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2018/11/lasagna-recipe-easy-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2018/11/lasagna-recipe-easy-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2018/11/lasagna-recipe-easy-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2018/11/lasagna-recipe-easy-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2018/11/lasagna-recipe-easy-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2018/11/lasagna-recipe-easy-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2018/11/lasagna-recipe-easy-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-crockpot-lasagna/" rel="bookmark">Easy Crockpot Veggie Lasagna</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-12002 post type-post status-publish format-standard has-post-thumbnail category-beef category-dinner category-food category-low-carb category-main-dish category-recipes tag-butter tag-cast-iron tag-dinner tag-easy-meals tag-garlic tag-healthy tag-keto tag-low-carb tag-skillet tag-steak">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/garlic-butter-steak-bites-skillet-dinner/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2022/02/garlic-butter-steak-bites-easy-low-carb-dinner-ideas-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2022/02/garlic-butter-steak-bites-easy-low-carb-dinner-ideas-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2022/02/garlic-butter-steak-bites-easy-low-carb-dinner-ideas-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2022/02/garlic-butter-steak-bites-easy-low-carb-dinner-ideas-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2022/02/garlic-butter-steak-bites-easy-low-carb-dinner-ideas-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2022/02/garlic-butter-steak-bites-easy-low-carb-dinner-ideas-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2022/02/garlic-butter-steak-bites-easy-low-carb-dinner-ideas-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/garlic-butter-steak-bites-skillet-dinner/" rel="bookmark">Garlic Butter Steak Bites</a></h3>	</header>
+		</article>
+						</li>
+
+									</ul>
+			</div>
+		</div>
+
+					</aside>
+			<meta itemprop="mainEntityOfPage" content="https://www.instrupix.com/easy-slow-cooker-pot-roast-recipe-with-vegetables/">
+	<meta itemprop="dateModified" content="2024-06-29T15:41:12">
+
+	<span itemprop="publisher" itemscope="" itemtype="http://schema.org/Organization">
+		<meta itemprop="name" content="Instrupix">
+		<meta itemprop="url" content="https://www.instrupix.com">
+		<span itemprop="logo" itemscope="" itemtype="http://schema.org/ImageObject">
+			<meta itemprop="url" content="">
+		</span>
+	</span>
+		<span itemprop="image" itemscope="" itemtype="http://schema.org/ImageObject">
+				<meta itemprop="url" content="https://www.instrupix.com/wp-content/uploads/2019/11/easy-crockpot-pot-roast-with-potatoes-and-carrots.jpg">
+		<meta itemprop="width" content="725">
+		<meta itemprop="height" content="907">
+	</span>
+	</article>
+
+
+
+				</div>
+				<!-- #content -->
+			</div>
+
+
+			<!-- #primary -->
+
+			<div id="secondary" class="g1-column g1-column-1of3">
+	<aside id="starmile_aboutme_widget-2" class="widget widget_starmile_aboutme_widget"><header><h2 class="g1-delta g1-delta-2nd widgettitle">About Me</h2></header>	<div class="g1-aboutme">
+					<a href="https://www.instrupix.com/about/" class="g1-aboutme-avatar">
+		
+			<img width="550" height="769" src="https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers.jpg" class="attachment-full size-full" alt="" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers.jpg 550w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-215x300.jpg 215w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-344x481.jpg 344w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-516x721.jpg 516w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-34x48.jpg 34w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-69x96.jpg 69w" sizes="(max-width: 550px) 100vw, 550px" nopin="nopin">
+					</a>
+		
+					
+			<div class="g1-aboutme-signature">
+							</div>
+							<div class="g1-aboutme-desc">
+				<p>I’m just a gal that likes to make fun stuff and whip up easy recipes in the kitchen.&nbsp;</p>
+			</div>
+							</div>
+	</aside><aside id="search-2" class="widget widget_search" data-slot-rendered-sidebarbtf="true"><header><h2 class="g1-delta g1-delta-2nd widgettitle">Search</h2></header>
+
+<div role="search" class="search-form-wrapper">
+	<form method="get" class="g1-searchform-tpl-default search-form" action="https://www.instrupix.com/">
+		<label>
+			<span class="screen-reader-text">Search for:</span>
+			<input type="search" class="search-field" placeholder="Search …" value="" name="s" title="Search for:">
+		</label>
+		<button class="search-submit">Search</button>
+	</form>
+</div>
+</aside>
+      <div id="sidebar_btf_placeholder" class="sidebar_btf_placeholder" style="height: 265px;"><div id="sidebar_btf_sticky_wrapper" class="" style="width: 324px;"><div id="sidebar_btf_wrapper" class="adunitwrapper sidebar_btf_wrapper mv-size-300x250" data-wrapper="sidebar_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+        <div id="sidebar_btf" class="adunit" data-google-query-id="CO_exPfNq4gDFS5IwgUd9ekCEw">
+        
+        <div id="google_ads_iframe_/1030006,16030400/instrupix/sticky_sidebar_0__container__" style="border: 0pt none;"><iframe id="google_ads_iframe_/1030006,16030400/instrupix/sticky_sidebar_0" name="google_ads_iframe_/1030006,16030400/instrupix/sticky_sidebar_0" title="3rd party ad content" width="300" height="250" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="attribution-reporting" data-load-complete="true" style="border: 0px; vertical-align: bottom;" data-google-container-id="3" data-hooks="true"></iframe></div></div>
+      <mv-ad-reporter data-slot-id="sidebar_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div></div></div>
+    </div><!-- #secondary -->
+
+		</div>
+	</div><!-- .g1-row -->
+
+
+<div class="g1-row g1-row-layout-page g1-footer">
+	<div class="g1-row-inner">
+		<div class="g1-column">
+			
+							<div class="g1-footer-social">
+					<ul id="g1-social-icons-3" class="g1-socials-items g1-socials-items-tpl-grid">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-32 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-32 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-32 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+				</div>
+						<nav id="g1-footer-nav" class="g1-footer-nav"><ul id="g1-footer-nav-menu" class=""><li id="menu-item-2676" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2676"><a href="https://www.instrupix.com/about/">About</a></li>
+<li id="menu-item-2677" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2677"><a href="https://www.instrupix.com/contact/">Contact</a></li>
+<li id="menu-item-2678" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy menu-item-2678"><a rel="privacy-policy" href="https://www.instrupix.com/privacy-policy/">Privacy Policy</a></li>
+<li id="menu-item-2665" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2665"><a href="https://www.instrupix.com/newsletter/">Newsletter</a></li>
+</ul></nav>			<p class="g1-footer-text g1-meta">© 2020 instrupix.com</p>
+				<div class="g1-footer-credits g1-dark">
+			</div>
+		</div>
+		<!-- .g1-column -->
+	</div>
+	<div class="g1-row-background">
+	</div>
+</div><!-- .g1-row -->
+	<a href="#page" class="g1-back-to-top g1-back-to-top-on" title="Back to Top">Back to Top</a>
+</div><!-- #page -->
+
+<div class="g1-canvas-overlay"></div>
+
+</div><!-- .g1-body-inner -->
+<div id="g1-breakpoint-desktop"></div>
+
+
+<div class="g1-canvas g1-canvas-global">
+	<div class="g1-canvas-content">
+		<a class="g1-canvas-toggle" href="#"></a>
+
+			<!-- BEGIN .g1-primary-nav -->
+	<nav id="g1-canvas-primary-nav" class="g1-primary-nav"><ul id="g1-canvas-primary-nav-menu" class="g1-menu-v"><li class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-has-children menu-item-2670"><a href="https://www.instrupix.com/category/recipes/">Recipes<span class="g1-link-toggle"></span></a>
+<ul class="sub-menu">
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-5847"><a href="https://www.instrupix.com/category/dinner/">Dinner</a></li>
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5848"><a href="https://www.instrupix.com/category/dessert/">Dessert</a></li>
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5846"><a href="https://www.instrupix.com/category/low-carb/">Low Carb</a></li>
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5849"><a href="https://www.instrupix.com/category/party-food/">Party Food</a></li>
+</ul>
+</li>
+<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-2671"><a href="https://www.instrupix.com/category/diy/">DIY</a></li>
+</ul></nav>		<!-- END .g1-primary-nav -->
+	
+	<ul id="g1-social-icons-4" class="g1-socials-items g1-socials-items-tpl-grid">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+
+
+<div role="search" class="search-form-wrapper">
+	<form method="get" class="g1-searchform-tpl-default search-form" action="https://www.instrupix.com/">
+		<label>
+			<span class="screen-reader-text">Search for:</span>
+			<input type="search" class="search-field" placeholder="Search …" value="" name="s" title="Search for:">
+		</label>
+		<button class="search-submit">Search</button>
+	</form>
+</div>
+	</div>
+	<div class="g1-canvas-background"></div>
+</div>
+
+<div class="adace-adi-popup-wrapper">
+	<div class="adace-adi-popup">
+		<div class="adace-adi-flag"></div>
+
+		<h2 class="adace-adi-title">Ad Blocker Detected!</h2>
+		<div class="adace-adi-content">Advertisements fund this website. Please disable your adblocking software or whitelist our website.<br>Thank You!</div>
+
+		<div class="adace-adi-buttons">
+						<a class="adace-adi-refresh-button">Refresh</a>
+		</div>
+
+	</div>
+</div>
+	<script>
+		(function ($) {
+			"use strict";
+
+						var triggerAlert = false;
+			
+			var adblockDetectedAlert = function() {
+				$('html').addClass('adace-adi-popup-visible');
+				$('.adace-adi-refresh-button').on('click', function(){
+					window.location.reload();
+				});
+				$('.adace-adi-close').on('click', function(){
+					console.log('e');
+					$('html').removeClass('adace-adi-popup-visible');
+				});
+			};
+
+			$(document).ready(function () {
+				// Only when the AdBlocker is enabled this script will be available.
+				if ( typeof $.adi === 'function' ) {
+					$.adi({
+						onOpen: function (el) {
+							adblockDetectedAlert();
+						}
+					});
+				}
+
+				// Show alert on demand. AdBlocker can be disabled.
+				if (triggerAlert) {
+					adblockDetectedAlert();
+				}
+			});
+		})(jQuery);
+	</script>
+	<script>window.wprm_recipes = {"recipe-4819":{"type":"food","name":"Easy Slow Cooker Pot Roast Recipe With Vegetables","slug":"wprm-easy-slow-cooker-pot-roast-recipe-with-vegetables","image_url":"https:\/\/www.instrupix.com\/wp-content\/uploads\/2019\/11\/simple-pot-roast-recipe-slow-cooker.jpg","originalServings":"6","originalServingsParsed":6,"currentServings":"6","currentServingsParsed":6,"currentServingsFormatted":"6","currentServingsMultiplier":1,"rating":{"count":0,"total":0,"average":0,"type":{"comment":0,"no_comment":0,"user":0}}}}</script><link rel="stylesheet" id="wprm-public-css" href="https://www.instrupix.com/wp-content/plugins/wp-recipe-maker/dist/public-modern.css?ver=9.5.3" type="text/css" media="all">
+<link rel="stylesheet" id="g1-socials-basic-screen-css" href="https://www.instrupix.com/wp-content/plugins/g1-socials/css/screen-basic.min.css?ver=1.1.16" type="text/css" media="screen">
+<link rel="stylesheet" id="g1-socials-snapcode-css" href="https://www.instrupix.com/wp-content/plugins/g1-socials/css/snapcode.min.css?ver=1.1.16" type="text/css" media="screen">
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/js/jquery.cresta-social-effect.min.js?ver=2.9.9.5" id="cresta-social-effect-js-js"></script>
+<script type="text/javascript" id="cresta-social-counter-js-js-extra">
+/* <![CDATA[ */
+var crestaShareSSS = {"FacebookCount":"1060"};
+var crestaPermalink = {"thePermalink":"https:\/\/www.instrupix.com\/easy-slow-cooker-pot-roast-recipe-with-vegetables\/","themorezero":"nomore","totalmorezero":"totalyesmore","themorenumber":"0"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/js/jquery.cresta-social-share-counter-both.min.js?ver=2.9.9.5" id="cresta-social-counter-js-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/lazy-load/js/lazysizes/lazysizes.min.js?ver=4.0" id="lazysizes-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/lazy-load/js/youtube.js?ver=1.2.3" id="mace-lazy-load-youtube-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/video-playlist/js/mejs-renderers/vimeo.min.js?ver=1.2.3" id="mace-vp-renderer-vimeo-js"></script>
+<script type="text/javascript" id="mediaelement-core-js-before">
+/* <![CDATA[ */
+var mejsL10n = {"language":"en","strings":{"mejs.download-file":"Download File","mejs.install-flash":"You are using a browser that does not have Flash player enabled or installed. Please turn on your Flash player plugin or download the latest version from https:\/\/get.adobe.com\/flashplayer\/","mejs.fullscreen":"Fullscreen","mejs.play":"Play","mejs.pause":"Pause","mejs.time-slider":"Time Slider","mejs.time-help-text":"Use Left\/Right Arrow keys to advance one second, Up\/Down arrows to advance ten seconds.","mejs.live-broadcast":"Live Broadcast","mejs.volume-help-text":"Use Up\/Down Arrow keys to increase or decrease volume.","mejs.unmute":"Unmute","mejs.mute":"Mute","mejs.volume-slider":"Volume Slider","mejs.video-player":"Video Player","mejs.audio-player":"Audio Player","mejs.captions-subtitles":"Captions\/Subtitles","mejs.captions-chapters":"Chapters","mejs.none":"None","mejs.afrikaans":"Afrikaans","mejs.albanian":"Albanian","mejs.arabic":"Arabic","mejs.belarusian":"Belarusian","mejs.bulgarian":"Bulgarian","mejs.catalan":"Catalan","mejs.chinese":"Chinese","mejs.chinese-simplified":"Chinese (Simplified)","mejs.chinese-traditional":"Chinese (Traditional)","mejs.croatian":"Croatian","mejs.czech":"Czech","mejs.danish":"Danish","mejs.dutch":"Dutch","mejs.english":"English","mejs.estonian":"Estonian","mejs.filipino":"Filipino","mejs.finnish":"Finnish","mejs.french":"French","mejs.galician":"Galician","mejs.german":"German","mejs.greek":"Greek","mejs.haitian-creole":"Haitian Creole","mejs.hebrew":"Hebrew","mejs.hindi":"Hindi","mejs.hungarian":"Hungarian","mejs.icelandic":"Icelandic","mejs.indonesian":"Indonesian","mejs.irish":"Irish","mejs.italian":"Italian","mejs.japanese":"Japanese","mejs.korean":"Korean","mejs.latvian":"Latvian","mejs.lithuanian":"Lithuanian","mejs.macedonian":"Macedonian","mejs.malay":"Malay","mejs.maltese":"Maltese","mejs.norwegian":"Norwegian","mejs.persian":"Persian","mejs.polish":"Polish","mejs.portuguese":"Portuguese","mejs.romanian":"Romanian","mejs.russian":"Russian","mejs.serbian":"Serbian","mejs.slovak":"Slovak","mejs.slovenian":"Slovenian","mejs.spanish":"Spanish","mejs.swahili":"Swahili","mejs.swedish":"Swedish","mejs.tagalog":"Tagalog","mejs.thai":"Thai","mejs.turkish":"Turkish","mejs.ukrainian":"Ukrainian","mejs.vietnamese":"Vietnamese","mejs.welsh":"Welsh","mejs.yiddish":"Yiddish"}};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/mediaelement/mediaelement-and-player.min.js?ver=4.2.17" id="mediaelement-core-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/mediaelement/mediaelement-migrate.min.js?ver=6.6.1" id="mediaelement-migrate-js"></script>
+<script type="text/javascript" id="mediaelement-js-extra">
+/* <![CDATA[ */
+var _wpmejsSettings = {"pluginPath":"\/wp-includes\/js\/mediaelement\/","classPrefix":"mejs-","stretching":"responsive","audioShortcodeLibrary":"mediaelement","videoShortcodeLibrary":"mediaelement"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/mediaelement/wp-mediaelement.min.js?ver=6.6.1" id="wp-mediaelement-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/video-playlist/js/playlist.js?ver=1.2.3" id="mace-vp-js"></script>
+<script type="text/javascript" id="mace-gallery-js-extra">
+/* <![CDATA[ */
+var macegallery = "{\"i18n\":{\"of\":\"of\"},\"html\":\"\\n<div class=\\\"g1-gallery-wrapper g1-gallery-dark\\\">\\n\\t<div class=\\\"g1-gallery\\\">\\n\\t\\t<div class=\\\"g1-gallery-header\\\">\\n\\t\\t\\t<div class=\\\"g1-gallery-header-left\\\">\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-logo\\\">\\n\\t\\t\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-title g1-gamma g1-gamma-1st\\\">{title}<\\\/div>\\n\\t\\t\\t<\\\/div>\\n\\t\\t\\t<div class=\\\"g1-gallery-header-right\\\">\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-back-to-slideshow\\\">Back to slideshow<\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbs-button\\\"><\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-numerator\\\">{numerator}<\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-close-button\\\"><\\\/div>\\n\\t\\t\\t<\\\/div>\\n\\t\\t<\\\/div>\\n\\t\\t<div class=\\\"g1-gallery-body\\\">\\n\\t\\t\\t<div class=\\\"g1-gallery-frames\\\">\\n\\t\\t\\t\\t{frames}\\n\\t\\t\\t<\\\/div>\\n\\t\\t\\t<div class=\\\"g1-gallery-thumbnails32\\\">\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-collection\\\">\\n\\t\\t\\t\\t\\t{thumbnails32}\\n\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t<\\\/div>\\n\\t\\t\\t<div class=\\\"g1-gallery-sidebar\\\">\\n\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-shares\\\">\\n\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-ad\\\">\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails\\\">\\n\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-up\\\"><\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-collection\\\">{thumbnails}<\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-down\\\"><\\\/div>\\n\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t<\\\/div>\\n\\t<\\\/div>\\n<\\\/div>\\n\",\"shares\":\"<script type=\\\"text\\\/javascript\\\">\\n\\t\\t\\t(function () {\\n\\t\\t\\t\\tvar triggerOnLoad = false;\\n\\n\\t\\t\\t\\twindow.apiShareOnFB = function() {\\n\\t\\t\\t\\t\\tjQuery('body').trigger('snaxFbNotLoaded');\\n\\t\\t\\t\\t\\ttriggerOnLoad = true;\\n\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\tvar _fbAsyncInitGallery = window.fbAsyncInitGallery;\\n\\n\\t\\t\\t\\twindow.fbAsyncInitGallery = function() {\\n\\t\\t\\t\\t\\tFB.init({\\n\\t\\t\\t\\t\\t\\tappId      : '',\\n\\t\\t\\t\\t\\t\\txfbml      : true,\\n\\t\\t\\t\\t\\t\\tversion    : 'v3.0'\\n\\t\\t\\t\\t\\t});\\n\\t\\t\\t\\t\\twindow.apiShareOnFB_mace_replace_unique = function() {\\n\\t\\t\\t\\t\\t\\tvar shareTitle \\t\\t    = 'mace_replace_noesc_title';\\n\\t\\t\\t\\t\\t\\tvar shareDescription\\t= '';\\n\\t\\t\\t\\t\\t\\tvar shareImage\\t        = 'mace_replace_noesc_image_url';\\n\\n\\t\\t\\t\\t\\t\\tFB.login(function(response) {\\n\\t\\t\\t\\t\\t\\t\\tif (response.status === 'connected') {\\n\\t\\t\\t\\t\\t\\t\\t\\tvar objectToShare = {\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t'og:url':           'mace_replace_noesc_shortlink', \\\/\\\/ Url to share.\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t'og:title':         shareTitle,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t'og:description':   shareDescription\\n\\t\\t\\t\\t\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\t\\t\\t\\t\\t\\\/\\\/ Add image only if set. FB fails otherwise.\\n\\t\\t\\t\\t\\t\\t\\t\\tif (shareImage) {\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tobjectToShare['og:image'] = shareImage;\\n\\t\\t\\t\\t\\t\\t\\t\\t}\\n\\n\\t\\t\\t\\t\\t\\t\\t\\tFB.ui({\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\tmethod: 'share_open_graph',\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\taction_type: 'og.shares',\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\taction_properties: JSON.stringify({\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\tobject : objectToShare\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t})\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t},\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\\/\\\/ callback\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tfunction(response) {\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t});\\n\\t\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t\\t});\\n\\t\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\t\\t\\\/\\\/ Fire original callback.\\n\\t\\t\\t\\t\\tif (typeof _fbAsyncInitGallery === 'function') {\\n\\t\\t\\t\\t\\t\\t_fbAsyncInitGallery();\\n\\t\\t\\t\\t\\t}\\n\\n\\t\\t\\t\\t\\t\\\/\\\/ Open share popup as soon as possible, after loading FB SDK.`\\n\\t\\t\\t\\t\\tif (triggerOnLoad) {\\n\\t\\t\\t\\t\\t\\tsetTimeout(function() {\\n\\t\\t\\t\\t\\t\\t\\tapiShareOnFB();\\n\\t\\t\\t\\t\\t\\t}, 1000);\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\t\\\/\\\/ JS SDK loaded before we hook into it. Trigger callback now.\\n\\t\\t\\t\\tif (typeof window.FB !== 'undefined') {\\n\\t\\t\\t\\t\\twindow.fbAsyncInitGallery();\\n\\t\\t\\t\\t}\\n\\t\\t\\t\\tjQuery('body').on('maceGalleryItemChanged', function(){\\n\\t\\t\\t\\t\\twindow.fbAsyncInitGallery();\\n\\t\\t\\t\\t});\\n\\t\\t\\t})();\\n\\t\\t<\\\/script>\\n\\n<a class=\\\"g1-gallery-share g1-gallery-share-fb\\\" href=\\\"#\\\" title=\\\"Share on Facebook\\\" onclick=\\\"apiShareOnFB_mace_replace_unique(); return false;\\\" target=\\\"_blank\\\" rel=\\\"nofollow\\\">Share on Facebook<\\\/a><a class=\\\"g1-gallery-share g1-gallery-share-twitter\\\" href=\\\"https:\\\/\\\/twitter.com\\\/home?status=mace_replace_title%20mace_replace_shortlink\\\" title=\\\"Share on Twitter\\\" target=\\\"_blank\\\" rel=\\\"nofollow\\\">Share on Twitter<\\\/a><a class=\\\"g1-gallery-share g1-gallery-share-pinterest\\\" href=\\\"https:\\\/\\\/pinterest.com\\\/pin\\\/create\\\/button\\\/?url=mace_replace_shortlink&description=mace_replace_title&media=mace_replace_image_url\\\" title=\\\"Share on Pinterest\\\" target=\\\"_blank\\\" rel=\\\"nofollow\\\">Share on Pinterest<\\\/a>\"}";
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/gallery/js/gallery.js?ver=1.2.3" id="mace-gallery-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/stickyfill/stickyfill.min.js?ver=1.3.1" id="stickyfill-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.placeholder/placeholders.jquery.min.js?ver=4.0.1" id="jquery-placeholder-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.timeago/jquery.timeago.js?ver=1.5.2" id="jquery-timeago-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.timeago/locales/jquery.timeago.en.js" id="jquery-timeago-en-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/matchMedia/matchMedia.js" id="match-media-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/matchMedia/matchMedia.addListener.js" id="match-media-add-listener-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/picturefill/picturefill.min.js?ver=2.3.1" id="picturefill-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.waypoints/jquery.waypoints.min.js?ver=4.0.0" id="jquery-waypoints-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/flickity/flickity.pkgd.min.js?ver=2.0.9" id="flickity-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/enquire/enquire.min.js?ver=2.1.2" id="enquire-js"></script>
+<script type="text/javascript" id="starmile-front-js-extra">
+/* <![CDATA[ */
+var starmile_front_config = "{\"ajax_url\":\"https:\\\/\\\/www.instrupix.com\\\/wp-admin\\\/admin-ajax.php\",\"timeago\":\"on\",\"sharebar\":\"off\",\"microshare\":\"off\",\"i18n\":{\"newsletter\":{\"subscribe_mail_subject_tpl\":\"Check out this great article: %subject%\"},\"bp_profile_nav\":{\"more_link\":\"More\"}},\"comment_types\":[\"wp\"],\"auto_load_limit\":0}";
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/front.js?ver=1.2.2" id="starmile-front-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile-child-theme/modifications.js" id="starmile-child-js"></script>
+<script type="text/javascript" id="wprm-public-js-extra">
+/* <![CDATA[ */
+var wprm_public = {"user":"0","endpoints":{"analytics":"https:\/\/www.instrupix.com\/wp-json\/wp-recipe-maker\/v1\/analytics","integrations":"https:\/\/www.instrupix.com\/wp-json\/wp-recipe-maker\/v1\/integrations","manage":"https:\/\/www.instrupix.com\/wp-json\/wp-recipe-maker\/v1\/manage"},"settings":{"features_comment_ratings":true,"template_color_comment_rating":"#343434","instruction_media_toggle_default":"on","video_force_ratio":false,"analytics_enabled":false,"google_analytics_enabled":false,"print_new_tab":true,"print_recipe_identifier":"slug"},"post_id":"4801","home_url":"https:\/\/www.instrupix.com\/","print_slug":"wprm_print","permalinks":"\/%postname%\/","ajax_url":"https:\/\/www.instrupix.com\/wp-admin\/admin-ajax.php","nonce":"ed50ec6080","api_nonce":"782075ab3a","translations":[]};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/wp-recipe-maker/dist/public-modern.js?ver=9.5.3" id="wprm-public-js"></script>
+<style type="text/css">.wprm-recipe-template-acme-compact-custom {
+    margin: 20px auto;
+    background-color: #fafafa; /*wprm_background type=color*/
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; /*wprm_main_font_family type=font*/
+    font-size: 0.9em; /*wprm_main_font_size type=font_size*/
+    line-height: 1.5em !important; /*wprm_main_line_height type=font_size*/
+    color: #333333; /*wprm_main_text type=color*/
+    max-width: 650px; /*wprm_max_width type=size*/
+}
+.wprm-recipe-template-acme-compact-custom a {
+    color: #929313; /*wprm_link type=color*/
+}
+.wprm-recipe-template-acme-compact-custom p, .wprm-recipe-template-acme-compact-custom li {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; /*wprm_main_font_family type=font*/
+    font-size: 1em !important;
+    line-height: 1.5em !important; /*wprm_main_line_height type=font_size*/
+}
+.wprm-recipe-template-acme-compact-custom li {
+    margin: 0 0 0 32px !important;
+    padding: 0 !important;
+}
+.rtl .wprm-recipe-template-acme-compact-custom li {
+    margin: 0 32px 0 0 !important;
+}
+.wprm-recipe-template-acme-compact-custom ol, .wprm-recipe-template-acme-compact-custom ul {
+    margin: 0 !important;
+    padding: 0 !important;
+}
+.wprm-recipe-template-acme-compact-custom br {
+    display: none;
+}
+.wprm-recipe-template-acme-compact-custom .wprm-recipe-name,
+.wprm-recipe-template-acme-compact-custom .wprm-recipe-header {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; /*wprm_header_font_family type=font*/
+    color: #212121; /*wprm_header_text type=color*/
+    line-height: 1.3em; /*wprm_header_line_height type=font_size*/
+}
+.wprm-recipe-template-acme-compact-custom h1,
+.wprm-recipe-template-acme-compact-custom h2,
+.wprm-recipe-template-acme-compact-custom h3,
+.wprm-recipe-template-acme-compact-custom h4,
+.wprm-recipe-template-acme-compact-custom h5,
+.wprm-recipe-template-acme-compact-custom h6 {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif; /*wprm_header_font_family type=font*/
+    color: #212121; /*wprm_header_text type=color*/
+    line-height: 1.3em; /*wprm_header_line_height type=font_size*/
+    margin: 0 !important;
+    padding: 0 !important;
+}
+.wprm-recipe-template-acme-compact-custom .wprm-recipe-header {
+    margin-top: 1.2em !important;
+}
+.wprm-recipe-template-acme-compact-custom h1 {
+    font-size: 2em; /*wprm_h1_size type=font_size*/
+}
+.wprm-recipe-template-acme-compact-custom h2 {
+    font-size: 1.8em; /*wprm_h2_size type=font_size*/
+}
+.wprm-recipe-template-acme-compact-custom h3 {
+    font-size: 1.2em; /*wprm_h3_size type=font_size*/
+}
+.wprm-recipe-template-acme-compact-custom h4 {
+    font-size: 1em; /*wprm_h4_size type=font_size*/
+}
+.wprm-recipe-template-acme-compact-custom h5 {
+    font-size: 1em; /*wprm_h5_size type=font_size*/
+}
+.wprm-recipe-template-acme-compact-custom h6 {
+    font-size: 1em; /*wprm_h6_size type=font_size*/
+}.wprm-recipe-template-acme-compact-custom {
+	border-style: dashed; /*wprm_border_style type=border*/
+	border-width: 2px; /*wprm_border_width type=size*/
+	border-color: #777777; /*wprm_border type=color*/
+	border-radius: 0px; /*wprm_border_radius type=size*/
+	padding: 10px;
+}.wprm-recipe-template-acme-jump-to-with-arrows {
+    font-family: inherit; /*wprm_font_family type=font*/
+    font-size: 0.8em; /*wprm_font_size type=font_size*/
+    text-align: left; /*wprm_text_align type=align*/
+    margin-top: 0px; /*wprm_margin_top type=size*/
+    margin-bottom: 10px; /*wprm_margin_bottom type=size*/
+}
+.wprm-recipe-template-acme-jump-to-with-arrows a  {
+    margin: 5px; /*wprm_margin_button type=size*/
+    margin: 5px; /*wprm_margin_button type=size*/
+}
+
+.wprm-recipe-template-acme-jump-to-with-arrows a:first-child {
+    margin-left: 0;
+}
+.wprm-recipe-template-acme-jump-to-with-arrows a:last-child {
+    margin-right: 0;
+}</style>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-105877338-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+
+
+<iframe name="__gppLocator" style="display: none;"></iframe><script type="text/javascript" async="" src="//in.getclicky.com/in.php?site_id=100964726&amp;href=%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F&amp;title=The%20BEST%20Easy%20Slow%20Cooker%20Pot%20Roast%20(Made%20with%20Ranch%2C%20Brown%20Gravy%20%26%20Italian%20Dressing%20Mix)&amp;res=1512x982&amp;lang=en-US&amp;tz=Asia%2FTokyo&amp;tc=&amp;ck=1&amp;x=7mn66"></script><iframe marginwidth="0" marginheight="0" scrolling="no" frameborder="0" id="1cf22c8f1f25e1" width="0" height="0" src="about:blank" name="__pb_locator__" style="display: none; height: 0px; width: 0px; border: 0px;"></iframe><div id="fixed_container_bottom" data-slot-rendered-universalplayer="true" data-slot-rendered-adhesion="true">        
+      
+    
+      <div id="adhesion_desktop_wrapper" class="adhesion_wrapper adhesion_container mv-dynamic-size" data-wrapper="adhesion_desktop" data-nosnippet="" style="min-height: 100px;">
+        <div id="adhesion_desktop" class="adunit" data-google-query-id="CJ2v3IPMq4gDFTuH6QUdVyYM8g" style="">
+          
+        <div id="google_ads_iframe_/1030006,16030400/instrupix/adhesion_0__container__" style="border: 0pt none;"><iframe id="google_ads_iframe_/1030006,16030400/instrupix/adhesion_0" name="google_ads_iframe_/1030006,16030400/instrupix/adhesion_0" title="3rd party ad content" width="970" height="100" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="attribution-reporting" data-load-complete="true" style="border: 0px; vertical-align: bottom; height: 100px; width: 970px;" data-google-container-id="2" data-hooks="true"></iframe></div></div>
+        <div class="adhesion_buttons" style="height: 100px;">
+          <div class="mv_close_button adhesion_desktop">
+            <span role="button" aria-label="Close ad">
+              <img class="mv_unbutton" alt="Close ad" id="iconCloseSvg" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHZpZXdCb3g9IjAgMCAxMCAxMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik05LjM5NDg1IDBMNS4wMDA0MyA0LjM5NTI4TDAuNjA1MTUzIDBMMCAwLjYwNTE1M0w0LjM5NDQyIDUuMDAwNDNMMCA5LjM5NDg1TDAuNjA1MTUzIDEwTDUuMDAwNDMgNS42MDQ3Mkw5LjM5NDg1IDEwTDEwIDkuMzk0ODVMNS42MDQ3MiA1LjAwMDQzTDEwIDAuNjA1MTUzTDkuMzk0ODUgMFoiIGZpbGw9IiM5MTkxOTEiLz4KPC9zdmc+Cg==">
+              <img class="mv_close_small" alt="Close ad" id="iconCloseSvg" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUiIGhlaWdodD0iMTUiIHZpZXdCb3g9IjAgMCAxNSAxNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE1IiBoZWlnaHQ9IjE1IiBmaWxsPSIjOTE5MTkxIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNy44MzIxMiA3LjVMMTAuMjQzNCA1LjA4ODYxQzEwLjMzNTUgNC45OTY1NCAxMC4zMzU1IDQuODQ4MTMgMTAuMjQzNCA0Ljc1NjU0QzEwLjE1MTkgNC42NjQ0OSAxMC4wMDM0IDQuNjY0NDkgOS45MTEzOSA0Ljc1NjU0TDcuNTAwMDQgNy4xNjc5NEw1LjA4ODI1IDQuNzU2NTRDNC45OTY2NiA0LjY2NDQ5IDQuODQ3NzggNC42NjQ0OSA0Ljc1NjE5IDQuNzU2NTRDNC42NjQ2IDQuODQ4MTMgNC42NjQ2IDQuOTk2NTQgNC43NTYxOSA1LjA4ODYxTDcuMTY3OTggNy41TDQuNzU2MTkgOS45MTE0QzQuNjY0NiAxMC4wMDM1IDQuNjY0NiAxMC4xNTE5IDQuNzU2MTkgMTAuMjQzNUM0LjgwMjIyIDEwLjI4OTUgNC44NjIzMyAxMC4zMTI1IDQuOTIyNDQgMTAuMzEyNUM0Ljk4MjU2IDEwLjMxMjUgNS4wNDI2OSAxMC4yODk1IDUuMDg4MjUgMTAuMjQzNUw3LjUwMDA0IDcuODMyMDZMOS45MTEzOSAxMC4yNDM1QzkuOTU3NDEgMTAuMjg5NSAxMC4wMTc1IDEwLjMxMjUgMTAuMDc3NyAxMC4zMTI1QzEwLjEzNzggMTAuMzEyNSAxMC4xOTc5IDEwLjI4OTUgMTAuMjQzNCAxMC4yNDM1QzEwLjMzNTUgMTAuMTUxOSAxMC4zMzU1IDEwLjAwMzUgMTAuMjQzNCA5LjkxMTRMNy44MzIxMiA3LjVaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+            </span>
+          </div>
+          
+        <mv-ad-reporter data-slot-id="adhesion_desktop" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+      </div>
+    </div><script>(function(o,n,e,p,l,u,s){o[l]=o[l]||function(){(o[l].q=o[l].q||[]).push(arguments);};
+
+u=n.createElement(e);u.async=1;u.src=p;s=n.getElementsByTagName(e)[0];s.parentNode.insertBefore(u,s);
+
+}(window,document,"script","https://cdn.opecloud.com/ope-dmplite.js","ope"));
+
+ope("dmplite", "init", "b4", "implied");</script><iframe height="0" width="0" frameborder="0" src="https://feed.pghub.io/tag?gdpr=0&amp;us_privacy=1---&amp;referrer_url=https%3A%2F%2Fwww.instrupix.com%2Fcategory%2Fdinner%2F&amp;page_url=https%3A%2F%2Fwww.instrupix.com%2Feasy-slow-cooker-pot-roast-recipe-with-vegetables%2F&amp;owner=P%26G&amp;bp_id=mediavine&amp;ch=%7B%22architecture%22%3A%22arm%22%2C%22bitness%22%3A%2264%22%2C%22brands%22%3A%5B%7B%22brand%22%3A%22Chromium%22%2C%22version%22%3A%22127%22%7D%2C%7B%22brand%22%3A%22Not)A%3BBrand%22%2C%22version%22%3A%2299%22%7D%5D%2C%22fullVersionList%22%3A%5B%7B%22brand%22%3A%22Chromium%22%2C%22version%22%3A%22127.0.6533.89%22%7D%2C%7B%22brand%22%3A%22Not)A%3BBrand%22%2C%22version%22%3A%2299.0.0.0%22%7D%5D%2C%22mobile%22%3Afalse%2C%22model%22%3A%22%22%2C%22platform%22%3A%22macOS%22%2C%22platformVersion%22%3A%2214.1.0%22%7D&amp;initiator=js&amp;data=%7B%22category%22%3A%22Food%20%26%20Drink%22%2C%22subcategory%22%3A%22Food%20%26%20Drink%22%2C%22liveramp_idl%22%3Anull%7D" style="display: none;"></iframe><iframe src="https://www.google.com/recaptcha/api2/aframe" width="0" height="0" style="display: none;"></iframe></body><iframe name="goog_topics_frame" src="https://securepubads.g.doubleclick.net/static/topics/topics_frame.html" style="display: none;"></iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="//exchange.mediavine.com/usersync/sync?origin=https://www.instrupix.com&amp;src=//exchange.mediavine.com&amp;s2sVersion=production&amp;mv_uuid=2dad46c0-6559-11ef-85c9-fbd3a38cbd43&amp;version=invalidate-verizon-pushes&amp;gdpr=0&amp;us_privacy=1---&amp;gppString=DBABzw~1---~BqgAAAAAAgA&amp;p=%7B%22appnexus%22%3Atrue%2C%22conversant%22%3Atrue%2C%22gumgum%22%3Atrue%2C%22huddled_masses%22%3Atrue%2C%22indexExchange%22%3Atrue%2C%22kargo%22%3Atrue%2C%22mediadotnet%22%3Atrue%2C%22mediagrid%22%3Atrue%2C%22openx%22%3Atrue%2C%22pubmatic%22%3Atrue%2C%22pulsepoint%22%3Atrue%2C%22rubicon%22%3Atrue%2C%22sharethrough%22%3Atrue%2C%22smartmedia%22%3Atrue%2C%22sovrn%22%3Atrue%2C%22triplelift%22%3Atrue%2C%22trustx%22%3Atrue%2C%22verizon%22%3Atrue%2C%22yieldmo%22%3Atrue%2C%22nativo%22%3Atrue%2C%22centro%22%3Atrue%7D">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://ads.pubmatic.com/AdServer/js/user_sync.html?p=157108&amp;userIdMacro=PID&amp;us_privacy=1---&amp;gdpr=0&amp;gdpr_consent=&amp;predirect=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dpubmatic%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3DPID">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://acdn.adnxs.com/dmp/async_usersync.html">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://u.openx.net/w/1.0/cm?id=7e872606-a65a-463e-adc2-6ddfd0bdaeea&amp;ph=0fd68730-06b2-46ad-be0b-befc4c4f19d2&amp;r=https://exchange.mediavine.com/usersync/redirect?partner=openx&amp;uuid=2dad46c0-6559-11ef-85c9-fbd3a38cbd43&amp;s2sVersion=production&amp;partnerId=">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://secure-assets.rubiconproject.com/utils/xapi/multi-sync.html?p=17404&amp;endpoint=us-west">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://ads.yieldmo.com/pbsync?gdpr=&amp;gdpr_consent=&amp;us_privacy=1---&amp;redirectUri=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dyieldmo%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24UID">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://eb2.3lift.com/getuid?gdpr=&amp;cmp_cs=&amp;us_privacy=1---&amp;redir=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dtriplelift%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24UID">
+    </iframe><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://x.bidswitch.net/check_uuid/https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dmediagrid%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24%7BBSW_UUID%7D?gdpr=0&amp;gdpr_consent=&amp;us_privacy=1---&amp;user_id=2dad46c0-6559-11ef-85c9-fbd3a38cbd43" alt="" width="1" height="1"></div><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://x.bidswitch.net/sync?ssp=themediagrid&amp;gdpr=0&amp;gdpr_consent=&amp;us_privacy=1---&amp;user_id=2dad46c0-6559-11ef-85c9-fbd3a38cbd43" alt="" width="1" height="1"></div><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://crb.kargo.com/api/v1/dsync/mediavine?exid=2dad46c0-6559-11ef-85c9-fbd3a38cbd43us_privacy=1---&amp;r=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dkargo%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24UID" alt="" width="1" height="1"></div><iframe sandbox="allow-scripts allow-same-origin" id="138c5005af685d0c" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://eus.rubiconproject.com/usync.html?us_privacy=1---&amp;gpp=DBABzw~1---~BqgAAAAAAgA&amp;gpp_sid=">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="139a2a437619f9d3" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://ads.pubmatic.com/AdServer/js/user_sync.html?kdntuid=1&amp;p=157108&amp;us_privacy=1---">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="140ebe1a5188bf6e" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://eb2.3lift.com/sync?us_privacy=1---&amp;gpp=DBABzw~1---~BqgAAAAAAgA&amp;">
+    </iframe></html>

--- a/tests/test_data/instrupix.com/instrupix_2.json
+++ b/tests/test_data/instrupix.com/instrupix_2.json
@@ -1,0 +1,12 @@
+{
+  "author": "Instrupix",
+  "canonical_url": "https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/",
+  "site_name": "Instrupix",
+  "host": "instrupix.com",
+  "language": "en-US",
+  "title": "Easy Keto Cheez-It Crackers",
+  "ingredients": [],
+  "instructions_list": [],
+  "description": "The best little easy keto snacks! These homemade crispy Keto Cheez It Crackers are perfect to bring to work or school. A super simple low carb snack for diabetics and weight loss. Even kids love these cheesy crackers! The perfect quick Keto snacks for beginners.",
+  "image": "https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy.jpg"
+}

--- a/tests/test_data/instrupix.com/instrupix_2.testhtml
+++ b/tests/test_data/instrupix.com/instrupix_2.testhtml
@@ -1,0 +1,2784 @@
+<html class="js cssanimations flexbox no-flexboxtweener" lang="en-US"><!--<![endif]--><head><script type="text/javascript" async="" src="https://cdn.id5-sync.com/api/1.0/id5PrebidModule.js"></script>
+	<meta charset="UTF-8">
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+	<link rel="pingback" href="https://www.instrupix.com/xmlrpc.php">
+	<meta property="fb:app_id" content="1060721147363596">
+	<script async="" src="https://cdn.opecloud.com/ope-dmplite.js"></script><script src="https://pghub.io/js/pandg-sdk.js" type="text/javascript"></script><script src="https://oa.openxcdn.net/esp.js" type="text/javascript" data-ox-ats="1"></script><script async="" src="//c.amazon-adsystem.com/aax2/apstag.js"></script><script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-0Q9V5TYVSH&amp;cx=c&amp;_slc=1" nonce="HMTAA31x"></script><script async="" src="https://www.google-analytics.com/analytics.js"></script><script src="https://scripts.grow.me/main.js" type="text/javascript"></script><script src="https://keywords.mediavine.com/keyword/web.keywords.js?pageUrl=https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/" type="text/javascript"></script><script src="https://exchange.mediavine.com/usersync.min.js?s2sVersion=production" type="text/javascript"></script><script src="https://scripts.mediavine.com/tags/3.6.17/wrapper.min.js?bust=1504223161" type="text/javascript"></script><script src="https://connect.facebook.net/en_US/sdk.js?hash=20be3e641648c86c61b32d42e0ec23c8" async="" crossorigin="anonymous"></script><script src="https://privacy-center.fides.mediavine.com/fides.js?property_id=FDS-F0G1B3&amp;gpp=true&amp;initialize=false" type="text/javascript"></script><script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.mediavine.com/tags/instrupix.js"></script>
+	<script>var clicky_site_ids = clicky_site_ids || []; clicky_site_ids.push(100964726);		</script>
+<script async="" src="//static.getclicky.com/js"></script>
+	
+	<!-- Google tag (gtag.js) -->
+<script async="" src="https://www.googletagmanager.com/gtag/js?id=G-0Q9V5TYVSH"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-0Q9V5TYVSH');
+</script>
+
+
+	<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+
+<meta name="viewport" content="initial-scale=1.0, width=device-width">
+
+	<!-- This site is optimized with the Yoast SEO plugin v23.4 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Copycat Keto Cheez-It Crackers (ONE ingredient!)</title>
+	<meta name="description" content="The best little easy keto snacks! These homemade crispy Keto Cheez It Crackers are perfect to bring to work or school. A super simple low carb snack for diabetics and weight loss. Even kids love these cheesy crackers! The perfect quick Keto snacks for beginners.">
+	<link rel="canonical" href="https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/">
+	<meta property="og:locale" content="en_US">
+	<meta property="og:type" content="article">
+	<meta property="og:title" content="Copycat Keto Cheez-It Crackers (ONE ingredient!)">
+	<meta property="og:description" content="The best little easy keto snacks! These homemade crispy Keto Cheez It Crackers are perfect to bring to work or school. A super simple low carb snack for diabetics and weight loss. Even kids love these cheesy crackers! The perfect quick Keto snacks for beginners.">
+	<meta property="og:url" content="https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/">
+	<meta property="og:site_name" content="Instrupix">
+	<meta property="article:publisher" content="https://www.facebook.com/instrupix">
+	<meta property="article:published_time" content="2020-01-24T18:25:23+00:00">
+	<meta property="article:modified_time" content="2024-03-05T00:23:04+00:00">
+	<meta property="og:image" content="https://www.instrupix.com/wp-content/uploads/2020/01/easy-keto-crackers-made-with-cheese-slices.jpg">
+	<meta property="og:image:width" content="1494">
+	<meta property="og:image:height" content="782">
+	<meta property="og:image:type" content="image/jpeg">
+	<meta name="author" content="Lilly">
+	<meta name="twitter:card" content="summary_large_image">
+	<meta name="twitter:label1" content="Written by">
+	<meta name="twitter:data1" content="Lilly">
+	<meta name="twitter:label2" content="Est. reading time">
+	<meta name="twitter:data2" content="3 minutes">
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/","url":"https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/","name":"Copycat Keto Cheez-It Crackers (ONE ingredient!)","isPartOf":{"@id":"https://www.instrupix.com/#website"},"primaryImageOfPage":{"@id":"https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/#primaryimage"},"image":{"@id":"https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/#primaryimage"},"thumbnailUrl":"https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezit-crackers-one-ingredient-low-carb-snack.jpg","datePublished":"2020-01-24T18:25:23+00:00","dateModified":"2024-03-05T00:23:04+00:00","author":{"@id":"https://www.instrupix.com/#/schema/person/8cee678a0fd4037cdf113bf130a4c54d"},"description":"The best little easy keto snacks! These homemade crispy Keto Cheez It Crackers are perfect to bring to work or school. A super simple low carb snack for diabetics and weight loss. Even kids love these cheesy crackers! The perfect quick Keto snacks for beginners.","breadcrumb":{"@id":"https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/#primaryimage","url":"https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezit-crackers-one-ingredient-low-carb-snack.jpg","contentUrl":"https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezit-crackers-one-ingredient-low-carb-snack.jpg","width":725,"height":967},{"@type":"BreadcrumbList","@id":"https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://www.instrupix.com/"},{"@type":"ListItem","position":2,"name":"Easy Keto Cheez-It Crackers"}]},{"@type":"WebSite","@id":"https://www.instrupix.com/#website","url":"https://www.instrupix.com/","name":"Instrupix","description":"Instructional Pictures","potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://www.instrupix.com/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-US"},{"@type":"Person","@id":"https://www.instrupix.com/#/schema/person/8cee678a0fd4037cdf113bf130a4c54d","name":"Lilly","image":{"@type":"ImageObject","inLanguage":"en-US","@id":"https://www.instrupix.com/#/schema/person/image/","url":"https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=96&d=mm&r=g","contentUrl":"https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=96&d=mm&r=g","caption":"Lilly"},"url":"https://www.instrupix.com/author/lilly/"}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel="dns-prefetch" href="//fonts.googleapis.com">
+<link rel="alternate" type="application/rss+xml" title="Instrupix » Feed" href="https://www.instrupix.com/feed/">
+<link rel="alternate" type="application/rss+xml" title="Instrupix » Comments Feed" href="https://www.instrupix.com/comments/feed/">
+<link rel="alternate" type="application/rss+xml" title="Instrupix » Easy Keto Cheez-It Crackers Comments Feed" href="https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/feed/">
+<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.instrupix.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.6.1"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83d\udc26\u200d\u2b1b","\ud83d\udc26\u200b\u2b1b")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+<style id="wp-emoji-styles-inline-css" type="text/css">
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel="stylesheet" id="adace-style-css" href="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/css/style.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="shoppable-images-css-css" href="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/css/shoppable-images-front.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-crestafont-css" href="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/css/csscfont.min.css?ver=2.9.9.5" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-wp-style-css" href="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/css/cresta-wp-css.min.css?ver=2.9.9.5" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-googlefonts-css" href="//fonts.googleapis.com/css?family=Noto+Sans:400,700&amp;display=swap" type="text/css" media="all">
+<link rel="stylesheet" id="cresta-social-hover-css" href="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/css/cresta-hover.min.css?ver=2.9.9.5" type="text/css" media="all">
+<link rel="stylesheet" id="mace-lazy-load-youtube-css" href="https://www.instrupix.com/wp-content/plugins/media-ace/includes/lazy-load/css/youtube.css?ver=1.2.3" type="text/css" media="all">
+<link rel="stylesheet" id="mediaelement-css" href="https://www.instrupix.com/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.17" type="text/css" media="all">
+<link rel="stylesheet" id="wp-mediaelement-css" href="https://www.instrupix.com/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="mace-vp-style-css" href="https://www.instrupix.com/wp-content/plugins/media-ace/includes/video-playlist/css/video-playlist.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="mace-gallery-css" href="https://www.instrupix.com/wp-content/plugins/media-ace/includes/gallery/css/gallery.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="g1-main-css" href="https://www.instrupix.com/wp-content/themes/starmile/css/1.2.2/styles/food-blogger/all-light.min.css?ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-iconfont-css" href="https://www.instrupix.com/wp-content/themes/starmile/css/1.2.2/fonts/styles.css?ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-google-fonts-css" href="//fonts.googleapis.com/css?family=Merriweather%3A400%2C400i%2C700%2C700i%7CMerriweather+Sans%3A400%2C400i%2C700%2C700i&amp;subset=latin%2Clatin-ext&amp;ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="font-awesome-css" href="https://www.instrupix.com/wp-content/themes/starmile/css/1.2.2/fonts/font-awesome/css/font-awesome.min.css?ver=6.6.1" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-dynamic-style-css" href="https://www.instrupix.com/wp-content/uploads/dynamic-style.css?respondjs=no&amp;ver=1.2.2" type="text/css" media="all">
+<link rel="stylesheet" id="starmile-style-css" href="https://www.instrupix.com/wp-content/themes/starmile-child-theme/style.css?ver=6.6.1" type="text/css" media="screen">
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script><link rel="preload" href="https://securepubads.g.doubleclick.net/tag/js/gpt.js" as="script"><style type="text/css">:root{--fides-overlay-primary-color:#8243f2;--fides-overlay-background-color:#f7fafc;--fides-overlay-embed-background-color:transparent;--fides-overlay-font-color:#4a5568;--fides-overlay-font-color-dark:#2d3748;--fides-overlay-hover-color:#edf2f7;--fides-overlay-gpc-applied-background-color:#38a169;--fides-overlay-gpc-applied-text-color:#fff;--fides-overlay-gpc-overridden-background-color:#e53e3e;--fides-overlay-gpc-overridden-text-color:#fff;--fides-overlay-background-dark-color:#e2e8f0;--fides-overlay-width:680px;--fides-overlay-primary-button-background-color:var(
+    --fides-overlay-primary-color
+  );--fides-overlay-primary-button-background-hover-color:#9569f4;--fides-overlay-primary-button-text-color:#fff;--fides-overlay-primary-button-border-color:transparent;--fides-overlay-secondary-button-background-color:var(
+    --fides-overlay-background-color
+  );--fides-overlay-secondary-button-background-hover-color:var(
+    --fides-overlay-hover-color
+  );--fides-overlay-secondary-button-text-color:#2d3748;--fides-overlay-secondary-button-border-color:var(
+    --fides-overlay-primary-color
+  );--fides-overlay-title-font-color:var(--fides-overlay-font-color);--fides-overlay-body-font-color:var(--fides-overlay-font-color);--fides-overlay-link-font-color:var(--fides-overlay-font-color-dark);--fides-overlay-primary-active-color:var(--fides-overlay-primary-color);--fides-overlay-inactive-color:#e2e8f0;--fides-overlay-inactive-font-color:#a0aec0;--fides-overlay-disabled-color:#e1e7ee;--fides-overlay-row-divider-color:#e2e8f0;--fides-overlay-row-hover-color:var(--fides-overlay-hover-color);--fides-overlay-badge-background-color:#718096;--fides-overlay-badge-border-radius:4px;--fides-overlay-select-border-color:#e2e8f0;--fides-overlay-language-button-border-radius:4px;--fides-overlay-font-family:Inter,sans-serif;--12px:0.75rem;--14px:0.875rem;--15px:0.9375rem;--16px:1rem;--fides-overlay-font-size-body-small:var(--12px);--fides-overlay-font-size-body:var(--14px);--fides-overlay-font-size-title:var(--16px);--fides-overlay-font-size-buttons:var(--14px);--fides-overlay-padding:24px;--fides-overlay-padding-tcf:40px;--fides-overlay-button-border-radius:6px;--fides-overlay-button-padding:8px 16px;--fides-overlay-link-v-padding:4px;--fides-overlay-link-h-padding:4px;--fides-overlay-link-padding:var(--fides-overlay-link-v-padding) var(--fides-overlay-link-h-padding);--fides-overlay-container-border-radius:12px;--fides-overlay-container-border-width:1px;--fides-overlay-component-border-radius:4px;--fides-overlay-banner-offset:48px;--fides-banner-font-size-title:var(--16px);--fides-overlay-language-loading-indicator-speed:5s}@keyframes spin{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}div.fides-overlay{position:fixed;z-index:1000}div#fides-overlay-wrapper *{box-sizing:border-box}.fides-banner,.fides-modal-container{-webkit-font-smoothing:antialiased;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-body);line-height:calc(1em + .4rem);white-space:pre-line}#fides-modal-link{cursor:pointer;display:none}#fides-modal-link.fides-modal-link-shown{display:inline}div#fides-banner-container:not(.fides-embedded){display:flex;justify-content:center;position:fixed;transform:translateY(0);transition:transform 1s,visibility 1s;visibility:visible;width:100%;z-index:1}div#fides-banner{align-items:center;background:var(--fides-overlay-background-color);border-top:var(--fides-overlay-container-border-width) solid var(--fides-overlay-primary-color);color:var(--fides-overlay-body-font-color);display:flex;flex-direction:row;flex-wrap:wrap;font-size:var(--fides-overlay-font-size-body);justify-content:space-between;overflow-y:hidden;padding:24px;position:relative}.fides-embedded div#fides-banner{border:none}div#fides-banner-inner{width:100%}div#fides-banner-container.fides-banner-bottom{bottom:0;left:0}div#fides-banner-container.fides-banner-hidden{visibility:hidden}div#fides-banner-container.fides-banner-hidden.fides-embedded{display:none}div#fides-banner-container.fides-banner-bottom.fides-banner-hidden{transform:translateY(150%)}div#fides-banner-container.fides-banner-top{left:0;top:0}div#fides-banner-container.fides-banner-top.fides-banner-hidden{transform:translateY(-150%)}div#fides-banner-inner div#fides-button-group{align-items:center;flex-direction:row-reverse;margin-bottom:0;margin-top:0;padding-bottom:0;padding-top:0;width:100%}.fides-modal-footer div#fides-button-group{align-items:center;flex-direction:column;gap:12px;margin-inline:var(--fides-overlay-padding)}div#fides-banner-inner-container{grid-column-gap:60px;display:grid;grid-template-columns:1fr 1fr}div#fides-banner-inner-description{grid-column:1;grid-row:1}div#fides-tcf-banner-inner{grid-column:2;grid-row:1/3;height:0;margin-top:40px;min-height:100%;overflow-y:auto;scrollbar-gutter:stable}div#fides-banner-heading{align-items:center;display:flex;margin-right:13px}div#fides-banner-title{color:var(--fides-overlay-title-font-color);flex:1;font-size:var(--fides-banner-font-size-title);font-weight:600;line-height:1.5em;min-width:33%}div#fides-banner-description{flex:1;font-size:var(--fides-overlay-font-size-body);margin-bottom:24px;margin-top:16px}div#fides-banner-notices{margin-top:16px}div#fides-button-group{background-color:var(--fides-overlay-background-color);display:flex;justify-content:space-between;margin-bottom:var(--fides-overlay-padding);margin-top:8px;z-index:5}button.fides-banner-button{background:var(--fides-overlay-primary-button-background-color);border:1px solid;border-radius:var(--fides-overlay-button-border-radius);color:var(--fides-overlay-primary-button-text-color);cursor:pointer;display:inline-block;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-buttons);font-weight:600;margin:4px 0 0;padding:var(--fides-overlay-button-padding);text-align:center;text-decoration:none}button.fides-banner-button:hover{background:var(--fides-overlay-primary-button-background-hover-color)}button.fides-banner-button.fides-banner-button-primary{background:var(--fides-overlay-primary-button-background-color);border:none;color:var(--fides-overlay-primary-button-text-color)}button.fides-banner-button.fides-banner-button-primary:hover{background:var(--fides-overlay-primary-button-background-hover-color)}button.fides-banner-button.fides-banner-button-secondary{background:var(--fides-overlay-secondary-button-background-color);border:1px solid var(--fides-overlay-primary-button-background-color);color:var(--fides-overlay-secondary-button-text-color)}button.fides-banner-button.fides-banner-button-secondary:hover{background:var(--fides-overlay-secondary-button-background-hover-color)}button.fides-banner-button.fides-banner-button-tertiary{background:none;border:none;color:var(--fides-overlay-link-font-color);cursor:pointer;font-size:var(--fides-overlay-font-size-body);font-weight:500;line-height:1.25em;padding:0;text-decoration:underline}button.fides-banner-button.fides-acknowledge-button{min-width:160px}div.fides-modal-content{background-color:var(--fides-overlay-background-color);border:var(--fides-overlay-container-border-width) solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-container-border-radius);color:var(--fides-overlay-body-font-color);display:flex;flex-direction:column;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-body);left:50%;max-height:680px;overflow:hidden;padding:0;position:fixed;top:50%;transform:translate(-50%,-50%);width:var(--fides-overlay-width);z-index:2}.fides-modal-container,.fides-modal-overlay{background-color:rgba(0,0,0,.25);bottom:0;left:0;position:fixed;right:0;top:0}div#fides-embed-container div#fides-consent-content .fides-modal-footer{position:inherit}div#fides-embed-container .fides-modal-body{padding-top:16px}div#fides-embed-container div#fides-consent-content{background-color:var(--fides-overlay-background-color);border:none;border-radius:var(--fides-overlay-container-border-radius);border-bottom-left-radius:0;border-bottom-right-radius:0;color:var(--fides-overlay-body-font-color);display:flex;flex-direction:column;font-family:var(--fides-overlay-font-family);font-size:var(--fides-overlay-font-size-body);left:50%;max-height:none;overflow:hidden;padding:0;position:static;top:50%;transform:none;width:var(--fides-overlay-width)}.fides-modal-container{display:flex;z-index:2}.fides-modal-container[aria-hidden=true]{display:none}div#fides-modal .fides-modal-header{display:flex;justify-content:end}div#fides-consent-content{overflow:auto;scrollbar-gutter:stable}div#fides-consent-content .fides-modal-title{color:var(--fides-overlay-title-font-color);font-size:var(--fides-overlay-font-size-title);font-weight:600;margin:0;text-align:center}div#fides-consent-content .fides-modal-body{height:100%;overflow-y:auto;padding-inline:var(--fides-overlay-padding)}.fides-modal-footer{background-color:var(--fides-overlay-background-color);border-bottom-left-radius:var(--fides-overlay-component-border-radius);border-bottom-right-radius:var(--fides-overlay-component-border-radius);bottom:0;display:flex;flex-direction:column;max-width:var(--fides-overlay-width);position:relative;width:100%;z-index:5}div#fides-consent-content .fides-modal-description{margin:8px 0 24px}.fides-banner-button-group{align-items:center;display:flex;gap:12px}.fides-modal-button-group{display:flex;flex-direction:row;gap:12px;margin-inline:var(--fides-overlay-padding);width:100%}.fides-modal-primary-actions .fides-banner-button{flex:1}.fides-banner-secondary-actions{justify-content:space-between}.fides-modal-secondary-actions{justify-content:center}.fides-banner-secondary-actions{gap:36px}.fides-tcf-banner-container div#fides-banner div#fides-banner-inner div#fides-button-group{gap:12px}.fides-no-scroll{overflow-y:hidden}@media (max-width:768px){div#fides-consent-content,div.fides-modal-content{width:100%!important}.fides-modal-button-group{flex-direction:column}button.fides-banner-button{margin:0 8px 12px 0}}div#fides-banner .fides-close-button{background:none;border:none;cursor:pointer;display:flex;position:absolute;right:3px;top:8px}.fides-modal-header .fides-close-button{background:none;border:none;cursor:pointer;padding-right:8px;padding-top:8px}.fides-close-button:hover{background:var(--fides-overlay-hover-color)}.fides-embedded .fides-close-button{display:none!important}.fides-modal-notices{margin-bottom:16px}.fides-privacy-policy,div#fides-banner-inner .fides-privacy-policy{color:var(--fides-overlay-primary-color);display:block;text-align:center}.fides-privacy-policy{font-family:var(--fides-overlay-font-family)}button.fides-banner-button.fides-banner-button-tertiary,div#fides-banner-inner .fides-privacy-policy,div.fides-i18n-pseudo-button{line-height:1;margin:0;padding:var(--fides-overlay-link-padding)}@media (prefers-reduced-motion:reduce){.fides-toggle-display{transition-duration:0ms}}.fides-toggle{align-items:center;display:inline-flex;flex-wrap:wrap;gap:1ch;position:relative}.fides-toggle .fides-toggle-input{cursor:pointer;height:100%;opacity:0;position:absolute;width:100%;z-index:4}.fides-toggle .fides-toggle-display{--offset:4px;--diameter:16px;align-items:center;background-color:var(--fides-overlay-inactive-color);border-radius:100vw;box-sizing:content-box;color:var(--fides-overlay-inactive-font-color);display:inline-flex!important;height:24px;justify-content:space-around;justify-content:end;padding-inline:8px;position:relative;transition:.25s;width:34px}div#fides-overlay-wrapper .fides-toggle .fides-toggle-display{box-sizing:content-box}.fides-toggle .fides-toggle-display:before{background-color:#fff;border-radius:50%;box-shadow:0 1.3px 2.7px rgba(0,0,0,.25);box-sizing:border-box;content:"";height:var(--diameter);left:var(--offset);position:absolute;top:50%;transform:translateY(-50%);transition:inherit;width:var(--diameter);z-index:3}.fides-toggle .fides-toggle-input:checked+.fides-toggle-display{background-color:var(--fides-overlay-primary-active-color);color:var(--fides-overlay-primary-button-text-color);justify-content:start}.fides-toggle .fides-toggle-input:checked+.fides-toggle-display:before{transform:translate(26px,-50%)}.fides-toggle .fides-toggle-input:disabled{cursor:not-allowed}.fides-toggle .fides-toggle-input:disabled+.fides-toggle-display,.fides-toggle .fides-toggle-input:disabled:checked+.fides-toggle-display{background-color:var(--fides-overlay-disabled-color)}.fides-toggle .fides-toggle-input:focus+.fides-toggle-display{outline:1px auto Highlight;outline:1px auto -webkit-focus-ring-color}.fides-toggle .fides-toggle-input:focus:not(:focus-visible)+.fides-toggle-display{outline:0}.fides-divider{border-color:var(--fides-overlay-row-divider-color);border-width:0 0 1px;margin:0}.fides-disclosure-hidden{display:flex;height:0;margin-bottom:0;margin-top:0;overflow:hidden;visibility:hidden}.fides-notice-toggle .fides-notice-toggle-title{align-items:center;border-bottom:1px solid var(--fides-overlay-row-divider-color);display:flex;justify-content:space-between;padding-inline:12px 12px}.fides-notice-toggle .fides-notice-toggle-trigger{align-items:center;display:flex;justify-content:flex-end;min-height:40px}.fides-notice-toggle .fides-notice-toggle-trigger svg{flex-shrink:0}.fides-notice-toggle .fides-notice-toggle-title:hover{background-color:var(--fides-overlay-row-hover-color);cursor:pointer}.fides-notice-toggle .fides-notice-toggle-trigger:before{border-style:solid;border-width:2px 2px 0 0;content:"";display:inline-block;height:8px;margin-right:calc(.5rem + 2px);min-width:8px;transform:translateY(-2px) rotate(135deg);transition:transform .12s ease-in-out}.fides-notice-toggle.fides-notice-toggle-expanded .fides-notice-toggle-trigger:before{transform:translateY(2px) rotate(-45deg)}#fides-tcf-banner-inner .fides-disclosure-visible{padding:12px}.fides-notice-toggle .fides-disclosure-visible{display:flex;flex-direction:column;gap:12px;overflow:auto;padding:12px}.fides-notice-toggle p{margin:0 0 18px}.fides-notice-toggle p:last-child{margin:0}.fides-notice-toggle-title .fides-flex-center{align-items:center;display:flex;white-space:wrap;width:100%}.fides-notice-toggle-expanded{background-color:var(--fides-overlay-row-hover-color)}.fides-notice-toggle-header{font-weight:600}.fides-record-header{border-bottom:1px solid var(--fides-overlay-row-divider-color);font-weight:600;padding:12px}.fides-gpc-banner{border:1px solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-component-border-radius);display:flex;margin-bottom:16px;padding:18px}.fides-gpc-banner p{margin:0}.fides-gpc-warning{color:var(--fides-overlay-primary-color);margin-right:8px}.fides-gpc-header{font-weight:700}.fides-gpc-label{display:inline-flex;font-size:var(--fides-overlay-font-size-body);font-weight:600;padding:0 8px;white-space:nowrap}.fides-gpc-badge{border-radius:var(--fides-overlay-badge-border-radius);display:inline-flex;font-weight:700;margin-left:4px;padding:0 4px;text-transform:uppercase}.fides-gpc-badge-applied,.fides-gpc-badge-detected{background:var(--fides-overlay-gpc-applied-background-color);color:var(--fides-overlay-gpc-applied-text-color)}.fides-gpc-badge-overridden{background:var(--fides-overlay-gpc-overridden-background-color);color:var(--fides-overlay-gpc-overridden-text-color)}.fides-tab-list{display:flex;list-style-type:none;padding:0}.fides-tab-list>li{width:100%}.fides-tab-button{background:none;border-width:0 0 1px;border-bottom:1px solid var(--fides-overlay-row-divider-color);color:var(--fides-overlay-body-font-color);cursor:pointer;font-weight:500;padding:10px 20px;width:100%}.fides-tab-button[aria-selected=true]{border-bottom-width:2px;border-color:var(--fides-overlay-primary-active-color);color:var(--fides-overlay-primary-active-color);font-weight:600}.fides-tab-button::focus-visible{outline:1px auto Highlight;outline:1px auto -webkit-focus-ring-color}.fides-tab-button:focus:not(:focus-visible){outline:0}.fides-notice-badge{align-items:center;background:var(--fides-overlay-badge-background-color);border-radius:var(--fides-overlay-badge-border-radius);color:#fff;display:inline-flex;font-size:var(--fides-overlay-font-size-body-small);font-weight:600;height:18px;margin-left:4px;margin-right:8px;padding:0 4px;text-transform:uppercase}.fides-background-dark{background-color:var(--fides-overlay-background-dark-color)}.fides-radio-button-group{background-color:var(
+    --fides-overlay-secondary-button-background-hover-color
+  );border:1px solid var(--fides-overlay-row-divider-color);display:flex;margin-bottom:22px;padding:4px}.fides-radio-button{background-color:transparent;border:none;cursor:pointer;flex:1;padding:5px 16px}.fides-radio-button[aria-checked=true]{background-color:var(--fides-overlay-primary-button-background-color);color:var(--fides-overlay-primary-button-text-color)}.fides-flex-center{align-items:center;display:flex}.fides-margin-right{margin-right:3px}.fides-justify-space-between{justify-content:space-between}.fides-tcf-toggle-content{font-size:var(--fides-overlay-font-size-body-small);font-weight:400;margin-right:60px}.fides-tcf-purpose-vendor-title{display:flex;font-weight:600;justify-content:space-between}.fides-tcf-illustration{font-size:var(--fides-overlay-font-size-body-small);padding:13px 60px 13px 13px}.fides-tcf-illustration,.fides-tcf-purpose-vendor{border-radius:var(--fides-overlay-component-border-radius)}.fides-tcf-purpose-vendor{padding:13px}.fides-tcf-purpose-vendor-list{font-weight:400;list-style:none;margin-bottom:0;margin-left:0;padding-left:0}.fides-tcf-vendor-toggles{display:flex}.fides-vendor-details-table{width:100%}.fides-vendor-details-table td,.fides-vendor-details-table th{font-size:var(--fides-overlay-font-size-body-small);text-align:left}.fides-vendor-details-table td{border-bottom:1px solid var(--fides-overlay-row-divider-color)}.fides-link-button{background:none;border:none;color:var(--fides-overlay-body-font-color);cursor:pointer;padding:0;text-decoration:underline}.fides-external-link,.fides-primary-text-color{color:var(--fides-overlay-primary-color)}.fides-external-link{font-size:var(--fides-overlay-font-size-body-small);font-weight:500;margin-right:16px}.fides-vendor-info-banner{border-radius:var(--fides-overlay-component-border-radius);display:flex;flex-direction:row;gap:30px;justify-content:space-around;margin-bottom:16px;padding:16px 12px;position:sticky;top:0}.fides-vendor-info-label{font-size:var(--fides-overlay-font-size-body-small);font-weight:600;margin-right:4px}.fides-info-box{background-color:var(--fides-overlay-hover-color);border-radius:var(--fides-overlay-component-border-radius);margin:10px 0;padding:16px}.fides-info-box p{margin:0}.fides-tabs .tabpanel-container{overflow:hidden}.tabpanel-container section[hidden]{display:none}@media screen and (min-width:768px){div#fides-banner{border:1px solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-component-border-radius);width:75%}div#fides-banner-container.fides-banner-bottom{bottom:var(--fides-overlay-banner-offset)}}@media only screen and (min-width:1280px){div#fides-banner{border:1px solid var(--fides-overlay-primary-color);width:60%}}@media screen and (max-width:992px){.fides-vendor-info-banner{flex-direction:column;gap:16px}}@media screen and (max-width:768px){div#fides-banner{padding:24px;width:100%}div#fides-banner-description{margin-bottom:0}div#fides-banner-inner div#fides-button-group{align-items:flex-start;flex-direction:column;gap:12px;padding-top:24px}.fides-banner-button-group{flex-direction:column;width:100%}button.fides-banner-button{margin:0;width:100%}div#fides-tcf-banner-inner{margin-top:24px;min-height:revert;overflow-y:revert}div#fides-banner-inner-container{display:flex;flex-direction:column;max-height:50vh;overflow-y:auto;scrollbar-gutter:stable}div#fides-privacy-policy-link{order:1;width:100%}.fides-modal-footer{max-width:100%}.fides-tcf-banner-container div#fides-banner div#fides-banner-inner div#fides-button-group .fides-banner-button-group{padding-left:0}.fides-banner-secondary-actions{gap:12px}.fides-banner-secondary-actions .fides-manage-preferences-button{order:0}.fides-banner-secondary-actions #fides-privacy-policy-link{order:1}.fides-banner-secondary-actions .fides-i18n-menu{order:2}}.fides-tcf-banner-container{bottom:0!important}.fides-tcf-banner-container #fides-banner{border-radius:0;border-width:1px 0 0;padding:var(--fides-overlay-padding) var(--fides-overlay-padding-tcf) var(--fides-overlay-padding-tcf) var(--fides-overlay-padding-tcf);width:100%}.fides-tcf-banner-container #fides-privacy-policy-link{margin:auto}@media screen and (max-width:768px){.fides-tcf-banner-container #fides-banner{padding:var(--fides-overlay-padding)}}.fides-paging-buttons{display:flex;gap:8px;justify-content:center}.fides-paging-info{color:var(--fides-overlay-font-color-dark);font-size:var(--fides-overlay-font-size-body-small);font-weight:600;padding:8px}.fides-paging-previous-button{margin-right:8px}.fides-paging-next-button,.fides-paging-previous-button{background-color:transparent;border:none;cursor:pointer;padding:6px}.fides-paging-next-button:disabled,.fides-paging-previous-button:disabled{cursor:default}.fides-i18n-menu{position:relative}.fides-modal-container .fides-i18n-menu{bottom:var(--fides-overlay-padding);left:var(--fides-overlay-padding);position:absolute}.fides-modal-container .fides-button-group-i18n{min-height:calc(var(--fides-overlay-font-size-body) + var(--fides-overlay-link-v-padding)*2)}@media screen and (max-width:768px){.fides-banner-button-group.fides-button-group-i18n{min-height:68px}.fides-i18n-menu{bottom:var(--fides-overlay-padding);left:var(--fides-overlay-padding);position:absolute}}div.fides-i18n-pseudo-button{align-items:center;cursor:pointer;display:flex;flex-direction:row;gap:2px;height:var(--fides-overlay-font-size-body);text-transform:uppercase;white-space:nowrap}#fides-i18n-icon{animation-duration:var(--fides-overlay-language-loading-indicator-speed);animation-iteration-count:infinite;animation-timing-function:linear;transform-origin:50% 50%}div#fides-overlay-wrapper .fides-i18n-pseudo-button{box-sizing:content-box}.fides-i18n-popover{bottom:100%;display:flex;flex-direction:column;gap:1px;height:0;left:0;max-height:7rem;overflow:hidden;position:absolute;transition:height .5s}.fides-i18n-menu:hover .fides-i18n-pseudo-button{background-color:var(--fides-overlay-hover-color);border-radius:var(--fides-overlay-language-button-border-radius)}.fides-i18n-menu:hover .fides-i18n-pseudo-button .fides-i18n-caret{transform:rotate(180deg)}.fides-i18n-menu:focus-within .fides-i18n-popover,.fides-i18n-menu:hover .fides-i18n-popover{background-color:var(--fides-overlay-background-dark-color);border:1px solid var(--fides-overlay-primary-color);border-radius:var(--fides-overlay-component-border-radius);height:auto;min-width:9rem;overflow:scroll}button.fides-banner-button.fides-menu-item{background:var(--fides-overlay-secondary-button-background-color);border:none;border-radius:0;color:var(--fides-overlay-secondary-button-text-color);margin:0;padding-left:1.5rem;text-align:left;width:100%}button.fides-banner-button.fides-menu-item[aria-pressed=true]{background:var(--fides-overlay-primary-button-background-color);color:var(--fides-overlay-primary-button-text-color)}button.fides-banner-button.fides-menu-item[aria-pressed=true]:before{content:"\2713";display:inline-block;margin-left:-1rem;margin-right:.25rem}button.fides-banner-button.fides-menu-item:not([aria-pressed=true]):hover{background:var(--fides-overlay-secondary-button-background-hover-color)}</style>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/js/slideup.js?ver=0.1" id="adace-slideup-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/ad-ace/includes/shoppable-images/assets/js/shoppable-images-front.js?ver=0.1" id="shoppable-images-js-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/ad-ace/assets/js/coupons.js?ver=0.1" id="adace-coupons-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/modernizr/modernizr-custom.min.js?ver=3.3.0" id="modernizr-js"></script>
+<link rel="https://api.w.org/" href="https://www.instrupix.com/wp-json/"><link rel="alternate" title="JSON" type="application/json" href="https://www.instrupix.com/wp-json/wp/v2/posts/5951"><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.instrupix.com/xmlrpc.php?rsd">
+<link rel="shortlink" href="https://www.instrupix.com/?p=5951">
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.instrupix.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F">
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.instrupix.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F&amp;format=xml">
+	<style type="text/css">
+		.adace-slot-wrapper-mobile{
+			display:none;
+		}
+		.adace-slot-wrapper-tablet{
+			display:none;
+		}
+		@media only screen and (max-width: 600px ) {
+			.adace-hide-on-mobile{
+				display:none;
+			}
+			.adace-slot-wrapper-mobile{
+				display:block;
+			}
+		}
+		@media only screen and (min-width: 601px  ) and  (max-width: 960px ){
+			.adace-hide-on-tablet{
+				display:none;
+			}
+			.adace-slot-wrapper-tablet{
+				display:block;
+			}
+		}
+	</style>
+	<style id="cresta-social-share-counter-pro-inline-css">.cresta-share-icon .sbutton, .cresta-share-icon .sbutton-total {font-family: 'Noto Sans', sans-serif;}#crestashareiconincontent {float: left;}
+			.cresta-share-icon .cresta-the-count-content, #crestashareiconincontent .sbutton a[data-name]:hover:before {color:#ffffff!important;} 
+			.cresta-share-icon .cresta-the-total-count, .cresta-share-icon .cresta-the-total-text {color:#000000!important;} 
+			#crestashareiconincontent .sbutton-total {border-right: 2px solid #000000!important;} 
+			
+				.cresta-share-icon .cresta-the-count-content, #crestashareiconincontent .sbutton a[data-name]:hover:before {background: #D60000!important;}
+				#crestashareiconincontent .sbutton a[data-name]:hover:after, #crestashareicon .sbutton a[data-name]:hover:after {border-color: #D60000 transparent !important;} 
+				
+					.cresta-share-icon i.c-icon-cresta-facebook {background: #666699;}
+					.cresta-share-icon i.c-icon-cresta-facebook:hover {border: 2px solid #666699!important; color: #666699; }
+					
+					.cresta-share-icon i.c-icon-cresta-pinterest {background: #cc6666;}
+					.cresta-share-icon i.c-icon-cresta-pinterest:hover {border: 2px solid #cc6666!important; color: #cc6666; }
+					
+					.cresta-share-icon i.c-icon-cresta-mail {background: #ffcc66;}
+					.cresta-share-icon i.c-icon-cresta-mail:hover {border: 2px solid #ffcc66!important; color: #ffcc66; }
+					</style>		<style>
+			:root {
+				--mv-create-radius: 0;
+			}
+		</style>
+		<style type="text/css"> .tippy-box[data-theme~="wprm"] { background-color: #333333; color: #FFFFFF; } .tippy-box[data-theme~="wprm"][data-placement^="top"] > .tippy-arrow::before { border-top-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="bottom"] > .tippy-arrow::before { border-bottom-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="left"] > .tippy-arrow::before { border-left-color: #333333; } .tippy-box[data-theme~="wprm"][data-placement^="right"] > .tippy-arrow::before { border-right-color: #333333; } .tippy-box[data-theme~="wprm"] a { color: #FFFFFF; } .wprm-comment-rating svg { width: 18px !important; height: 18px !important; } img.wprm-comment-rating { width: 90px !important; height: 18px !important; } body { --comment-rating-star-color: #343434; } body { --wprm-popup-font-size: 16px; } body { --wprm-popup-background: #ffffff; } body { --wprm-popup-title: #000000; } body { --wprm-popup-content: #444444; } body { --wprm-popup-button-background: #444444; } body { --wprm-popup-button-text: #ffffff; }</style><style type="text/css">.wprm-glossary-term {color: #5A822B;text-decoration: underline;cursor: help;}</style><link rel="icon" href="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-32x32.jpg" sizes="32x32">
+<link rel="icon" href="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-192x192.jpg" sizes="192x192">
+<link rel="apple-touch-icon" href="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-180x180.jpg">
+<meta name="msapplication-TileImage" content="https://www.instrupix.com/wp-content/uploads/2020/09/cropped-instrupix-favicon-270x270.jpg">
+		<style type="text/css" id="wp-custom-css">
+			blockquote:before {
+content: "";
+}
+
+blockquote {
+border-top: 2px solid #aeac4a;
+border-bottom: 2px solid #aeac4a;
+padding: 5px 5px;
+margin: 5px 5px 5px 5px;
+}
+
+blockquote h3 {
+margin: 2rem 0;
+padding: 5px 5px;
+text-align: center;
+color: #aeac4a !important;
+font-size: 2rem;
+}
+
+mashicon-pinterest mash-large mash-center mashsb-noshadow a {
+color: #2d5f9a;
+}
+
+.acme-related-posts {
+	border-bottom: 1px solid #ccc;
+	border-top: 1px solid #ccc;
+	font-size: 16px;
+	font-size: 1.6rem;
+	min-height: 180px;
+	position: relative;
+	line-height: 1.5;
+}
+
+.acme-related-posts p {
+	line-height: 1.5;
+}
+
+.acme-related-posts strong,
+.acme-related-posts strong a{
+	color: #b4c246;
+}
+
+.acme-related-posts a:hover {
+	text-decoration: none
+}
+
+.acme-related-posts a {
+	color: #534640;
+	font-family: Arial, Helvetica, Tahoma, sans-serif;
+	font-size: 18px;
+	font-weight: normal;
+	line-height: 1.5;
+	margin: 0;
+	padding: 0;
+	text-decoration: none;
+}
+
+.acme-related-posts h5 {
+	color: #b3b3b3;
+	font-family: 'Tahoma', sans-serif;
+	font-size: 2rem !important;
+	font-weight: normal;
+	margin: -13px 0 0;
+	text-align: center;
+	text-transform: uppercase
+}
+
+.acme-related-posts h5 span {
+	background: #fff;
+	padding: 0 15px
+}
+.related-thumbnail { 
+	float:left;
+	display:inline;
+	margin: 0 12px 0 0;
+}
+
+a {
+	color: #b4c246;
+}
+
+.hiddenimage {
+	display: none
+}
+
+.g1-socials-section .g1-socials-item-tooltip-inner {
+	font-size: 24px;
+}
+
+[type="submit"],
+[type="reset"],
+[type="button"],
+button,
+.g1-button-solid,
+.g1-button-solid:hover,
+.g1-arrow-solid,
+.author-link,
+.author-info .author-link {
+border-color: #b6bc72;
+background-color: #b6bc72;
+color: #000000;
+}
+
+.button_89 {
+  border-radius: 4px;
+  background-color: #f4511e;
+  border: none;
+  color: #FFFFFF;
+  text-align: center;
+  font-size: 28px;
+  padding: 20px;
+  width: 500px;
+  transition: all 0.5s;
+  cursor: pointer;
+  margin: 5px;
+}
+
+.button_89 span {
+  cursor: pointer;
+  display: inline-block;
+  position: relative;
+  transition: 0.5s;
+}
+
+.button_89 span:after {
+  content: '\00bb';
+  position: absolute;
+  opacity: 0;
+  top: 0;
+  right: -20px;
+  transition: 0.5s;
+}
+
+.button_89:hover span {
+  padding-right: 25px;
+}
+
+.button_89:hover span:after {
+  opacity: 1;
+  right: 0;
+}
+
+hr:before {
+    content: "\2605\2605\2605\2605\2605"
+}
+
+/* Style all font awesome icons */
+.fa {
+    padding: 10px;
+    font-size: 20px;
+    width: 20px;
+    text-align: center;
+    text-decoration: none;
+    border-radius: 50%;
+}
+/* Add a hover effect if you want */
+.fa:hover {
+    opacity: 0.7;
+}
+
+/* Set a specific color for each brand */
+
+/* Facebook */
+.fa-facebook {
+    background: #3B5998;
+    color: white;
+}
+
+/* Twitter */
+.fa-pinterest {
+    background:  #c8232c;
+    color: white;
+}
+
+.g1-socials-item-icon-facebook {
+color: #3b5998 !important;
+}
+
+.g1-socials-item-icon-pinterest {
+color: #cb2027 !important;
+}
+
+.g1-socials-item-icon-instagram {
+color: purple !important;
+}
+
+
+.starmile-search {
+	color: #000 !important;
+}
+
+.wp-caption-text a {
+-webkit-box-shadow: none;
+-moz-box-shadow: none;
+box-shadow: none;
+font-size: 12px;
+font-family: 'Tahoma';
+font-weight: 700;
+font-style: normal;
+text-transform: none;
+letter-spacing: .1em;
+color: #b4c246;
+}
+
+.hideimage {
+	display: none
+}
+
+.g1-bin-1 .g1-hb-search-form, .g1-bin-1 .g1-id, .g1-bin-1 .g1-mobile-logo-wrapper, .g1-bin-1 .g1-primary-nav, .g1-bin-1 .g1-small-logo-wrapper, .g1-bin-1 .g1-socials-hb-list, .g1-bin-1 .wpml-ls {
+	margin-right: 5px;
+}
+.g1-bin-3 .g1-hb-search-form, .g1-bin-3 .g1-id, .g1-bin-3 .g1-mobile-logo-wrapper, .g1-bin-3 .g1-primary-nav, .g1-bin-3 .g1-small-logo-wrapper, .g1-bin-3 .g1-socials-hb-list, .g1-bin-3 .wpml-ls {
+	margin-left: 5px;
+}
+
+.g1-socials-item-icon.g1-socials-item-icon-28 {
+	padding: 0 5px;
+}
+
+.g1-bin .g1-socials-items .g1-socials-item-icon.g1-socials-item-icon-28 {
+	font-size: 20px;
+}
+.g1-hb-row .sub-menu .menu-item > a {
+	color: #000;
+}
+.g1-canvas-content, .g1-canvas-toggle, .g1-canvas-content .menu-item > a, .g1-canvas-content .g1-menu-v .menu-item>a, .g1-canvas-content .g1-hamburger, .g1-canvas-content .g1-drop-toggle, .g1-canvas-content .g1-socials-item-link {
+	color: #000;
+}
+.relatedposts2 {
+	padding-top: 10px;
+}
+
+.fb-root {
+	width:100%
+}
+
+.fb_iframe_widget_fluid_desktop iframe {
+min-width: 100%;
+position: relative;
+}
+g1-alpha g1-alpha-2nd page-title archive-title .page-title {
+	margin-bottom: 50px;
+}
+
+.instructional_picutures body {
+	margin-bottom: .5rem;
+	color: #999
+}
+
+h88 {
+	color: #999;
+}
+
+.wp-caption-text a {
+	margin-top: 1em;
+	font-size: 18px;
+	letter-spacing: 0em;
+	font-weight: 550;
+}
+
+.wp-caption-text {
+	margin-top: 1em;
+	font-size: 18px;
+	letter-spacing: 0em;
+	font-weight: 550;
+	line-height: normal;
+
+}
+
+.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] [data-style="minimal"] {
+	padding: 20px !important;
+}
+
+.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="dark"], .formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="light"] {
+	display: none;
+}
+
+.formkit-form[data-uid="ae3b256f6f"] .formkit-header {
+	margin: 0 0 0 0; 
+}
+
+
+.g1-delta, h4 {
+	font-size: 18px !important;
+}
+
+.acme-helpful-tips-margin-top {
+	margin-top:30px;
+	margin-bottom: 30px;
+}
+
+.acme-helpful-tips {
+	border-bottom: 1px solid #ccc;
+	border-top: 1px solid #ccc;
+	border-left: 1px solid #ccc;
+	border-right: 1px solid #ccc;
+	font-size: 16px;
+	font-size: 1.6rem;
+	min-height: 180px;
+	position: relative;
+	line-height: 1.5;
+}
+
+.acme-helpful-tips p {
+	line-height: 1.5;
+}
+
+.acme-helpful-tips strong,
+.acme-helpful-tips strong a{
+	color: #b4c246;
+	font-size: 2rem;
+}
+
+.acme-helpful-tips a:hover {
+	text-decoration: none
+}
+
+
+.acme-helpful-tips ul,
+.acme-helpful-tips li {
+	color: #797979;
+	margin-left: 30px;
+	font-size: 15px;
+	padding-right: 20px;
+	
+}
+
+
+.acme-helpful-tips p {
+	color: #797979;
+	margin-left: 30px;
+	font-size: 15px;
+	padding-right: 20px;
+	
+}
+
+.acme-helpful-tips a {
+	color: #999a34;
+	font-family: Arial, Helvetica, Tahoma, sans-serif;
+	line-height: 1.5;
+	margin: 0;
+	padding: 0;
+	text-decoration: underline;
+}
+
+.acme-helpful-tips h5 {
+	color: #454545;
+	font-family: 'Merriweather', sans-serif;
+	font-size: 2rem !important;
+	font-weight: normal;
+	margin: -13px 0 0;
+	text-align: center;
+	text-transform: uppercase
+}
+
+.acme-helpful-tips h5 span {
+	background: #fff;
+	padding: 0 15px;
+	font-size: 2.2rem;
+}
+
+.fb_iframe_widget_fluid_desktop iframe {
+	min-width: 100% !important;
+}
+.acme_featured_image {
+	padding-bottom: 5px;
+}
+
+
+.grey_bg {
+				padding: 25px;
+        background-color: #f3f3f3;
+	margin-top: 20px;
+	margin-bottom: 20px;
+    }
+
+ul {
+list-style-type: disc;
+}
+
+
+
+
+.g1-alpha-3rd, .g1-beta-3rd, .g1-delta-3rd, .g1-epsilon-3rd, .g1-gamma-3rd, .g1-giga-3rd, .g1-mega-3rd, .g1-zeta-3rd {
+	
+	color: #666666;
+}		</style>
+		<script src="https://rumcdn.geoedge.be/c54a9b7d-22ff-4c98-a8a8-c195c2d2dc75/grumi-ip.js" async=""></script><style type="text/css">
+  :root {
+    --adhesion-background-color: rgba(0, 0, 0, 0.9);
+  }
+
+  .mv-empty-wrapper {	
+    margin: 0 !important;	
+    height: 0px !important;	
+    min-height: unset !important;	
+  } 
+  .adunitwrapper {
+    overflow: visible;
+    position: relative;
+    /* Typical height + padding for adunitlabels */
+    height: 264px;
+    /* Typical Width */
+    width: 300px;
+    /* try transition in separate a/b test */
+    /* transition: all 0.5s; */
+    white-space: normal !important;
+  }
+
+  div#fixed_container_bottom {
+    -webkit-transform: translate3d(0,0,0);
+    position: fixed;
+    bottom: 0;
+    width: 100vw;
+    height: 400px;
+    gap: 15px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    z-index: 2147483535;
+    pointer-events: none;
+    left: 0px !important;
+  }
+
+  div#fixed_container_bottom > * {
+    pointer-events: auto;
+    transition: all .3s ease-in;
+    transition-delay: 500ms;
+  }
+
+  div#fixed_container_bottom.highImpact_adhesion .adhesion_wrapper {
+    min-height: 150px !important;
+  }
+
+  div#fixed_container_bottom .adhesion_wrapper[data-slot-wrapper-hidden] {
+    visibility: hidden !important;
+  }
+
+  div#fixed_container_bottom[data-position=right] .universalPlayer__bottom {
+    transform: translateY(150px) !important;
+    align-self: start !important;
+  }
+
+  div#fixed_container_bottom[data-position=left] .universalPlayer__bottom {
+    transform: translateY(150px) !important;
+    align-self: end !important;
+  }
+
+  body .adunitwrapper[style*='display: block']>.adunit:before {
+    content: "Loading Ad...";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    -webkit-align-content: center;
+    align-content: center;
+    justify-content: center;
+    font-size: 14px;
+    color: #999;
+    display: -webkit-box;
+    -webkit-box-pack: center;
+    -webkit-box-align: center;
+    box-sizing: border-box;
+  }
+
+  div.mv_slot_target[data-slot] {
+    height: 264px;
+  }
+
+  div.mv_slot_target[data-hint-slot-inserted="true"],
+  div.mv_slot_target[data-hint-slot-inserted="blocked"] {
+    height: revert;
+  }
+
+  .mv-outstream-container + .adunit:before { 
+    display: none!important;
+  }
+
+  .mv-outstream-container + .adunitwrapper>.adunit:before {
+    display: none!important;
+  }
+
+  body .adunitwrapper[style*='display: block']>.adunit {
+    position: relative;
+  }
+
+  body .adunitwrapper[style*='display: block']>.adunit>div {
+    position: relative;
+  }
+
+  .adhesion_wrapper {
+    display: none;
+    max-height: 90px!important;
+  }
+
+  body.adhesion.highImpact_adhesion .adhesion_wrapper {
+    max-height: 150px!important;
+  }
+
+  .mv-native-size {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: initial;
+    overflow: hidden !important;
+  }
+
+  .mv-native-size.sidebar_atf_wrapper,
+  .mv-native-size.sidebar_btf_wrapper {
+    padding-left: 0px;
+    padding-bottom: 19px;
+  }
+
+  .mv-native-size div[id^='google_ads'] {
+    min-height: 100%!important;
+    height: 100%!important;
+    width: 100%!important;
+  }
+
+  .mv-dynamic-size div[id^='google_ads'] {
+    height: initial!important;
+    width: initial!important;
+  }
+
+  mv-ad-reporter {
+    display: none;
+    position: absolute;
+    height: 20px;
+    width: 20px;
+    z-index: 10;
+    line-height: 1.0;
+  }
+
+  .adunitwrapper mv-ad-reporter {
+    bottom: 0px;
+    right: -22px;
+  }
+  
+  .adunitwrapper.sidebar_atf_wrapper mv-ad-reporter,
+  .adunitwrapper.sidebar_btf_wrapper mv-ad-reporter,
+  .adunitwrapper.gutter_atf_wrapper mv-ad-reporter {
+    bottom: -20px;
+    right: 1px;
+  }
+
+  /* Hide Gutter Ad Reporters until the slot is filled with an ad.*/
+  .ad_gutter_middle .adunitwrapper.sidebar_btf_wrapper.mv-empty-wrapper mv-ad-reporter {
+    display: none;
+  }
+
+  #adhesion_mobile_wrapper mv-ad-reporter,
+  #adhesion_desktop_wrapper mv-ad-reporter,
+  #adhesion_tablet_wrapper mv-ad-reporter {
+    position: relative;
+    left: 3px;
+  }
+
+  @media (max-width: 391px) {
+    .adunitwrapper mv-ad-reporter {
+      bottom: -20px;
+      right: 1px;
+    }
+  }
+
+  .adunitwrapper.mv-native-size mv-ad-reporter {
+    right: 1px;
+    bottom: 0px;
+  }
+
+  .mv-ad-box mv-ad-reporter {
+    bottom: 1px;
+    right: 1px;
+  }
+
+  .mv-outstream-container {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+  }
+
+  .mv-outstream-container.active {
+    z-index: 1000;
+  }
+
+  .mv-outstream-container.inactive {
+    z-index: -1;
+  }
+
+  .adhesion_wrapper .mv-outstream-container {
+    top: -51px;
+    left: 5%;
+    width: auto;
+  }
+  
+  .mv-outstream-mute {
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    width: 30px;
+    height: 30px;
+    z-index: 999;
+  }
+
+  .mv-mute-button {
+    pointer-events: none;
+  }
+
+  .mv-mute-button img {
+    width: 32px;
+  }
+
+  #arrival_wrapper {
+    margin: 10px auto 20px auto!important;
+  }
+
+  .mv-arrival-continue-button {
+    margin: 0 auto;
+    display: block;
+    width: 300px;
+    text-align: center;
+    border-top: 1px solid #efefef;
+    padding: 15px 0px;
+    z-index: 1001;
+  }
+
+  body.adhesion {
+    padding-bottom: 90px!important;
+  }
+
+  body.adhesion.highImpact_adhesion {
+    padding-bottom: 150px!important;
+  }
+
+  .mediavine img {
+    margin : 0 !important;
+    padding : 0 !important;
+    border : 0 !important;
+    box-shadow: none !important;
+  }
+
+  .sidebar_btf_wrapper {
+    margin : 0 auto 0 auto;
+    width : 300px;
+  }
+
+  /* This is a fix for trellis */
+  .mv-sticky-slot #sidebar_btf_sticky_wrapper.mv-stuck {
+    position: static;
+  }
+
+  .recipe_mobile_wrapper,
+  .content_mobile_wrapper,
+  .comments_mobile_wrapper {
+    margin-bottom : 10px;
+  }
+
+  [data-recipe-ads-inserted] .recipe_btf_wrapper,
+  [data-recipe-ads-inserted] .recipe_mobile_wrapper {
+    margin: 0 auto;
+  }
+
+  .wprm-recipe-ingredients-container .recipe_btf_wrapper{
+    float: right;
+  }
+
+  .tasty-recipes-ingredients .recipe_btf_wrapper{
+    float: right;
+  }
+
+  @media (max-width: 1023px) {
+    #sidebar_btf_sticky_wrapper, .sidebar_btf_wrapper, .sidebarBtfStacked, .sidebarBtfStackedSpacer {
+      display : none !important;
+    }
+  }
+
+
+  .mv-create-target { 
+    max-width: 300px !important;
+  }
+
+  .adunit a,
+  .adunit object,
+  .adunit embed,
+  .adunit img,
+  .adunit div,
+  .adunit iframe {
+    margin: 0 auto !important;
+    text-align: center;
+  }
+
+  .content_btf_wrapper.native,
+  .content_mobile_wrapper.native {
+    max-width : 600px;
+  }
+
+  .content_float_right {
+    margin : 0 0 10px 20px;
+    float : right;
+  }
+
+  .content_mobile_wrapper,
+  .comments_mobile_wrapper,
+  .comments_btf_wrapper,
+  .comments_mobile_wrapper,
+  .content_btf_wrapper,
+  .feed_mobile_wrapper,
+  .feed_btf_wrapper {
+    margin : 10px auto 20px auto;
+    text-align : center;
+  }
+
+  
+
+  .content_btf_wrapper,
+  .content_mobile_wrapper {
+    clear: both;
+  }
+  .sidebar_atf_wrapper,
+  .leaderboard_btf_wrapper {
+    margin : 0px auto 20px auto;
+    text-align : center;
+  }
+  .leaderboard_btf_wrapper {
+    margin-top : 20px;
+  }
+
+  @media (max-width : 727px) {
+    .leaderboard_atf_wrapper {
+      display : none !important;
+    }
+  }
+
+  .leaderboard_atf_wrapper {
+    margin: 0px auto 0px auto;
+  }
+
+  .leaderboard_atf_wrapper.adunitwrapper {
+    height: 250px;
+  }
+
+
+  .adhesion_wrapper.adhesion_container {
+    position: relative;
+    text-align: center;
+    width: 100% !important;
+    z-index: 2147483535;
+    order: 2;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--adhesion-background-color, 
+      rgba(0, 0, 0, 0.9))
+  }
+
+  .adhesion_wrapper>.adunit>div {
+    position: sticky;
+  }
+
+  .adhesion_wrapper div {
+    margin: 0px;
+  }
+
+  .gumgumAdhesion .adhesion_wrapper {
+    min-height: 100px !important;
+    visibility: hidden;
+  }
+
+  #skin_desktop_wrapper {
+    position: fixed;
+    top: 0;
+  }
+
+  .adhesion_wrapper .adhesion_buttons {
+    height: 80px;
+    width: 48px;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: space-around;
+    margin-left: 3px;
+  }
+
+  .adhesion_wrapper .mv_close_button {
+    width: 24px;
+    height: 24px;
+    display: block;
+    position: relative;
+    cursor: pointer; 
+  }
+
+  .adhesion_wrapper .mv_unbutton {
+    padding: unset;
+    border: unset;
+    background-color: transparent;
+  }
+
+  .adhesion_wrapper .mv_close_button img {
+    width: 24px;
+    height: 24px;
+    pointer-events: none;
+    /* Position it 50% from the top-left corner. */
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    /* Then move it back half its width and height for perfect centering. */
+    transform: translate(-50%, -50%);
+  }
+
+  .universalPlayer_wrapper.uvp_fadeout {
+    opacity: 0%;
+    transition: all 0.5s linear 3s;
+  }
+
+  .universalPlayer_wrapper.uvp_hidden {
+    visibility: hidden !important;
+  }
+
+  .universalPlayer_wrapper {
+    display: block;
+    position: fixed;
+    background: none;
+    box-shadow: rgb(0 0 0 / 15%) 0px 2px 10px;
+    z-index: 1100;
+    overflow: visible;
+    right: 20px;
+    bottom: 20px;
+    transition: all .3s ease-in;
+    transition-delay: 500ms;
+  }
+
+  div#fixed_container_bottom .universalPlayer_wrapper {
+    position: relative;
+    order: 1;
+    align-self: end;
+  }
+
+  .universalPlayer_wrapper:after {
+    content: "\00B7\00B7\00B7";
+    position: absolute;
+    top: 0px;
+    display: flex!important;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+    color: #C4C4C4;
+    font-size: 62px;
+    letter-spacing: 2px;
+    z-index: 999;
+    animation: fadeOut 1s linear 0s infinite;
+    animation-direction: alternate;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-container {
+    border-radius: 10px;
+    overflow: hidden;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-mute {
+    top: unset;
+    bottom: 4px;
+    left: 30px;
+    width: unset;
+    opacity: 0.75;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-mute:after {
+    content: "Ad";
+    position: absolute;
+    top: 6px;
+    color: whitesmoke;
+    text-shadow: 0px 0px 8px black;
+    font-weight: lighter;
+    font-size: 12px;
+    width: fit-content;
+    word-break: normal;
+  }
+
+  .universalPlayer_wrapper .mv-outstream-mute img {
+    width: 29px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu-backdrop {
+    display: none;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+
+    background: rgb(0,0,0, 40%);
+    border-radius: 10px;
+    z-index: 1002;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu {
+    position: absolute;
+    z-index: 1003;
+    display: flex;
+    flex-direction: column;
+    width: 55%;
+    height: 60%;
+    background: white;
+    border-radius: 5px;
+    align-items: center;
+    justify-content: space-around;
+    font-weight: 300;
+    font-size: 15px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item {
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;       
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item a {
+    text-decoration: none;
+    color: inherit;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item a:hover {
+    text-decoration: underline;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu #iconReportSvg {
+    margin-right: 3px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item:not(:last-child) {
+    border-bottom: solid lightgrey 1px;
+  }
+
+  .universalPlayer_wrapper .mv-uvp-menu .mv-uvp-menu-item.mv-ad-report-button > * {
+    pointer-events: none;
+  }
+
+  .universalPlayer_report {
+    position: absolute;
+    left: 3px;
+    bottom: 5px;
+    z-index: 1001;
+    height: 26px;
+    width: 26px;
+
+    display: flex;
+    align-items: center;
+
+    background: rgba(30, 30, 30, 0.5);
+    border-radius: 15px;
+  }
+
+  .universalPlayer_report img {
+    opacity: 100%;
+    width: 20px;
+    height: 20px;
+    pointer-events: none;
+    margin: 0 auto !important;
+  }
+
+  .universalPlayer_close {
+    position: absolute;
+    top: 7px;
+    z-index: 3000;
+    padding: 0px 10px;
+    line-height: 35px;
+    cursor: pointer;
+    filter: drop-shadow(0px 0px 6px black);
+  }
+
+  .universalPlayer_close img {
+    width: 15px;
+    height: 15px;
+    pointer-events: none;
+    margin: 0 auto !important;
+  }
+
+  .universalPlayer_close.outside_player_display {
+    transform: translateY(-45px);
+    padding-top: 10px;
+    padding-bottom: 10px;
+    border-radius: 18px;
+    background: rgba(30, 30, 30, 0.5);
+  }
+
+  .adunit#universalPlayer {
+    background: black;
+    border-radius: 10px;
+    width: 100%;
+    height: 100%;
+    visibility: hidden;
+  }
+
+  .universalPlayer__top {
+    top: 0;
+  }
+
+  .universalPlayer__bottom {
+    bottom: 0;
+  }
+
+  .universalPlayer__right {
+    right: 15px;
+  }
+
+  .universalPlayer__left {
+    left: 15px;
+  }
+
+  /* Note: this rule and others that specifically target '.universalPlayer__bottom.universalPlayer__left'
+    are specifically to fix a conflict with Slipstream.  Adding an extra rule makes it more specific than Slipstream's
+    and force it to have higher priority.
+    https://mediavine.atlassian.net/browse/SUP-565 */
+    div#fixed_container_bottom .universalPlayer__bottom.universalPlayer__left{
+    transform: translateX(0);
+    align-self: start;
+  }
+
+  body.adhesion div#fixed_container_bottom .universalPlayer__bottom {
+    transform: translateX(0);
+  }
+
+  /* make grow me inserted content typically used with dynamic sidebars sticky */
+  body.grow-me-scroll-carousel-active .growInsertedContent {
+    top: 60px;
+  }
+  .growInsertedContent {
+    position: sticky;
+    top: 0;
+  }
+
+
+  body.adhesion.gumgumAdhesion div#fixed_container_bottom .universalPlayer__bottom.universalPlayer__left {
+    align-self: start;
+    transform: translateX(0);
+  }
+
+  /*Keep Close Button on screen for small devices*/
+  @media(min-width: 350px) {
+    .adhesion_wrapper .mv_close_small {
+      display: none;
+    }
+
+  }
+
+  /*Push Logo Up*/
+  @media (max-width: 350px) {
+    .adhesion_wrapper .mv_unbutton {
+      display: none;
+    }
+
+    .adhesion_wrapper .adhesion_buttons {
+      position: absolute;
+      bottom: 51px;
+      right: 0px;
+      z-index: 11;
+      width: 20px;
+      height: 20px !important;
+    }
+
+    #adhesion_mobile_wrapper mv-ad-reporter {
+      display: none !important;
+    }
+  }
+
+  @media (min-width: 728px) and (max-width: 840px) {
+    
+  }
+
+  @media (max-width: 727px) {
+    body.adhesion {
+      padding-bottom : 50px;
+    }
+
+    body.adhesion.highImpact_adhesion {
+      padding-bottom: 150px!important;
+    }
+
+    .adhesion_wrapper.adhesion_container {
+      justify-content: center;
+    }
+
+    /* Provides centered padding for Mediavine logo and Report Button */
+    .mv-native-size .adunitlabel {
+      max-width: calc(100vw - 15px) !important;
+    }
+  }
+
+  @media (min-width: 728px) {
+    body.adhesion {
+      padding-bottom : 90px;
+    }
+
+    body.adhesion.highImpact_adhesion {
+      padding-bottom: 150px!important;
+    }
+  }
+
+  
+  #recipe_btf_wrapper {
+    float : right;
+  }
+  
+
+  @media print {
+    .adunit,
+    .adunitwrapper,
+    .adhesion_wrapper,
+    .mv-ad-box, 
+    mv-ad-reporter {
+      display : none !important;
+    }
+  }
+
+  #sovrn_beacon {
+    position: absolute
+  }
+
+  
+    .triplelift {
+      margin-bottom : 5px !important;
+    }
+
+    .triplelift .entry-title {
+      background : none !important;
+      font-size : 18px;
+      line-height : 22px;
+      clear : none !important;
+    }
+    .triplelift .entry-content {
+      clear : none !important;
+      background : none !important;
+    }
+    .triplelift .entry-meta {
+      display : block !important;
+      background : none !important;
+      clear : none !important;
+      border : none !important;
+      float : none !important;
+    }
+    .triplelift .entry-title a {
+      line-height: inherit !important;
+      float: none !important;
+      width: auto !important;
+      height: auto !important;
+      background: none !important;
+      color: inherit !important;
+      font-size: inherit !important;
+      line-height: inherit !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+    
+
+  
+.mv-native-ad {
+  text-align: left;
+  position: relative;
+  margin: 0 auto;
+	width: fit-content;
+}
+
+.mv-native-ad div {
+  box-sizing: border-box !important;
+}
+
+.mv-native-ad + .adunit {
+  height: 0px;
+  width: 0px;
+}
+
+.mv-native-ad-icon {
+	height: 16px;
+	width: 16px;
+	color: #FFF;
+	background: #919191;
+	font-size: 10px;
+	text-align: center;
+  align-items: center;
+	justify-content: center;
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+</style><style type="text/css" data-fbcssmodules="css:fb.css.base css:fb.css.dialog css:fb.css.iframewidget css:fb.css.customer_chat_plugin_iframe">.fb_hidden{position:absolute;top:-10000px;z-index:10001}.fb_reposition{overflow:hidden;position:relative}.fb_invisible{display:none}.fb_reset{background:none;border:0;border-spacing:0;color:#000;cursor:auto;direction:ltr;font-family:'lucida grande', tahoma, verdana, arial, sans-serif;font-size:11px;font-style:normal;font-variant:normal;font-weight:normal;letter-spacing:normal;line-height:1;margin:0;overflow:visible;padding:0;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;visibility:visible;white-space:normal;word-spacing:normal}.fb_reset>div{overflow:hidden}@keyframes fb_transform{from{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}}.fb_animate{animation:fb_transform .3s forwards}
+.fb_hidden{position:absolute;top:-10000px;z-index:10001}.fb_reposition{overflow:hidden;position:relative}.fb_invisible{display:none}.fb_reset{background:none;border:0;border-spacing:0;color:#000;cursor:auto;direction:ltr;font-family:'lucida grande', tahoma, verdana, arial, sans-serif;font-size:11px;font-style:normal;font-variant:normal;font-weight:normal;letter-spacing:normal;line-height:1;margin:0;overflow:visible;padding:0;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;visibility:visible;white-space:normal;word-spacing:normal}.fb_reset>div{overflow:hidden}@keyframes fb_transform{from{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}}.fb_animate{animation:fb_transform .3s forwards}
+.fb_dialog{background:rgba(82, 82, 82, .7);position:absolute;top:-10000px;z-index:10001}.fb_dialog_advanced{border-radius:8px;padding:10px}.fb_dialog_content{background:#fff;color:#373737}.fb_dialog_close_icon{background:url(https://connect.facebook.net/rsrc.php/v3/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 0 transparent;cursor:pointer;display:block;height:15px;position:absolute;right:18px;top:17px;width:15px}.fb_dialog_mobile .fb_dialog_close_icon{left:5px;right:auto;top:5px}.fb_dialog_padding{background-color:transparent;position:absolute;width:1px;z-index:-1}.fb_dialog_close_icon:hover{background:url(https://connect.facebook.net/rsrc.php/v3/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -15px transparent}.fb_dialog_close_icon:active{background:url(https://connect.facebook.net/rsrc.php/v3/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -30px transparent}.fb_dialog_iframe{line-height:0}.fb_dialog_content .dialog_title{background:#6d84b4;border:1px solid #365899;color:#fff;font-size:14px;font-weight:bold;margin:0}.fb_dialog_content .dialog_title>span{background:url(https://connect.facebook.net/rsrc.php/v3/yd/r/Cou7n-nqK52.gif) no-repeat 5px 50%;float:left;padding:5px 0 7px 26px}body.fb_hidden{height:100%;left:0;margin:0;overflow:visible;position:absolute;top:-10000px;transform:none;width:100%}.fb_dialog.fb_dialog_mobile.loading{background:url(https://connect.facebook.net/rsrc.php/v3/ya/r/3rhSv5V8j3o.gif) white no-repeat 50% 50%;min-height:100%;min-width:100%;overflow:hidden;position:absolute;top:0;z-index:10001}.fb_dialog.fb_dialog_mobile.loading.centered{background:none;height:auto;min-height:initial;min-width:initial;width:auto}.fb_dialog.fb_dialog_mobile.loading.centered #fb_dialog_loader_spinner{width:100%}.fb_dialog.fb_dialog_mobile.loading.centered .fb_dialog_content{background:none}.loading.centered #fb_dialog_loader_close{clear:both;color:#fff;display:block;font-size:18px;padding-top:20px}#fb-root #fb_dialog_ipad_overlay{background:rgba(0, 0, 0, .4);bottom:0;left:0;min-height:100%;position:absolute;right:0;top:0;width:100%;z-index:10000}#fb-root #fb_dialog_ipad_overlay.hidden{display:none}.fb_dialog.fb_dialog_mobile.loading iframe{visibility:hidden}.fb_dialog_mobile .fb_dialog_iframe{position:sticky;top:0}.fb_dialog_content .dialog_header{background:linear-gradient(from(#738aba), to(#2c4987));border-bottom:1px solid;border-color:#043b87;box-shadow:white 0 1px 1px -1px inset;color:#fff;font:bold 14px Helvetica, sans-serif;text-overflow:ellipsis;text-shadow:rgba(0, 30, 84, .296875) 0 -1px 0;vertical-align:middle;white-space:nowrap}.fb_dialog_content .dialog_header table{height:43px;width:100%}.fb_dialog_content .dialog_header td.header_left{font-size:12px;padding-left:5px;vertical-align:middle;width:60px}.fb_dialog_content .dialog_header td.header_right{font-size:12px;padding-right:5px;vertical-align:middle;width:60px}.fb_dialog_content .touchable_button{background:linear-gradient(from(#4267B2), to(#2a4887));background-clip:padding-box;border:1px solid #29487d;border-radius:3px;display:inline-block;line-height:18px;margin-top:3px;max-width:85px;padding:4px 12px;position:relative}.fb_dialog_content .dialog_header .touchable_button input{background:none;border:none;color:#fff;font:bold 12px Helvetica, sans-serif;margin:2px -12px;padding:2px 6px 3px 6px;text-shadow:rgba(0, 30, 84, .296875) 0 -1px 0}.fb_dialog_content .dialog_header .header_center{color:#fff;font-size:16px;font-weight:bold;line-height:18px;text-align:center;vertical-align:middle}.fb_dialog_content .dialog_content{background:url(https://connect.facebook.net/rsrc.php/v3/y9/r/jKEcVPZFk-2.gif) no-repeat 50% 50%;border:1px solid #4a4a4a;border-bottom:0;border-top:0;height:150px}.fb_dialog_content .dialog_footer{background:#f5f6f7;border:1px solid #4a4a4a;border-top-color:#ccc;height:40px}#fb_dialog_loader_close{float:left}.fb_dialog.fb_dialog_mobile .fb_dialog_close_icon{visibility:hidden}#fb_dialog_loader_spinner{animation:rotateSpinner 1.2s linear infinite;background-color:transparent;background-image:url(https://connect.facebook.net/rsrc.php/v3/yD/r/t-wz8gw1xG1.png);background-position:50% 50%;background-repeat:no-repeat;height:24px;width:24px}@keyframes rotateSpinner{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+.fb_iframe_widget{display:inline-block;position:relative}.fb_iframe_widget span{display:inline-block;position:relative;text-align:justify}.fb_iframe_widget iframe{position:absolute}.fb_iframe_widget_fluid_desktop,.fb_iframe_widget_fluid_desktop span,.fb_iframe_widget_fluid_desktop iframe{max-width:100%}.fb_iframe_widget_fluid_desktop iframe{min-width:220px;position:relative}.fb_iframe_widget_lift{z-index:1}.fb_iframe_widget_fluid{display:inline}.fb_iframe_widget_fluid span{width:100%}
+.fb_mpn_mobile_landing_page_slide_out{animation-duration:200ms;animation-name:fb_mpn_landing_page_slide_out;transition-timing-function:ease-in}.fb_mpn_mobile_landing_page_slide_out_from_left{animation-duration:200ms;animation-name:fb_mpn_landing_page_slide_out_from_left;transition-timing-function:ease-in}.fb_mpn_mobile_landing_page_slide_up{animation-duration:500ms;animation-name:fb_mpn_landing_page_slide_up;transition-timing-function:ease-in}.fb_mpn_mobile_bounce_in{animation-duration:300ms;animation-name:fb_mpn_bounce_in;transition-timing-function:ease-in}.fb_mpn_mobile_bounce_out{animation-duration:300ms;animation-name:fb_mpn_bounce_out;transition-timing-function:ease-in}.fb_mpn_mobile_bounce_out_v2{animation-duration:300ms;animation-name:fb_mpn_fade_out;transition-timing-function:ease-in}.fb_customer_chat_bounce_in_v2{animation-duration:300ms;animation-name:fb_bounce_in_v2;transition-timing-function:ease-in}.fb_customer_chat_bounce_in_from_left{animation-duration:300ms;animation-name:fb_bounce_in_from_left;transition-timing-function:ease-in}.fb_customer_chat_bounce_out_v2{animation-duration:300ms;animation-name:fb_bounce_out_v2;transition-timing-function:ease-in}.fb_customer_chat_bounce_out_from_left{animation-duration:300ms;animation-name:fb_bounce_out_from_left;transition-timing-function:ease-in}.fb_invisible_flow{display:inherit;height:0;overflow-x:hidden;width:0}@keyframes fb_mpn_landing_page_slide_out{0%{margin:0 12px;width:100% - 24px}60%{border-radius:18px}100%{border-radius:50%;margin:0 24px;width:60px}}@keyframes fb_mpn_landing_page_slide_out_from_left{0%{left:12px;width:100% - 24px}60%{border-radius:18px}100%{border-radius:50%;left:12px;width:60px}}@keyframes fb_mpn_landing_page_slide_up{0%{bottom:0;opacity:0}100%{bottom:24px;opacity:1}}@keyframes fb_mpn_bounce_in{0%{opacity:.5;top:100%}100%{opacity:1;top:0}}@keyframes fb_mpn_fade_out{0%{bottom:30px;opacity:1}100%{bottom:0;opacity:0}}@keyframes fb_mpn_bounce_out{0%{opacity:1;top:0}100%{opacity:.5;top:100%}}@keyframes fb_bounce_in_v2{0%{opacity:0;transform:scale(0, 0);transform-origin:bottom right}50%{transform:scale(1.03, 1.03);transform-origin:bottom right}100%{opacity:1;transform:scale(1, 1);transform-origin:bottom right}}@keyframes fb_bounce_in_from_left{0%{opacity:0;transform:scale(0, 0);transform-origin:bottom left}50%{transform:scale(1.03, 1.03);transform-origin:bottom left}100%{opacity:1;transform:scale(1, 1);transform-origin:bottom left}}@keyframes fb_bounce_out_v2{0%{opacity:1;transform:scale(1, 1);transform-origin:bottom right}100%{opacity:0;transform:scale(0, 0);transform-origin:bottom right}}@keyframes fb_bounce_out_from_left{0%{opacity:1;transform:scale(1, 1);transform-origin:bottom left}100%{opacity:0;transform:scale(0, 0);transform-origin:bottom left}}@keyframes slideInFromBottom{0%{opacity:.1;transform:translateY(100%)}100%{opacity:1;transform:translateY(0)}}@keyframes slideInFromBottomDelay{0%{opacity:0;transform:translateY(100%)}97%{opacity:0;transform:translateY(100%)}100%{opacity:1;transform:translateY(0)}}</style><script type="text/javascript" src="https://scripts.grow.me/app.1.8.33.js" defer="" data-grow-headless-beta-name="1.8.33" data-grow-headless-beta-version="1.8.33" data-grow-mediavine-site-id="119d89d8-e3eb-43cf-89ab-65f8b2bca672"></script><style type="text/css">
+  body .adunitwrapper[style*='display: block']>.adunit:before {
+    display: none!important;
+  }
+  .mv-ad-box {
+    justify-content: center;
+    position: relative;
+    margin-bottom: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: #fafafa;
+    overflow: clip;
+    padding-top: 0px;
+  }
+
+  @media (min-width: 320px) and (max-width: 360px) {
+    .mv-ad-box {
+      overflow: visible;
+    }
+
+    .adunitwrapper {
+      max-width: 100vw;
+    }
+  }
+
+  
+
+  .sidebarBtfStacked .mv-ad-box {
+    background-color: unset;
+  }
+
+  .mv-ad-box .remove_padding {
+    /* 
+      This trick is incompatible with ad box when overflow 
+      is applied. 
+    */
+    margin-left: 0px;
+    margin-right: 0px;
+  }
+
+  .mv-ad-box > div {
+    z-index: 1;
+  }
+
+  @keyframes fadeOut {
+    0% { opacity: 1;}
+    100% { opacity: 0.01 }
+  }
+
+  .mv-ad-box:before {
+    content: "ADVERTISEMENT";
+    position: absolute;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    height: 20px;
+    width: 100%;
+    text-align: center;
+    color: #a5a5a5;
+    font-size: 11px;
+    letter-spacing: 2px;
+    top: 2px
+  }
+
+  .mv-ad-box:after {
+    content: "\00B7\00B7\00B7";
+    position: absolute;
+    display: flex!important;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+    color: #C4C4C4;
+    font-size: 62px;
+    letter-spacing: 2px;
+    z-index: 0;
+    animation: fadeOut 1s linear 0s infinite;
+    animation-direction: alternate;
+  }
+  .sidebarBtfStacked .mv-ad-box:after {
+    content: "";
+  }
+
+  .mv-ad-box .adunitlabel {
+    width: 100%!important;
+    left: 0; 
+    bottom: 0;
+    padding-left: 10px;
+    padding-right: 10px;
+    padding-bottom: 5px;
+  }
+
+  .mv-ad-box .adunitwrapper {
+    position: relative;
+    margin: 0 !important;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mv-ad-box[data-slotid="recipe_btf"] {
+    float: right;
+  }
+
+  .mv-ad-box .adunitwrapper.mv-native-size {
+    margin-bottom: 0px;
+    background-color: #fafafa;
+    padding: 12px;
+  }
+  .mv-ad-box [data-wrapper=recipe_btf].adunitwrapper.mv-native-size,
+  .mv-ad-box [data-wrapper=recipe_mobile].adunitwrapper.mv-native-size {
+    padding: unset;
+  }
+
+  .mv-ad-box .mv-outstream-container {
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mv-pre-create-target[style*=height] {
+    min-height: 379px !important;
+  }
+</style><script src="https://securepubads.g.doubleclick.net/tag/js/gpt.js" async=""></script><meta http-equiv="origin-trial" content="AlK2UR5SkAlj8jjdEc9p3F3xuFYlF6LYjAML3EOqw1g26eCwWPjdmecULvBH5MVPoqKYrOfPhYVL71xAXI1IBQoAAAB8eyJvcmlnaW4iOiJodHRwczovL2RvdWJsZWNsaWNrLm5ldDo0NDMiLCJmZWF0dXJlIjoiV2ViVmlld1hSZXF1ZXN0ZWRXaXRoRGVwcmVjYXRpb24iLCJleHBpcnkiOjE3NTgwNjcxOTksImlzU3ViZG9tYWluIjp0cnVlfQ=="><meta http-equiv="origin-trial" content="Amm8/NmvvQfhwCib6I7ZsmUxiSCfOxWxHayJwyU1r3gRIItzr7bNQid6O8ZYaE1GSQTa69WwhPC9flq/oYkRBwsAAACCeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZXN5bmRpY2F0aW9uLmNvbTo0NDMiLCJmZWF0dXJlIjoiV2ViVmlld1hSZXF1ZXN0ZWRXaXRoRGVwcmVjYXRpb24iLCJleHBpcnkiOjE3NTgwNjcxOTksImlzU3ViZG9tYWluIjp0cnVlfQ=="><meta http-equiv="origin-trial" content="A9uiHDzQFAhqALUhTgTYJcz9XrGH2y0/9AORwCSapUO/f7Uh7ysIzyszNkuWDLqNYg8446Uj48XIstBW1qv/wAQAAACNeyJvcmlnaW4iOiJodHRwczovL2RvdWJsZWNsaWNrLm5ldDo0NDMiLCJmZWF0dXJlIjoiRmxlZGdlQmlkZGluZ0FuZEF1Y3Rpb25TZXJ2ZXIiLCJleHBpcnkiOjE3Mjc4MjcxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"><meta http-equiv="origin-trial" content="A9R+gkZL3TWq+Z7RJ2L0c7ZN7FZD5z4mHmVvjrPitg/EMz9P3j5d3W7Vw5ZR9jtJGmWKltM4BO3smNzpCgwYuwwAAACTeyJvcmlnaW4iOiJodHRwczovL2dvb2dsZXN5bmRpY2F0aW9uLmNvbTo0NDMiLCJmZWF0dXJlIjoiRmxlZGdlQmlkZGluZ0FuZEF1Y3Rpb25TZXJ2ZXIiLCJleHBpcnkiOjE3Mjc4MjcxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9"><script src="https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202408290101/pubads_impl.js" nonce="HMTAA31x" async=""></script><script src="https://sb.scorecardresearch.com/cs/27053452/beacon.js" async=""></script><style type="text/css">
+      #sidebar_btf_sticky_wrapper.mv-stuck {
+        position : fixed;
+        top : 155px;
+      }
+    </style><script src="https://config.aps.amazon-adsystem.com/configs/38918095-8e45-4332-88bf-226b3514cb64" type="text/javascript" async="async"></script></head>
+	<body class="post-template-default single single-post postid-5951 single-format-standard g1-layout-boxed g1-hoverable g1-has-mobile-logo mv-loaded mv-device-desktop highImpact_adhesion adhesion" itemscope="" itemtype="http://schema.org/WebPage"><div id="fb-root" class=" fb_reset"><div style="position: absolute; top: -10000px; width: 0px; height: 0px;"><div></div></div></div>
+<script async="" defer="" crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v8.0&amp;appId=1060721147363596&amp;autoLogAppEvents=1" nonce="HMTAA31x"></script>
+
+<div class="g1-body-inner">
+	<div id="page">
+
+	<aside class="g1-row g1-sharebar g1-sharebar-off">
+		<div class="g1-row-inner">
+			<div class="g1-column g1-sharebar-inner">
+			</div>
+		</div>
+		<div class="g1-row-background">
+		</div>
+	</aside>
+					<div class="g1-sticky-top-wrapper g1-hb-row-1 g1-loaded">
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-normal g1-hb-row-a g1-hb-row-1 g1-hb-boxed g1-hb-sticky-on g1-hb-shadow-on">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+																<a class="g1-small-logo-wrapper" href="https://www.instrupix.com/">
+		<img class="g1-small-logo" width="241" height="70" src="https://www.instrupix.com/wp-content/uploads/2019/06/Instrupix-copy.png" alt="">	</a>
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+																<!-- BEGIN .g1-primary-nav -->
+	<nav id="g1-primary-nav" class="g1-primary-nav"><ul id="g1-primary-nav-menu" class="g1-primary-nav-menu g1-menu-h"><li id="menu-item-2670" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-has-children menu-item-g1-standard menu-item-2670"><a href="https://www.instrupix.com/category/recipes/">Recipes<span class="g1-link-toggle"></span></a>
+<ul class="sub-menu">
+	<li id="menu-item-5847" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5847"><a href="https://www.instrupix.com/category/dinner/">Dinner</a></li>
+	<li id="menu-item-5848" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5848"><a href="https://www.instrupix.com/category/dessert/">Dessert</a></li>
+	<li id="menu-item-5846" class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-5846"><a href="https://www.instrupix.com/category/low-carb/">Low Carb</a></li>
+	<li id="menu-item-5849" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5849"><a href="https://www.instrupix.com/category/party-food/">Party Food</a></li>
+</ul>
+</li>
+<li id="menu-item-2671" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-g1-standard menu-item-2671"><a href="https://www.instrupix.com/category/diy/">DIY</a></li>
+</ul></nav>	<!-- END .g1-primary-nav -->
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+															<ul id="g1-social-icons-1" class="g1-socials-items g1-socials-items-tpl-grid g1-socials-hb-list ">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+															<div class="g1-drop g1-drop-before g1-drop-the-search  g1-drop-l">
+	<a class="g1-drop-toggle" href="https://www.instrupix.com/?s=">
+		<i class="starmile-iconfont starmile-search"></i>Search		<span class="g1-drop-toggle-arrow"></span>
+	</a>
+	<div class="g1-drop-content">
+		
+
+<div role="search" class="search-form-wrapper">
+	<form method="get" class="g1-searchform-tpl-default search-form" action="https://www.instrupix.com/">
+		<label>
+			<span class="screen-reader-text">Search for:</span>
+			<input type="search" class="search-field" placeholder="Search …" value="" name="s" title="Search for:">
+		</label>
+		<button class="search-submit">Search</button>
+	</form>
+</div>
+	</div>
+</div>
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				</div>
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-normal g1-hb-row-b g1-hb-row-2 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+			<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-normal g1-hb-row-c g1-hb-row-3 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-mobile g1-hb-row-a g1-hb-row-1 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				<div class="g1-sticky-top-wrapper g1-hb-row-2 g1-loaded">
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-mobile g1-hb-row-b g1-hb-row-2 g1-hb-boxed g1-hb-sticky-on g1-hb-shadow-on">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+																<a class="g1-mobile-logo-wrapper" href="https://www.instrupix.com/">
+		<img class="g1-mobile-logo" width="241" height="70" src="https://www.instrupix.com/wp-content/uploads/2019/06/Instrupix-copy.png" alt="">	</a>
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-left g1-bin-grow-on">
+																<a class="g1-hamburger g1-hamburger-show  " href="#">
+		<span class="g1-hamburger-icon"></span>
+		<span class="g1-hamburger-label">Menu</span>
+	</a>
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+															<ul id="g1-social-icons-2" class="g1-socials-items g1-socials-items-tpl-grid g1-socials-hb-list ">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+				</div>
+				<div class="g1-row g1-row-layout-page g1-hb-row g1-hb-row-mobile g1-hb-row-c g1-hb-row-3 g1-hb-boxed g1-hb-sticky-off g1-hb-shadow-off">
+			<div class="g1-row-inner">
+				<div class="g1-column g1-dropable">
+											<div class="g1-bin g1-bin-1 g1-bin-align-left g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-2 g1-bin-align-center g1-bin-grow-off">
+													</div>
+											<div class="g1-bin g1-bin-3 g1-bin-align-right g1-bin-grow-off">
+													</div>
+									</div>
+			</div>
+			<div class="g1-row-background"></div>
+		</div>
+		
+	<div class="g1-row g1-row-layout-page g1-row-padding-m">
+		<div class="g1-row-background">
+		</div>
+		<div class="g1-row-inner">
+
+			<div class="g1-column g1-column-2of3" id="primary">
+				<div id="content" role="main">
+
+
+					
+
+
+<article id="post-5951" class="entry-tpl-classic entry-single post-5951 post type-post status-publish format-standard has-post-thumbnail category-food category-low-carb category-recipes category-snacks tag-cheese tag-cheez-its tag-crackers tag-crispy tag-easy tag-keto tag-low-carb tag-snack tag-snacks" itemscope="" itemtype="http://schema.org/Article">
+	<header class="entry-header entry-single-header entry-header-01">
+					<div class="entry-before-title">
+								
+				
+				
+			</div>
+						
+		<div class="acme_featured_image"><div><img width="725" height="533" src="https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy.jpg" class="attachment-full size-full" alt="" decoding="async" fetchpriority="high" srcset="https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy.jpg 725w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy-300x221.jpg 300w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy-344x253.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy-688x506.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy-516x379.jpg 516w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy-65x48.jpg 65w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheese-crackers-easy-131x96.jpg 131w" sizes="(max-width: 725px) 100vw, 725px" nopin="nopin"></div></div>
+		<h1 class="g1-giga g1-giga-1st entry-title" itemprop="headline">Easy Keto Cheez-It Crackers</h1>
+		<h2 class="entry-subtitle g1-beta g1-beta-3rd">A super easy low carb snack!</h2>		
+							<div class="g1-meta entry-meta entry-meta-byline entry-meta-with-avatar">
+									<span class="entry-author" itemscope="" itemprop="author" itemtype="http://schema.org/Person">
+				<span class="entry-meta-label">by</span>
+			<a href="https://www.instrupix.com/author/lilly/" title="Posts by Lilly" rel="author">			<img alt="" src="https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=30&amp;d=mm&amp;r=g" srcset="https://secure.gravatar.com/avatar/f1b1fbd079199ecb116dd6b12d040b3d?s=60&amp;d=mm&amp;r=g 2x" class="avatar avatar-30 photo" height="30" width="30" decoding="async">							<span itemprop="name">Lilly</span>
+					</a>
+	</span>
+	<time class="entry-date" datetime="2020-01-24T18:25:23" itemprop="datePublished" title="January 24, 2020, 6:25 pm">5 years ago</time>					</div>
+				
+		<div class="entry-after-title">
+								</div>
+	</header>
+
+	
+		<div class="g1-content-narrow g1-typography-xl entry-content" itemprop="articleBody" data-content-ads-inserted="true">
+		<!--www.crestaproject.com Cresta Social Share Counter Content Start--><div id="crestashareiconincontent" class="cresta-share-icon   fifteenth_style"><div class="sbutton-total" id="total-shares-content" data-twittershares="0" data-facebookshares="2024" data-vkshares="0" data-buffershares="0" data-redditshares="0" data-okshares="0" data-xingshares="0" data-tumblrshares="0" data-pinterestshares="560562"><span class="cresta-the-total-count" id="total-count-content">562.6K</span><span class="cresta-the-total-text">Shares</span></div><div class="sbutton  facebook-cresta-share 1" id="facebook-cresta-c"><a rel="nofollow" href="https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F&amp;t=Easy+Keto+Cheez-It+Crackers" data-name="Share to Facebook" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-facebook"></i></a><span class="cresta-the-count-content" id="facebook-count-content">2K</span></div><div class="sbutton  pinterest-cresta-share 1" id="pinterest-cresta-c"><a rel="nofollow" href="javascript:void((function()%7Bvar%20e=document.createElement('script');e.setAttribute('type','text/javascript');e.setAttribute('charset','UTF-8');e.setAttribute('src','https://assets.pinterest.com/js/pinmarklet.js?r='+Math.random()*99999999);document.body.appendChild(e)%7D)());" data-name="Share to Pinterest"><i class="cs c-icon-cresta-pinterest"></i></a><span class="cresta-the-count-content" id="pinterest-count-content">560.6K</span></div><div class="sbutton  email-cresta-share 1" id="email-cresta-c"><a rel="nofollow" href="mailto:?subject=Easy%20Keto%20Cheez-It%20Crackers&amp;body=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F" data-name="Share via Email" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-mail"></i></a></div><div style="clear: both;"></div></div><div style="clear: both;"></div><!--www.crestaproject.com Cresta Social Share Counter Content End--><p data-slot-rendered-content="true">I’ve seen this <strong>quick and</strong>&nbsp;<strong>easy keto snack idea</strong> for a while now floating around Pinterest and I finally got around to making them. It’s the simplest thing you’ll ever do! There’s really no recipe here. You’re just going to bake little squares of cheese until they’re nice and crispy.</p>
+<div class="mv-ad-box" data-slotid="content_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="content_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+          <div id="content_btf" class="content_btf adunit" data-google-query-id="CLjL2LvYq4gDFbDIFgUdfSYi2g">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_0__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://7f8ac644685545821fb396ed5a6298a3.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/content_0" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="4" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<p><strong>This easy keto snack is perfect for on the go</strong>! Bring them to work or school with you for a satisfying little snack without any guilt.</p>
+<p class="g1-content-img-wrap"><img decoding="async" src="https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers-.jpg" alt="Easy Keto Cheese Crackers made with one ingredient!" width="725" height="744" class="aligncenter size-full wp-image-13745" srcset="https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers-.jpg 725w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers--292x300.jpg 292w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers--344x353.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers--688x706.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers--516x530.jpg 516w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers--47x48.jpg 47w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheddar-crackers--94x96.jpg 94w" sizes="(max-width: 725px) 100vw, 725px"></p>
+<h1>DIY Keto “Cheez-It Crackers”</h1>
+<p data-slot-rendered-content="true">You can use any type of sliced cheese as long as it is REALLY THIN. I recommend the <strong>Sargento Ultra Thin Cheese</strong>. The cheddar tastes JUST like Cheez-Its when it’s baked, but you can also use pepper jack or swiss if you’d like.</p>
+<div class="mv-ad-box" data-slotid="content_2_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_2_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-320x250" data-wrapper="content_2_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 320px;">
+          <div id="content_2_btf" class="content_btf adunit" data-google-query-id="CKa10YjPq4gDFWtYDwIdobsX1w">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_1__container__" style="border: 0pt none;"><iframe id="google_ads_iframe_/1030006,16030400/instrupix/content_1" name="google_ads_iframe_/1030006,16030400/instrupix/content_1" title="3rd party ad content" width="320" height="250" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="attribution-reporting" data-load-complete="true" style="border: 0px; vertical-align: bottom;" data-google-container-id="5" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_2_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+
+<div class="grey_bg">
+<h1>Instructions</h1>
+<ol>
+<li>Preheat your oven to 250 degrees Fahrenheit and line a baking sheet with parchment paper.</li>
+<li>I was able to fit 6 pieces of sliced cheese (cut into 9 pieces each) onto my baking sheet, making a total of 54 mini crackers, but you can cut them to any size you’d like.</li>
+<li>Bake for 30-35 minutes and then pull them out of the oven to cool. My husband and I practically ate them all in one sitting!</li>
+</ol>
+</div>
+<p data-slot-rendered-content="true"><img loading="lazy" decoding="async" class="aligncenter wp-image-5952 size-full" src="https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient.jpg" alt="Looking for quick and easy keto snack ideas for on the go? These DIY Keto Cheez It Crackers are perfect to bring to work or school! Super crispy and yummy. Just ONE ingredient! A super simple low carb snack for diabetics and weight loss. Even kids love them! These low carb cheese crackers are perfect Keto snacks for beginners. #instrupix #ketosnacks Instrupix.com " width="725" height="1504" srcset="https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient.jpg 725w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient-145x300.jpg 145w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient-494x1024.jpg 494w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient-344x714.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient-688x1427.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient-516x1070.jpg 516w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient-23x48.jpg 23w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-snack-ideas-baked-keto-cheezits-low-carb-1-ingredient-46x96.jpg 46w" sizes="(max-width: 725px) 100vw, 725px"><img loading="lazy" decoding="async" class="hideimage aligncenter size-full wp-image-8740" src="https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese.jpg" alt="If you're looking for easy and yummy low carb snack ideas, these cheese crackers are made with just one ingredient and have almost zero carbs! You guessed it, cheese. They are so easy to bake in your oven. Just cut thinly sliced cheese into small bite sized pieces, bake and enjoy! You don't have to be on a keto or low carb diet to enjoy them, either. Even your kids will love them, especially if they like Cheez-Its. They are so crunchy and cheesy but with NO GUILT!" width="725" height="1506" srcset="https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese.jpg 725w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese-144x300.jpg 144w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese-493x1024.jpg 493w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese-344x715.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese-688x1429.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese-516x1072.jpg 516w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese-23x48.jpg 23w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-crackers-one-ingredient-made-with-just-cheese-46x96.jpg 46w" sizes="(max-width: 725px) 100vw, 725px"><br>
+<a href="https://www.instagram.com/instrupix/" target="_blank" rel="noopener"><img loading="lazy" decoding="async" class="aligncenter size-full wp-image-9478" src="https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow.jpg" alt="" width="444" height="240" srcset="https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow.jpg 444w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-300x162.jpg 300w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-344x186.jpg 344w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-89x48.jpg 89w, https://www.instrupix.com/wp-content/uploads/2021/03/Instagram-Follow-178x96.jpg 178w" sizes="(max-width: 444px) 100vw, 444px"></a><br>
+<img loading="lazy" decoding="async" class="hideimage aligncenter size-full wp-image-10453" src="https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack.jpg" alt="Keto Cheezit Crackers | This easy keto snack is perfect for on the go! Bring them to work or school with you for a satisfying little snack without any guilt. You can use any type of sliced cheese as long as it is really thin. I recommend the Sargento Ultra Thin Cheese. The cheddar tastes JUST like Cheez-Its when it’s baked, but you can also use pepper jack or swiss if you’d like. You simply slice the cheese into bite size pieces and then bake them at a low temperature for about 30 minutes. The BEST low carb snack!" width="725" height="1382" srcset="https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack.jpg 725w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack-157x300.jpg 157w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack-537x1024.jpg 537w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack-344x656.jpg 344w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack-688x1311.jpg 688w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack-516x984.jpg 516w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack-25x48.jpg 25w, https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezits-crackers-snack-50x96.jpg 50w" sizes="(max-width: 725px) 100vw, 725px"><br>
+</p>
+<div class="mv-ad-box" data-slotid="content_3_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_3_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-300x250 mv-dynamic-size" data-wrapper="content_3_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+          <div id="content_3_btf" class="content_btf adunit" data-google-query-id="CLO9qqXYq4gDFbxtDwIds-4GWA">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_2__container__" style="border: 0pt none; display: inline-block; width: 1px; height: 1px;"><iframe frameborder="0" src="https://7f8ac644685545821fb396ed5a6298a3.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/content_2" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="1" height="1" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="6" style="border: 0px; vertical-align: bottom; height: 250px; width: 300px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_3_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+<div data-post-id="6437" class="insert-page insert-page-6437 "><div id="list_post_wrapper">
+  	<hr>
+	<div class="adace-slot-wrapper adace-shortcode-9988">
+	<div class="adace-disclaimer">
+		</div>
+	<div class="adace-slot"><style scoped="">@media(max-width: 600px) {.adace_ad_66d98211d50e6 {display:block !important;}}
+@media(min-width: 601px) {.adace_ad_66d98211d50e6 {display:block !important;}}
+@media(min-width: 801px) {.adace_ad_66d98211d50e6 {display:block !important;}}
+@media(min-width: 961px) {.adace_ad_66d98211d50e6 {display:block !important;}}
+</style>		<div class="adace_ad_66d98211d50e6">
+	<script src="https://f.convertkit.com/ckjs/ck.5.js"></script>
+      <form action="https://app.convertkit.com/forms/2246692/subscriptions" style="background-color: rgb(237, 237, 237); border-top-left-radius: 6px; border-top-right-radius: 6px; border-bottom-right-radius: 6px; border-bottom-left-radius: 6px;" class="seva-form formkit-form" method="post" data-sv-form="2246692" data-uid="ae3b256f6f" data-format="inline" data-version="5" data-options="{&quot;settings&quot;:{&quot;after_subscribe&quot;:{&quot;action&quot;:&quot;message&quot;,&quot;success_message&quot;:&quot;Check your inbox and confirm your subscription for super awesome stuff. &quot;,&quot;redirect_url&quot;:&quot;&quot;},&quot;analytics&quot;:{&quot;google&quot;:null,&quot;facebook&quot;:null,&quot;segment&quot;:null,&quot;pinterest&quot;:null,&quot;sparkloop&quot;:null,&quot;googletagmanager&quot;:null},&quot;modal&quot;:{&quot;trigger&quot;:&quot;timer&quot;,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:5,&quot;devices&quot;:&quot;all&quot;,&quot;show_once_every&quot;:15},&quot;powered_by&quot;:{&quot;show&quot;:true,&quot;url&quot;:&quot;https://convertkit.com/?utm_campaign=poweredby&amp;utm_content=form&amp;utm_medium=referral&amp;utm_source=dynamic&quot;},&quot;recaptcha&quot;:{&quot;enabled&quot;:false},&quot;return_visitor&quot;:{&quot;action&quot;:&quot;show&quot;,&quot;custom_content&quot;:&quot;&quot;},&quot;slide_in&quot;:{&quot;display_in&quot;:&quot;bottom_right&quot;,&quot;trigger&quot;:&quot;timer&quot;,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:5,&quot;devices&quot;:&quot;all&quot;,&quot;show_once_every&quot;:15},&quot;sticky_bar&quot;:{&quot;display_in&quot;:&quot;top&quot;,&quot;trigger&quot;:&quot;timer&quot;,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:5,&quot;devices&quot;:&quot;all&quot;,&quot;show_once_every&quot;:15}},&quot;version&quot;:&quot;5&quot;}" min-width="400 500 600"><div style="opacity: 0;" class="formkit-background"></div><div data-style="minimal"><div class="formkit-header" style="color: rgb(48, 48, 48); font-size: 25px; font-weight: 700;" data-element="header"><h2>Newsletter</h2></div><div class="formkit-subheader" style="color: rgb(142, 132, 132); font-size: 15px;" data-element="subheader"><p>Recipes &amp; other inspiration in your inbox. </p></div><ul class="formkit-alert formkit-alert-error" data-element="errors" data-group="alert"></ul><div data-element="fields" data-stacked="true" class="seva-fields formkit-fields"><div class="formkit-field"><input class="formkit-input" aria-label="Name" style="color: rgb(0, 0, 0); border-color: rgb(227, 227, 227); border-top-left-radius: 4px; border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; font-weight: 400;" name="fields[first_name]" placeholder="Name" type="text"></div><div class="formkit-field"><input class="formkit-input" name="email_address" style="color: rgb(0, 0, 0); border-color: rgb(227, 227, 227); border-top-left-radius: 4px; border-top-right-radius: 4px; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; font-weight: 400;" aria-label="Email address" placeholder="Email address" required="" type="email"></div><button data-element="submit" class="formkit-submit formkit-submit" style="color: rgb(255, 255, 255); background-color: rgb(102, 102, 102); border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; font-weight: 700;"><div class="formkit-spinner"><div></div><div></div><div></div></div><span class="">Signup</span></button></div><div class="formkit-guarantee" style="color: rgb(77, 77, 77); font-size: 13px; font-weight: 400;" data-element="guarantee"><p>We won't send you spam or anything crappy. Unsubscribe at any time.</p></div><div class="formkit-powered-by-convertkit-container"><a href="https://convertkit.com/?utm_campaign=poweredby&amp;utm_content=form&amp;utm_medium=referral&amp;utm_source=dynamic" data-element="powered-by" class="formkit-powered-by-convertkit" data-variant="dark" target="_blank" rel="noopener noreferrer">Built with ConvertKit</a></div></div><style>.formkit-form[data-uid="ae3b256f6f"] *{box-sizing:border-box;}.formkit-form[data-uid="ae3b256f6f"]{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}.formkit-form[data-uid="ae3b256f6f"] legend{border:none;font-size:inherit;margin-bottom:10px;padding:0;position:relative;display:table;}.formkit-form[data-uid="ae3b256f6f"] fieldset{border:0;padding:0.01em 0 0 0;margin:0;min-width:0;}.formkit-form[data-uid="ae3b256f6f"] body:not(:-moz-handler-blocked) fieldset{display:table-cell;}.formkit-form[data-uid="ae3b256f6f"] h1,.formkit-form[data-uid="ae3b256f6f"] h2,.formkit-form[data-uid="ae3b256f6f"] h3,.formkit-form[data-uid="ae3b256f6f"] h4,.formkit-form[data-uid="ae3b256f6f"] h5,.formkit-form[data-uid="ae3b256f6f"] h6{color:inherit;font-size:inherit;font-weight:inherit;}.formkit-form[data-uid="ae3b256f6f"] p{color:inherit;font-size:inherit;font-weight:inherit;}.formkit-form[data-uid="ae3b256f6f"] ol:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] ul:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] blockquote:not([template-default]){text-align:left;}.formkit-form[data-uid="ae3b256f6f"] p:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] hr:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] blockquote:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] ol:not([template-default]),.formkit-form[data-uid="ae3b256f6f"] ul:not([template-default]){color:inherit;font-style:initial;}.formkit-form[data-uid="ae3b256f6f"] .ordered-list,.formkit-form[data-uid="ae3b256f6f"] .unordered-list{list-style-position:outside !important;padding-left:1em;}.formkit-form[data-uid="ae3b256f6f"] .list-item{padding-left:0;}.formkit-form[data-uid="ae3b256f6f"][data-format="modal"]{display:none;}.formkit-form[data-uid="ae3b256f6f"][data-format="slide in"]{display:none;}.formkit-form[data-uid="ae3b256f6f"][data-format="sticky bar"]{display:none;}.formkit-sticky-bar .formkit-form[data-uid="ae3b256f6f"][data-format="sticky bar"]{display:block;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input,.formkit-form[data-uid="ae3b256f6f"] .formkit-select,.formkit-form[data-uid="ae3b256f6f"] .formkit-checkboxes{width:100%;}.formkit-form[data-uid="ae3b256f6f"] .formkit-button,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit{border:0;border-radius:5px;color:#ffffff;cursor:pointer;display:inline-block;text-align:center;font-size:15px;font-weight:500;cursor:pointer;margin-bottom:15px;overflow:hidden;padding:0;position:relative;vertical-align:middle;}.formkit-form[data-uid="ae3b256f6f"] .formkit-button:hover,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:hover,.formkit-form[data-uid="ae3b256f6f"] .formkit-button:focus,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:focus{outline:none;}.formkit-form[data-uid="ae3b256f6f"] .formkit-button:hover > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:hover > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-button:focus > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit:focus > span{background-color:rgba(0,0,0,0.1);}.formkit-form[data-uid="ae3b256f6f"] .formkit-button > span,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit > span{display:block;-webkit-transition:all 300ms ease-in-out;transition:all 300ms ease-in-out;padding:12px 24px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input{background:#ffffff;font-size:15px;padding:12px;border:1px solid #e3e3e3;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;line-height:1.4;margin:0;-webkit-transition:border-color ease-out 300ms;transition:border-color ease-out 300ms;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input:focus{outline:none;border-color:#1677be;-webkit-transition:border-color ease 300ms;transition:border-color ease 300ms;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input::-webkit-input-placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input::-moz-placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input:-ms-input-placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] .formkit-input::placeholder{color:inherit;opacity:0.8;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"]{position:relative;display:inline-block;width:100%;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"]::before{content:"";top:calc(50% - 2.5px);right:10px;position:absolute;pointer-events:none;border-color:#4f4f4f transparent transparent transparent;border-style:solid;border-width:6px 6px 0 6px;height:0;width:0;z-index:999;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"] select{height:auto;width:100%;cursor:pointer;color:#333333;line-height:1.4;margin-bottom:0;padding:0 6px;-webkit-appearance:none;-moz-appearance:none;appearance:none;font-size:15px;padding:12px;padding-right:25px;border:1px solid #e3e3e3;background:#ffffff;}.formkit-form[data-uid="ae3b256f6f"] [data-group="dropdown"] select:focus{outline:none;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"]{text-align:left;margin:0;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"]{margin-bottom:10px;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] *{cursor:pointer;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"]:last-of-type{margin-bottom:0;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"]{display:none;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"] + label::after{content:none;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"]:checked + label::after{border-color:#ffffff;content:"";}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] input[type="checkbox"]:checked + label::before{background:#10bf7a;border-color:#10bf7a;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label{position:relative;display:inline-block;padding-left:28px;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::before,.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::after{position:absolute;content:"";display:inline-block;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::before{height:16px;width:16px;border:1px solid #e3e3e3;background:#ffffff;left:0px;top:3px;}.formkit-form[data-uid="ae3b256f6f"] [data-group="checkboxes"] [data-group="checkbox"] label::after{height:4px;width:8px;border-left:2px solid #4d4d4d;border-bottom:2px solid #4d4d4d;-webkit-transform:rotate(-45deg);-ms-transform:rotate(-45deg);transform:rotate(-45deg);left:4px;top:8px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert{background:#f9fafb;border:1px solid #e3e3e3;border-radius:5px;-webkit-flex:1 0 auto;-ms-flex:1 0 auto;flex:1 0 auto;list-style:none;margin:25px auto;padding:12px;text-align:center;width:100%;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert:empty{display:none;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert-success{background:#d3fbeb;border-color:#10bf7a;color:#0c905c;}.formkit-form[data-uid="ae3b256f6f"] .formkit-alert-error{background:#fde8e2;border-color:#f2643b;color:#ea4110;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;height:0px;width:0px;margin:0 auto;position:absolute;top:0;left:0;right:0;width:0px;overflow:hidden;text-align:center;-webkit-transition:all 300ms ease-in-out;transition:all 300ms ease-in-out;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner > div{margin:auto;width:12px;height:12px;background-color:#fff;opacity:0.3;border-radius:100%;display:inline-block;-webkit-animation:formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f- 1.4s infinite ease-in-out both;animation:formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f- 1.4s infinite ease-in-out both;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner > div:nth-child(1){-webkit-animation-delay:-0.32s;animation-delay:-0.32s;}.formkit-form[data-uid="ae3b256f6f"] .formkit-spinner > div:nth-child(2){-webkit-animation-delay:-0.16s;animation-delay:-0.16s;}.formkit-form[data-uid="ae3b256f6f"] .formkit-submit[data-active] .formkit-spinner{opacity:1;height:100%;width:50px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-submit[data-active] .formkit-spinner ~ span{opacity:0;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by[data-active="false"]{opacity:0.35;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit-container{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;width:100%;z-index:5;margin:10px 0;position:relative;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit-container[data-active="false"]{opacity:0.35;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit{-webkit-align-items:center;-webkit-box-align:center;-ms-flex-align:center;align-items:center;background-color:#ffffff;border:1px solid #dce1e5;border-radius:4px;color:#373f45;cursor:pointer;display:block;height:36px;margin:0 auto;opacity:0.95;padding:0;-webkit-text-decoration:none;text-decoration:none;text-indent:100%;-webkit-transition:ease-in-out all 200ms;transition:ease-in-out all 200ms;white-space:nowrap;overflow:hidden;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;width:190px;background-repeat:no-repeat;background-position:center;background-image:url("data:image/svg+xml;charset=utf8,%3Csvg width='162' height='20' viewBox='0 0 162 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M83.0561 15.2457C86.675 15.2457 89.4722 12.5154 89.4722 9.14749C89.4722 5.99211 86.8443 4.06563 85.1038 4.06563C82.6801 4.06563 80.7373 5.76407 80.4605 8.28551C80.4092 8.75244 80.0387 9.14403 79.5686 9.14069C78.7871 9.13509 77.6507 9.12841 76.9314 9.13092C76.6217 9.13199 76.3658 8.88106 76.381 8.57196C76.4895 6.38513 77.2218 4.3404 78.618 2.76974C80.1695 1.02445 82.4289 0 85.1038 0C89.5979 0 93.8406 4.07791 93.8406 9.14749C93.8406 14.7608 89.1832 19.3113 83.1517 19.3113C78.8502 19.3113 74.5179 16.5041 73.0053 12.5795C72.9999 12.565 72.9986 12.5492 73.0015 12.534C73.0218 12.4179 73.0617 12.3118 73.1011 12.2074C73.1583 12.0555 73.2143 11.907 73.2062 11.7359L73.18 11.1892C73.174 11.0569 73.2075 10.9258 73.2764 10.8127C73.3452 10.6995 73.4463 10.6094 73.5666 10.554L73.7852 10.4523C73.9077 10.3957 74.0148 10.3105 74.0976 10.204C74.1803 10.0974 74.2363 9.97252 74.2608 9.83983C74.3341 9.43894 74.6865 9.14749 75.0979 9.14749C75.7404 9.14749 76.299 9.57412 76.5088 10.1806C77.5188 13.1 79.1245 15.2457 83.0561 15.2457Z' fill='%23373F45'/%3E%3Cpath d='M155.758 6.91365C155.028 6.91365 154.804 6.47916 154.804 5.98857C154.804 5.46997 154.986 5.06348 155.758 5.06348C156.53 5.06348 156.712 5.46997 156.712 5.98857C156.712 6.47905 156.516 6.91365 155.758 6.91365ZM142.441 12.9304V9.32833L141.415 9.32323V8.90392C141.415 8.44719 141.786 8.07758 142.244 8.07986L142.441 8.08095V6.55306L144.082 6.09057V8.08073H145.569V8.50416C145.569 8.61242 145.548 8.71961 145.506 8.81961C145.465 8.91961 145.404 9.01047 145.328 9.08699C145.251 9.16351 145.16 9.2242 145.06 9.26559C144.96 9.30698 144.853 9.32826 144.745 9.32822H144.082V12.7201C144.082 13.2423 144.378 13.4256 144.76 13.4887C145.209 13.5629 145.583 13.888 145.583 14.343V14.9626C144.029 14.9626 142.441 14.8942 142.441 12.9304Z' fill='%23373F45'/%3E%3Cpath d='M110.058 7.92554C108.417 7.88344 106.396 8.92062 106.396 11.5137C106.396 14.0646 108.417 15.0738 110.058 15.0318C111.742 15.0738 113.748 14.0646 113.748 11.5137C113.748 8.92062 111.742 7.88344 110.058 7.92554ZM110.07 13.7586C108.878 13.7586 108.032 12.8905 108.032 11.461C108.032 10.1013 108.878 9.20569 110.071 9.20569C111.263 9.20569 112.101 10.0995 112.101 11.459C112.101 12.8887 111.263 13.7586 110.07 13.7586Z' fill='%23373F45'/%3E%3Cpath d='M118.06 7.94098C119.491 7.94098 120.978 8.33337 120.978 11.1366V14.893H120.063C119.608 14.893 119.238 14.524 119.238 14.0689V10.9965C119.238 9.66506 118.747 9.16047 117.891 9.16047C117.414 9.16047 116.797 9.52486 116.502 9.81915V14.069C116.502 14.1773 116.481 14.2845 116.44 14.3845C116.398 14.4845 116.337 14.5753 116.261 14.6519C116.184 14.7284 116.093 14.7891 115.993 14.8305C115.893 14.8719 115.786 14.8931 115.678 14.8931H114.847V8.10918H115.773C115.932 8.10914 116.087 8.16315 116.212 8.26242C116.337 8.36168 116.424 8.50033 116.46 8.65577C116.881 8.19328 117.428 7.94098 118.06 7.94098ZM122.854 8.09713C123.024 8.09708 123.19 8.1496 123.329 8.2475C123.468 8.34541 123.574 8.48391 123.631 8.64405L125.133 12.8486L126.635 8.64415C126.692 8.48402 126.798 8.34551 126.937 8.2476C127.076 8.1497 127.242 8.09718 127.412 8.09724H128.598L126.152 14.3567C126.091 14.5112 125.986 14.6439 125.849 14.7374C125.711 14.831 125.549 14.881 125.383 14.8809H124.333L121.668 8.09713H122.854Z' fill='%23373F45'/%3E%3Cpath d='M135.085 14.5514C134.566 14.7616 133.513 15.0416 132.418 15.0416C130.496 15.0416 129.024 13.9345 129.024 11.4396C129.024 9.19701 130.451 7.99792 132.191 7.99792C134.338 7.99792 135.254 9.4378 135.158 11.3979C135.139 11.8029 134.786 12.0983 134.38 12.0983H130.679C130.763 13.1916 131.562 13.7662 132.615 13.7662C133.028 13.7662 133.462 13.7452 133.983 13.6481C134.535 13.545 135.085 13.9375 135.085 14.4985V14.5514ZM133.673 10.949C133.785 9.87621 133.061 9.28752 132.191 9.28752C131.321 9.28752 130.734 9.93979 130.679 10.9489L133.673 10.949Z' fill='%23373F45'/%3E%3Cpath d='M137.345 8.11122C137.497 8.11118 137.645 8.16229 137.765 8.25635C137.884 8.35041 137.969 8.48197 138.005 8.62993C138.566 8.20932 139.268 7.94303 139.759 7.94303C139.801 7.94303 140.068 7.94303 140.489 7.99913V8.7265C140.489 9.11748 140.15 9.4147 139.759 9.4147C139.31 9.4147 138.651 9.5829 138.131 9.8773V14.8951H136.462V8.11112L137.345 8.11122ZM156.6 14.0508V8.09104H155.769C155.314 8.09104 154.944 8.45999 154.944 8.9151V14.8748H155.775C156.23 14.8748 156.6 14.5058 156.6 14.0508ZM158.857 12.9447V9.34254H157.749V8.91912C157.749 8.46401 158.118 8.09506 158.574 8.09506H158.857V6.56739L160.499 6.10479V8.09506H161.986V8.51848C161.986 8.97359 161.617 9.34254 161.161 9.34254H160.499V12.7345C160.499 13.2566 160.795 13.44 161.177 13.503C161.626 13.5774 162 13.9024 162 14.3574V14.977C160.446 14.977 158.857 14.9086 158.857 12.9447ZM98.1929 10.1124C98.2033 6.94046 100.598 5.16809 102.895 5.16809C104.171 5.16809 105.342 5.44285 106.304 6.12953L105.914 6.6631C105.654 7.02011 105.16 7.16194 104.749 6.99949C104.169 6.7702 103.622 6.7218 103.215 6.7218C101.335 6.7218 99.9169 7.92849 99.9068 10.1123C99.9169 12.2959 101.335 13.5201 103.215 13.5201C103.622 13.5201 104.169 13.4717 104.749 13.2424C105.16 13.0799 105.654 13.2046 105.914 13.5615L106.304 14.0952C105.342 14.7819 104.171 15.0566 102.895 15.0566C100.598 15.0566 98.2033 13.2842 98.1929 10.1124ZM147.619 5.21768C148.074 5.21768 148.444 5.58663 148.444 6.04174V9.81968L151.82 5.58131C151.897 5.47733 151.997 5.39282 152.112 5.3346C152.227 5.27638 152.355 5.24607 152.484 5.24611H153.984L150.166 10.0615L153.984 14.8749H152.484C152.355 14.8749 152.227 14.8446 152.112 14.7864C151.997 14.7281 151.897 14.6436 151.82 14.5397L148.444 10.3025V14.0508C148.444 14.5059 148.074 14.8749 147.619 14.8749H146.746V5.21768H147.619Z' fill='%23373F45'/%3E%3Cpath d='M0.773438 6.5752H2.68066C3.56543 6.5752 4.2041 6.7041 4.59668 6.96191C4.99219 7.21973 5.18994 7.62695 5.18994 8.18359C5.18994 8.55859 5.09326 8.87061 4.8999 9.11963C4.70654 9.36865 4.42822 9.52539 4.06494 9.58984V9.63379C4.51611 9.71875 4.84717 9.88721 5.05811 10.1392C5.27197 10.3882 5.37891 10.7266 5.37891 11.1543C5.37891 11.7314 5.17676 12.1841 4.77246 12.5122C4.37109 12.8374 3.81152 13 3.09375 13H0.773438V6.5752ZM1.82373 9.22949H2.83447C3.27393 9.22949 3.59473 9.16064 3.79688 9.02295C3.99902 8.88232 4.1001 8.64502 4.1001 8.31104C4.1001 8.00928 3.99023 7.79102 3.77051 7.65625C3.55371 7.52148 3.20801 7.4541 2.7334 7.4541H1.82373V9.22949ZM1.82373 10.082V12.1167H2.93994C3.37939 12.1167 3.71045 12.0332 3.93311 11.8662C4.15869 11.6963 4.27148 11.4297 4.27148 11.0664C4.27148 10.7324 4.15723 10.4849 3.92871 10.3237C3.7002 10.1626 3.35303 10.082 2.88721 10.082H1.82373Z' fill='%23373F45'/%3E%3Cpath d='M13.011 6.5752V10.7324C13.011 11.207 12.9084 11.623 12.7034 11.9805C12.5012 12.335 12.2068 12.6089 11.8201 12.8022C11.4363 12.9927 10.9763 13.0879 10.4402 13.0879C9.6433 13.0879 9.02368 12.877 8.5813 12.4551C8.13892 12.0332 7.91772 11.4531 7.91772 10.7148V6.5752H8.9724V10.6401C8.9724 11.1704 9.09546 11.5615 9.34155 11.8135C9.58765 12.0654 9.96557 12.1914 10.4753 12.1914C11.4656 12.1914 11.9607 11.6714 11.9607 10.6313V6.5752H13.011Z' fill='%23373F45'/%3E%3Cpath d='M15.9146 13V6.5752H16.9649V13H15.9146Z' fill='%23373F45'/%3E%3Cpath d='M19.9255 13V6.5752H20.9758V12.0991H23.696V13H19.9255Z' fill='%23373F45'/%3E%3Cpath d='M28.2828 13H27.2325V7.47607H25.3428V6.5752H30.1724V7.47607H28.2828V13Z' fill='%23373F45'/%3E%3Cpath d='M41.9472 13H40.8046L39.7148 9.16796C39.6679 9.00097 39.6093 8.76074 39.539 8.44727C39.4687 8.13086 39.4262 7.91113 39.4116 7.78809C39.3823 7.97559 39.3339 8.21875 39.2665 8.51758C39.2021 8.81641 39.1479 9.03905 39.1039 9.18554L38.0405 13H36.8979L36.0673 9.7832L35.2236 6.5752H36.2958L37.2143 10.3193C37.3578 10.9199 37.4604 11.4502 37.5219 11.9102C37.5541 11.6611 37.6025 11.3828 37.6669 11.0752C37.7314 10.7676 37.79 10.5186 37.8427 10.3281L38.8886 6.5752H39.9301L41.0024 10.3457C41.1049 10.6943 41.2133 11.2158 41.3276 11.9102C41.3715 11.4912 41.477 10.958 41.644 10.3105L42.558 6.5752H43.6215L41.9472 13Z' fill='%23373F45'/%3E%3Cpath d='M45.7957 13V6.5752H46.846V13H45.7957Z' fill='%23373F45'/%3E%3Cpath d='M52.0258 13H50.9755V7.47607H49.0859V6.5752H53.9155V7.47607H52.0258V13Z' fill='%23373F45'/%3E%3Cpath d='M61.2312 13H60.1765V10.104H57.2146V13H56.1643V6.5752H57.2146V9.20312H60.1765V6.5752H61.2312V13Z' fill='%23373F45'/%3E%3C/svg%3E");}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit:hover,.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit:focus{background-color:#ffffff;-webkit-transform:scale(1.025) perspective(1px);-ms-transform:scale(1.025) perspective(1px);transform:scale(1.025) perspective(1px);opacity:1;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="dark"],.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="light"]{background-color:transparent;border-color:transparent;width:166px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit[data-variant="light"]{color:#ffffff;background-image:url("data:image/svg+xml;charset=utf8,%3Csvg width='162' height='20' viewBox='0 0 162 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M83.0561 15.2457C86.675 15.2457 89.4722 12.5154 89.4722 9.14749C89.4722 5.99211 86.8443 4.06563 85.1038 4.06563C82.6801 4.06563 80.7373 5.76407 80.4605 8.28551C80.4092 8.75244 80.0387 9.14403 79.5686 9.14069C78.7871 9.13509 77.6507 9.12841 76.9314 9.13092C76.6217 9.13199 76.3658 8.88106 76.381 8.57196C76.4895 6.38513 77.2218 4.3404 78.618 2.76974C80.1695 1.02445 82.4289 0 85.1038 0C89.5979 0 93.8406 4.07791 93.8406 9.14749C93.8406 14.7608 89.1832 19.3113 83.1517 19.3113C78.8502 19.3113 74.5179 16.5041 73.0053 12.5795C72.9999 12.565 72.9986 12.5492 73.0015 12.534C73.0218 12.4179 73.0617 12.3118 73.1011 12.2074C73.1583 12.0555 73.2143 11.907 73.2062 11.7359L73.18 11.1892C73.174 11.0569 73.2075 10.9258 73.2764 10.8127C73.3452 10.6995 73.4463 10.6094 73.5666 10.554L73.7852 10.4523C73.9077 10.3957 74.0148 10.3105 74.0976 10.204C74.1803 10.0974 74.2363 9.97252 74.2608 9.83983C74.3341 9.43894 74.6865 9.14749 75.0979 9.14749C75.7404 9.14749 76.299 9.57412 76.5088 10.1806C77.5188 13.1 79.1245 15.2457 83.0561 15.2457Z' fill='white'/%3E%3Cpath d='M155.758 6.91365C155.028 6.91365 154.804 6.47916 154.804 5.98857C154.804 5.46997 154.986 5.06348 155.758 5.06348C156.53 5.06348 156.712 5.46997 156.712 5.98857C156.712 6.47905 156.516 6.91365 155.758 6.91365ZM142.441 12.9304V9.32833L141.415 9.32323V8.90392C141.415 8.44719 141.786 8.07758 142.244 8.07986L142.441 8.08095V6.55306L144.082 6.09057V8.08073H145.569V8.50416C145.569 8.61242 145.548 8.71961 145.506 8.81961C145.465 8.91961 145.404 9.01047 145.328 9.08699C145.251 9.16351 145.16 9.2242 145.06 9.26559C144.96 9.30698 144.853 9.32826 144.745 9.32822H144.082V12.7201C144.082 13.2423 144.378 13.4256 144.76 13.4887C145.209 13.5629 145.583 13.888 145.583 14.343V14.9626C144.029 14.9626 142.441 14.8942 142.441 12.9304Z' fill='white'/%3E%3Cpath d='M110.058 7.92554C108.417 7.88344 106.396 8.92062 106.396 11.5137C106.396 14.0646 108.417 15.0738 110.058 15.0318C111.742 15.0738 113.748 14.0646 113.748 11.5137C113.748 8.92062 111.742 7.88344 110.058 7.92554ZM110.07 13.7586C108.878 13.7586 108.032 12.8905 108.032 11.461C108.032 10.1013 108.878 9.20569 110.071 9.20569C111.263 9.20569 112.101 10.0995 112.101 11.459C112.101 12.8887 111.263 13.7586 110.07 13.7586Z' fill='white'/%3E%3Cpath d='M118.06 7.94098C119.491 7.94098 120.978 8.33337 120.978 11.1366V14.893H120.063C119.608 14.893 119.238 14.524 119.238 14.0689V10.9965C119.238 9.66506 118.747 9.16047 117.891 9.16047C117.414 9.16047 116.797 9.52486 116.502 9.81915V14.069C116.502 14.1773 116.481 14.2845 116.44 14.3845C116.398 14.4845 116.337 14.5753 116.261 14.6519C116.184 14.7284 116.093 14.7891 115.993 14.8305C115.893 14.8719 115.786 14.8931 115.678 14.8931H114.847V8.10918H115.773C115.932 8.10914 116.087 8.16315 116.212 8.26242C116.337 8.36168 116.424 8.50033 116.46 8.65577C116.881 8.19328 117.428 7.94098 118.06 7.94098ZM122.854 8.09713C123.024 8.09708 123.19 8.1496 123.329 8.2475C123.468 8.34541 123.574 8.48391 123.631 8.64405L125.133 12.8486L126.635 8.64415C126.692 8.48402 126.798 8.34551 126.937 8.2476C127.076 8.1497 127.242 8.09718 127.412 8.09724H128.598L126.152 14.3567C126.091 14.5112 125.986 14.6439 125.849 14.7374C125.711 14.831 125.549 14.881 125.383 14.8809H124.333L121.668 8.09713H122.854Z' fill='white'/%3E%3Cpath d='M135.085 14.5514C134.566 14.7616 133.513 15.0416 132.418 15.0416C130.496 15.0416 129.024 13.9345 129.024 11.4396C129.024 9.19701 130.451 7.99792 132.191 7.99792C134.338 7.99792 135.254 9.4378 135.158 11.3979C135.139 11.8029 134.786 12.0983 134.38 12.0983H130.679C130.763 13.1916 131.562 13.7662 132.615 13.7662C133.028 13.7662 133.462 13.7452 133.983 13.6481C134.535 13.545 135.085 13.9375 135.085 14.4985V14.5514ZM133.673 10.949C133.785 9.87621 133.061 9.28752 132.191 9.28752C131.321 9.28752 130.734 9.93979 130.679 10.9489L133.673 10.949Z' fill='white'/%3E%3Cpath d='M137.345 8.11122C137.497 8.11118 137.645 8.16229 137.765 8.25635C137.884 8.35041 137.969 8.48197 138.005 8.62993C138.566 8.20932 139.268 7.94303 139.759 7.94303C139.801 7.94303 140.068 7.94303 140.489 7.99913V8.7265C140.489 9.11748 140.15 9.4147 139.759 9.4147C139.31 9.4147 138.651 9.5829 138.131 9.8773V14.8951H136.462V8.11112L137.345 8.11122ZM156.6 14.0508V8.09104H155.769C155.314 8.09104 154.944 8.45999 154.944 8.9151V14.8748H155.775C156.23 14.8748 156.6 14.5058 156.6 14.0508ZM158.857 12.9447V9.34254H157.749V8.91912C157.749 8.46401 158.118 8.09506 158.574 8.09506H158.857V6.56739L160.499 6.10479V8.09506H161.986V8.51848C161.986 8.97359 161.617 9.34254 161.161 9.34254H160.499V12.7345C160.499 13.2566 160.795 13.44 161.177 13.503C161.626 13.5774 162 13.9024 162 14.3574V14.977C160.446 14.977 158.857 14.9086 158.857 12.9447ZM98.1929 10.1124C98.2033 6.94046 100.598 5.16809 102.895 5.16809C104.171 5.16809 105.342 5.44285 106.304 6.12953L105.914 6.6631C105.654 7.02011 105.16 7.16194 104.749 6.99949C104.169 6.7702 103.622 6.7218 103.215 6.7218C101.335 6.7218 99.9169 7.92849 99.9068 10.1123C99.9169 12.2959 101.335 13.5201 103.215 13.5201C103.622 13.5201 104.169 13.4717 104.749 13.2424C105.16 13.0799 105.654 13.2046 105.914 13.5615L106.304 14.0952C105.342 14.7819 104.171 15.0566 102.895 15.0566C100.598 15.0566 98.2033 13.2842 98.1929 10.1124ZM147.619 5.21768C148.074 5.21768 148.444 5.58663 148.444 6.04174V9.81968L151.82 5.58131C151.897 5.47733 151.997 5.39282 152.112 5.3346C152.227 5.27638 152.355 5.24607 152.484 5.24611H153.984L150.166 10.0615L153.984 14.8749H152.484C152.355 14.8749 152.227 14.8446 152.112 14.7864C151.997 14.7281 151.897 14.6436 151.82 14.5397L148.444 10.3025V14.0508C148.444 14.5059 148.074 14.8749 147.619 14.8749H146.746V5.21768H147.619Z' fill='white'/%3E%3Cpath d='M0.773438 6.5752H2.68066C3.56543 6.5752 4.2041 6.7041 4.59668 6.96191C4.99219 7.21973 5.18994 7.62695 5.18994 8.18359C5.18994 8.55859 5.09326 8.87061 4.8999 9.11963C4.70654 9.36865 4.42822 9.52539 4.06494 9.58984V9.63379C4.51611 9.71875 4.84717 9.88721 5.05811 10.1392C5.27197 10.3882 5.37891 10.7266 5.37891 11.1543C5.37891 11.7314 5.17676 12.1841 4.77246 12.5122C4.37109 12.8374 3.81152 13 3.09375 13H0.773438V6.5752ZM1.82373 9.22949H2.83447C3.27393 9.22949 3.59473 9.16064 3.79688 9.02295C3.99902 8.88232 4.1001 8.64502 4.1001 8.31104C4.1001 8.00928 3.99023 7.79102 3.77051 7.65625C3.55371 7.52148 3.20801 7.4541 2.7334 7.4541H1.82373V9.22949ZM1.82373 10.082V12.1167H2.93994C3.37939 12.1167 3.71045 12.0332 3.93311 11.8662C4.15869 11.6963 4.27148 11.4297 4.27148 11.0664C4.27148 10.7324 4.15723 10.4849 3.92871 10.3237C3.7002 10.1626 3.35303 10.082 2.88721 10.082H1.82373Z' fill='white'/%3E%3Cpath d='M13.011 6.5752V10.7324C13.011 11.207 12.9084 11.623 12.7034 11.9805C12.5012 12.335 12.2068 12.6089 11.8201 12.8022C11.4363 12.9927 10.9763 13.0879 10.4402 13.0879C9.6433 13.0879 9.02368 12.877 8.5813 12.4551C8.13892 12.0332 7.91772 11.4531 7.91772 10.7148V6.5752H8.9724V10.6401C8.9724 11.1704 9.09546 11.5615 9.34155 11.8135C9.58765 12.0654 9.96557 12.1914 10.4753 12.1914C11.4656 12.1914 11.9607 11.6714 11.9607 10.6313V6.5752H13.011Z' fill='white'/%3E%3Cpath d='M15.9146 13V6.5752H16.9649V13H15.9146Z' fill='white'/%3E%3Cpath d='M19.9255 13V6.5752H20.9758V12.0991H23.696V13H19.9255Z' fill='white'/%3E%3Cpath d='M28.2828 13H27.2325V7.47607H25.3428V6.5752H30.1724V7.47607H28.2828V13Z' fill='white'/%3E%3Cpath d='M41.9472 13H40.8046L39.7148 9.16796C39.6679 9.00097 39.6093 8.76074 39.539 8.44727C39.4687 8.13086 39.4262 7.91113 39.4116 7.78809C39.3823 7.97559 39.3339 8.21875 39.2665 8.51758C39.2021 8.81641 39.1479 9.03905 39.1039 9.18554L38.0405 13H36.8979L36.0673 9.7832L35.2236 6.5752H36.2958L37.2143 10.3193C37.3578 10.9199 37.4604 11.4502 37.5219 11.9102C37.5541 11.6611 37.6025 11.3828 37.6669 11.0752C37.7314 10.7676 37.79 10.5186 37.8427 10.3281L38.8886 6.5752H39.9301L41.0024 10.3457C41.1049 10.6943 41.2133 11.2158 41.3276 11.9102C41.3715 11.4912 41.477 10.958 41.644 10.3105L42.558 6.5752H43.6215L41.9472 13Z' fill='white'/%3E%3Cpath d='M45.7957 13V6.5752H46.846V13H45.7957Z' fill='white'/%3E%3Cpath d='M52.0258 13H50.9755V7.47607H49.0859V6.5752H53.9155V7.47607H52.0258V13Z' fill='white'/%3E%3Cpath d='M61.2312 13H60.1765V10.104H57.2146V13H56.1643V6.5752H57.2146V9.20312H60.1765V6.5752H61.2312V13Z' fill='white'/%3E%3C/svg%3E");}@-webkit-keyframes formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f-{0%,80%,100%{-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);}40%{-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}}@keyframes formkit-bouncedelay-formkit-form-data-uid-ae3b256f6f-{0%,80%,100%{-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);}40%{-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1);}}.formkit-form[data-uid="ae3b256f6f"] blockquote{padding:10px 20px;margin:0 0 20px;border-left:5px solid #e1e1e1;} .formkit-form[data-uid="ae3b256f6f"]{border:1px solid #e3e3e3;max-width:700px;position:relative;overflow:hidden;}.formkit-form[data-uid="ae3b256f6f"] .formkit-background{width:100%;height:100%;position:absolute;top:0;left:0;background-size:cover;background-position:center;opacity:0.3;}.formkit-form[data-uid="ae3b256f6f"] [data-style="minimal"]{padding:20px;width:100%;position:relative;}.formkit-form[data-uid="ae3b256f6f"] .formkit-header{margin:0 0 27px 0;text-align:center;}.formkit-form[data-uid="ae3b256f6f"] .formkit-subheader{margin:18px 0;text-align:center;}.formkit-form[data-uid="ae3b256f6f"] .formkit-guarantee{font-size:13px;margin:10px 0 15px 0;text-align:center;}.formkit-form[data-uid="ae3b256f6f"] .formkit-guarantee > p{margin:0;}.formkit-form[data-uid="ae3b256f6f"] .formkit-powered-by-convertkit-container{margin-bottom:0;}.formkit-form[data-uid="ae3b256f6f"] .formkit-fields{display:-webkit-box;display:-webkit-flex;display:-ms-flexbox;display:flex;-webkit-flex-wrap:wrap;-ms-flex-wrap:wrap;flex-wrap:wrap;margin:25px auto 0 auto;}.formkit-form[data-uid="ae3b256f6f"] .formkit-field{min-width:220px;}.formkit-form[data-uid="ae3b256f6f"] .formkit-field,.formkit-form[data-uid="ae3b256f6f"] .formkit-submit{margin:0 0 15px 0;-webkit-flex:1 0 100%;-ms-flex:1 0 100%;flex:1 0 100%;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] [data-style="minimal"]{padding:40px;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"]{margin-left:-5px;margin-right:-5px;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-field,.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-submit{margin:0 5px 15px 5px;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-field{-webkit-flex:100 1 auto;-ms-flex:100 1 auto;flex:100 1 auto;}.formkit-form[data-uid="ae3b256f6f"][min-width~="600"] .formkit-fields[data-stacked="false"] .formkit-submit{-webkit-flex:1 1 auto;-ms-flex:1 1 auto;flex:1 1 auto;} </style></form><br>		</div>
+		</div>
+</div>
+    <div class="acme-related-posts">
+				
+
+    		<h5>
+				<span>You Might Also Like</span>
+			</h5>
+     			<a href="https://www.instrupix.com/keto-parmesan-pizza-crisps/"> 
+     			   <img loading="lazy" decoding="async" width="200" height="135" src="https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-200x135.jpg" class="related-thumbnail wp-post-image" alt="" nopin="nopin">     			 
+		<p><strong>Keto Parmesan Pizza Crisps</strong><br>
+<span style="color: #000000;">This 2 ingredient crispy keto snack won’t have you missing carbs anymore! They’re just like eating chips, only better.</span></p>
+</a>
+    </div>
+  </div></div><p></p>
+<!--www.crestaproject.com Cresta Social Share Counter Content Start--><div id="crestashareiconincontent" class="cresta-share-icon   fifteenth_style"><div class="sbutton-total" id="total-shares-content" data-twittershares="0" data-facebookshares="2024" data-vkshares="0" data-buffershares="0" data-redditshares="0" data-okshares="0" data-xingshares="0" data-tumblrshares="0" data-pinterestshares="560562"><span class="cresta-the-total-count" id="total-count-content">562.6K</span><span class="cresta-the-total-text">Shares</span></div><div class="sbutton  facebook-cresta-share 1" id="facebook-cresta-c"><a rel="nofollow" href="https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F&amp;t=Easy+Keto+Cheez-It+Crackers" data-name="Share to Facebook" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-facebook"></i></a><span class="cresta-the-count-content" id="facebook-count-content">2K</span></div><div class="sbutton  pinterest-cresta-share 1" id="pinterest-cresta-c"><a rel="nofollow" href="javascript:void((function()%7Bvar%20e=document.createElement('script');e.setAttribute('type','text/javascript');e.setAttribute('charset','UTF-8');e.setAttribute('src','https://assets.pinterest.com/js/pinmarklet.js?r='+Math.random()*99999999);document.body.appendChild(e)%7D)());" data-name="Share to Pinterest"><i class="cs c-icon-cresta-pinterest"></i></a><span class="cresta-the-count-content" id="pinterest-count-content">560.6K</span></div><div class="sbutton  email-cresta-share 1" id="email-cresta-c"><a rel="nofollow" href="mailto:?subject=Easy%20Keto%20Cheez-It%20Crackers&amp;body=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F" data-name="Share via Email" onclick="window.open(this.href,'targetWindow','toolbars=0,location=0,status=0,menubar=0,scrollbars=1,resizable=1,width=640,height=320,left=200,top=200');return false;"><i class="cs c-icon-cresta-mail"></i></a></div><div style="clear: both;"></div></div><div style="clear: both;"></div><!--www.crestaproject.com Cresta Social Share Counter Content End--><div data-slot-rendered-content="true"><h3>Leave a comment...</h3><div class="fb-comments fb_iframe_widget fb_iframe_widget_fluid_desktop" data-href="https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/" data-numposts="5" data-width="100%" fb-xfbml-state="rendered" fb-iframe-plugin-query="app_id=1060721147363596&amp;container_width=662&amp;height=100&amp;href=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F&amp;locale=en_US&amp;numposts=5&amp;sdk=joey&amp;version=v8.0&amp;width=" style="width: 100%;"><span style="vertical-align: bottom; width: 100%; height: 989px;"><iframe name="f8cbff34a81f42aa3" width="1000px" height="100px" data-testid="fb:comments Facebook Social Plugin" title="fb:comments Facebook Social Plugin" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" src="https://www.facebook.com/v8.0/plugins/comments.php?app_id=1060721147363596&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fx%2Fconnect%2Fxd_arbiter%2F%3Fversion%3D46%23cb%3Dfd0cd8d18c0ff7558%26domain%3Dwww.instrupix.com%26is_canvas%3Dfalse%26origin%3Dhttps%253A%252F%252Fwww.instrupix.com%252Ff2542ad80fa1b5738%26relation%3Dparent.parent&amp;container_width=662&amp;height=100&amp;href=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F&amp;locale=en_US&amp;numposts=5&amp;sdk=joey&amp;version=v8.0&amp;width=" style="border: none; visibility: visible; width: 100%; height: 989px;" class=""></iframe></span></div>
+</div>
+<div class="mv-ad-box" data-slotid="content_4_btf" style="height: 324px; width: max(300px, 100%);">
+  
+        <div id="content_4_btf_wrapper" class="adunitwrapper content_btf_wrapper mv-size-320x250" data-wrapper="content_4_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 320px;">
+          <div id="content_4_btf" class="content_btf adunit" data-google-query-id="COePzKbYq4gDFacyewcd5EUOOg">
+            
+          <div id="google_ads_iframe_/1030006,16030400/instrupix/content_3__container__" style="border: 0pt none;"><iframe id="google_ads_iframe_/1030006,16030400/instrupix/content_3" name="google_ads_iframe_/1030006,16030400/instrupix/content_3" title="3rd party ad content" width="320" height="250" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" aria-label="Advertisement" tabindex="0" allow="attribution-reporting" data-load-complete="true" data-google-container-id="7" data-hooks="true" style="border: 0px; vertical-align: bottom;"></iframe></div></div>
+        </div>
+    
+<mv-ad-reporter data-slot-id="content_4_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+	</div>
+
+		
+	<aside class="g1-related-entries">
+
+		
+		<h2 class="g1-gamma g1-gamma-2nd">You may also like</h2>
+
+		<div class="g1-collection g1-collection-columns-2">
+			<div class="g1-collection-viewport">
+				<ul class="g1-collection-items  ">
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-3920 post type-post status-publish format-standard has-post-thumbnail category-food category-low-carb category-recipes category-snacks tag-broccoli tag-cheese tag-keto tag-low-carb tag-snacks">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/low-carb-crispy-broccoli-cheese-rounds/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2019/07/crispy-broccoli-cheese-rounds-recipe-keto-low-carb-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2019/07/crispy-broccoli-cheese-rounds-recipe-keto-low-carb-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/07/crispy-broccoli-cheese-rounds-recipe-keto-low-carb-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2019/07/crispy-broccoli-cheese-rounds-recipe-keto-low-carb-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/07/crispy-broccoli-cheese-rounds-recipe-keto-low-carb-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2019/07/crispy-broccoli-cheese-rounds-recipe-keto-low-carb-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2019/07/crispy-broccoli-cheese-rounds-recipe-keto-low-carb-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/low-carb-crispy-broccoli-cheese-rounds/" rel="bookmark">Low Carb Crispy Broccoli Cheese Rounds</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-3467 post type-post status-publish format-standard has-post-thumbnail category-appetizers category-food category-low-carb category-recipes category-snacks tag-4-ingredients tag-breadsticks tag-cheese tag-keto tag-low-carb tag-snacks">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/keto-cheesy-garlic-breadsticks-4-ingredients/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2019/02/easy-keto-recipes-low-carb-cheesy-breadsticks-made-with-4-ingredients-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2019/02/easy-keto-recipes-low-carb-cheesy-breadsticks-made-with-4-ingredients-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2019/02/easy-keto-recipes-low-carb-cheesy-breadsticks-made-with-4-ingredients-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2019/02/easy-keto-recipes-low-carb-cheesy-breadsticks-made-with-4-ingredients-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2019/02/easy-keto-recipes-low-carb-cheesy-breadsticks-made-with-4-ingredients-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2019/02/easy-keto-recipes-low-carb-cheesy-breadsticks-made-with-4-ingredients-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2019/02/easy-keto-recipes-low-carb-cheesy-breadsticks-made-with-4-ingredients-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/keto-cheesy-garlic-breadsticks-4-ingredients/" rel="bookmark">Keto Cheesy Garlic Breadsticks</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-2486 post type-post status-publish format-standard has-post-thumbnail category-2-ingredient category-food category-low-carb category-recipes category-snacks tag-cheese tag-chips tag-crisps tag-keto tag-low-carb tag-parmesan tag-pepperoni tag-pizza tag-snack">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/keto-parmesan-pizza-crisps/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2018/10/pepperoni-cheese-crisps-easy-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/keto-parmesan-pizza-crisps/" rel="bookmark">Keto Pepperoni Pizza Chips</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-1450 post type-post status-publish format-standard has-post-thumbnail category-breakfast category-food category-low-carb category-recipes category-snacks category-weight-loss tag-breakfast tag-cheese tag-coconut-flour tag-keto tag-low-carb tag-sausage tag-snacks">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/cheesy-sausage-puffs-keto-low-carb/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2018/01/sausage-puff-balls-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2018/01/sausage-puff-balls-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2018/01/sausage-puff-balls-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2018/01/sausage-puff-balls-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2018/01/sausage-puff-balls-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2018/01/sausage-puff-balls-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2018/01/sausage-puff-balls-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/cheesy-sausage-puffs-keto-low-carb/" rel="bookmark">Cheesy Sausage Puffs (Keto &amp; Low Carb)</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-12636 post type-post status-publish format-standard has-post-thumbnail category-chicken category-dinner category-food category-low-carb category-lunch category-recipes category-snacks tag-canned-chicken tag-chicken tag-easy tag-healthy tag-keto tag-low-carb tag-mozzarella tag-oven-baked tag-parmesan tag-quick">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-baked-chicken-nuggets-made-with-canned-chicken/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2022/07/keto-chicken-nuggets-with-canned-chicken-easy-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2022/07/keto-chicken-nuggets-with-canned-chicken-easy-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2022/07/keto-chicken-nuggets-with-canned-chicken-easy-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2022/07/keto-chicken-nuggets-with-canned-chicken-easy-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2022/07/keto-chicken-nuggets-with-canned-chicken-easy-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2022/07/keto-chicken-nuggets-with-canned-chicken-easy-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2022/07/keto-chicken-nuggets-with-canned-chicken-easy-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-baked-chicken-nuggets-made-with-canned-chicken/" rel="bookmark">Easy Baked Chicken Nuggets (Made with Canned Chicken)</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-12420 post type-post status-publish format-standard has-post-thumbnail category-food category-health category-low-carb category-recipes category-snacks tag-almond-flour tag-fritters tag-keto tag-low-carb tag-parmesan tag-snacks tag-zucchini">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-healthy-keto-zucchini-fritters/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2022/03/best-easy-keto-zucchini-fritters-recipe-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2022/03/best-easy-keto-zucchini-fritters-recipe-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2022/03/best-easy-keto-zucchini-fritters-recipe-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2022/03/best-easy-keto-zucchini-fritters-recipe-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2022/03/best-easy-keto-zucchini-fritters-recipe-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2022/03/best-easy-keto-zucchini-fritters-recipe-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2022/03/best-easy-keto-zucchini-fritters-recipe-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-healthy-keto-zucchini-fritters/" rel="bookmark">Easy Low Carb Zucchini Fritters</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-12187 post type-post status-publish format-standard has-post-thumbnail category-dinner category-food category-low-carb category-lunch category-recipes category-snacks tag-crispy tag-keto tag-low-carb tag-parmesan tag-pizza">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-keto-crispy-parmesan-crust-mini-pizzas/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2022/02/parmesan-crust-mini-pizzas-keto-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2022/02/parmesan-crust-mini-pizzas-keto-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2022/02/parmesan-crust-mini-pizzas-keto-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2022/02/parmesan-crust-mini-pizzas-keto-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2022/02/parmesan-crust-mini-pizzas-keto-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2022/02/parmesan-crust-mini-pizzas-keto-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2022/02/parmesan-crust-mini-pizzas-keto-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-keto-crispy-parmesan-crust-mini-pizzas/" rel="bookmark">Crispy Parmesan Crust Mini Pizzas</a></h3>	</header>
+		</article>
+						</li>
+
+					
+						<li class="g1-collection-item g1-collection-item-1of3">
+							<article class="entry-tpl-grid post-11385 post type-post status-publish format-standard has-post-thumbnail category-dinner category-food category-low-carb category-main-dish category-recipes category-weight-loss tag-dinner tag-easy tag-keto tag-ketogenic tag-low-carb tag-soup">
+	<figure class="entry-featured-media starmile-grid-standard "><a class="g1-frame" href="https://www.instrupix.com/easy-keto-soup-recipes-for-dinner-low-carb/"><div class="g1-frame-inner" style="padding-bottom: 75.00000000%;"><img width="344" height="258" src="https://www.instrupix.com/wp-content/uploads/2022/01/list-of-healthy-keto-soup-recipes-quick-and-easy-to-make-with-few-ingredients-344x258.jpg" class="attachment-starmile-grid-standard size-starmile-grid-standard wp-post-image" alt="" decoding="async" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2022/01/list-of-healthy-keto-soup-recipes-quick-and-easy-to-make-with-few-ingredients-344x258.jpg 344w, https://www.instrupix.com/wp-content/uploads/2022/01/list-of-healthy-keto-soup-recipes-quick-and-easy-to-make-with-few-ingredients-500x375.jpg 500w, https://www.instrupix.com/wp-content/uploads/2022/01/list-of-healthy-keto-soup-recipes-quick-and-easy-to-make-with-few-ingredients-688x516.jpg 688w, https://www.instrupix.com/wp-content/uploads/2022/01/list-of-healthy-keto-soup-recipes-quick-and-easy-to-make-with-few-ingredients-536x402.jpg 536w, https://www.instrupix.com/wp-content/uploads/2022/01/list-of-healthy-keto-soup-recipes-quick-and-easy-to-make-with-few-ingredients-120x90.jpg 120w, https://www.instrupix.com/wp-content/uploads/2022/01/list-of-healthy-keto-soup-recipes-quick-and-easy-to-make-with-few-ingredients-240x180.jpg 240w" sizes="(max-width: 344px) 100vw, 344px" nopin="nopin">	<span class="g1-frame-icon g1-frame-icon-"></span></div></a></figure>	<header class="entry-header">
+				<h3 class="g1-gamma g1-gamma-1st entry-title"><a href="https://www.instrupix.com/easy-keto-soup-recipes-for-dinner-low-carb/" rel="bookmark">10 Crazy Easy Keto Soup Recipes</a></h3>	</header>
+		</article>
+						</li>
+
+									</ul>
+			</div>
+		</div>
+
+					</aside>
+			<meta itemprop="mainEntityOfPage" content="https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/">
+	<meta itemprop="dateModified" content="2024-03-05T00:23:04">
+
+	<span itemprop="publisher" itemscope="" itemtype="http://schema.org/Organization">
+		<meta itemprop="name" content="Instrupix">
+		<meta itemprop="url" content="https://www.instrupix.com">
+		<span itemprop="logo" itemscope="" itemtype="http://schema.org/ImageObject">
+			<meta itemprop="url" content="">
+		</span>
+	</span>
+		<span itemprop="image" itemscope="" itemtype="http://schema.org/ImageObject">
+				<meta itemprop="url" content="https://www.instrupix.com/wp-content/uploads/2020/01/keto-cheezit-crackers-one-ingredient-low-carb-snack.jpg">
+		<meta itemprop="width" content="725">
+		<meta itemprop="height" content="967">
+	</span>
+	</article>
+
+
+
+				</div>
+				<!-- #content -->
+			</div>
+
+
+			<!-- #primary -->
+
+			<div id="secondary" class="g1-column g1-column-1of3">
+	<aside id="starmile_aboutme_widget-2" class="widget widget_starmile_aboutme_widget"><header><h2 class="g1-delta g1-delta-2nd widgettitle">About Me</h2></header>	<div class="g1-aboutme">
+					<a href="https://www.instrupix.com/about/" class="g1-aboutme-avatar">
+		
+			<img width="550" height="769" src="https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers.jpg" class="attachment-full size-full" alt="" loading="lazy" srcset="https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers.jpg 550w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-215x300.jpg 215w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-344x481.jpg 344w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-516x721.jpg 516w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-34x48.jpg 34w, https://www.instrupix.com/wp-content/uploads/2018/09/Lilly-Childers-69x96.jpg 69w" sizes="(max-width: 550px) 100vw, 550px" nopin="nopin">
+					</a>
+		
+					
+			<div class="g1-aboutme-signature">
+							</div>
+							<div class="g1-aboutme-desc">
+				<p>I’m just a gal that likes to make fun stuff and whip up easy recipes in the kitchen.&nbsp;</p>
+			</div>
+							</div>
+	</aside><aside id="search-2" class="widget widget_search" data-slot-rendered-sidebarbtf="true"><header><h2 class="g1-delta g1-delta-2nd widgettitle">Search</h2></header>
+
+<div role="search" class="search-form-wrapper">
+	<form method="get" class="g1-searchform-tpl-default search-form" action="https://www.instrupix.com/">
+		<label>
+			<span class="screen-reader-text">Search for:</span>
+			<input type="search" class="search-field" placeholder="Search …" value="" name="s" title="Search for:">
+		</label>
+		<button class="search-submit">Search</button>
+	</form>
+</div>
+</aside>
+      <div id="sidebar_btf_placeholder" class="sidebar_btf_placeholder" style="height: 265px;"><div id="sidebar_btf_sticky_wrapper" class="" style="width: 324px;"><div id="sidebar_btf_wrapper" class="adunitwrapper sidebar_btf_wrapper mv-size-300x250" data-wrapper="sidebar_btf" data-nosnippet="" style="visibility: visible; height: 250px; min-height: 250px; width: 300px;">
+        <div id="sidebar_btf" class="adunit" data-google-query-id="CImq5LvYq4gDFTRFwgUdUukBRA">
+        
+        <div id="google_ads_iframe_/1030006,16030400/instrupix/sticky_sidebar_0__container__" style="border: 0pt none; display: inline-block; width: 300px; height: 250px;"><iframe frameborder="0" src="https://7f8ac644685545821fb396ed5a6298a3.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/sticky_sidebar_0" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="300" height="250" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="3" style="border: 0px; vertical-align: bottom;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+      <mv-ad-reporter data-slot-id="sidebar_btf" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div></div></div>
+    </div><!-- #secondary -->
+
+		</div>
+	</div><!-- .g1-row -->
+
+
+<div class="g1-row g1-row-layout-page g1-footer">
+	<div class="g1-row-inner">
+		<div class="g1-column">
+			
+							<div class="g1-footer-social">
+					<ul id="g1-social-icons-3" class="g1-socials-items g1-socials-items-tpl-grid">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-32 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-32 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-32 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+				</div>
+						<nav id="g1-footer-nav" class="g1-footer-nav"><ul id="g1-footer-nav-menu" class=""><li id="menu-item-2676" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2676"><a href="https://www.instrupix.com/about/">About</a></li>
+<li id="menu-item-2677" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2677"><a href="https://www.instrupix.com/contact/">Contact</a></li>
+<li id="menu-item-2678" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-privacy-policy menu-item-2678"><a rel="privacy-policy" href="https://www.instrupix.com/privacy-policy/">Privacy Policy</a></li>
+<li id="menu-item-2665" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2665"><a href="https://www.instrupix.com/newsletter/">Newsletter</a></li>
+</ul></nav>			<p class="g1-footer-text g1-meta">© 2020 instrupix.com</p>
+				<div class="g1-footer-credits g1-dark">
+			</div>
+		</div>
+		<!-- .g1-column -->
+	</div>
+	<div class="g1-row-background">
+	</div>
+</div><!-- .g1-row -->
+	<a href="#page" class="g1-back-to-top g1-back-to-top-on" title="Back to Top">Back to Top</a>
+</div><!-- #page -->
+
+<div class="g1-canvas-overlay"></div>
+
+</div><iframe name="__gppLocator" style="display: none;"></iframe><!-- .g1-body-inner -->
+<div id="g1-breakpoint-desktop"></div>
+
+
+<div class="g1-canvas g1-canvas-global">
+	<div class="g1-canvas-content">
+		<a class="g1-canvas-toggle" href="#"></a>
+
+			<!-- BEGIN .g1-primary-nav -->
+	<nav id="g1-canvas-primary-nav" class="g1-primary-nav"><ul id="g1-canvas-primary-nav-menu" class="g1-menu-v"><li class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-has-children menu-item-2670"><a href="https://www.instrupix.com/category/recipes/">Recipes<span class="g1-link-toggle"></span></a>
+<ul class="sub-menu">
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5847"><a href="https://www.instrupix.com/category/dinner/">Dinner</a></li>
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5848"><a href="https://www.instrupix.com/category/dessert/">Dessert</a></li>
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category current-post-ancestor current-menu-parent current-post-parent menu-item-5846"><a href="https://www.instrupix.com/category/low-carb/">Low Carb</a></li>
+	<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-5849"><a href="https://www.instrupix.com/category/party-food/">Party Food</a></li>
+</ul>
+</li>
+<li class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-2671"><a href="https://www.instrupix.com/category/diy/">DIY</a></li>
+</ul></nav>		<!-- END .g1-primary-nav -->
+	
+	<ul id="g1-social-icons-4" class="g1-socials-items g1-socials-items-tpl-grid">
+			<li class="g1-socials-item g1-socials-item-facebook">
+	   <a class="g1-socials-item-link" href="https://www.facebook.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-facebook"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Facebook</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-instagram">
+	   <a class="g1-socials-item-link" href="https://www.instagram.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-instagram"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Instagram</span>
+		   </span>
+	   </a>
+	</li>
+			<li class="g1-socials-item g1-socials-item-pinterest">
+	   <a class="g1-socials-item-link" href="https://www.pinterest.com/instrupix" target="_blank">
+		   <i class="g1-socials-item-icon g1-socials-item-icon-28 g1-socials-item-icon-text g1-socials-item-icon-pinterest"></i>
+		   <span class="g1-socials-item-tooltip">
+			   <span class="g1-socials-item-tooltip-inner">Pinterest</span>
+		   </span>
+	   </a>
+	</li>
+	</ul>
+
+
+<div role="search" class="search-form-wrapper">
+	<form method="get" class="g1-searchform-tpl-default search-form" action="https://www.instrupix.com/">
+		<label>
+			<span class="screen-reader-text">Search for:</span>
+			<input type="search" class="search-field" placeholder="Search …" value="" name="s" title="Search for:">
+		</label>
+		<button class="search-submit">Search</button>
+	</form>
+</div>
+	</div>
+	<div class="g1-canvas-background"></div>
+</div>
+
+<div class="adace-adi-popup-wrapper">
+	<div class="adace-adi-popup">
+		<div class="adace-adi-flag"></div>
+
+		<h2 class="adace-adi-title">Ad Blocker Detected!</h2>
+		<div class="adace-adi-content">Advertisements fund this website. Please disable your adblocking software or whitelist our website.<br>Thank You!</div>
+
+		<div class="adace-adi-buttons">
+						<a class="adace-adi-refresh-button">Refresh</a>
+		</div>
+
+	</div>
+</div>
+	<script>
+		(function ($) {
+			"use strict";
+
+						var triggerAlert = false;
+			
+			var adblockDetectedAlert = function() {
+				$('html').addClass('adace-adi-popup-visible');
+				$('.adace-adi-refresh-button').on('click', function(){
+					window.location.reload();
+				});
+				$('.adace-adi-close').on('click', function(){
+					console.log('e');
+					$('html').removeClass('adace-adi-popup-visible');
+				});
+			};
+
+			$(document).ready(function () {
+				// Only when the AdBlocker is enabled this script will be available.
+				if ( typeof $.adi === 'function' ) {
+					$.adi({
+						onOpen: function (el) {
+							adblockDetectedAlert();
+						}
+					});
+				}
+
+				// Show alert on demand. AdBlocker can be disabled.
+				if (triggerAlert) {
+					adblockDetectedAlert();
+				}
+			});
+		})(jQuery);
+	</script>
+	<link rel="stylesheet" id="g1-socials-basic-screen-css" href="https://www.instrupix.com/wp-content/plugins/g1-socials/css/screen-basic.min.css?ver=1.1.16" type="text/css" media="screen">
+<link rel="stylesheet" id="g1-socials-snapcode-css" href="https://www.instrupix.com/wp-content/plugins/g1-socials/css/snapcode.min.css?ver=1.1.16" type="text/css" media="screen">
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/js/jquery.cresta-social-effect.min.js?ver=2.9.9.5" id="cresta-social-effect-js-js"></script>
+<script type="text/javascript" id="cresta-social-counter-js-js-extra">
+/* <![CDATA[ */
+var crestaShareSSS = {"FacebookCount":"2024"};
+var crestaPermalink = {"thePermalink":"https:\/\/www.instrupix.com\/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea\/","themorezero":"nomore","totalmorezero":"totalyesmore","themorenumber":"0"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/cresta-social-share-counter-pro/js/jquery.cresta-social-share-counter-both.min.js?ver=2.9.9.5" id="cresta-social-counter-js-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/lazy-load/js/lazysizes/lazysizes.min.js?ver=4.0" id="lazysizes-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/lazy-load/js/youtube.js?ver=1.2.3" id="mace-lazy-load-youtube-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/video-playlist/js/mejs-renderers/vimeo.min.js?ver=1.2.3" id="mace-vp-renderer-vimeo-js"></script>
+<script type="text/javascript" id="mediaelement-core-js-before">
+/* <![CDATA[ */
+var mejsL10n = {"language":"en","strings":{"mejs.download-file":"Download File","mejs.install-flash":"You are using a browser that does not have Flash player enabled or installed. Please turn on your Flash player plugin or download the latest version from https:\/\/get.adobe.com\/flashplayer\/","mejs.fullscreen":"Fullscreen","mejs.play":"Play","mejs.pause":"Pause","mejs.time-slider":"Time Slider","mejs.time-help-text":"Use Left\/Right Arrow keys to advance one second, Up\/Down arrows to advance ten seconds.","mejs.live-broadcast":"Live Broadcast","mejs.volume-help-text":"Use Up\/Down Arrow keys to increase or decrease volume.","mejs.unmute":"Unmute","mejs.mute":"Mute","mejs.volume-slider":"Volume Slider","mejs.video-player":"Video Player","mejs.audio-player":"Audio Player","mejs.captions-subtitles":"Captions\/Subtitles","mejs.captions-chapters":"Chapters","mejs.none":"None","mejs.afrikaans":"Afrikaans","mejs.albanian":"Albanian","mejs.arabic":"Arabic","mejs.belarusian":"Belarusian","mejs.bulgarian":"Bulgarian","mejs.catalan":"Catalan","mejs.chinese":"Chinese","mejs.chinese-simplified":"Chinese (Simplified)","mejs.chinese-traditional":"Chinese (Traditional)","mejs.croatian":"Croatian","mejs.czech":"Czech","mejs.danish":"Danish","mejs.dutch":"Dutch","mejs.english":"English","mejs.estonian":"Estonian","mejs.filipino":"Filipino","mejs.finnish":"Finnish","mejs.french":"French","mejs.galician":"Galician","mejs.german":"German","mejs.greek":"Greek","mejs.haitian-creole":"Haitian Creole","mejs.hebrew":"Hebrew","mejs.hindi":"Hindi","mejs.hungarian":"Hungarian","mejs.icelandic":"Icelandic","mejs.indonesian":"Indonesian","mejs.irish":"Irish","mejs.italian":"Italian","mejs.japanese":"Japanese","mejs.korean":"Korean","mejs.latvian":"Latvian","mejs.lithuanian":"Lithuanian","mejs.macedonian":"Macedonian","mejs.malay":"Malay","mejs.maltese":"Maltese","mejs.norwegian":"Norwegian","mejs.persian":"Persian","mejs.polish":"Polish","mejs.portuguese":"Portuguese","mejs.romanian":"Romanian","mejs.russian":"Russian","mejs.serbian":"Serbian","mejs.slovak":"Slovak","mejs.slovenian":"Slovenian","mejs.spanish":"Spanish","mejs.swahili":"Swahili","mejs.swedish":"Swedish","mejs.tagalog":"Tagalog","mejs.thai":"Thai","mejs.turkish":"Turkish","mejs.ukrainian":"Ukrainian","mejs.vietnamese":"Vietnamese","mejs.welsh":"Welsh","mejs.yiddish":"Yiddish"}};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/mediaelement/mediaelement-and-player.min.js?ver=4.2.17" id="mediaelement-core-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/mediaelement/mediaelement-migrate.min.js?ver=6.6.1" id="mediaelement-migrate-js"></script>
+<script type="text/javascript" id="mediaelement-js-extra">
+/* <![CDATA[ */
+var _wpmejsSettings = {"pluginPath":"\/wp-includes\/js\/mediaelement\/","classPrefix":"mejs-","stretching":"responsive","audioShortcodeLibrary":"mediaelement","videoShortcodeLibrary":"mediaelement"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-includes/js/mediaelement/wp-mediaelement.min.js?ver=6.6.1" id="wp-mediaelement-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/video-playlist/js/playlist.js?ver=1.2.3" id="mace-vp-js"></script>
+<script type="text/javascript" id="mace-gallery-js-extra">
+/* <![CDATA[ */
+var macegallery = "{\"i18n\":{\"of\":\"of\"},\"html\":\"\\n<div class=\\\"g1-gallery-wrapper g1-gallery-dark\\\">\\n\\t<div class=\\\"g1-gallery\\\">\\n\\t\\t<div class=\\\"g1-gallery-header\\\">\\n\\t\\t\\t<div class=\\\"g1-gallery-header-left\\\">\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-logo\\\">\\n\\t\\t\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-title g1-gamma g1-gamma-1st\\\">{title}<\\\/div>\\n\\t\\t\\t<\\\/div>\\n\\t\\t\\t<div class=\\\"g1-gallery-header-right\\\">\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-back-to-slideshow\\\">Back to slideshow<\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbs-button\\\"><\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-numerator\\\">{numerator}<\\\/div>\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-close-button\\\"><\\\/div>\\n\\t\\t\\t<\\\/div>\\n\\t\\t<\\\/div>\\n\\t\\t<div class=\\\"g1-gallery-body\\\">\\n\\t\\t\\t<div class=\\\"g1-gallery-frames\\\">\\n\\t\\t\\t\\t{frames}\\n\\t\\t\\t<\\\/div>\\n\\t\\t\\t<div class=\\\"g1-gallery-thumbnails32\\\">\\n\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-collection\\\">\\n\\t\\t\\t\\t\\t{thumbnails32}\\n\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t<\\\/div>\\n\\t\\t\\t<div class=\\\"g1-gallery-sidebar\\\">\\n\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-shares\\\">\\n\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-ad\\\">\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails\\\">\\n\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-up\\\"><\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-collection\\\">{thumbnails}<\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t<div class=\\\"g1-gallery-thumbnails-down\\\"><\\\/div>\\n\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t\\t\\t\\t\\t\\t\\t<\\\/div>\\n\\t\\t<\\\/div>\\n\\t<\\\/div>\\n<\\\/div>\\n\",\"shares\":\"<script type=\\\"text\\\/javascript\\\">\\n\\t\\t\\t(function () {\\n\\t\\t\\t\\tvar triggerOnLoad = false;\\n\\n\\t\\t\\t\\twindow.apiShareOnFB = function() {\\n\\t\\t\\t\\t\\tjQuery('body').trigger('snaxFbNotLoaded');\\n\\t\\t\\t\\t\\ttriggerOnLoad = true;\\n\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\tvar _fbAsyncInitGallery = window.fbAsyncInitGallery;\\n\\n\\t\\t\\t\\twindow.fbAsyncInitGallery = function() {\\n\\t\\t\\t\\t\\tFB.init({\\n\\t\\t\\t\\t\\t\\tappId      : '',\\n\\t\\t\\t\\t\\t\\txfbml      : true,\\n\\t\\t\\t\\t\\t\\tversion    : 'v3.0'\\n\\t\\t\\t\\t\\t});\\n\\t\\t\\t\\t\\twindow.apiShareOnFB_mace_replace_unique = function() {\\n\\t\\t\\t\\t\\t\\tvar shareTitle \\t\\t    = 'mace_replace_noesc_title';\\n\\t\\t\\t\\t\\t\\tvar shareDescription\\t= '';\\n\\t\\t\\t\\t\\t\\tvar shareImage\\t        = 'mace_replace_noesc_image_url';\\n\\n\\t\\t\\t\\t\\t\\tFB.login(function(response) {\\n\\t\\t\\t\\t\\t\\t\\tif (response.status === 'connected') {\\n\\t\\t\\t\\t\\t\\t\\t\\tvar objectToShare = {\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t'og:url':           'mace_replace_noesc_shortlink', \\\/\\\/ Url to share.\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t'og:title':         shareTitle,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t'og:description':   shareDescription\\n\\t\\t\\t\\t\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\t\\t\\t\\t\\t\\\/\\\/ Add image only if set. FB fails otherwise.\\n\\t\\t\\t\\t\\t\\t\\t\\tif (shareImage) {\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tobjectToShare['og:image'] = shareImage;\\n\\t\\t\\t\\t\\t\\t\\t\\t}\\n\\n\\t\\t\\t\\t\\t\\t\\t\\tFB.ui({\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\tmethod: 'share_open_graph',\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\taction_type: 'og.shares',\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\taction_properties: JSON.stringify({\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\tobject : objectToShare\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t})\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t},\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t\\\/\\\/ callback\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tfunction(response) {\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t});\\n\\t\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t\\t});\\n\\t\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\t\\t\\\/\\\/ Fire original callback.\\n\\t\\t\\t\\t\\tif (typeof _fbAsyncInitGallery === 'function') {\\n\\t\\t\\t\\t\\t\\t_fbAsyncInitGallery();\\n\\t\\t\\t\\t\\t}\\n\\n\\t\\t\\t\\t\\t\\\/\\\/ Open share popup as soon as possible, after loading FB SDK.`\\n\\t\\t\\t\\t\\tif (triggerOnLoad) {\\n\\t\\t\\t\\t\\t\\tsetTimeout(function() {\\n\\t\\t\\t\\t\\t\\t\\tapiShareOnFB();\\n\\t\\t\\t\\t\\t\\t}, 1000);\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t};\\n\\n\\t\\t\\t\\t\\\/\\\/ JS SDK loaded before we hook into it. Trigger callback now.\\n\\t\\t\\t\\tif (typeof window.FB !== 'undefined') {\\n\\t\\t\\t\\t\\twindow.fbAsyncInitGallery();\\n\\t\\t\\t\\t}\\n\\t\\t\\t\\tjQuery('body').on('maceGalleryItemChanged', function(){\\n\\t\\t\\t\\t\\twindow.fbAsyncInitGallery();\\n\\t\\t\\t\\t});\\n\\t\\t\\t})();\\n\\t\\t<\\\/script>\\n\\n<a class=\\\"g1-gallery-share g1-gallery-share-fb\\\" href=\\\"#\\\" title=\\\"Share on Facebook\\\" onclick=\\\"apiShareOnFB_mace_replace_unique(); return false;\\\" target=\\\"_blank\\\" rel=\\\"nofollow\\\">Share on Facebook<\\\/a><a class=\\\"g1-gallery-share g1-gallery-share-twitter\\\" href=\\\"https:\\\/\\\/twitter.com\\\/home?status=mace_replace_title%20mace_replace_shortlink\\\" title=\\\"Share on Twitter\\\" target=\\\"_blank\\\" rel=\\\"nofollow\\\">Share on Twitter<\\\/a><a class=\\\"g1-gallery-share g1-gallery-share-pinterest\\\" href=\\\"https:\\\/\\\/pinterest.com\\\/pin\\\/create\\\/button\\\/?url=mace_replace_shortlink&description=mace_replace_title&media=mace_replace_image_url\\\" title=\\\"Share on Pinterest\\\" target=\\\"_blank\\\" rel=\\\"nofollow\\\">Share on Pinterest<\\\/a>\"}";
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/plugins/media-ace/includes/gallery/js/gallery.js?ver=1.2.3" id="mace-gallery-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/stickyfill/stickyfill.min.js?ver=1.3.1" id="stickyfill-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.placeholder/placeholders.jquery.min.js?ver=4.0.1" id="jquery-placeholder-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.timeago/jquery.timeago.js?ver=1.5.2" id="jquery-timeago-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.timeago/locales/jquery.timeago.en.js" id="jquery-timeago-en-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/matchMedia/matchMedia.js" id="match-media-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/matchMedia/matchMedia.addListener.js" id="match-media-add-listener-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/picturefill/picturefill.min.js?ver=2.3.1" id="picturefill-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/jquery.waypoints/jquery.waypoints.min.js?ver=4.0.0" id="jquery-waypoints-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/flickity/flickity.pkgd.min.js?ver=2.0.9" id="flickity-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/enquire/enquire.min.js?ver=2.1.2" id="enquire-js"></script>
+<script type="text/javascript" id="starmile-front-js-extra">
+/* <![CDATA[ */
+var starmile_front_config = "{\"ajax_url\":\"https:\\\/\\\/www.instrupix.com\\\/wp-admin\\\/admin-ajax.php\",\"timeago\":\"on\",\"sharebar\":\"off\",\"microshare\":\"off\",\"i18n\":{\"newsletter\":{\"subscribe_mail_subject_tpl\":\"Check out this great article: %subject%\"},\"bp_profile_nav\":{\"more_link\":\"More\"}},\"comment_types\":[\"wp\"],\"auto_load_limit\":0}";
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile/js/front.js?ver=1.2.2" id="starmile-front-js"></script>
+<script type="text/javascript" src="https://www.instrupix.com/wp-content/themes/starmile-child-theme/modifications.js" id="starmile-child-js"></script>
+
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-105877338-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+
+
+<iframe src="about:blank" style="display: none;"></iframe><script type="text/javascript" async="" src="//in.getclicky.com/in.php?site_id=100964726&amp;href=%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F&amp;title=Copycat%20Keto%20Cheez-It%20Crackers%20(ONE%20ingredient!)&amp;res=1512x982&amp;lang=en-US&amp;tz=Asia%2FTokyo&amp;tc=&amp;ck=1&amp;x=f2acnk"></script><iframe marginwidth="0" marginheight="0" scrolling="no" frameborder="0" id="1e7824767e75d2" width="0" height="0" src="about:blank" name="__pb_locator__" style="display: none; height: 0px; width: 0px; border: 0px;"></iframe><div id="fixed_container_bottom" data-slot-rendered-universalplayer="true" data-slot-rendered-adhesion="true">        
+      <div id="universalPlayer_wrapper" class="adunitwrapper universalPlayer__right universalPlayer__bottom universalPlayer_wrapper mv-empty-wrapper " data-wrapper="universalPlayer" data-nosnippet="" style="visibility: hidden;">
+        <span class="universalPlayer_close mv_unbutton" role="button" aria-label="Close ad" style="display: none;">
+          <img id="iconCloseSvg" data-pin-nopin="true" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHZpZXdCb3g9IjAgMCAxMCAxMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbD0iIzAwMDAwMCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLW9wYWNpdHk9Jy42JyBzdHJva2Utd2lkdGg9IjEiIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNOS4zOTQ4NSAwTDUuMDAwNDMgNC4zOTUyOEwwLjYwNTE1MyAwTDAgMC42MDUxNTNMNC4zOTQ0MiA1LjAwMDQzTDAgOS4zOTQ4NUwwLjYwNTE1MyAxMEw1LjAwMDQzIDUuNjA0NzJMOS4zOTQ4NSAxMEwxMCA5LjM5NDg1TDUuNjA0NzIgNS4wMDA0M0wxMCAwLjYwNTE1M0w5LjM5NDg1IDBaIi8+Cjwvc3ZnPgo=" alt="" aria-label="Close Ad">
+        </span>
+        <span class="universalPlayer_report">
+          <img id="iconMenuSvg" data-pin-nopin="true" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iOCIgdmlld0JveD0iMCAwIDEyIDgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMTEuMjU5MiAwLjU4NjMwOUMxMC45NDk4IDAuNjc2MTIzIDEwLjM2OCAwLjg5ODU1NSAxMC4xNDE1IDEuMzQzNjJDOS45MjgxOSAxLjc2MjIxIDEwLjA2OSAyLjMzNzU0IDEwLjE5NzUgMi42N0MxMC41MDY3IDIuNTgwMjkgMTEuMDg5OSAyLjM1Nzg2IDExLjMxNjUgMS45MTIzOEMxMS41NDMyIDEuNDY3MzEgMTEuMzczMSAwLjg4MTIwOCAxMS4yNTkyIDAuNTg2MzA5VjAuNTg2MzA5Wk05LjkwMDYxIDMuMjU1OUw5LjgxMjMgMy4wODUyQzkuNzg4OTMgMy4wMzk3MyA5LjI0MjA5IDEuOTYyNzggOS42NzMwMyAxLjExNjg4QzEwLjEwMzYgMC4yNzA3NzggMTEuMzEzNiAwLjA0MzkzMjEgMTEuMzY0OCAwLjAzNDY5NEwxMS41NTc2IDBMMTEuNjQ1OSAwLjE3MDY5OUMxMS42NjkzIDAuMjE2MTcxIDEyLjIxNiAxLjI5MzAyIDExLjc4NDkgMi4xMzkxMkMxMS4zNTQ4IDIuOTg0ODIgMTAuMTQ0NyAzLjIxMTg3IDEwLjA5MzMgMy4yMjExMUw5LjkwMDYxIDMuMjU1OVoiIGZpbGw9IiNGRkZGRkYiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yLjY0NDc1IDIuNjQ3NzlDMi41NzkxNyAxLjI4MzQzIDEuNDQwMjIgMC4xOTQ4NzggMC4wMzI5NTkgMC4xNjE2MjFWNS4zODI1NkMwLjAzNDAxMTYgNS4zODI1NiAwLjAzNTA2NDIgNS4zODI0NiAwLjAzNjExNjkgNS4zODIzNkMwLjEwMTY5NiA2Ljc0NjcyIDEuMjQwNjQgNy44MzUzNyAyLjY0NzkxIDcuODY4NTJWMi42NDc2OUMyLjY0Njg1IDIuNjQ3NjkgMi42NDU4IDIuNjQ3NzkgMi42NDQ3NSAyLjY0Nzc5IiBmaWxsPSIjRkZGRkZGIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNS43MTcyNiAyLjY0Nzc5QzUuNjUxNjggMS4yODM0MyA0LjUxMjczIDAuMTk0ODc4IDMuMTA1NDcgMC4xNjE2MjFWNS4zODI1NkMzLjEwNjUyIDUuMzgyNTYgMy4xMDc1NyA1LjM4MjQ2IDMuMTA4NzMgNS4zODIzNkMzLjE3NDIxIDYuNzQ2NzIgNC4zMTMxNSA3LjgzNTM3IDUuNzIwNTIgNy44Njg1MlYyLjY0NzY5QzUuNzE5NDcgMi42NDc2OSA1LjcxODMxIDIuNjQ3NzkgNS43MTcyNiAyLjY0Nzc5IiBmaWxsPSIjRkZGRkZGIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNOC43OTAwMSAyLjY0Nzc5QzguNzI0MzMgMS4yODM0MyA3LjU4NTQ5IDAuMTk0ODc4IDYuMTc4MjIgMC4xNjE2MjFWNS4zODI1NkM2LjE3OTI4IDUuMzgyNTYgNi4xODAzMyA1LjM4MjQ2IDYuMTgxMzggNS4zODIzNkM2LjI0Njk2IDYuNzQ2NzIgNy4zODYwMSA3LjgzNTM3IDguNzkzMTcgNy44Njg1MlYyLjY0NzY5QzguNzkyMTIgMi42NDc2OSA4Ljc5MTA2IDIuNjQ3NzkgOC43OTAwMSAyLjY0Nzc5IiBmaWxsPSIjRkZGRkZGIi8+Cjwvc3ZnPgo=" alt="" aria-label="Ad Menu">
+        </span>
+        <div class="mv-uvp-menu-backdrop">
+          <div class="mv-uvp-menu">
+            <div class="mv-uvp-menu-item mv-uvp-menu-item-learn-more">
+          <a href="https://www.mediavine.com?utm_source=mediavine&amp;utm_medium=ad&amp;utm_campaign=logo" target="_blank" rel="noopener nofollow" aria-label="mediavine">
+              What is this?</a>
+            </div>
+            <div class="mv-uvp-menu-item mv-ad-report-button" data-target="universalPlayer" data-adtype="display" role="button" aria-label="Report ad">
+                  <img id="iconReportSvg" data-pin-nopin="true" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwKSI+CjxwYXRoIGQ9Ik0xMS45MiAxMC43Mkw2LjgwMDAxIDAuNDhDNi40ODAwMSAtMC4xNiA1LjYwMDAxIC0wLjE2IDUuMjgwMDEgMC40OEwwLjA4MDAwNTMgMTAuNzJDLTAuMjM5OTk1IDExLjI4IDAuMjQwMDA1IDEyIDAuODgwMDA1IDEySDExLjEyQzExLjc2IDEyIDEyLjE2IDExLjI4IDExLjkyIDEwLjcyWk02LjAwMDAxIDEwLjRDNS4zNjAwMSAxMC40IDQuODAwMDEgOS44NCA0LjgwMDAxIDkuMkM0LjgwMDAxIDguNTYgNS4yODAwMSA4IDYuMDAwMDEgOEM2LjcyMDAxIDggNy4yMDAwMSA4LjU2IDcuMjAwMDEgOS4yQzcuMjAwMDEgOS45MiA2LjY0MDAxIDEwLjQgNi4wMDAwMSAxMC40Wk02LjgwMDAxIDcuMkg1LjIwMDAxTDQuODAwMDEgNC40QzQuODAwMDEgNC4xNiA0Ljk2MDAxIDQgNS4yMDAwMSA0SDYuODAwMDFDNy4wNDAwMSA0IDcuMjAwMDEgNC4xNiA3LjIwMDAxIDQuNEw2LjgwMDAxIDcuMloiIGZpbGw9IiMwMDAwMDAiLz4KPC9nPgo8ZGVmcz4KPGNsaXBQYXRoIGlkPSJjbGlwMCI+CjxyZWN0IHdpZHRoPSIxMiIgaGVpZ2h0PSIxMiIgZmlsbD0id2hpdGUiLz4KPC9jbGlwUGF0aD4KPC9kZWZzPgo8L3N2Zz4K" alt="" aria-label="Report Ad"> Report Ad
+                </div>
+            
+          </div>
+        </div>
+        
+        <div id="universalPlayer" class="adunit" data-google-query-id="CKy817vYq4gDFfNgDwIdV6Mqpg" style="display: none;"> <div id="google_ads_iframe_/1030006,16030400/instrupix/universal_player_0__container__" style="border: 0pt none; width: 177px; height: 0px;"></div></div> 
+      </div>
+    
+      <div id="adhesion_desktop_wrapper" class="adhesion_wrapper adhesion_container mv-dynamic-size" data-wrapper="adhesion_desktop" data-nosnippet="" style="min-height: 90px;">
+        <div id="adhesion_desktop" class="adunit" style="" data-google-query-id="CKyw57vYq4gDFTNvDwIdfE8FXw">
+          
+        <div id="google_ads_iframe_/1030006,16030400/instrupix/adhesion_0__container__" style="border: 0pt none; display: inline-block; width: 728px; height: 90px;"><iframe frameborder="0" src="https://7f8ac644685545821fb396ed5a6298a3.safeframe.googlesyndication.com/safeframe/1-0-40/html/container.html" id="google_ads_iframe_/1030006,16030400/instrupix/adhesion_0" title="3rd party ad content" name="" scrolling="no" marginwidth="0" marginheight="0" width="728" height="90" data-is-safeframe="true" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-top-navigation-by-user-activation" allow="attribution-reporting" aria-label="Advertisement" tabindex="0" data-google-container-id="2" style="border: 0px; vertical-align: bottom; height: 90px; width: 728px;" data-load-complete="true" data-hooks="true"></iframe></div></div>
+        <div class="adhesion_buttons" style="height: 90px;">
+          <div class="mv_close_button adhesion_desktop">
+            <span role="button" aria-label="Close ad">
+              <img class="mv_unbutton" alt="Close ad" id="iconCloseSvg" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHZpZXdCb3g9IjAgMCAxMCAxMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik05LjM5NDg1IDBMNS4wMDA0MyA0LjM5NTI4TDAuNjA1MTUzIDBMMCAwLjYwNTE1M0w0LjM5NDQyIDUuMDAwNDNMMCA5LjM5NDg1TDAuNjA1MTUzIDEwTDUuMDAwNDMgNS42MDQ3Mkw5LjM5NDg1IDEwTDEwIDkuMzk0ODVMNS42MDQ3MiA1LjAwMDQzTDEwIDAuNjA1MTUzTDkuMzk0ODUgMFoiIGZpbGw9IiM5MTkxOTEiLz4KPC9zdmc+Cg==">
+              <img class="mv_close_small" alt="Close ad" id="iconCloseSvg" src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUiIGhlaWdodD0iMTUiIHZpZXdCb3g9IjAgMCAxNSAxNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjE1IiBoZWlnaHQ9IjE1IiBmaWxsPSIjOTE5MTkxIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNNy44MzIxMiA3LjVMMTAuMjQzNCA1LjA4ODYxQzEwLjMzNTUgNC45OTY1NCAxMC4zMzU1IDQuODQ4MTMgMTAuMjQzNCA0Ljc1NjU0QzEwLjE1MTkgNC42NjQ0OSAxMC4wMDM0IDQuNjY0NDkgOS45MTEzOSA0Ljc1NjU0TDcuNTAwMDQgNy4xNjc5NEw1LjA4ODI1IDQuNzU2NTRDNC45OTY2NiA0LjY2NDQ5IDQuODQ3NzggNC42NjQ0OSA0Ljc1NjE5IDQuNzU2NTRDNC42NjQ2IDQuODQ4MTMgNC42NjQ2IDQuOTk2NTQgNC43NTYxOSA1LjA4ODYxTDcuMTY3OTggNy41TDQuNzU2MTkgOS45MTE0QzQuNjY0NiAxMC4wMDM1IDQuNjY0NiAxMC4xNTE5IDQuNzU2MTkgMTAuMjQzNUM0LjgwMjIyIDEwLjI4OTUgNC44NjIzMyAxMC4zMTI1IDQuOTIyNDQgMTAuMzEyNUM0Ljk4MjU2IDEwLjMxMjUgNS4wNDI2OSAxMC4yODk1IDUuMDg4MjUgMTAuMjQzNUw3LjUwMDA0IDcuODMyMDZMOS45MTEzOSAxMC4yNDM1QzkuOTU3NDEgMTAuMjg5NSAxMC4wMTc1IDEwLjMxMjUgMTAuMDc3NyAxMC4zMTI1QzEwLjEzNzggMTAuMzEyNSAxMC4xOTc5IDEwLjI4OTUgMTAuMjQzNCAxMC4yNDM1QzEwLjMzNTUgMTAuMTUxOSAxMC4zMzU1IDEwLjAwMzUgMTAuMjQzNCA5LjkxMTRMNy44MzIxMiA3LjVaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K">
+            </span>
+          </div>
+          
+        <mv-ad-reporter data-slot-id="adhesion_desktop" data-offering="1" data-offering-name="mediavine" data-offering-domain="mediavine.com" style="display: block;"></mv-ad-reporter></div>
+      </div>
+    </div><script>(function(o,n,e,p,l,u,s){o[l]=o[l]||function(){(o[l].q=o[l].q||[]).push(arguments);};
+
+u=n.createElement(e);u.async=1;u.src=p;s=n.getElementsByTagName(e)[0];s.parentNode.insertBefore(u,s);
+
+}(window,document,"script","https://cdn.opecloud.com/ope-dmplite.js","ope"));
+
+ope("dmplite", "init", "b4", "implied");</script><iframe src="https://www.google.com/recaptcha/api2/aframe" width="0" height="0" style="display: none;"></iframe><div id="popUpParent">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&amp;display=swap" rel="stylesheet">
+    <style>
+         #popUpParent .nm {
+                padding: 0;
+                margin: 0;
+                direction: ltr !important;
+            }
+
+            #rbuPopUp.rbu-popUp {
+                margin: 0;
+                padding: 0;
+                height: initial;
+                width: initial;
+                all: initial;
+                direction: ltr !important;
+            }
+
+            #rbuPopUp.rbu-popUp {
+                text-align: center;
+                /* for IE */
+                background-color: #fff;
+                display: none;
+                position: fixed;
+                z-index: 99999999;
+                width: 260px;
+                height: 312px;
+                border-radius: 5px;
+                box-shadow: 0px 0px 7px 0px rgba(0, 0, 0, 0.25);
+
+                top: 50%;
+                left: 50%;
+                -webkit-transform: translate(-50%, -50%);
+                transform: translate(-50%, -50%);
+                padding: 30px 20px 14px 20px;
+                box-sizing: border-box;
+                overflow: hidden;
+            }
+
+            .popup-heading#popup-heading {
+                all: unset;
+                display: block;
+                margin-bottom: 49px;
+                text-align: left;
+                width: 100%;
+            }
+
+            .popup-title#headingTitle,
+            .popup-title-secondary#popup-title-secondary {
+                all: initial;
+                font-family: Roboto;
+                font-size: 16px;
+                font-weight: 700;
+                line-height: 19px;
+                letter-spacing: 0em;
+                text-align: center;
+                color: rgba(0, 0, 0, 1);
+                text-align: left;
+            }
+
+            .popup-title-secondary#popup-title-secondary {
+                margin-bottom: 21px;
+            }
+
+            .popup-reasons#popup-reasons {
+                all: unset;
+                display: block;
+                text-align: left;
+                margin-bottom: 21px;
+            }
+
+            .popup-reasons-selection#popup-reasons-selection {
+                all: unset;
+                display: block;
+                text-align: left;
+                width: 100%;
+                margin: 0;
+                padding: 0;
+            }
+
+            #popUpParent .form-action {
+                all: unset;
+                display: block;
+                margin-bottom: 12px !important;
+                width: 100%;
+                text-align: center;
+            }
+
+            .submit#reportButton {
+                all: initial;
+                background: rgba(49, 128, 249, 1);
+                padding: 4px 31px !important;
+                outline: none;
+                border: 0px;
+                color: #fff;
+
+                font-family: Roboto;
+                font-size: 13px !important;
+                font-weight: 400;
+                line-height: 15px !important;
+                letter-spacing: 0em;
+                text-align: center;
+                border-radius: 3px;
+                width: 101px !important;
+                height: 24px !important;
+                cursor: pointer;
+            }
+
+            .rbu-footer#rbu-footer {
+                all: initial;
+                display: block;
+                margin-top: 14px !important;
+                width: 100%;
+            }
+
+            .rbu-description#rbu-description {
+                all: initial;
+                font-family: Roboto;
+                display: flex;
+                font-size: 12px !important;
+                font-weight: 400;
+                line-height: 12px !important;
+                letter-spacing: 0em;
+                text-align: left;
+                margin-right: 3px;
+                color: rgba(114, 112, 112, 1);
+                width: 60px !important;
+                height: 20px !important;
+                justify-content: center;
+                align-items: center;
+            }
+
+            .rbu-link#rbu-link {
+                all: initial;
+                text-decoration: none;
+                color: black;
+                display: flex;
+                align-content: center;
+                justify-content: center;
+                cursor: pointer;
+                height: 30px !important;
+            }
+
+            .rbu-link#rbu-link img {
+                width: 60px !important;
+                height: 24px !important;
+            }
+
+            #popUpParent .float-l {
+                float: left;
+            }
+
+            .reasons-list#reasonsList {
+                all: unset;
+                margin-bottom: 40px;
+                display: block;
+            }
+
+            .reasons-item#reasons-item {
+                all: unset;
+                clear: both;
+                height: 14px !important;
+                margin-bottom: 12px !important;
+                display: block;
+                padding: 0;
+                width: auto;
+                line-height: 14px !important;
+            }
+
+            .reasons-item#reasons-item .radio {
+                -webkit-appearance: auto;
+                appearance: auto;
+                display: block !important;
+                width: 14px !important;
+                height: 14px !important;
+            }
+
+            .reasons-item-name#reasons-item-name {
+                all: initial;
+                cursor: pointer;
+                font-family: Roboto;
+                font-size: 12px !important;
+                font-weight: 400;
+                line-height: 14px !important;
+                letter-spacing: 0em;
+                text-align: left;
+                margin-left: 12px !important;
+            }
+
+            #popUpParent .reasons-form {
+                width: 100%;
+            }
+
+            .submit#reportButton:disabled {
+                color: rgba(0, 0, 0, 0.25);
+                background: #f5f5f5;
+                border-color: #d9d9d9;
+                text-shadow: none;
+                -webkit-box-shadow: none;
+                box-shadow: none;
+                cursor: auto;
+            }
+
+            .close#close {
+                all: unset;
+                position: absolute;
+                right: 5px !important;
+                top: 5px !important;
+                cursor: pointer;
+            }
+
+            #popUpParent .close img {
+                width: 28px !important;
+                height: 28px !important;
+            }
+
+
+
+
+            /* RWD */
+            @media all and (max-width: 300px) {
+                #rbuPopUp.rbu-popUp {
+                    width: 280px !important;
+                    direction: ltr !important;
+                }
+
+                .popup-heading#popup-heading {
+                    margin-bottom: 16px !important;
+                }
+
+                .popup-title#headingTitle,
+                .popup-title-secondary#popup-title-secondary {
+                    font-size: 13px !important;
+                    line-height: 16px !important;
+                }
+
+                .reasons-item#reasons-item {
+                    height: unset;
+                }
+
+                .reasons-list#reasonsList {
+                    margin-bottom: 16px !important;
+                }
+
+                .submit#reportButton {
+                    width: 60px !important;
+                }
+            }
+
+            @media all and (max-width: 160px) {
+                #rbuPopUp.rbu-popUp {
+                    width: 95% !important;
+                    padding: 30px 7px 5px 7px !important;
+                    direction: ltr !important;
+                }
+
+                #popUpParent .close img {
+                    width: 20px !important;
+                    height: 20px !important;
+                }
+
+                .popup-heading#popup-heading {
+                    margin-bottom: 20px !important;
+                }
+
+                .popup-title#headingTitle,
+                .popup-title-secondary#popup-title-secondary {
+                    font-size: 13px !important;
+                    line-height: 16px !important;
+                }
+
+                .reasons-item#reasons-item {
+                    height: unset;
+                }
+
+                .reasons-list#reasonsList {
+                    margin-bottom: 20px !important;
+                }
+
+                .submit#reportButton {
+                    width: 60px !important;
+                }
+            }
+
+            @media all and (max-height: 300px) {
+                #rbuPopUp.rbu-popUp {
+                    height: 290px !important;
+                    padding: 26px 14px 4px 14px !important;
+                    direction: ltr !important;
+                }
+
+                .popup-heading#popup-heading {
+                    margin-bottom: 20px !important;
+                }
+            }
+
+            @media all and (max-height: 250px) {
+
+                #rbuPopUp.rbu-popUp {
+                    height: 220px !important;
+                    padding: 20px 14px 4px 14px !important;
+                    direction: ltr !important;
+                }
+
+                .popup-heading#popup-heading {
+                    margin-bottom: 8px !important;
+                }
+
+                .reasons-list#reasonsList {
+                    margin-bottom: 8px !important;
+                }
+
+                #popUpParent .form-action {
+                    margin-bottom: 0px;
+                }
+
+                .rbu-footer#rbu-footer {
+                    margin-top: 0px;
+                }
+            }
+
+            @media all and (max-height: 90px) {
+                #rbuPopUp.rbu-popUp {
+                    height: 80px !important;
+                    padding: 10px !important;
+                    padding-bottom: 0px;
+                    width: 714px !important;
+                    direction: ltr !important;
+                }
+
+                .reasons-list#reasonsList {
+                    display: flex;
+                    width: 600px !important;
+                    justify-content: space-between;
+                    align-items: center;
+                    margin-bottom: 0;
+                }
+
+                .popup-heading#popup-heading {
+                    margin-bottom: 4px;
+                }
+
+                .reasons-item-name#reasons-item-name {
+                    margin-bottom: 0;
+                    margin-left: 4px !important;
+                    font-size: 11px !important;
+                }
+
+                .reasons-item#reasons-item {
+                    margin-bottom: 0;
+                    line-height: 10px !important;
+                }
+
+                #popUpParent .reasons-form {
+                    width: 100%;
+                    display: flex;
+                }
+
+                #popUpParent .form-action {
+                    width: 114px !important;
+                }
+
+                .submit#reportButton {
+                    padding: 5px 17px !important;
+                    font-size: 13px !important;
+                    list-style: 13px !important;
+                    width: 60px !important;
+                    height: 20px !important;
+                }
+
+                .rbu-footer#rbu-footer {
+                    display: none;
+                }
+            }
+    </style>
+    <div class="rbu-popUp" id="rbuPopUp">
+        <div class="close" id="close">
+            <img alt="Close Popup" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAIuSURBVHgBtZbBUfMwEIXfigH+f4ZDSjAV4AAFOBUQKiCUQAUoFQAVQAeECoA7A6ICXIIPzDAEsNi1nRCHSLGS8E62taPPK72VltBA+/ojyWEPLJAANuJPrWooA8gQYBTo5kGv382bi3yDu/qtZ6FO+TFCM6UE6j/qjSuEAGP9FhHWrjmbGIsptcg7Rv9PpwfU9Ie9/ucRQT0tARNFMkes37vTA7UM9zggB66xQvG+Hxq9OfgFLJdRMhsbYlXKeHnbo+VVP2R1+wcwUYv9cDl6KYDiRjR34gKyya4e9sbAyvousePsCYqacyqrYlInErZgKClqeLIj2Auj/51bfHQc0EzGJEZi4VbEPklUjq+uJ4j/jE5jPYyN3jIzoBVsy8T6NZZY31wKa13Fy7kDv3jT7e0MaA1GWJ9rOi6RHdWwwH9BQ2EVMqK2frdoLs6KGLRh5CUMVkohWEMsIwFmDWNre+YxkncOBlLaJHB6zxxGmiMyipDfh8JQ7lkrFMoH9zPXoR34g2zf48YaVGJ9c3HND4rbgp36Avdpk8oJUhW1y42ZwLimjzxllj7pze3qLM19fxYx7Ax+67fKGHdN83jBGN+HbT1c9pb3qchOHtTPH3wdorm9QyQXcGf0MgbKjcwDJ1ix+Bg7nmymaicND1xJD4LVZCqZHU/2MyJPm1i0HBEWEhnZolltorcRZnCPAhthcaMJbYRngBNu5bvl3Vk4ebLVT+W0kgOEM7qbN9c38co0nAqeAnwAAAAASUVORK5CYII=">
+        </div>
+        <div class="popup-heading" id="popup-heading">
+            <h2 class="popup-title nm" id="headingTitle">
+                Thanks for reporting this ad
+            </h2>
+        </div>
+
+        <div class="popup-reasons-selection" id="popup-reasons-selection">
+            <form class="reasons-form" name="rbuForm" id="rbuForm">
+                <div class="reasons-list" id="reasonsList"></div>
+                <div class="form-action">
+                    <input type="submit" value="Report" class="submit" id="reportButton" disabled="">
+                </div>
+            </form>
+        </div>
+
+        <div class="rbu-footer" id="rbu-footer">
+            <a href="https://www.geoedge.com/" rel="noopener" target="_blank" class="rbu-link" id="rbu-link">
+                <span class="rbu-description" id="rbu-description">Secured By</span>
+                <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTQiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCA1NCAyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CjxyZWN0IHdpZHRoPSI1NCIgaGVpZ2h0PSIyMCIgZmlsbD0idXJsKCNwYXR0ZXJuMCkiLz4KPGRlZnM+CjxwYXR0ZXJuIGlkPSJwYXR0ZXJuMCIgcGF0dGVybkNvbnRlbnRVbml0cz0ib2JqZWN0Qm91bmRpbmdCb3giIHdpZHRoPSIxIiBoZWlnaHQ9IjEiPgo8dXNlIHhsaW5rOmhyZWY9IiNpbWFnZTBfMTQ1N18xMDE2NiIgdHJhbnNmb3JtPSJtYXRyaXgoMC4wMDE4MjQ0OCAwIDAgMC4wMDQ5MjYxMSAtMC4wMDE3MzMyNiAwKSIvPgo8L3BhdHRlcm4+CjxpbWFnZSBpZD0iaW1hZ2UwXzE0NTdfMTAxNjYiIHdpZHRoPSI1NTAiIGhlaWdodD0iMjAzIiB4bGluazpocmVmPSJkYXRhOmltYWdlL3BuZztiYXNlNjQsaVZCT1J3MEtHZ29BQUFBTlNVaEVVZ0FBQWlZQUFBRExDQU1BQUFCdFZhZ0JBQUFBQ1hCSVdYTUFBQzRqQUFBdUl3RjRwVDkyQUFBQVNGQk1WRVZIY0V4eWNIQnljSEIvaW1SNmdHWnljSEI5aDJOeWNIQ0VqbWh5Y0hDWnhEaHljSEJ5Y0hCeWNIQ1p3emlVdUVHWndqbDRmMmQ2Z21keWNIQ1p4RGg1ZDNaMWMzT2h6am11NXZvSUFBQUFFM1JTVGxNQWk4UVJQTndsL0FWZmxhQ3g4ZFQ1WWZhb0hPZTNPZ0FBSUFCSlJFRlVlQUh0WFlsaTRqb001Q1lVYU9tajBQLy8wemNqWDVLUGtBQ2w3Ulp2RjBMaTJKWThsaVg1bWt6K2pkQk5Kb3Z0Zm4xY1RoZVRDWDQ4dzVNRE5RNHNadWZUK25nOG40NjcxUk1uTlE3OTAvZUNaQWpmRFdJM0FNa2FNRG11MTZmOTRrTGtSaHJQMjcrWkE5MXF0WnFEZ0hiZGQ5M21CSHdBSklLVDgzSFJFL2szcytKWjlpb0hnSXpOZHJrK3J2ZTdEWkhTQ292ejJZTkVnSEpldGlJKzcvK0xIT2hXczlQcGpKN2tmRG90TjIwS1oxUkxRbGdmOTZmTlU1eTB1ZldQUGVrbW0vVTVhQnhBeXJSRjN5SjBPQjRwNjlOVG5MUjQ5ZS9kN3haT0xZV2s0TjhlT0tucEo5MWtxb1VKb2JKZXIvNDlkandwcW5OZ3ZnYzhRbTlDb0p3YXF1a09jQXBkam55dno0dXVocWg2UHMrN3Y1Z0RYWmNKaWZXNnBack90QUlyMHVSOFVUbnBuamo2eGVCUVJaL3ZzOXFIUzZUdUVZRUdXMGdUbFZCNUdTUk4rQzVqUE8vOERnNUFmeTAxanRPMm9wMTBrMjBlODlpcm13QWMzV3F6MlJCelQ2RDhEamkwU2xsUlRLR252TS9MZWkwQjFleWRmR2J6NlJJVzltbS9uTTZmT0dsVndDKzUzNVV5QWtyc1M2MWVWM3Vyd0s1UC85V2lCY0kzZS9oaTFoZ25QSi8yUGM2WUVQMzUvWU01MEUwSyt3VzJ6dnRIeGRMdEp2L1pYbWY5L3RKRDJlWUVaNHlZMkZDS1Q1dW5LdHZEcXgvL3FLWnhISS92bnhWeDBrME9HVXcrRGkxcHdoNEttckhUZU9HNmF4clpQNTVCendJNkRrQ0Z0ZllMZXBiM3o0OVZxWjFNRmgvYUtGcS9mUjZhVEp3dmRWUU1BeXo3Qm91YXlUd2YvQXdPZEpPRlVUamNqN2ZQbWppWmRLOGY3ekgyK2UzanMrR0htM0FzV1dNUGN1VTUvdk16S3Z6cVVoVHVrT1B4N1lNUXlFTTNlZjM4ZUh2SEdDSGt6UnZpVkVXT2U4dU1FaUwrK2pUTGszdisva1VjZ0RneDNRTXhRQVI4dmhaNkI1U1RUeno1ZUJPSThLclprU3hPVEVlRjlYcmZqUHlMdVBWM2l5cWVFOTFESE5HZElOUjZsSVhBaEU4bHZEWnF2cHU4bUQ1SDROTHJpdnNtOXM4WEtqU0krYWFpL2NCc3A1aVVsbHIrMldFQTRxUUljNCtQZGd5K0FxbGpkRjJYOUw1aVl4Y1pQUFNHek1ZN0g4OXIrZjlVbmk0eHY1dlN4ZUhEZTRCQ1RaeEFPWW5oclFZa2w5WHJXeTVOTUlucHg3Vlc4U3M3MXc2VnA2ZHI1eEpPSnF0MzFDdVI4aTRkem9mWFRyTDMwSmw4dXVlQ2xhbzFKTUxrVTFsRURuM3I4ODlUWWNVZUE5SDhnMmZuNG1oM3hvMi85N09iekYvZjN2RlBnUURhU2U0OUN6cXNGeWdObUV4b0VEbDdLRWdvTnRiNlpLZnY1TFgzQVhvY1A2WEo1Ym9nVGo0L1ZJOUNKRlE2bGJuR1VRRWp5YWZyWUE5OWZpU0U4R3A5L25sOWp2SHVjRHloTU8wdTgrMnZ4ZWpnTzh0UVVoRW5JaWk4TElGM0xaYzJqbWtFSEt4bWpaT2ZLZEtmMG1ROHl1R2JMM0h5bW5uc3FaeUkzaUpRcVhqZ3FKa2dDa1B5MTZMemI4L0RIbC9TdTcyaGZjVlBhVEtRclVDRXIyQ3BaY2dEaWhNN3NKc3BKMVVUTnhyTlVaNnN6K2ZtYlAyQmhmdVNhRTlwY2cxYm9aOFlRd1pvK1N3Y2FDdVBJZm1xbUxoT21JZ0c4L1pHZ2NMaG5HWHArTCttZ1BkKzV5bE5ydVJvWitVSmNKSlBLTkFhVE1YL05wa1lIQUVwK0Flc1paM1hsY1c3ODJ0UGFYSTFRN1h1VVJFbkhZQVVqSjJLSVFUaklRTWFqQjRvT0Q4U0pVOUw1MnFVZVAwa0lLRVFKMGs1Z2FIelloVVh5VFFiOVdFQ1B4VWxBSy9NblhJbTJkTUxPdzQwYmhRNHFTQldBZWtTRHRBaDVVR21HcVJYS1k1cVdNcGYrNmJmVDkza2VzYUxkeXpVTkkyZFREdUpoa3p4eEx2cHc3dnluYjk5ZmJtKzRNMm5OTG1CcWNDSkdNT3g0N0ZtTDVVUDk2am1YWHVObWd0UjhsWVJPRGVVN042dlBxWEpMUnpsUEFBVnJFQ0kzalBJbVh5S28zbVJVQUtRZm5KNFNwTWJhOGZneEN6R3dHUzM0Tk92T0dFelAyN2RtWDlqMmU3MytsT2EzTVpMWU1HSUUyUFJlT1VFMGlKemgwUXJLSFJYUHh3bFQwdm5OcFJRRjExOUpDMGpFeHRSWkZnYkNHOEZmQUJqYjU4ZmVaOTBhNkh1L3Y1VG10ektVc0dKYUxKVU1mVHM2YWljNU42MStFQUUwZWZyejk4UDlNL29KcVkzRUdpVWQ5cUl3ZDRqVGZlb200RGl1eDZ0ckxKckVhbVJ3MlN5ZXZYUkJWbXJkdHJ0RWpXZUZFbjFGTHlSUk8zMlE2VkpoWVphbVNyM2JpTTI1TnZOc1ZQbllzSHRPbjJsTit0ZWwrRlNwSzV6ODBaWTlSWVJidFNHeHE1T0l3b1RZQWl6WkRPOVJlYzg3anJrTVE5a3prZVJHVEtyODNxRUY3YWVRRWkrLy90NkdzS2JTQjhWMGc0cW5pa0s3MlAza09sdXR0eGpvd0RPZU43dmw3UHRkQ051anRack9nM1plOFE2UmZSandZblhOcXlMeENrbkdVejBtTi9kaG5HRWpQbkNrY21wdXBITUJSV2pJVlNDdllvcVZMYml0VnFiMkRmZlJLVmdYbGNwdVV1VlVicThuZ1o1czF1Qi9PMXN0a1RZTi82VzYvb01VaVF3NTA2dTJEMkVHM1dHd04xRVR2dlp0TGIrTjVYYlhXMW00TXpwdE40MUIvblRoRFl6aHo2SURUc1hKZHdWNFFNdnZxNmJQR3ZVbGVKOC9qVDlaaHFyelc1NUpGbllBME5RZ28zUVdlN3pmc1lHMFpjTkUzTFBoZFhUN2M0eE8zSjd2OFFPbG9GM3JURWRsNExVRlpwa1gyWHRhNVBDQXcxU05WSlZrcVB3L294dGVOczA4TTBGcUhlVmZEb2pZT0pPOWUvYzJMZG9zcG91d1Nvc3BlTnEvOEJBWHN0Mkl1Y2Q5aE54OUpGWGxkRHRnQkJ1ODRrcXdKU2hlbHpjalY3VlE0cUR1YTRVTXBudkxMcFRMZ3oyMWJPcUZCRVpkb3ZkWHNna1pRNGxJQmFCWktOQmJOdE1sZ1NSVnpkZlRNRnE0VFdTVWdFTVR5RGhscmkxdWJBczdXcXpuZTJsbXQzNzFackNXcC9hOXFlUkJpbDJxS3BBQkJKdDBZQ001OU1aYWdmTkl3WjJHclUvekVldnNYVzFQUklqNUJ3aFlnTnZuODY3WG9uU2NkMHdBOHR3bXVXV2JhZzA1TzNuQlJqdFpQNEJENXRWUDlLWW56am9hNFVPaWFLSmJLZlNOL2JHd2tNZW84QUNna1pMWldEVzZianRHWDVHQ3ZQTmpoVk1Ya21Ed3JjRXgyemhYMkJlVFpvZ2hRNHBRSGl4R0NHNGw4dlBjbWZESGhva2I2UUlDdXQ3U2MyMzJFV0lXYktLNVNPVXRQeGVsOUlFZk1FMlJLN1k1UXZ1RGhJL1laUEZkdURXTjhKNWZ1eFA3NGVHUUpFSmJleEh1RWNGaUpZQTU5c3JVSkp1OE9Vb1RIcUhjWkRFQm5YUHNNWUpHajBCT1cvUjJsRktLV2VGVW1KRkpzYUZjaFdwZFJTNWlPUVRhU1VrYWRla0NWbU5GSmdQNnNxSFNrbmNyWEtMc1VDRHErZktpNUxzbVpQN0xBMWswMXBLM3FUZXBFYVkySUNpNzRneUV5Mzd3WWVRS1BtcklTRzZDN2dWYkF6ci9kdExzODdDUENNMWV4cmtIL0s5SHAxYUs3UHRRejdGTjZpZmIxMFRBYzlQeDQxbGpvNFB2ODB5UURtV3M3eEFhenpXK2dwSmlwdDZzVzQxcVdVUzRVNU5taXlXd3VwaEtXREJtcVVIYmVjNkdzRGZHY0E1ck53b1AzaVo3Nm5ZelprMVlkQWI4SGpmeE1uRTdpb0JSR0hibTBOZG9JQnkxKzhvY2FMcjAxMTMzb1BQWkN5dlVsemNuNzlnY2FFVVhxcXZ2Y0tyNnhaWTJ0dExvVHlrUkdub0ZHeE43R2d1SitKU3F1Z21VNHF6Z2UralJySk9CelNJOG5lNXFqSWFwSW5zbFdWeXNRamxXam1Qa290dklrTDVzcSt6VlVZN2NQTHhTYmRwbzRvRko5Yit6UzBWZ1VtZmd4NGdXV0YrcE1EREZ4N2N5V1dTTHlEYW9kUlFWczRxMFVneGw5bE1CZTF4UUd0U0taYlNwTElwbllwZlhHWXdnY3dXbEZ4QkF3VnBrWHpQallvMEdaUEMvbHhqSVB1Y29wSEFkR2tLbEFuOHJnaE53eG1WNHN6aDlqQ09nQVNqUktaMW84ZlkxMFZQdHhva1M4ZzV5SlBhZmwyaW8vZHd0bmhVNmlaQVNSR3I3NFk5NkFFaWdjUU9Ta0pvVUp4d0NPL0xLM3RXNkNaYnExVXdPaHVvQzluTGhSaDBiVlZna2tWZG85ZWg4UUlvcU9LNitMeDFlSVhHMmh1Nmw0OVhLRGlWdCtVZUpBa21UNy9iamlRVHRpbjlib21JR1ljRGtkbHRNcURvbVNlMTdTa3prdk9mVnBwdzB4ZWp2K1hSeTkrWmJsS2hJWkxRUjBOdHo4VDBvcjZLUmNpa1NhV0NBVmhuT01CMm9MNFdYNVdMNm1FV3RRMkRaWDhrNE9TVytjMGRUUEFLU25Dclc3MENKRWhlTFFSaytVRGVMbUVqWHJsZDlEVXBKQ3lRU1QrQ3BSSlByYVNyOEVtM3BqcXJqVzVTUzBHL2xxNVRVVXluNHlwYkZ4U3ZES0dCL1MyanBxRGVReVdyb0tKWUxZOElOU25BL2JKZTd1Q0dvSXNSSGdMYldpbE95b29URnVoVW1KMUlFeEVvaDZwQWFkeU1WZXVlMXpLRCs4T0JCS2tud3R3VmU1M3lIVERLaWhMNmdmWXpUK1lTYmd6N1dNU0pLZ25LUW1ta2c2NGp4V2p0d2M2a1NaWkNLd0cxZDVpQnlRUm5ENWtpREtIQnNTS3pMOUFicmtsOEVYYVJRQ3ROWkVCVDV3MmJFdDdlNlBpR3Y1RU9sZmkyTk5lYXVaZ2ZuNFEzL05nTmdmTFNjcmFabWhqMGczUWZJa2pzNm5OWHpPb1dTbFlyQUlQMzAwMFk3eE9YR1h3S2lrcVNyTzE1UGZBcjBlakVPdS9SblBJd1RXZDZHTjJrRUxoU3laVUV0dHUwOGJiVlRUSWFjSURtZGpHQUJnZ1R2OUdNSXhBWjR5emZTbE9DUlpDYWd0Vk5yREJCQ3Q3VlNxQzRWam1mcWxFS1pBUVBheTJMcktsZ21BVDRDSUdPczFydk1RZ1lPbElHRXFTdjY5YXpRZGV2ZjNsaDlCSjRSdUNtUk9CQWtKYzlxMTNXSEhLaGEyRGtXSTAwU2xhd1Rud3cwb1NuZ3NRbjdCeFp5WnEyZUoxWWFYUVR1KzJobzBGcTZSSU5zT05UeHVnTzF0NUw2cXBZZlhZcEN5Tk5zdjRTUFIxVE1LVGp4eUk3OWlUcnRrbGUwZHEwTUVGbFFrT3BzeVR5WnNnRnl0SkJrb1NwVFFMQ1REY0IvOHRkVCt6NVByU0dxRmRyTXZrRHU4V3BZT1c5WWlEalFQUkFGckU0L0dmLzB1NjFXcHFVbk41aVhnUlRzRy9qcDlvbFdSWENxcUZOR3JSckJKSGtSRHllQ3hCeEFnRUZxMERUcmppLzBQSDBDREdBRmxPQUJFQi9VcVJBbjQ2T1ZQZWRkTTVGbHhpZCtoeXBUdGpHNU9rTkFTL1BWWGNqcVpxOUxDVHY2bWF4Y3pqRllzbkF2THI1bENxWVNNQXhZYkd3V1krQlBPcTZOWEdqWEFOR21taVRGTEtOQTZsMWRuU3BzQW9tazZ0b2tCYXRTdVJNL1hxK29MWWhUVXpla0RNYVFKRkhqdlRJWmVSVXRTVldWdVprS0tGRWFUdmJVbDdOSzVEV3ZTU2R4SU1FZ2lVVlRLNHFsaGh3YmhwRDQ2emp6aDdjWVJOS0hZSHZkaHVzQmt4aS82NmxDVndlcWFXaVBkYThUNDcyVGluTFNUZkpwTkZ4T0ExaXlTc205ZVNNM2NGamExSzZpWUUrcXI4MnVZRmxseU10WWs3MURSU2hLTzFSR1VIdUpKU2txOCtQQzVOR21oaWhHSnJuSVBFSjIxNm41bDZ6c3FEVkdKQ0hPVlRNV05iNlBCZGtJUjFPdGJTR3BVbWEyRnB1RmtHU05KMU8wQU9GQmxXSDlRYU45NjNRb1hkQXdRNjlaZk5GNWwyWEpqbi9Xa0FUd3p2Q0JIaEs0bGdJOHg5enpFWEE5QWtnRW5zM0puVEVoaytCVW45VHAxSy9ocXVOYmhLRVBHRWpUaUFSSzNaWWw2eVBxdTdpczh6WWNZeVdQOFJSRkJFVUpwVXNVcW1yMHNSb0Zyb3JTZS9GS3dPVGROeXVrbWRJb0tYcFpUVFFlN0ZLTllmQzEvdGJ5UnpWbkVTZUFaVHFNSTFXSGNzY0xyVGxuUnBKZU9wendjeW03V3lKdlJ2RjgxVlVLT3FZeHh0Y0U5SWNXb0dLK1ZBNGdRRlMyME5KU3dsRGZsNFVMVFRBM0RDL3hqVGwva3FHMk1Bc0xoODBveFFETCtCTXRYNlZsNXpGR3RQdGtRa3JwWWFSQmlwTDRiMnE0cWFZa0ZxRHRYU1dNYzJtWnNKVU1veFdQTm1TRi92cnJsc2RYbDQ5VUNwSXVRWW5lcmFqUTRnUktUTDRKOTFkZlVhTWxRVVZPMDBLTHgrcU1pRTBnOVRRNVBmeWlaeFN0YUs4c0txVzY1MTJLb09XSm1IMm1wVm54NkUwaUhCTkJhSWdiT2pOTHZ1NmJtTDBxdjV6b3JYN3JBZVRRYkVqVkNBNjJFOUlqYXBxN1owOWtKaGxyK0p5THlWSGtHYm8yOTdFRFhyRzdMNEtGM1ROb2U2VEdMZFo0SmVSR29hbnlpRHM1NU5rRmx0dnFoV0k4eERJdnNDbm9nZ3NoYlowdkc1eUF3MzYxRTJxQysyc3RXNmhwSW0rVGY2MStqdlNvaURPcU8yOEdOazluUzlFcWlnM2g0REZ6aDVnOUFFaHpKOTFjSE9mR1BkaitIaDdmWDE1T2ZBNFVlZUp5SlBUc2dCMW44KzJNZEdUMUtVT0VxTXE1WVlLckhuRi9rQjlSalVtV1RwYUdGd1FSeERIU1F1Sm9CNU9nNmxVb1VFcFp2M0hza0tGcmVrbW1pUWtXRE56RXcrVU9LNTVzRkpFZCtWYjlmendBdDB6U1JVSWdDdGc0anNkaHc0cU9KTGlxOERqc09MUUFoWXh5R2RlRFBjYkoxU0d4a3pWcENlc2ttS2hPVUtuVU9qZm0vYWdUN2F1bTFqSjMxTUMweUlWVE5RcG14ZTZqcHdHaGJxSzY5RVVKYlVTTFUzVW1oTGRkc3liN29mUjFHRXRWUHpoNVZzT0t0amJCSE1HSEZUWVpWelY2V0E2dmc4Zkh3NGRpNVZxMUlCSWtHR1ZZbkFLUUpUNHZXSTNNeDZqZzBEcHdCZTZETjA3YUdtU1lJSUs2SlA4RmlaQk56SE9qNlEwbGNUaWpwSkdFUHl6U2FUOVVvK1JXVHBoUWlzbFdSeG02b2VvN2JYN1ZTaFQ5aUJWRnBBcUVBUDR3NzVwVndTNDF0QzF2QndPcXptN0ZxWkJaT0JpUUhLUWhJbFgvU2E1RnBxcGIxWE9pQXRTVnlSMHlDenkxUFlaNS9xNFcrQ0txbVpsZmFxQ0hjLzlyVlQxTWhSSG9ZV2dHMDBVaGN6c2QxV2FjQmdqVWdTU2VqaHV4Mno2TlNHYk0zNTVxSFFMU0pYWHc0QnFMVkp3SmZQcFNJcUQ0QkhTVVh3N1ZzZVBRMFRPSFE4Y0FWT2pGcUlNWmNLa2g0U0dORkdjUnJyOVNGVnFZT3gwSmtvN3VpVE1MUTNqWUtLOXNNSG9OaUpDWUNMOWUrVURqRWxTMHptWUltZUhYY1FxamhmRDNvdXhLRHU4R0luM2hsNmtsaWpHYUlYQWNFdjNUemdXTy9ScjhMU0hjQmttU2IxcFM1TWVvRmxMSjlwbGlnYkNOeFM0OG0xb09PNkhTeE90L1NyZHhFcVRDeGpQWWRKSGFLdjYrTTQxNzdYU0czcGZLNkQ3L3BlU2ZFVnJpQ3JZY0poZ05VeVVSMG8zTWRJRXVrbFBNSlpPMUUyVU5MbllkU2h0RjRzaGhzTWtzM1MwYmhJNzdmVzZuR0tqcDl6c29wM25wTWwzVkhjUGMzc2Y2VTVucllrcXI1TlpBUEZ4QlV3RzZpWjkzS3Y1VFNabWdjc1lHc2JCSkZaeVE1cUFLWHFtWG5tdEpqSWdpYjdsZjcwMTloMFBPU1UrOWhsKzVXOUpvTHNUbXcxQWNpVk1ZbVl0YWRJdnQ0MDBpYzVBSlUxUXNGYnBDeHBBeFhCcGtsazZWZDBFQ2ZhSHdHaTJzdjV4eHUrQVFtK2VDaWFqeUl5ajllaDBBdEMrWGplcHFyQkdtdlJYVlRSZVhZME5oMGxyaEZqM21KSW11Tkg2VXlnQlRQcXNvdDRhKzVhSFNUZUpWRGFhaEtZU2lBcEt4SERkUk92NkxXblNyNXRvaDdlYWI2STdUcGF5VlU4QnpwR1NVVENKclVIOGFLNnlqS1VUa3gxd2NjR1YrUzFRNk1zMFovRUFFaGxsRFduaXduQnBBaFUyVFhtOTB0SkorbEhEYnpLdy9DN2FjSmdNc0hSRzVmekxwSW5XVGNiUW1aYUkzbGVhOU9zbVJwcFVkWk14TkJ5UHcyR1NXVG9OM1dSNDd1T2tDVDFoOEpidzczdnNZZHV2RHlmVGREcEJtSCs5Ym1Jc25lZzNTU0ptQkFHTU9nb201MGltR3Znc2RKT0JKYmdnVFlMTHA2OGZlT2l6VERjWlNDWDBOTlhwaEpjdXcrU2lwZE92bXhoTEovcE5KbGQybkdOZ2tsazZWYjlKWU1PUTc5TFNhZmtCTUhLTExTRVBpd05HaWw4d0xIT2xyLzVHVUYzTjRqQkdOMXczZVlqZlpFZ2R4VGozbGlZTjViOTJ1K0kzRVNjOHRqVGtScUVIQkE4TDdPc2F4bmJkOStGcVAyd0xpaGN4WkhXVEdqMnRlK09seVJBdmJMOXVZcVJKUXpkcGxiZDJmeFJNdEtYVDBFM0N3dXQrM3cyZm5vM2ZCTlczbUhKRHdobWtSWTRLTmR0TUpyS1ZCMEplckdVZDRib1JJZU0zdVV4ZWlxRmdFanZ0aTBOL3Q0N3BEUENicEJKZXZob09rMkdXem13M09Nd0MvMUNGbUxxOUE4S3daZVo1ZmNLdU5TN2dPMXdhcFBEd2d1dkM0dUJuTUkrSGl0Wk45b09KUk1Rd1lQOXRsazdVVGJRWDlyZ2VROE53bUdTV1RsVTN1VFM4YmVzMlZSWDFIcmMraHhJdmJrT1FZU1ArdlBZQU50bW5BcXJOd2ErdFRnV3dCYXYrU3JwSmJSbFA5UlY3Y3hSTXZ0cHZncUcvVVUwdGFpbDNtRzhDcjF2UTF5eUhLcitza29EWjJFRWdzMER2RVJHVkMyNnpaZCt1SkYrOUpYT21xZDFnWjV4RFdLSTlFQ3RLTjVINW1ZTktnRWdwM2lnVjlrWkw1N0xmaEJNY1V0bXE3TkkzQjhNa3MzUzBiaElIQUM0WXVUcGZldzJEM3VBa3pGak5VSUxiV1BWM3NPOE8vcVZPSW81WThad2FnQld0bTJERjN1QmNZMFM5ZktKZk40RUtlNnR1Y3Nsdndqa3pZMmlJVll6MkhHZlFSTkxNUlhYMm1wbVNkaDFNWkFoREN4TkFGL2lvUUFXQzVLVi9jcDhwY1BhalV5ZGhVT2toVmpEcmNhQzZvbUZpdGkzSmNtbit6T2JDTnVOUkFsWG5tNWhaeHlNc25haWIyTGxHUVdmcUtVaDZwTHBjQUN6ZHIxeFYxK21ZT2g3bldVMVpvQW95bUJpTThJY0lrdGNEU3ppbUZhUTg4SnJmbWRxSUtPbUNxSzY0bUcyeG9sZlpvSTdHRjZKYlJpSTVDYmtudFB3bTlseU0zaUlZYVJMWDZaalpsNk5vVUcvYXZYMXlNaHFXamthK2pBaU81OThFczBRemxKVGFDUlNLRjVwR1Z5U2ZLRGxRaUJnRUNtUmlGeFNhU1ptSm5hOTgxZUMyc2pNdUNHN05VejFDckdRTTVYWlBxUHROektLc2NUU29DWG1YdW96cU9oMXVvaFQxbXpRN3Q0ZUU4cEZhelJhU0NrcXNyMVAwRHJjSWtwQWw5K1F6c2tUOUNGaHhwLy9rUUNGTVl2OE1vWmsvRHpuMGZlc1cyYmRhRzAyaHBwdm9tUnhza0czQmgwTFUvQ1k1RFdPYVhFSW9zZzU2YVozWXFtNENtRVQyb1k3NzU1eFgwOVdyMlFKS2xEU1IzZ2FDUkFiOXFna012NG5LNVVaSnVUeUp2ei9mM3Q3ZjMyZTdjamR5eU5Kb2ZJQlJ2WDFHdlR4bXQ2VkxMVExWU3BJbTJIZ3l5dHl3aDFFOUs5elZNQW02aVJaU3NHdEgwYUJuTnZUYTBwbWxFL3dtS0JMTkZGKy9JTDhYNUhXeUZweVdZVU9RSmxRMFgxOTQ4TlUxN2JlVzNkenRYaEdob1FUS0I3WWs1NGtscDlPeUZPbG02NGFyZE5oVTl4ZUFodnFzc2xRcHdiSUNvNGNsOVhVNnlpWUh5OGZvc0t0WXhYaXh2NytxU3hPemx1K3Fkb1pkVitvd2NZTGtRRzcwY0tTR2hmWTlKTlRxZWQ3ZXdRdE82TUk4M1hMNXAycWZGK1Z1TFh2cWRxa3BwR2tvbGJpNjJTdHBnaW5QNTlpY0xnd3lxOUlxVFVEZEhVbURnaDBkYkgwK0YyUHBxUDVKdFpKTFNLdndoTGQwcisxWUNZVGcxQW9JRW00UDBNYklFTkdGS1FrbVcveVNMZm9LWlZadG1RU2dGT3FIS3VSWXI0UEwzMVpTajh4djZDYTJRZll2aHpPV1RweHZvaGw5YWVzTHd6TmJSWVJvcTFJYWxnNW1DbWx4ZkFGcFdkN3VwMjQ4b2IySklCRzFOYXZrSWdXTGdjYmpQRkxhTjhuMU9jeE9vUVNDTlplc3hqK0UxdEMvcHI0b2h0eFFRTU15TDlYUXN1aWFJVnFhYU1jSnhGNlBIOVZZT2tFM1FWWFpGajJHQnYwbXlJZk8wYW9ZWStrbzNVVExRcVFBS3oydmxZd041VS9qdTBJZHZYOSt2am43dHplcEJYeGpaV0wyemh3VEVvS2hHNTRnVWQvekFCOCtxUDJTaUZVMWc5Uy9wYnRua05rOFlpNWtrbjlMNWFkT0E5dmJ0QmxWMTAyeXJhMjRtV1NMMVVhYWhMM1hRSFZvaGtMaUNCcVUrdXhlWGNyQWJaZzhGcjZKbmJwdWttR1VPQkgvUmd0c09mZmt0OTdCRVFyQ2FZajkyODF4TElFY2oxRk5VbTdpOEFNNlc4dlRkQUFVMy9ONGxGaGhRcHdVaXBvV0JuaU1QVm5acEhweGJFcldHUjBNKytlR0ZBS1Q1VnVTVEcxWFN4TzdDQmhJM291bWJWNTNQNHlsRStlYklHbE5BeVJtS0lFcFovMkhkWUZpLytEZEptOTk3a1d6eTdRU21aMTFqeUdGclpvalVNL1UzZ1VFWlFkSDFnNEt2OGF3RGNpMWNiSmYyRExSN2R6NTJldE5YRGcvU1hXakM5L3plSUZpK2h5QmlTSVJtZXVld0RXby9mU2lLRE9GTnJxRjVJQVU2bFNpUlFhNW80eEh1NG9CeXZiNUpNZVVtbHo4anpUdFZhbXdlcjVUb0dIWTBFNUJQYXFKWjhGT3NYTlFGcVpNV1FKeHFNV2Q4dEhoT1N0NnVkM0lTZFU0ckxvWkRCaFhPR3FQbGdDc1VabWhVV2RmWklpZ1JBUkIvejVzd1oxV0FSTnlXQ2ozdlRKREhJMmxjMFFaR3FUeVRENWRKbE5SWW1SK1lGU0YwNXR0TkdtTU5PRk9uRks0OElHNld2T001eklrNHpHdDB5SDNEQTNRa1BEK0FCcjRaZ0tlNDQ4WWhPV01KcHg0RUVwSGtjczNROUFHUGVPUWhlNkFGRnFYOWJBM0xoYldHYzliQmI0V2xKc2g1Y1ozUWdtUGpXM0g5bWU0RVUrVlRTcWhHOFNlSjFOTlFFT1MxYTRRVnJjZ2tYTENpRDVvdFVwcGtxd2lUaElUbVVROG8wVHpHL2hMc1pRMFFjczBEUktSMkVOWFE2d3FvMlhsTkRBQjFoU0o2UXNVcHNxL0tJbnIrRHlWenY5SDBVUGhNMmxTU0NTZnEwdU5zS245dHo1ZnFuTWRCQS8zdFdwZ0k5MVdLQUZNdEZ4RFo1V2l3Um5wTlE5T1FLalkrb2dyUFEvN0hTbXMrcWk1Z013eWZlOWlRVVU1eGxTSkJPMEpKaWlQM1VXYmJQRkJNWm9NandXeDBxU1NRRXdoMUpNN3NqWW1rT05kYXlkU00xSUFSME9MaENONFdtQ2NMNGZTODhML1o4YWgrSVZmSDVtSFo2NkFMa2RoSUM3TGI2cUlwa1pqWmR1N3V0TEROYVpFaHM1RXhFUzRYL2xPcm5rZWZGOEczUE5wbGJySnJuaUJ0WnlUNlg2WEJBclZZRjFjUTR6TWFRWkVIc2FLOVBVVUdlM2VESSsxTkVFQ1VHNXRDUmpQMVphcUt4MG5FNHQ5TkZUcXlSVkdHS2RtWm9YQzlYOW4wb1FNMEZORisxOTJUNUdFVlJITEttemRnU3poU0s4TFZwaDAyTTVQNlpVd2RHSkU3RTVkVFJCWWtKNG5nMG10ZkhBUnNkV01DbW1kRG5QdjV0VnE3a2t4a3laNk81bWV0L1FqcTVzQXFhTnB3RG9kbGgzbVV3MmpPcS9zT3ROTnJrdml5cVhtV3BhZ3QxQ29nSDVEOC9kQW9uelFVNUhhTzdheDU2RnlvaUdROXE4SmFaRlRQSFV6NDhXbG43clRRUkxRTGthbFlLUUppNksybEx5VXRUelBQRUJYMFNBc0FFN2tHT0pCdVRKU1JacDAvdVRVd1duWXd5RlNWVnk2TXJJazEweGNYNVJNcURnVlNhemVsbEVFZ1FMcitsM1hIaWlzK3lqRmNoOU1KUHVCM0dEZkhNY0FwWkFtbENkNTE5ZGJucXpUQVg5SDBvRFVZNlhJT1d1YVVmMVpGejBHRk5CeHhVY3JRZXNjSGJRc1liZGpIQTl1VjNyakpGRVRZS0hISHF5R0czT1hua2VmcktXMjFvdVJlSUhzWnlOcnlVb1RwTEVZbFVJaFRlRDhXSTRwUWdHVDhUUWttRXhXMnpVekh5UVJTMmxDRG5hZ0h3MWxHTlpxZlQvcjRVS3dzc1JhdzNTNU1taVlkSjF5amRoSEppZmdwSXVIaFlPR0U4N2Vxb0lZTi8zaDliM3RLRDYwdWduelJJTmlQWXZDR2FNMUx5clNCR21nVVFQVXcxaHRkUk5YZ25FMEtHa0M4bGZUSll6b1pFTTNpNDVleC9wTm1EZHgwbTNFU1lieWV4SUltY3AvdVhXTk5ER3loQjJKRmlaQllkVmFyZHlUSGtjUTlGRzY3VjNaV1h1VHhkSXovOHhEeXBxaG0wOFIwZk9KVEFJNThjOWZxUnNGM29DVE9Sa2xGUjA0MVdSMlJacWdxT0QwNExvNnB6R2RTRk5CZ3kwM2Y4WC91SXp2Q1orNkZSWm9pcjhHazNPazRGTGg0U09TVXBVbWtnS1dlQkpyUEJFSCtmU0ZhM1NUVEpaWVlRS1lPc21oWVFMNmxPMU1xRlRjYko0SjBzd2hVdUZEeGxnSjZxSVIrR1N6WFlvSDhTS1pwVFRCMjhpSnJNYkp1NTVUUGF5Q0c3SXNDNTFMSzVTQnJBNUoyRFJpWGVWK0UwZlVTQm9NSjRRejg5Vm1nOE9EbDhzOUp5OXlNbGNNS3V0Q04wbTVvL3pUSFY2SGg3RTM1SDRUVTVUcUR5TkxSRHBraDFVSUl0Nk01UnRFVEpoZFVuV3orZHhRZTVQVllyTWdrdG9vUVdRK25DODJPUGRuZjVITStrb0p4Mm9rQVU2VDBVMU9BYld0Q1lFb0pFbzdkWFVGeDQxSlE5VlY3azUyMUk2aXdUTW9ma254K1NIN0FuQm5nQlJjY1RKV0FBQVZUVWxFUVZRMlRzQ2dBQTFwSXFsSUN1QWlQS3JwMWVwVmoxeVA1ZEVYcU1Qb0wvR1dpOUZJTys5enRZNjBicTc3SEtnbnJ4VjNiTWdHaFJlRWVDTEM3Zkk3UkJoQVpvaWFKeEx1Y3dPR1hsWWx3ODBrNFFvcUhPRE9IbGtheWQxYjZpWSttVmlBL04yeXRrekc0WFgzUG9waGFvRittWURScW00UzAvS3ZoV0xFKzdkZEFDV1lFbUNDV2RwRnVlRVJvVWM5bzAwYzNqVENwaXlTY0wrOFhibmp5TFE4cWtUcnVSVVkzSnRHLzhNbzlqSnVMNk4vcDdCMGRJRnVwOEduaHV6bGo0NW1CWlBMTHRUUUxFTUNMaG56cVF0ODZacXl4SWFzdmxQM2d1RmdGVHErRnlRS3YxdnVFL1hPbU1zZSt0eWpJWW4xSnpJa0JUQldKZElwYVRKZ0RyMTZVNmVTcmdlVmdKSGd2UnNIazhFcEQ0cFlrU1dGTmhwdDN3UHBpNkhMbE5qY0p4Y2ova01YbUFFVmdzd25mQmhwTXVxVXNpNVhLSHhwU2FJc2dUandrcUVRQ3ZISVIrMDRJYjdWd003SEcwTm1DMzFweWI4bjhWVVUvSnhJOE5BeXFOR0lpakgvcFVVcFpBbWhZalFUWkI4N3BRSUZibzA1RWZidUxOajN3NWNXOTdzVHp4UUVNemZvaTh0bWpwc2VzWkhKUFlvRmxIQTVIb0tYSk5Rd3NnRmZKVFF5bUNRbDFvOEN3M1NFUWY4dkJ6MkYvdnFoK0tzNHhCVTlVWlN0dGZ2enF1Ukd2YlI1RDNsSG9IeG1mcklBQmdBcFIxQ1FNMm11Z0F3VmpDckJyNHBzWnQwK1dQSnJlemlkT2ZVUTlyRzdpd2hsMzBFb2FDMlZwWUFQTnNpYTRwa290eEVsY0VYVmgwb2VRc3hETWtuMk1BWldpdUdDcnl1Q21kWDlVSzFJRnRJREpCb242SFF5WVFLWUtJTkdPMDZveEhLQ3ZabnRDdFNOV2tQN2RZejlncFJGTlluc0FxRjVpL3FDUEVPUzZrUkRHZmw3Vk5hZ21mTXpFdFhISXc2WUx2b1ZPSzZCSFIrczQ0UVU0QXppWUtXNWI0aVR5NjZmUVB0dis5YkxjZUJkZTFSVnNVSHFTVlBvN2g3SU9hd1owQ0RCRG40NFBEUVhKa3FEUlk5ME1JNFRzWWx6bUR5VWZRL2tGdXVLSHE3QU1qck1INFFUT1BqVWNrVTB4eXUyTWJtYVU4cjVHd1FDaEVsT2VkQmdSWjdrTUFIcjdPUTBsOURZUWFXclNYam9peEMvYVpFTyt1b0hOV21wa0ttWjJsV3VkUG95UmhpZEtNTGtvNktWS2RVa3M0alp3RjdlUXZNS2lXQkpmNDYxTDZQaVVRbkxFTTBtT2VwSjZ4YzNhWXhMZVRiT01kdEtNNWtBZlJ5SDdlSVkwTDFldjJVK0U5YkNIRDYwWU9sVVlMTFNPQmVrMEFMNFowS3NyRzZ4STZXeHVscHpldTlNT2FaVjdQYWMvU2lzZGZ3ZHVhZm9qU1VxbGdBZDEzQ2lGakJkeGRGamJJeFN3S2liL0dlUVRrS3Uyby94Um1LKzlQV09NNVV3cTByVmxmUTVCYSt1S3NWMHRwdnhML3ZZVHFlWU5MUEhaRFk2TFZUV2NPc0ZPWE5WZnFOZU1wNGloOUwxNmI4aWlhN1RBemMxMWNVc3EwUkNGM1pUTEhMNEdUY1dVbEZGWmUxaVhaa0dUZjlRMmdQbkpncFlENWdubC85eC9oM3ZJMXNHcVNEM2NkMVdRZGVXc2FLYjFOMktjWGhZbE5oU084MVhNVDFJR2w5TGQvVTlEcjltVlNVVjV5dkxWNVdwckh2cEI4N1VkVG5VUHBWZnk4RUVzKzVLa1YrbDZqNDNNMHNIVEtncVpVcURoVVZjVVR2c1dud01uRmJVNFB1VStBdFQ0WTRXOWNCRnlGb3BrY3E2WjF2d0hoSHBXT0lIeTZKN21paE9rUFBqdWh4aHVCNUxRakhxcEtkRjVaUW1GWXVZczZwVU8yTXE5K216dnhBVWVkTE92UW9xWWpYSkZYNlJNa1dkcnkydU5yb1RrV1huSHhGUnVjQ1kyYmdUTm5KS1IvODI4MXlFR2ZDeTU3U0Rmd0JITUhScU1NRXJlaUxFdzhrWVRYZjlCVFUxckZJNzJTM2c1bTRTMDNVNldRYXRudzRsZVNYVkticmZYVlcvYURmMUdmbGFnNFdwWTNlejhFV1JaWWtpc284RSs2UEp1SjBoSWsxYWRWUGNYNStQMkN2bTlsd2xoVEhTQkhVMCt3NzJibW1SdTBETnFBeGhpUTQ3SElZNlRMaXFFa281Rkw0MXR2TzhGd1BMMG56WkhlZUdML0JRdXdGdVllWGkzVkFDa3ZSb1RTMUhmdy85SDloTGorYmpBOVpqc241Undjc0c2VWFEclRoT1hKazdPQmFXeTkwR2h0QjNrSEU3NHpKOXZsVmRCQWwzQUx3ZmtVT2tDUnN5dG45YWIwczc4M2JLQjZVdzMreVcreVYyZEd2VXI5VmdLN05SSkJmUE5iU3grL0Z2VVBIdkZHbUlOUEYxZFp4aEtPS09WQkltTktaNmdtd1FocTNjc0s3b2pobVBZWjFrTzVkMVRiVVN4T0hocE1RMkFPM2VycVV4cGpqZkZSZTZDWlN6M29EMWcxaWN2SnpDSTNCWEtnbVQzZ0FQMnhLNy9aSHZkODE0SEs5OTF2VVNSSmc0elFSZ3FUbE94bVg0TTJQRHZkWWJ6dXY5REp0b2trMTFWbDFQMWdadStXbnJQN2FTWFBtVnV2Zk85L29TNTIrR1dRUllXL0grSmhLbGRKems3L3pPM3l0VVZiV3VlQk4xdFZoQklVRkZmVTFkTWRYYS81amZQVlhtTDZnZ1RuQjg4eE9QenB4Vi9hL0N4Qy9ZTGVwS1lCRXFTWDdjbjh0VTZab0I4UG1pYk85SUNDWTQ2dGxwNy8vdWdxMW1WUW1BZm41TjNiSFN4eVpGMVVTamhBY1p2LzRDY0krbDh4bi9KZzV3YmxwYU0wdGZ3dnE5bUhGeVV3N1BsLzhKRHJ4a2M0NHdaUE9Vdi85RXpkNlRpUG03bmJJRmNWTGZwT2llbVQ3VCttMGNtUE9VUGhNZXZIRDJ0ekhzYjVaWHJWdjFZTG5iNUw2L3lkQi9rZXA4UmdwVldQaTBHMXVXRGVKQVhGUXdLUFl6MG0vZ2dNQWs2M1FBbGNvOHg0SFVPTzMzc2c0Y1Z6MVUwaFUvVkhHL2ZyZUk5cVUzK2tyOXBSbC9jK0l5TDgxb0p2S2pNZmczcExEelJYbU01SkQzbm5GK01BZnEwdVRxV2FCdzF1RVVRUnhLR1h6ZkxkSVBMNGNYbkVwWURUTDJraDBZeEgyOEVSb25LVmFUK1lLYkc1YmhrWHNVZkFFTlZ5YTV5ZzBkekt1K2RzTXhETmJMdnFJOGNLV3YzK0Z3STBKMU5pV0JpNUF0a2ZGM2NYendkNFlsUy9iWXRSSGZTYTdKTzV0OER4MzJobTBwNGtTNDN2cDBvOUp0bU96MytWN3hnQWsycGViSjhkOFpacWQ5ZFgvejd5elRZL0tXWHNjcUo3VkRrd1lWUmsxZHFVTWdwSElKSnBobW1FbVRTY2VkV2g2NTNVZ29xLzdtZWNKL1ZacndHRHB0Njl4Rm1KUkxURFc3KzJEQ3cxUUFpS3pmRXpRUGtpWmlFUFgxZUxvZ0k2OTV3SmFIeVZkbU03SlVqNG1PUS9qUzNzWllGbmkxWmhJMlhYckJQTGkzWHUyRU1HbXQ5QWlBeUlubkpqRkRPcDB0cHYzaXhQSXZBUXEyeDE4dFhMKzMrOEpzY3RKL3hHL29uZUZZZEs2QU8xVk9rQmxXVGljalBsNWxLK0xlWG9jeHNXdFRVNFdGYUMrbENYWWV1UXlUYnNManUyNVFyb2FSaXFPcm1jMFhvWEZvR1I0ZEQ0ZXJ5VkZJbU45OXZHWFRWeXF3MlBpQ0s5ZDdlNTBMMGtUa1JzWURyNXZrS214dWVITUgzbjJqL2lRdU9vc3M1VEUvazNzTnE2ci9tallMeG0yMnNDTXd2M3NLeDlyVmZKUnpFTkRiY08vSGNpTnJUQkZMTlNKSTB0SkVQV3ZvSmoyZFRrcFpObW9HVEhJNFdhSlVabEtrL0hjcXAzMVAzZmZhckxyek55N243SGpCN3g2VzlUTWliSk15bDgyWGlpNUYwdVhaNnhJc1ROd3pPZGdHVDNuY2NHN3BCSTFGcXI5YitGUndjcEpNZEZZRjQwYU02SFRtTG9wWEpFaFV0OWxNdHdodW5ZTjZReTVqd1Z6S21nbGtERm1EZUN1bTZoREl2UTkxTmk0QmkwNVh6anlyMy93NzhpVmVqS2RHTnBmRmdjVk9SeWwyWGNKcDJLK3ZQT3VZZ2VJbTZpYkljNEVUOE9TZ0xXZWJGNWFPMkQ5SDBVMEVNVGpvVHY2NHY5Rnl0bzNMcjV3ME9YSjNmY1E0eGsySFZ1N2dPTHJIVHJKYVM1TzN3b2xvZTUrZWZDa3Z0Qk96eUlzTHoyZEkxeXNrbENZSUtadmxDYy8wUHFnY0IwRnFlNTNUUDNGOUEwUkl2NndlbEhOb1plMjZYZTdUaVJkZjRFR0lNQ1NZTEhqSW94eWNnT29GNjh1TmlwUTBnY3JOK1hhMDRWMU44ZDJsM3o2Zzg5dTZ1dDBwZ2k3YmJlUmtWd2dBQnV4aGxSUXdISUdJWTE4bGM1Y2tVazM3Z0NNMXlRdHZPWmhBaERpOVZYWjhRVnBTV3FCUjltekkvRG9pY1I1NU5zSXZRR0h3cmJIanF0ZzZORzJ5NEdGQ0JNQWZvUUpoMG1mcHNGY0tML2hGbHllcFJ1cFZzdDJjVHd4SFp3cjAxWFlLZUlKWFZiTmZRUXlvdktYbW96UmhZajV3eHcvVys5a3QxNGMwOFRERkRtUE1SamJaTWZQK1Zqd2cxVWYvQlJYNG9DTE9uWUhEM0hCcDl2cnpwaklFU0FoSm1sQTRTRDFCS1BnQS92Zm9KazZhWUtmckVFUklCRnRacEVsNmlPMS9jY2F6d09vSUU5YnRoc2Zzd2xTSkRodHRJcVRVa2pUQm1iL3FtVWdUL0ZiU3hKMDl5bUl3R3c1NktQaDUrZkxObzFBUHF2c1IyYVErSndxVytIWTRqL0pWQm9ZeE5vd056bU9udzRhSm5tREp4Wk1NVy95c1NST3MyT2VZRHFRUEt1UzRoMHJLdnlrT05tYTl1eHB5MHVROGN5bE5wN0xVRXhYSW5tU0taWDJyelU0Nk43OTlOT3VTK3dXZmx1RUZaaDUzMnlTRWtDblUzZzBYZ2NOWklqQWhXYnc4WTNjL0Y3alZBM2VTTWNXVzJNOCtKNEtBRng0YW4yNEpyb2NNN29ablhFMzQ2cXh0M0pTOUkzMm5neFhnckptMDlRckZkN21KSWx1Mmg0a2YzdUhxTEVsL1F6WEYxWkRvSm16eFBpQUdoUWtleTZnaHN5Yklvdm9CR1lCbjZ4aC9NbmN3a1dMam1DNkJIMTZTakRwUk5xSnVrbWREOEtvSlhTdEtxVlNTVUtLLy9aMlpOOTdSRm5naUE4ZXZjL3EyM0Y4MGlFVTNSVTJob3NJemdVbEZOL0hTQkVZUFBHakFFWDFkQ0hoUHRvU1NVem04M3dRV0IrL2pBNSt5QncxM0UyTmQ0d1VvSEhGb2hudWV1TXg5L0FWL2kyN2l0V1lVaEFrSlRqSnB3djRuWklPZTF2UTY3dTMxczg4SkVQRGYzS2s2OUNORnJ5T29vYW5zZ25PeGVHbkNXb1J2UGp4RDYwZXp2S1NiV0hIVExTa2dwSmtUQkVGLzhMbUpESWliQ25wbFUvb29wMzBRY1Q0cVhDT0FDVG9kL0hibzA0Y2JXR21DMFM4bldNSzdKRVQxT29LcFhYajQvQ1lIWXAvak9TNG5yOFRoUDRHUU9zWEhpeDduaFpWNlRRNEhWNDJLM2NKZ05FNmVnWjUwRXpNaFJRYTVSYjRuYVJMcnBhTXhwR3VVeDlhNHN5MmNwQUVTUWtEbURpYkFqWWRKS2xtaG0raEVFWjE5SVNkaE9NeXQ4bXhESG4vNU8vUTUwUTNwNUlkbmlRT05tbUFMM1NTcXNHanNwbDJLTk1sMUU5OERPSmc0M1NTeFcyb2JWaWtxS09vbVVUNTBjNHdaMmhWcVhyd1FDWkFBN3NXUUdxVko4SnVJbkVzdWxvbVZKb0s5OEJxL0pTTnY2MGg1TWR3ZSthRWovdUZyMmY1Q1hMQmtRdWgxUEpjRUpoOXBtMVdDS280USt3NC8xcXQ0SUhKcFFpOXNIQ0YyMnF4bXRxOVFLZ3FaY0VJM1FsTkdGSmZ3QnFOSUJrVnNuSjhKYlppV0RwT0txWVlYSzdwSmVPUXhsemJlbFhJOGVodmdWSm9mZXJVUVQ4Z0J6R1dBQk5hL25lR1RwQWwxa3lCTlFoTU5kTUhOTVZZM2lSWEtuS1Y2dE5MZ1lMTGt1UUkraUhpUjZYRXV0dTVYRm5UemV5SGdSVTBvMlFWcEFnR0NnZ2RBdXA1Tmx5TW04M2N2WEovejhaRkVBbzUrdzl3a1B3YnNwRW1DeVdTME5NbDBFMWc2YWxwTWhFbFZtc3hwcDhKL3huL3VqL2F6bjlBaThpSEJCTkpFNlNianBBbDdIZEdDUkJJNVQ3RW0rZStpUTFFdXVzaHJHTG5GT0tyenlUcmNpRFNCQ2h1Q3RuU0NOSWtJdTBrM3FVc1R3S0lJM0haQk9oMmptM1MrMDVHU2VwaUVVanRwNGd3cThkdUwwaHlmK2w3SzkyYnk3dFBPU2R5Ukt5Y3Z2RE1lWCt4eUVMeXQ0ODdyU1Z1dEdrc24wMDB1V2pyMG0wQzNNSE9xWTdzdnRBMnZtMkRDbGNpUytPVXQ3a0tUMFpaT1REVVEyNnViSUpJVVRBNlA2SmIwekcyaUN5Q2s4S2UvdzFRVGh3MzE2WHVkWERlaEY3YWxtOVQ5SmdFYjBJbWQ1YWxoRWpzZFBDeDBFN0YwanV1Z2w4UnZad1ZYT3gydm0zU0FpUlUxQ2RFMHdXbWY2WUFoVDJqTFludUxSQXhxaW83enQ2LzFPY1lLSlIvWW40dmhka3NuMDAxb3FjUmV5a3Q3YjRvVzhxRzBkR0pkbFoxTzlKc3dkUzlOWXZRd3BzTm55bThmbjN0UlJrOGVYeTJ0dFJqemoxNkl1SGdMdzcvK20zakJwQlBvbGNHOUZyaWpMWjJjNGM3UzBjS0NiNGtmd2czTTlFZ1RaRlZJRStmT3FCOW5FY1ZRZ0Z4VVlTWEx2TlBSYXBUcWZ3SlZ2cEIwbHJqaDRxZWRFMW5EaStBbHdmQ3YvcGU4OTkwSGxKWG9rK1VyMFc4U2FrcjE0a1BIZEppT0Q3SGRoK1JRcGhCNnE0eWpRZG9mTDM0VE42WWowc1IwT2xxYUZIYTNaQWZKSmNORkhNNDhudi9tYXVQQTkvSmJ6QnJmd2NTblhacC9RdXM0alBmd3ViSjAvQUE4RkZKZnNkZjZUVUtGRmhYdktqZU82Y1R5U1RuRWJtWHpEN2ZoTi9Gak9oUHFKcHlmRUVPU0poVkh2b3NsNk5uSldPVDFLMWxpaHYvWWhWTlJNYlJuZ2p1bVIwWm1PVTNwNCtPUXlJNGp4SmdHQzZlVXFZMmFOS0VYdGptbW8wUUlPeWQ0TDlSUmRheFIrbUd0dWhsSzRqSlhodXN3djRudkErTXNONStjdTQzY3pXQnh5T3VQZjRkaHYwTnFrK1JJSjRxcjYycTh2Znl5NGx3Q0JrTEltMEhzRk9EKzJpM0NNNEdKc1hjcGFwd1ZmTW5TRWZzWDVzYmVuUk1nWFJscW5uZXFPMDc0ekdjYm56bk9QM0JqT2hRdmtDWkJSa2tWSjJrQzRwQWtkQ1U1TmtaMW1KSVhlNXpvanBVM254K3NRc29HclBiTG1lRmNibkpYWWtCRGVmVUJsOTVINndDQUhuMk41Wll1c0tiNjU1dFl2NG1TSnNnTWNwOW1LU2JjSXpWeHNMTHp3SjA5SFBiUlo3OFVnOWlKR3Zwb1krYWxGemFSbFF4aXVOcGtzaE1URGRsSVBONFdrR2hUTEtYd2w2L2NWSk44YitxZzJJcnpkVVhJSUFSalNDN0RjaTUyNkF3NEd3b3p5YkRZQWFDNVNwcEFCRGp2bkRSMUhEYmxqT1M1bSs4S3BQQWtGQjlDQnF6NmxMazQ5c1BBcnRkTm90NmlwWW1mWUl0Q3gyd0FBWm5BUW1FQ0N0SVF3Ri9HUnFUZHdhRzJ0bHhXLzBtdkEwTVR1eWdKVU1KSGNLOHhIUnczdzI1Qi9ybEtXOWVreWZvWTVwdEEvY2o4SmxnUjZwUk5TaWRmOCt3eUJEbVlQVThGaUZuNHo3U0J5aHdMWStVSlZSbytsVTVIWHR1ZUpkVUlFejJ6ZnRLRjZmb29Ockx4a2Vqc0YyRnk5ZTRma2EvLzJJWE1DZ0FHaWo1bkFnTUhRVHhzOEdnYy9GcXVLRkhDd0NENHNabkpMUFV3Tm9mdjBOZ2pzMUQ1NkJxWUNScXlqZERCSnNFZDMzeGhLaTJaa0p4Ymh5bnZsRENUS1c4eEJUNFJlWkl5OEptNyt4UmxUcHJRV1lhb3h0TGhqZWdOMlN5Wm1BZ295VWFLS3AwUjBzaVc3RVF5L3ZBRlZ2Tzl2cjRVREFCK2NQdjF4ZU1IM1FIMld4UGR4SDFpaDdiMHptb3psV1BwZ3pOOXE1NGhGbDdtazUxVStvSWFockpPZ0FMY1dBWmJCaTE3Z2NRWWFSbTNjSnN2cGx2Y1NFRm5nTXhEN2t1UkptNlUwcWVhU3NJVWNHQmlMRFd5V2Zwcy9FM0tNbWpreno0bjhpaGRKTDZsZStFS1ZvMi9sRy8zdzk4S1Q2Uzk2MWpvNDhQNzZadXpCSnFoOGtqU1NQZmx5ditrdDdiNmhOT1NnQk0vMzZUSXNKYWtsRFVsQmdOL0t4MWNXQWpVTFBMelFZc0RvVzQwVjBQY2lJTGF3eEFwZlYrSVZUNzJlY2RzVWxLNDRrUCtRUTVCVVJuY1lRUjZkRnJKWDZqdlBxLy9KUTZFcWZZbHlrWlErZlN0aldEV2I0d0s2UkNuVTE5WmZzZ2o5amxtTWZHVlNUMWYrN0Vjd0hSV3JMKzV5ZVZCb0EzdXRuNHNJNTRGYTNJQTFwQnpqYVhwbU0yNHJRZHpLTEMwYzI3cXRscUpQKzkvRHdkZ3YwYjNQVXpvTmJheWdhKzJPcHA4c1lBZGsxcGl0ME1rZ1Q3bmlaT0xIUHMxRWNSbFM1OFovdkJCWXhpTHVhNFNKaHhZZ3JPTlhsek9ZSG1HZjRnRHRHeWNBNTl1ZWdaNGVxK1RCREtLS083Kzh4TWwveEJFU0VxUUpuVGlPNEd5MzZvNVNtT29GV2tpTWltNWZzZTgvNHo3a3ptUWRKUFpib2Y5YmpDeWNLVlcwVzNneWtjU3lwbi9rd2wvbHUwbURsd0pFcnB3NFhhUnQ2OU80cWFDUDE5K0ZBZnFudnhSdWRmODk2TVNlRVorY3VESmdTY0huaHg0Y3VCNkR2d1BKbklUcTJLWHZZUUFBQUFBU1VWT1JLNUNZSUk9Ii8+CjwvZGVmcz4KPC9zdmc+Cg==" alt="Secured By GeoEdge.">
+            </a>
+        </div>
+    </div>
+</div>
+<iframe height="0" width="0" frameborder="0" src="https://feed.pghub.io/tag?gdpr=0&amp;us_privacy=1---&amp;referrer_url=&amp;page_url=https%3A%2F%2Fwww.instrupix.com%2Feasy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea%2F&amp;owner=P%26G&amp;bp_id=mediavine&amp;ch=%7B%22architecture%22%3A%22arm%22%2C%22bitness%22%3A%2264%22%2C%22brands%22%3A%5B%7B%22brand%22%3A%22Chromium%22%2C%22version%22%3A%22127%22%7D%2C%7B%22brand%22%3A%22Not)A%3BBrand%22%2C%22version%22%3A%2299%22%7D%5D%2C%22fullVersionList%22%3A%5B%7B%22brand%22%3A%22Chromium%22%2C%22version%22%3A%22127.0.6533.89%22%7D%2C%7B%22brand%22%3A%22Not)A%3BBrand%22%2C%22version%22%3A%2299.0.0.0%22%7D%5D%2C%22mobile%22%3Afalse%2C%22model%22%3A%22%22%2C%22platform%22%3A%22macOS%22%2C%22platformVersion%22%3A%2214.1.0%22%7D&amp;initiator=js&amp;data=%7B%22category%22%3A%22Food%20%26%20Drink%22%2C%22subcategory%22%3A%22Food%20%26%20Drink%22%2C%22liveramp_idl%22%3Anull%7D" style="display: none;"></iframe><script>
+window.rbuPopUp = (function () {
+function buildReasons(reasons) {
+var reasonsListParent = document.getElementById("reasonsList");
+var reportButton = document.getElementById("reportButton");
+
+reasonsListParent.innerHTML = "";
+
+if (reasonsListParent && reportButton) {
+reasons.forEach(function (reason) {
+var item = document.createElement("div");
+item.className = "reasons-item";
+item.setAttribute("id", "reasons-item");
+
+var radio = document.createElement("input");
+radio.type = "radio";
+radio.value = reason.value;
+radio.name = "rbuReason";
+radio.className = "radio float-l nm";
+
+var p = document.createElement("p");
+p.textContent = reason.label;
+p.className = "float-l nm reasons-item-name";
+p.setAttribute("id", "reasons-item-name");
+
+p.addEventListener("click", function (ev) {
+radio.checked = !radio.checked;
+if (radio.checked) {
+reportButton.removeAttribute("disabled");
+} else {
+reportButton.setAttribute("disabled", true);
+}
+});
+
+radio.onchange = function(ev){
+if(ev.target.checked) {
+reportButton.removeAttribute("disabled");
+}
+else {
+reportButton.setAttribute("disabled", true);
+}
+}
+
+item.appendChild(radio);
+item.appendChild(p);
+
+reasonsListParent.appendChild(item);
+});
+}
+}
+
+function appendStyling(styling) {
+var headingTitle = document.getElementById("headingTitle");
+var reportButton = document.getElementById("reportButton");
+
+if (headingTitle && reportButton) {
+headingTitle.textContent = styling.text;
+
+headingTitle.style.color = styling.fontColor;
+headingTitle.style.backgroundColor = styling.backgroundColor;
+
+// reportButton.style.color = styling.report.fontColor;
+// reportButton.style.backgroundColor = styling.report.backgroundColor;
+reportButton.setAttribute('disabled', true)
+}
+}
+
+function popUpBuilder(popupObject, callback, onCloseCallback) {
+var rbuPopUp = document.getElementById("rbuPopUp");
+var close = document.getElementById("close");
+rbuPopUp.style.display = "block";
+
+if (rbuPopUp !== null) {
+appendStyling(popupObject);
+buildReasons(popupObject.reasons);
+var rbuForm = document.getElementById("rbuForm");
+
+function submitHandler(ev) {
+ev.preventDefault();
+var fd = new FormData(ev.target);
+var collectedReason = fd.get("rbuReason");
+
+if (
+collectedReason &&
+callback &&
+typeof callback === "function"
+) {
+callback(collectedReason);
+rbuPopUp.style.display = "none";
+}
+
+rbuForm.removeEventListener("submit", submitHandler);
+close.removeEventListener('click', closeHandler)
+}
+
+function closeHandler() {
+rbuPopUp.style.display = "none";
+if (onCloseCallback && typeof onCloseCallback === "function") {
+onCloseCallback();
+}
+rbuForm.removeEventListener("submit", submitHandler);
+close.removeEventListener('click', closeHandler)
+}
+
+rbuForm.addEventListener("submit", submitHandler);
+close.addEventListener("click", closeHandler);
+}
+}
+
+function validation(params) {
+if (!params) return false;
+
+if (params.text && params.text.trim() === "") {
+return false;
+}
+if (params.backgroundColor && params.backgroundColor.trim() === "") {
+return false;
+}
+if (params.fontColor && params.fontColor.trim() === "") {
+return false;
+}
+
+var report = params.report;
+if (report.backgroundColor && report.backgroundColor.trim() === "") {
+return false;
+}
+if (report.fontColor && report.fontColor.trim() === "") {
+return false;
+}
+var reasons = params.reasons;
+if (reasons && typeof reasons !== "object" && !reasons.length > 0) {
+return false;
+}
+return true;
+}
+
+function init(params, callback, onCloseCallback) {
+var popup = params.popup;
+if (validation(popup)) {
+var popUpParent = document.getElementById('popUpParent')
+var newParent = popUpParent.cloneNode(true);
+// reseting all event listeners
+popUpParent.parentNode.replaceChild(newParent, popUpParent);
+popUpBuilder(popup, callback, onCloseCallback);
+}
+}
+
+return init;
+})();
+
+/**
+* [Function] window.rbuPopUp
+* @param {Object} params - The parameters used to initialize the function.
+* @param {Function} callback - The function to be executed upon completion.
+* @param {Function} onCloseCallback - The function to be executed when the function is closed.
+*/</script></body><iframe name="goog_topics_frame" src="https://securepubads.g.doubleclick.net/static/topics/topics_frame.html" style="display: none;"></iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="//exchange.mediavine.com/usersync/sync?origin=https://www.instrupix.com&amp;src=//exchange.mediavine.com&amp;s2sVersion=production&amp;mv_uuid=2dad46c0-6559-11ef-85c9-fbd3a38cbd43&amp;version=invalidate-verizon-pushes&amp;gdpr=0&amp;us_privacy=1---&amp;gppString=DBABzw~1---~BqgAAAAAAgA&amp;p=%7B%22appnexus%22%3Atrue%2C%22conversant%22%3Atrue%2C%22gumgum%22%3Atrue%2C%22huddled_masses%22%3Atrue%2C%22indexExchange%22%3Atrue%2C%22kargo%22%3Atrue%2C%22mediadotnet%22%3Atrue%2C%22mediagrid%22%3Atrue%2C%22openx%22%3Atrue%2C%22pubmatic%22%3Atrue%2C%22pulsepoint%22%3Atrue%2C%22rubicon%22%3Atrue%2C%22sharethrough%22%3Atrue%2C%22smartmedia%22%3Atrue%2C%22sovrn%22%3Atrue%2C%22triplelift%22%3Atrue%2C%22trustx%22%3Atrue%2C%22verizon%22%3Atrue%2C%22yieldmo%22%3Atrue%2C%22nativo%22%3Atrue%2C%22centro%22%3Atrue%7D">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://ads.pubmatic.com/AdServer/js/user_sync.html?p=157108&amp;userIdMacro=PID&amp;us_privacy=1---&amp;gdpr=0&amp;gdpr_consent=&amp;predirect=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dpubmatic%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3DPID">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://acdn.adnxs.com/dmp/async_usersync.html">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://u.openx.net/w/1.0/cm?id=7e872606-a65a-463e-adc2-6ddfd0bdaeea&amp;ph=0fd68730-06b2-46ad-be0b-befc4c4f19d2&amp;r=https://exchange.mediavine.com/usersync/redirect?partner=openx&amp;uuid=2dad46c0-6559-11ef-85c9-fbd3a38cbd43&amp;s2sVersion=production&amp;partnerId=">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://secure-assets.rubiconproject.com/utils/xapi/multi-sync.html?p=17404&amp;endpoint=us-west">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://ads.yieldmo.com/pbsync?gdpr=&amp;gdpr_consent=&amp;us_privacy=1---&amp;redirectUri=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dyieldmo%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24UID">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://eb2.3lift.com/getuid?gdpr=&amp;cmp_cs=&amp;us_privacy=1---&amp;redir=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dtriplelift%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24UID">
+    </iframe><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://x.bidswitch.net/check_uuid/https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dmediagrid%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24%7BBSW_UUID%7D?gdpr=0&amp;gdpr_consent=&amp;us_privacy=1---&amp;user_id=2dad46c0-6559-11ef-85c9-fbd3a38cbd43" alt="" width="1" height="1"></div><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://x.bidswitch.net/sync?ssp=themediagrid&amp;gdpr=0&amp;gdpr_consent=&amp;us_privacy=1---&amp;user_id=2dad46c0-6559-11ef-85c9-fbd3a38cbd43" alt="" width="1" height="1"></div><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://crb.kargo.com/api/v1/dsync/mediavine?exid=2dad46c0-6559-11ef-85c9-fbd3a38cbd43us_privacy=1---&amp;r=https%3A%2F%2Fexchange.mediavine.com%2Fusersync%2Fredirect%3Fpartner%3Dkargo%26uuid%3D2dad46c0-6559-11ef-85c9-fbd3a38cbd43%26s2sVersion%3Dproduction%26partnerId%3D%24UID" alt="" width="1" height="1"></div><iframe sandbox="allow-scripts allow-same-origin" id="6763481c1a2e3c1" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://eus.rubiconproject.com/usync.html?us_privacy=1---&amp;gpp=DBABzw~1---~BqgAAAAAAgA&amp;gpp_sid=">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="689ebd7d44cae0c" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://ads.pubmatic.com/AdServer/js/user_sync.html?kdntuid=1&amp;p=157108&amp;us_privacy=1---">
+    </iframe><iframe sandbox="allow-scripts allow-same-origin" id="69a7ecbeb433426" frameborder="0" allowtransparency="true" marginheight="0" marginwidth="0" width="0" hspace="0" vspace="0" height="0" style="height:0px;width:0px;display:none;" scrolling="no" src="https://eb2.3lift.com/sync?us_privacy=1---&amp;gpp=DBABzw~1---~BqgAAAAAAgA&amp;">
+    </iframe></html>


### PR DESCRIPTION
I've noticed that while most recent recipes from Instrupix include a structured recipe schema, older recipes do not follow consistent HTML tag conventions.As a result, scraping critical data like instructions and ingredients from these older recipes has proven challenging. This issue is demonstrated in the second test case: [Keto Cheez-It Crackers Recipe](https://www.instrupix.com/easy-diy-keto-cheez-it-crackers-recipe-low-carb-snack-idea/).

Currently, the scraper throws an exception when encountering older recipes without a recipe schema, which might be more appropriate than returning incomplete or blank recipe data. Would love to hear what others think!