### PR TITLE
Fix(maangchi): use regex string to find ingredients header 

### DIFF
--- a/recipe_scrapers/maangchi.py
+++ b/recipe_scrapers/maangchi.py
@@ -1,3 +1,5 @@
+import re
+
 from ._abstract import AbstractScraper
 from ._utils import normalize_string
 
@@ -8,7 +10,9 @@ class Maangchi(AbstractScraper):
         return "maangchi.com"
 
     def ingredients(self):
-        before = self.soup.find("h2", string="Ingredients").find_all_next("li")
+        before = self.soup.find(
+            "h2", string=re.compile(r"Ingredients(\s*\(.*\))?")
+        ).find_all_next("li")
         after = self.soup.find("h2", string="Directions").find_all_previous("li")
         list_before = [normalize_string(b.get_text()) for b in before]
         list_after = [normalize_string(a.get_text()) for a in after]

--- a/recipe_scrapers/maangchi.py
+++ b/recipe_scrapers/maangchi.py
@@ -10,9 +10,9 @@ class Maangchi(AbstractScraper):
         return "maangchi.com"
 
     def ingredients(self):
-        before = self.soup.find(
-            "h2", string=re.compile(r"Ingredients(\s*\(.*\))?")
-        ).find_all_next("li")
+        before = self.soup.find("h2", string=re.compile(r"Ingredients")).find_all_next(
+            "li"
+        )
         after = self.soup.find("h2", string="Directions").find_all_previous("li")
         list_before = [normalize_string(b.get_text()) for b in before]
         list_after = [normalize_string(a.get_text()) for a in after]


### PR DESCRIPTION
### Resolves #1310 


Utilizes a regex string to find ingredient headers matching patterns like "Ingredients (serves _n_ to _m_)"

Example recipes
- https://www.maangchi.com/recipe/gimbap 
- https://www.maangchi.com/recipe/budae-jjigae
- https://www.maangchi.com/recipe/maeuntang

Unittests passing:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/33e3dbae-75a3-485d-947c-adc305040508">

Any feedback or discussion is appreciated!
