### PR TITLE
v14: ci: enable unittest-parallel at class-level

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -32,4 +32,4 @@ jobs:
       - name: Run Tests
         env:
           PYTHONWARNINGS: "always:::recipe_scrapers,ignore:::recipe_scrapers.plugins.static_values"
-        run: unittest-parallel --level test
+        run: unittest-parallel --level class

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -27,7 +27,9 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: python -m pip install .[dev]
+      - name: Install parallel test runner
+        run: python -m pip install unittest-parallel
       - name: Run Tests
         env:
           PYTHONWARNINGS: "always:::recipe_scrapers,ignore:::recipe_scrapers.plugins.static_values"
-        run: python -m unittest
+        run: unittest-parallel --level test


### PR DESCRIPTION
In `main` / v15, we run the continuous integration unit test suite using `unittest-parallel`, and this provides a significant speedup (see #1345).

Unfortunately when merging this back to `v14`, build errors occurred.  The cause seems to be that we have some [legacy tests](https://github.com/hhursev/recipe-scrapers/blob/bbb7e2d850eff6ec81b32228f1cfbf10de740dbb/tests/legacy/__init__.py) that perform class-level test setup (in a `setUpClass` method).

These have caused some problems with individual-test-level parallelism using `unittest-parallel` in the past (see craigahobbs/unittest-parallel#14), but there is now a `--level` argument that we can provide to specify how granularly parallelism should be applied.  By parallelizing at the `class` level instead, we can fix the problem.