### PR TITLE
Tests: prepare test cases at module import-time

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -166,16 +166,40 @@ def test_func_factory(
     return test_func
 
 
+def prepare_test_cases():
+    """
+    This function dynamically generates the class definition for RecipeTestCase by adding
+    a test function for each pair of testhtml and testjson files found in the
+    tests/test_data directory.
+    """
+    test_dir = pathlib.Path("tests/test_data")
+    for host in test_dir.iterdir():
+        if not host.is_dir():
+            continue
+
+        for testhtml in host.glob("*.testhtml"):
+            testjson = testhtml.with_suffix(".json")
+            if not testjson.is_file():
+                continue
+
+            # Add a new function to RecipeTestCase class to test this scraper
+            # The name of this function the path to the testjson file.
+            setattr(
+                RecipeTestCase,
+                str(testjson),
+                test_func_factory(host.name, testhtml, testjson),
+            )
+
+
+prepare_test_cases()
+
+
 def load_tests(
     loader: unittest.TestLoader, standard_tests: unittest.TestSuite, pattern: str
 ) -> unittest.TestSuite:
     """
     Customise the loading of tests. This function is automatically picked up by the
     unittest test loader.
-
-    This function dynamically generates the class definition for RecipeTestCase by adding
-    a test function for each pair of testhtml and testjson files found in the
-    tests/test_data directory.
 
     This also includes the library tests from the tests/library folder as well.
 
@@ -197,23 +221,6 @@ def load_tests(
         A TestSuite object populated with tests from the pairs of testhtml and testjson
         files, and the library tests.
     """
-    test_dir = pathlib.Path("tests/test_data")
-    for host in test_dir.iterdir():
-        if not host.is_dir():
-            continue
-
-        for testhtml in host.glob("*.testhtml"):
-            testjson = testhtml.with_suffix(".json")
-            if not testjson.is_file():
-                continue
-
-            # Add a new function to RecipeTestCase class to test this scraper
-            # The name of this function the path to the testjson file.
-            setattr(
-                RecipeTestCase,
-                str(testjson),
-                test_func_factory(host.name, testhtml, testjson),
-            )
 
     # Create a test suite and load all tests from the RecipeTestClass definition
     suite = unittest.TestSuite()


### PR DESCRIPTION
In combination with #1342 and #1343, this enables the unit test suite to run using `unittest-parallel` (again, as it did in the past).

This improves the runtime duration of the tests from ~45 seconds to ~25 seconds on my local machine, and I anticipate that we'd achieve similar time savings during GitHub Actions workflows.