### PR TITLE
Type-hinting: modernize: remove some legacy `typing` imports

### DIFF
--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -1,6 +1,5 @@
 import inspect
 from collections import OrderedDict
-from typing import List
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
@@ -98,7 +97,7 @@ class AbstractScraper:
         """Ingredients of the recipe."""
         raise NotImplementedError("This should be implemented.")
 
-    def ingredient_groups(self) -> List[IngredientGroup]:
+    def ingredient_groups(self) -> list[IngredientGroup]:
         """List of ingredient groups."""
         return [IngredientGroup(purpose=None, ingredients=self.ingredients())]
 
@@ -106,7 +105,7 @@ class AbstractScraper:
         """Instructions to prepare the recipe."""
         raise NotImplementedError("This should be implemented.")
 
-    def instructions_list(self) -> List[str]:
+    def instructions_list(self) -> list[str]:
         """Instructions to prepare the recipe as a list."""
         return [
             instruction

--- a/recipe_scrapers/_grouping_utils.py
+++ b/recipe_scrapers/_grouping_utils.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, List, Optional
 
 from bs4 import BeautifulSoup
 
@@ -9,10 +10,8 @@ from ._utils import normalize_string
 
 @dataclass
 class IngredientGroup:
-    ingredients: List[str]
-    purpose: Optional[str] = (
-        None  # this group of ingredients is {purpose} (e.g. "For the dressing")
-    )
+    ingredients: list[str]
+    purpose: str | None = None  # this group of ingredients is {purpose} (e.g. "For the dressing")
 
 
 def score_sentence_similarity(first: str, second: str) -> float:
@@ -50,7 +49,7 @@ def score_sentence_similarity(first: str, second: str) -> float:
     return 2 * intersection / (len(first_bigrams) + len(second_bigrams))
 
 
-def best_match(test_string: str, target_strings: List[str]) -> str:
+def best_match(test_string: str, target_strings: list[str]) -> str:
     """Find the best match for a given test string within a list of target strings.
 
     This function utilizes the score_sentence_similarity function to compare the test string
@@ -61,7 +60,7 @@ def best_match(test_string: str, target_strings: List[str]) -> str:
     ----------
     test_string : str
         The string to find the best match for.
-    target_strings : List[str]
+    target_strings : list[str]
         A list of strings to compare against the test string.
 
     Returns
@@ -78,11 +77,11 @@ def best_match(test_string: str, target_strings: List[str]) -> str:
 
 
 def group_ingredients(
-    ingredients_list: List[str],
+    ingredients_list: list[str],
     soup: BeautifulSoup,
     group_heading: str,
     group_element: str,
-) -> List[IngredientGroup]:
+) -> list[IngredientGroup]:
     """
     Group ingredients into sublists according to the heading in the recipe.
 
@@ -93,7 +92,7 @@ def group_ingredients(
 
     Parameters
     ----------
-    ingredients_list : List[str]
+    ingredients_list : list[str]
         Ingredients extracted by the scraper.
     soup : BeautifulSoup
         Parsed HTML of the recipe page.
@@ -104,7 +103,7 @@ def group_ingredients(
 
     Returns
     -------
-    List[IngredientGroup]
+    list[IngredientGroup]
         groupings of ingredients categorized by their purpose or heading.
 
     Raises
@@ -119,7 +118,7 @@ def group_ingredients(
             f"Found {len(found_ingredients)} grouped ingredients but was expecting to find {len(ingredients_list)}."
         )
 
-    groupings: Dict[Optional[str], List[str]] = defaultdict(list)
+    groupings: dict[str | None, list[str]] = defaultdict(list)
     current_heading = None
 
     elements = soup.select(f"{group_heading}, {group_element}")

--- a/recipe_scrapers/kitchenaidaustralia.py
+++ b/recipe_scrapers/kitchenaidaustralia.py
@@ -1,5 +1,4 @@
 import re
-from typing import List
 
 from ._abstract import AbstractScraper
 from ._grouping_utils import IngredientGroup
@@ -36,7 +35,7 @@ class KitchenAidAustralia(AbstractScraper):
         elements = self._parse_list(ingredients)
         return elements
 
-    def ingredient_groups(self) -> List[IngredientGroup]:
+    def ingredient_groups(self) -> list[IngredientGroup]:
         recipe = self._get_recipe()
         ingredients = recipe.find("div", {"class": "leftPanel"})
 
@@ -54,7 +53,7 @@ class KitchenAidAustralia(AbstractScraper):
     def instructions(self):
         return "\n".join(self.instructions_list())
 
-    def instructions_list(self) -> List[str]:
+    def instructions_list(self) -> list[str]:
         recipe = self._get_recipe()
         method = recipe.find("div", {"class": "rightPanel"})
 
@@ -87,7 +86,7 @@ class KitchenAidAustralia(AbstractScraper):
         """
         return item.find_next_sibling("p").text
 
-    def _parse_list(self, container) -> List[str]:
+    def _parse_list(self, container) -> list[str]:
         """
         Get the text from each of the li elements contained by the given container.
         """

--- a/recipe_scrapers/nihhealthyeating.py
+++ b/recipe_scrapers/nihhealthyeating.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ._abstract import AbstractScraper
 from ._exceptions import ElementNotFoundInHtml, StaticValueException
 from ._grouping_utils import IngredientGroup
@@ -69,7 +67,7 @@ class NIHHealthyEating(AbstractScraper):
 
         return image_relative_url
 
-    def ingredient_groups(self) -> List[IngredientGroup]:
+    def ingredient_groups(self) -> list[IngredientGroup]:
         # This content must be present for recipes on this website.
         ingredients_div = self.soup.find("div", {"id": "ingredients"})
         section = []
@@ -123,7 +121,7 @@ class NIHHealthyEating(AbstractScraper):
 
         return [IngredientGroup(ingredients_list)]
 
-    def ingredients(self) -> List[str]:
+    def ingredients(self) -> list[str]:
         results = []
         for ingredient_group in self.ingredient_groups():
             results.extend(ingredient_group.ingredients)

--- a/recipe_scrapers/plugins/_interface.py
+++ b/recipe_scrapers/plugins/_interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Iterable
+from collections.abc import Iterable
 
 
 class PluginInterface(ABC):

--- a/recipe_scrapers/streetkitchen.py
+++ b/recipe_scrapers/streetkitchen.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ._abstract import AbstractScraper
 from ._grouping_utils import IngredientGroup, group_ingredients
 from ._utils import get_minutes, get_yields, normalize_string
@@ -61,7 +59,7 @@ class StreetKitchen(AbstractScraper):
             self.soup.find("a", {"rel": "author"}).find("img")["alt"]
         )
 
-    def ingredient_groups(self) -> List[IngredientGroup]:
+    def ingredient_groups(self) -> list[IngredientGroup]:
         return group_ingredients(
             self.ingredients(),
             self.soup,

--- a/tests/library/test_readme.py
+++ b/tests/library/test_readme.py
@@ -11,14 +11,14 @@ else:
     # only available in importlib.metadata from py3.10 onwards
     from importlib_metadata import PackageNotFoundError, metadata
 
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 from recipe_scrapers import SCRAPERS, AbstractScraper
 
 START_LIST = "-----------------------"
 END_LIST = "(*) offline saved files only"
 
-ScraperIndex = Dict[str, Tuple[AbstractScraper, List[str]]]
+ScraperIndex = dict[str, tuple[AbstractScraper, list[str]]]
 
 
 def get_scraper_domains():
@@ -56,7 +56,7 @@ def get_scraper_index() -> ScraperIndex:
     return scraper_index
 
 
-def get_shared_prefix(domains: List[str]) -> str:
+def get_shared_prefix(domains: list[str]) -> str:
     """
     Find the longest-common-prefix of the domains
     """
@@ -78,12 +78,12 @@ def get_shared_prefix(domains: List[str]) -> str:
 
 def get_secondary_domains(
     scraper_index: ScraperIndex, primary_domain: str
-) -> List[str]:
+) -> list[str]:
     _, suffixes = scraper_index[primary_domain]
     return [suffix for suffix in suffixes if not primary_domain.endswith(suffix)]
 
 
-def parse_primary_line(line: str) -> Optional[Tuple[str, str]]:
+def parse_primary_line(line: str) -> Optional[tuple[str, str]]:
     match = re.search(
         r"^- `https?://(?:www\.)?([^/\s]+)[^<]*<https?://(?:www\.)?([^/\s]*)[^>]*>`_(?: \(\*\))?$",
         line,
@@ -95,17 +95,17 @@ def parse_primary_line(line: str) -> Optional[Tuple[str, str]]:
     return None
 
 
-def parse_secondary_line(line: str) -> List[Tuple[str, str]]:
+def parse_secondary_line(line: str) -> list[tuple[str, str]]:
     return re.findall(r"`(\.[^\s]+)\s<https?://(?:www\.)?([^/>]+)[^>]*>`_", line)
 
 
-def get_package_description() -> List[str]:
+def get_package_description() -> list[str]:
     pkg_metadata = metadata("recipe_scrapers")
     return pkg_metadata["Description"].splitlines()
 
 
-def get_list_lines() -> List[str]:
-    list_lines: List[str] = []
+def get_list_lines() -> list[str]:
+    list_lines: list[str] = []
     started_list = False
     for line in get_package_description():
         stripped_line = line.strip()


### PR DESCRIPTION
Dropping support for Python 3.8 makes it easier to modernize some of the type hinting used in the codebase here.

Credit is due to [`pyupgrade`](https://github.com/asottile/pyupgrade) for suggesting most of these.

Follow-up to pull request #1265.