### PR TITLE
schema.org: correction for present-but-empty 'recipeYield' values

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -184,8 +184,8 @@ class SchemaOrg:
         yield_data = self.data.get("recipeYield") or self.data.get("yield")
         if yield_data and isinstance(yield_data, list):
             yield_data = yield_data[0]
-        recipe_yield = str(yield_data)
-        return get_yields(recipe_yield)
+        if yield_data:
+            return get_yields(str(yield_data))
 
     def image(self):
         image = self.data.get("image")

--- a/tests/test_data/usapears.org/usapears_3.json
+++ b/tests/test_data/usapears.org/usapears_3.json
@@ -23,7 +23,7 @@
     "Drizzle some dressing over the salad and garnish with candied walnuts.",
     "Serve immediately with additional dressing on the side."
   ],
-  "yields": "0 servings",
+  "yields": null,
   "description": "It doesn't get any simpler! Slice pears and place them on a bed of spicy baby arugula with dollops of the creamiest burrata cheese. If you can't find burrata, substitute with mozzarella! A simple vinaigrette is all you need to bring it all together to serve with dinner! Recipe by Liren Baker (@kitchconfidante).",
   "total_time": 10,
   "ratings": 5.0,


### PR DESCRIPTION
When a `schema.org` recipe's [`recipeYield`](https://schema.org/recipeYield) value is found on a recipe webpage, but contains an empty value (and/or the empty string), handle that as incomplete information, and respond with Python `None` (JSON `null`).

- Depends-upon #1307. 
- Resolves #1318.