### PR TITLE
schema.org parser: allow aggregation from multiple Recipe entities

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,7 @@
 # and would error on `str.format()` usage
 ignore = E203, E501, W503, FS002, N818
 max-line-length = 88
-max-complexity = 20
+max-complexity = 21
 select = B,C,E,F,N,W,T4,B9
 exclude =
     ./.tox/

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -101,6 +101,8 @@ class SchemaOrg:
                     existing_value = self.data.get(prop)
                     encountered_value = recipe.get(prop)
                     if existing_value and encountered_value == existing_value:
+                        if syntax != self.format:
+                            pass  # TODO: single recipe represented using multiple formats; what should we do?
                         self.format = syntax
                         self.data.update(
                             {k: self.data.get(k, v) for k, v in recipe.items()}

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -85,17 +85,29 @@ class SchemaOrg:
 
                 # If the item itself is a recipe, then use it directly as our datasource
                 if recipe := self._find_entity(item, "Recipe"):
-                    if not self.data or recipe.get("@id", "") == self.data.get("@id", ""):
+                    should_update = not self.data
+                    for prop in ("@id", "name"):
+                        existing_value = self.data.get(prop)
+                        encountered_value = recipe.get(prop)
+                        if existing_value and encountered_value == existing_value:
+                            should_update = True
+                    if should_update:
                         self.format = syntax
-                        self.data.update(recipe)
+                        self.data.update({k: self.data.get(k, v) for k, v in recipe.items()})
 
                 # If the item is a webpage and describes a recipe entity, use the entity as our datasource
                 if self._contains_schematype(item, "WebPage"):
                     main_entity = item.get("mainEntity", {})
                     if self._contains_schematype(main_entity, "Recipe"):
-                        if not self.data or main_entity.get("@id", "") == self.data.get("@id", ""):
+                        should_update = not self.data
+                        for prop in ("@id", "name"):
+                            existing_value = self.data.get(prop)
+                            encountered_value = main_entity.get(prop)
+                            if existing_value and encountered_value == existing_value:
+                                should_update = True
+                        if should_update:
                             self.format = syntax
-                            self.data.update(main_entity)
+                            self.data.update({k: self.data.get(k, v) for k, v in main_entity.items()})
 
     def site_name(self):
         if not self.website_name:

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -87,7 +87,9 @@ class SchemaOrg:
                 if recipe := self._find_entity(item, "Recipe"):
                     pass
                 # If the item is a webpage and describes a recipe entity, use the entity as our datasource
-                elif self._contains_schematype(item, "WebPage") and (recipe := item.get("mainEntity", {})):
+                elif self._contains_schematype(item, "WebPage") and (
+                    recipe := item.get("mainEntity", {})
+                ):
                     pass
                 else:
                     continue
@@ -100,7 +102,9 @@ class SchemaOrg:
                     encountered_value = recipe.get(prop)
                     if existing_value and encountered_value == existing_value:
                         self.format = syntax
-                        self.data.update({k: self.data.get(k, v) for k, v in recipe.items()})
+                        self.data.update(
+                            {k: self.data.get(k, v) for k, v in recipe.items()}
+                        )
 
     def site_name(self):
         if not self.website_name:

--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -85,29 +85,22 @@ class SchemaOrg:
 
                 # If the item itself is a recipe, then use it directly as our datasource
                 if recipe := self._find_entity(item, "Recipe"):
-                    should_update = not self.data
-                    for prop in ("@id", "name"):
-                        existing_value = self.data.get(prop)
-                        encountered_value = recipe.get(prop)
-                        if existing_value and encountered_value == existing_value:
-                            should_update = True
-                    if should_update:
+                    pass
+                # If the item is a webpage and describes a recipe entity, use the entity as our datasource
+                elif self._contains_schematype(item, "WebPage") and (recipe := item.get("mainEntity", {})):
+                    pass
+                else:
+                    continue
+                if not self._contains_schematype(recipe, "Recipe"):
+                    continue
+
+                self.data = self.data or recipe
+                for prop in ("@id", "name"):
+                    existing_value = self.data.get(prop)
+                    encountered_value = recipe.get(prop)
+                    if existing_value and encountered_value == existing_value:
                         self.format = syntax
                         self.data.update({k: self.data.get(k, v) for k, v in recipe.items()})
-
-                # If the item is a webpage and describes a recipe entity, use the entity as our datasource
-                if self._contains_schematype(item, "WebPage"):
-                    main_entity = item.get("mainEntity", {})
-                    if self._contains_schematype(main_entity, "Recipe"):
-                        should_update = not self.data
-                        for prop in ("@id", "name"):
-                            existing_value = self.data.get(prop)
-                            encountered_value = main_entity.get(prop)
-                            if existing_value and encountered_value == existing_value:
-                                should_update = True
-                        if should_update:
-                            self.format = syntax
-                            self.data.update({k: self.data.get(k, v) for k, v in main_entity.items()})
 
     def site_name(self):
         if not self.website_name:

--- a/tests/library/test_schemaorg.py
+++ b/tests/library/test_schemaorg.py
@@ -1,0 +1,72 @@
+import unittest
+
+from recipe_scrapers._schemaorg import SchemaOrg
+
+JSONLD_PAGE_TEMPLATE = """
+<html>
+<head>
+<link href="http://recipe.test/template" type="canonical" />
+<script type="application/ld+json">{jsonld}</script>
+</head>
+</html>
+"""
+
+SIMPLE_SCHEMA = """
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "name": "Test Recipe",
+  "recipeIngredient": ["1 slice of bread", "5g margarine"],
+  "recipeInstructions": ["spread the margarine on the bread"]
+}
+"""
+
+MULTI_ENTITY_SCHEMA = """
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    "@id": "http://recipe.test/template",
+    "name": "Test Recipe",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Recipe",
+    "@id": "http://recipe.test/other",
+    "name": "Another great test recipe",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "http://recipe.test/template",
+    "mainEntity": {
+      "@context": "https://schema.org",
+      "@type": "Recipe",
+      "@id": "http://recipe.test/template",
+      "recipeIngredient": ["1 slice of bread", "5g margarine"],
+      "recipeInstructions": ["spread the margarine on the bread"]
+    }
+  }
+]
+"""
+
+
+class TestSchemaOrg(unittest.TestCase):
+
+    def test_simple(self):
+        page_data = JSONLD_PAGE_TEMPLATE.format(jsonld=SIMPLE_SCHEMA)
+        parser = SchemaOrg(page_data)
+
+        self.assertEqual("Test Recipe", parser.title())
+        self.assertIn("1 slice of bread", parser.ingredients())
+        self.assertIn("5g margarine", parser.ingredients())
+        self.assertEqual("spread the margarine on the bread", parser.instructions())
+
+    def test_multi_entity_aggregation(self):
+        page_data = JSONLD_PAGE_TEMPLATE.format(jsonld=MULTI_ENTITY_SCHEMA)
+        parser = SchemaOrg(page_data)
+
+        self.assertEqual("Test Recipe", parser.title())
+        self.assertIn("1 slice of bread", parser.ingredients())
+        self.assertIn("5g margarine", parser.ingredients())
+        self.assertEqual("spread the margarine on the bread", parser.instructions())


### PR DESCRIPTION
As encountered during #1378, some recipe websites include multiple `Recipe` entities within individual HTML files.  This is valid; they could refer to aspects of multiple distinct recipes (for example, promoting other similar recipes), but in some cases they may also refer to the same, single recipe displayed on the page that we're interested in retrieving.

In that latter case (single recipe on the page, but presented using multiple `Recipe` entities), we currently use short-circuit logic that returns the first entity that we find.  If that's incomplete, then it could lead to recipe information being omitted.

The logic presented here is a draft; currently it assumes that all recipes that match the `@id` of the first `Recipe` found on the page -- or that all have an empty `@id` if the first one does -- relate to the recipe we're retrieving.  This probably isn't perfect -- `WebPage.mainEntity` should likely have an increased priority, for example, but that isn't implemented here yet.

Resolves #1380.
May unblock #1378.