### PR TITLE
Project: relocate development dependencies into 'pyproject.toml'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -500,7 +500,7 @@ Assuming you have ``>=python3.9`` installed, navigate to the directory where you
     python -m venv .venv &&
     source .venv/bin/activate &&
     python -m pip install --upgrade pip &&
-    pip install -r requirements-dev.txt &&
+    pip install -e .[dev] &&
     pip install pre-commit &&
     pre-commit install &&
     python -m unittest

--- a/docs/how-to-develop-scraper.md
+++ b/docs/how-to-develop-scraper.md
@@ -41,7 +41,7 @@ $ cd recipe-scrapers
 ```shell
 $ python -m venv .venv --upgrade-deps
 $ source .venv/bin/activate
-$ pip install -r requirements-dev.txt
+$ pip install -e .[dev]
 $ pip install pre-commit
 $ pre-commit install
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "coverage >=7.4.4",
+    "types-beautifulsoup4>=4.12.0",
+    "importlib-metadata>=4.6 ; python_version < '3.10'",
+]
 online = [
     "requests >= 2.31.0",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
--e .
-coverage>=7.4.4
-types-beautifulsoup4>=4.12.0
-importlib-metadata>=4.6 ; python_version < "3.10"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = true
 
 [testenv]
-deps = -r{toxinidir}/requirements-dev.txt
+extras = dev
 commands = coverage run -m unittest {posargs}
 
 # The system-provided libxml2 on MacOS is typically outdated and this can lead to lxml parsing issues


### PR DESCRIPTION
Resolves #1336.