### PR TITLE
LICENSE: add copyright notice line encompassing all contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Hristo Harsev
+Copyright (c) 2019-2024 The recipe-scrapers contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Hristo Harsev
-Copyright (c) 2019-2024 The recipe-scrapers contributors
+Copyright (c) 2015 The recipe-scrapers contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Although this is a single-line change, it has a few details to explain:

  * I've read in at least two places now (Linux Foundation training, and this blog post: https://ben.balter.com/2015/06/03/copyright-notices-for-websites-and-open-source-projects - that grouping copyright by a generic 'the project contributors' is a worthwhile practice for FOSS projects because they may have many and varying contributors over time).
  * The first external contributions began in 2017 - but the next subsequent release I can find on PyPi is v5.0.0 in 2019.
    * ~~As the blog post mentions, there could be some debate about what initiates publication for software - is it simply a push/merge to the host `git` repo?  I think a versioned and  package release is more appropriate generally, partly because pre-release reverts / fixups / etc can happen, and also a versioned release should generally be more of a thoughtful and deliberate practice of getting the work into an updated form that is ready for consumers.~~
    * Update: referring to the date that authorship of the work (in this case, development of the software code) seems more appropriate after all.
  * Adding a current year to a copyright notice is in some ways redundant; how long copyright applies to a work in the long term has to be evaluated based on geographic considerations.  Because the added line is a collective of authors, though, I think we should add the current year to clarify that work is ongoing.  It does mean we should remember to update it.. hopefully I can remember to add a lint/continuous-integration check for that.