### PR TITLE
ci: Enable `pip` caching for `setup-python` in GitHub Actions

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
       - name: Run Tests
         run: |
           pip install tox


### PR DESCRIPTION
Ref: https://github.com/actions/setup-python/tree/65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236#caching-packages-dependencies