### PR TITLE
Maintenance: declare Python3.13 support

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0-rc.3"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           # set toxenv to workaround-darwin on macos (check tox.ini)
           - toxenv: py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Follow-up to #1266:

  * Enable unit testing using final release versions of Python 3.13
  * Declare support for Python 3.13 using the package's Python [trove classifiers](https://github.com/pypa/trove-classifiers)