### PR TITLE
Tests: correctness: ensure that deprecation warnings are always emitted when checking for them

### DIFF
--- a/tests/library/test_main_methods.py
+++ b/tests/library/test_main_methods.py
@@ -1,7 +1,7 @@
 import pathlib
 import unittest
 from unittest import mock
-from warnings import catch_warnings
+from warnings import catch_warnings, simplefilter
 
 from recipe_scrapers import (
     NoSchemaFoundInWildMode,
@@ -80,6 +80,7 @@ class TestMainMethods(unittest.TestCase):
         mock_get.return_value.text = recipe_html.read_text()
 
         with catch_warnings(record=True) as ws:
+            simplefilter("always", category=DeprecationWarning)
             scrape_html(
                 html=None,
                 org_url="https://recipe-scrapers.example/algorithmic-cupcakes.html",
@@ -104,6 +105,7 @@ class TestMainMethods(unittest.TestCase):
 
         with self.assertRaises(NoSchemaFoundInWildMode):
             with catch_warnings(record=True) as ws:
+                simplefilter("always", category=DeprecationWarning)
                 scrape_html(html=html, org_url=url, online=False, wild_mode=True)
 
         self.assertTrue(any(w.category is DeprecationWarning for w in ws))


### PR DESCRIPTION
Without this fix applied, these tests could fail if Python warning filtering was configured in a way that interfered with the emission of the warnings - for example, when `PYTHONWARNINGS="ignore"` is configured as an environment variable.

By adding a `simplefilter` to always-emit `DeprecationWarning` notices, we can ensure that the test assertions apply correctly regardless of Python warning configuration.