### PR TITLE
Maintenance: add preliminary support for Python3.13

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
         include:
           # set toxenv to workaround-darwin on macos (check tox.ini)
           - toxenv: py


### PR DESCRIPTION
Initially, add Python 3.13.0-rc.3 to the `unittest` continuous integration matrix.