### PR TITLE
Maintenance: upgrade MacOS version for GitHub Actions unit testing

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -17,6 +17,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          # set toxenv to workaround-darwin on macos (check tox.ini)
+          - toxenv: py
+          - os: macos-latest
+            toxenv: workaround-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -27,4 +32,4 @@ jobs:
       - name: Run Tests
         run: |
           pip install tox
-          tox
+          tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -17,11 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          # set toxenv to workaround-darwin on macos (check tox.ini)
-          - toxenv: py
-          - os: macos-latest
-            toxenv: workaround-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -32,4 +27,4 @@ jobs:
       - name: Run Tests
         run: |
           pip install tox
-          tox -e ${{ matrix.toxenv }}
+          tox

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           # set toxenv to workaround-darwin on macos (check tox.ini)
           - toxenv: py
-          - os: macos-13
+          - os: macos-latest
             toxenv: workaround-darwin
     runs-on: ${{ matrix.os }}
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,15 @@ isolated_build = true
 deps = -r{toxinidir}/requirements-dev.txt
 commands = coverage run -m unittest {posargs}
 
+# The system-provided libxml2 on MacOS is typically outdated and this can lead to lxml parsing issues
+# Using PyPi-provided binary wheels instead resolves this
+# We are affected by https://bugs.launchpad.net/lxml/+bug/1949271 in test_wild_mode when using system-provided libxml2 on MacOS
+platform =
+    workaround-darwin: darwin
+install_command =
+    py: python -I -m pip install {opts} {packages}
+    workaround-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
+
 [testenv:lint]
 # note: skip_install affects whether the package-under-test is installed; not whether deps are installed
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,6 @@ isolated_build = true
 deps = -r{toxinidir}/requirements-dev.txt
 commands = coverage run -m unittest {posargs}
 
-# The system-provided libxml2 on MacOS is typically outdated and this can lead to lxml parsing issues
-# Using PyPi-provided binary wheels instead resolves this
-# We are affected by https://bugs.launchpad.net/lxml/+bug/1949271 in test_wild_mode when using system-provided libxml2 on MacOS
-platform =
-    workaround-darwin: darwin
-install_command =
-    py: python -I -m pip install {opts} {packages}
-    workaround-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
-
 [testenv:lint]
 # note: skip_install affects whether the package-under-test is installed; not whether deps are installed
 skip_install = true


### PR DESCRIPTION
As [noticed recently](https://github.com/hhursev/recipe-scrapers/pull/1308#discussion_r1807830905), the version of MacOS we're using for unit testing during GitHub Actions workflows is outdated; we're using MacOS 13 instead of the latest stable version labeled as `macos-latest`, which currently refers to MacOS 14.

This changeset updates the unit tests workflow to use `macos-latest` (MacOS 14).

I'm tempted to try removing some of the workarounds for MacOS in `tox.ini` at the same time; I think it depends on a sense about how many developers we may still have using MacOS 13 themselves.  It's probably worth _testing_ during this pull request -- whether it's sensible to remove the workarounds, assuming tests pass with them removed on MacOS 14, however, is a seperate question.