### PR TITLE
Utils: reject empty input in `get_yields`

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -199,6 +199,8 @@ def get_yields(element):
         serve_text = element
     else:
         serve_text = element.get_text()
+    if not serve_text:
+        raise ValueError("Cannot extract yield information from empty string")
 
     if SERVE_REGEX_TO.search(serve_text):
         serve_text = serve_text.split(SERVE_REGEX_TO.split(serve_text, 2)[1], 2)[1]

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -6,6 +6,7 @@ from recipe_scrapers._utils import (
     get_minutes,
     get_nutrition_keys,
     get_url_slug,
+    get_yields,
     url_path_to_dict,
 )
 
@@ -168,3 +169,10 @@ class TestUtils(unittest.TestCase):
             "cholesterolContent",
         ]
         self.assertEqual((expected_order), (nutrition_keys))
+
+    def test_get_yields(self):
+        self.assertEqual("5 servings", get_yields("5"))
+
+    def test_get_yields_empty_string(self):
+        with self.assertRaises(ValueError):
+            get_yields("")


### PR DESCRIPTION
Resolves #1313.