### PR TITLE
ci: simplify 'linters' GitHub Actions workflow

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -19,5 +19,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - run: pip install tox
-      - run: tox -e lint
+          cache: pip
+          cache-dependency-path: .pre-commit-config.yaml
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,3 @@ platform =
 install_command =
     py: python -I -m pip install {opts} {packages}
     workaround-darwin: python -I -m pip install --only-binary=lxml {opts} {packages}
-
-[testenv:lint]
-# note: skip_install affects whether the package-under-test is installed; not whether deps are installed
-skip_install = true
-install_command = python -I -m pip install {opts} {packages}
-# end skip_install note
-deps = pre-commit >= 2.20.0
-commands = pre-commit run --all-files


### PR DESCRIPTION
Similar to #1339, but for the `linters` workflow in GitHub Actions.

Should contribute towards #1340, on aggregate.