### PR TITLE
ci: coverage: remove Python version pin

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "< 3.12"  # ref: https://github.com/hhursev/recipe-scrapers/issues/909
+          python-version: "3.x"
       - name: run unittests
         run: |
           pip install tox


### PR DESCRIPTION
This is a cleanup for a version pin, added to workaround #909, that should have been applied alongside #919.

Relates-to commit 65f462e6e9e4734cad94fced153579bb4c17044e.