### PR TITLE
GitHub Actions: releases: confirm commit exists on release branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Check that the release commit can be found in a release branch
+        run: git branch main v14 --contains ${{ github.sha }} | egrep '.+'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test_publish.yaml
+++ b/.github/workflows/test_publish.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
+      - name: Check that the release commit can be found in a release branch
+        run: git branch main v14 --contains ${{ github.sha }} | egrep '.+'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
During the GitHub Actions package publication workflows, confirm that the commit-to-be-packaged exists on at least one of the release branches (currently: `main`, `v14`).

This is intended to prevent mistakes like the one described in #1272 from occurring in future.