### PR TITLE
Documentation: apply a few `mdl` recommendations

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,10 @@
 {
-  "__": "Adapted from: https://github.com/DavidAnson/markdownlint/blob/b2305efafb034b1f328845aec9928b5363ffd646/schema/.markdownlint.jsonc#L67-L85",
-  "_": "// MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md013.md",
+  "_": "Adapted from: https://github.com/DavidAnson/markdownlint/blob/b2305efafb034b1f328845aec9928b5363ffd646/schema/.markdownlint.jsonc#L67-L85",
+  "_MD007": "// Indentation: use kramdown-compatible indentation : https://kramdown.gettalong.org/syntax.html#ordered-and-unordered-lists",
+  "MD007": {
+    "indent": 3
+  },
+  "_MD013": "// Line length : https://github.com/DavidAnson/markdownlint/blob/v0.34.0/doc/md013.md",
   "MD013": {
     "line_length": 800,
     "heading_line_length": 80,

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Sometimes it is simple and straightforward to achieve all these goals, and somet
 
 * [How To: Develop a New Scraper](how-to-develop-scraper.md)
 * In Depth Guides:
-  * [Debugging](in-depth-guide-debugging.md) (coming soon)
-  * [HTML Scraping](in-depth-guide-html-scraping.md)
-  * [Ingredient Groups](in-depth-guide-ingredient-groups.md)
-  * [Scraper Functions](in-depth-guide-scraper-functions.md)
+   * [Debugging](in-depth-guide-debugging.md) (coming soon)
+   * [HTML Scraping](in-depth-guide-html-scraping.md)
+   * [Ingredient Groups](in-depth-guide-ingredient-groups.md)
+   * [Scraper Functions](in-depth-guide-scraper-functions.md)

--- a/docs/how-to-develop-scraper.md
+++ b/docs/how-to-develop-scraper.md
@@ -30,26 +30,29 @@ To create a fork, click the Fork button near the top of page on the project GitH
 
 You can then clone the fork to your computer and set it up for development.
 
-**Clone the repository**, replacing \<username> with your username
+**Clone the repository**, replacing \<username> with your username:
 
 ```shell
-$ git clone git@github.com:<username>/recipe-scrapers.git
-$ cd recipe-scrapers
+git clone git@github.com:<username>/recipe-scrapers.git
+cd recipe-scrapers
 ```
 
-**Create a virtual environment, activate and install dependencies**
+**Create a virtual environment, activate and install dependencies**:
+
 ```shell
-$ python -m venv .venv --upgrade-deps
-$ source .venv/bin/activate
-$ pip install -e .[dev]
-$ pip install pre-commit
-$ pre-commit install
+python -m venv .venv --upgrade-deps
+source .venv/bin/activate
+pip install -e .[dev]
+pip install pre-commit
+pre-commit install
 ```
 
-**Check that everything is working by running the tests**
+**Check that everything is working by running the tests**:
+
 ```shell
-$ python -m unittest
+python -m unittest
 ```
+
 This will run all the tests for all the scrapers. You should not see any errors or failures.
 
 ## 3. Identify a recipe and generate the scraper and test file
@@ -78,7 +81,7 @@ If Recipe Schema is not available, then `scraper.schema.data` will return an emp
 Next, generate the scraper class and test files by running this command:
 
 ```shell
-$ python generate.py <ClassName> <URL>
+python generate.py <ClassName> <URL>
 ```
 
 This will generate a file for the scraper with name \<ClassName> with basic code that you will need to modify. This will also download the recipe at \<URL> and create a test case.
@@ -165,7 +168,7 @@ A test case was automatically created when the scraper class was created. It can
 The test case comprises two parts:
 
 1. testhtml file containing the html from the URL used to generate the scraper
-2. json file containing the expected output from the scraper when the scraper is run on the testhtml file.
+1. json file containing the expected output from the scraper when the scraper is run on the testhtml file.
 
 The generated json file will look something like this, with only the host field populated:
 
@@ -195,7 +198,7 @@ In some cases, a scraper is not able to support one or more of the mandatory fun
 You can check whether your scraper is passing the tests by running
 
 ```shell
-$ python -m unittest -k <ClassName.lower()>
+python -m unittest -k <ClassName.lower()>
 ```
 
 Where `ClassName` is the name that you used earlier to generate the scraper.

--- a/docs/in-depth-guide-ingredient-groups.md
+++ b/docs/in-depth-guide-ingredient-groups.md
@@ -4,9 +4,9 @@ Sometimes a website will format lists of ingredients using groups, where each gr
 
 Some examples of recipes that have ingredient groups are:
 
-* https://cooking.nytimes.com/recipes/1024570-green-salad-with-warm-goat-cheese-salade-de-chevre-chaud
-* https://lifestyleofafoodie.com/air-fryer-frozen-french-fries
-* https://www.bbcgoodfood.com/recipes/monster-cupcakes
+* <https://cooking.nytimes.com/recipes/1024570-green-salad-with-warm-goat-cheese-salade-de-chevre-chaud>
+* <https://lifestyleofafoodie.com/air-fryer-frozen-french-fries>
+* <https://www.bbcgoodfood.com/recipes/monster-cupcakes>
 
 Not all websites use ingredient groups and those that do use ingredient groups will not use them for all recipes.
 
@@ -38,8 +38,8 @@ The `ingredient_groups()` function has a default implementation in the `Abstract
 Adding ingredient group support to a scraper involves overriding the `ingredient_groups` function for it. There are three important points to consider:
 
 1. The schema.org Recipe format does not support groupings - so scraping from the HTML is required in the implementation.
-2. The ingredients found in `ingredients()` and `ingredient_groups()` should be the same because we're presenting the same set of ingredients, just in a different way. There can sometimes be minor differences in the ingredients in the schema and the ingredients in the HTML which needs to be handled.
-3. Not all recipes on a website will use ingredient groups, so the implementation must degrade gracefully in cases where groupings aren't available. For recipes that don't have ingredient groups, the output should be the same as default implementation (i.e. a single `IngredientGroup` with `purpose=None` and `ingredients=ingredients()`).
+1. The ingredients found in `ingredients()` and `ingredient_groups()` should be the same because we're presenting the same set of ingredients, just in a different way. There can sometimes be minor differences in the ingredients in the schema and the ingredients in the HTML which needs to be handled.
+1. Not all recipes on a website will use ingredient groups, so the implementation must degrade gracefully in cases where groupings aren't available. For recipes that don't have ingredient groups, the output should be the same as default implementation (i.e. a single `IngredientGroup` with `purpose=None` and `ingredients=ingredients()`).
 
 In many cases the structure of how ingredients and group heading appear in the HTML is very similar. Some helper functions have been developed to make the implementation easier.
 
@@ -65,9 +65,9 @@ def group_ingredients(
 
 ### Example
 
-Many recipe blogs use WordPress and the WordPress Recipe Manager plugin. This means they often use the same HTML elements and CSS classes to represent the same things. One such example is https://rainbowplantlife.com.
+Many recipe blogs use WordPress and the WordPress Recipe Manager plugin. This means they often use the same HTML elements and CSS classes to represent the same things. One such example is <https://rainbowplantlife.com>.
 
-If we look at the recipe: https://rainbowplantlife.com/vegan-pasta-salad/
+If we look at the recipe: <https://rainbowplantlife.com/vegan-pasta-salad/>
 
 The group headings in this recipe are all `h4` headings inside an element with the class `wprm-recipe-ingredient-group`. Therefore we can select all ingredient group headings with the selector: `.wprm-recipe-ingredient-group h4`
 
@@ -101,7 +101,7 @@ Some other examples of scrapers that support ingredient groups are:
 * [PickUpLimes](https://github.com/hhursev/recipe-scrapers/blob/main/recipe_scrapers/pickuplimes.py)
 * [RealFoodTesco](https://github.com/hhursev/recipe-scrapers/blob/main/recipe_scrapers/realfoodtesco.py)
 
-### What if `group_ingredients()` doesn't work?
+**What if `group_ingredients()` doesn't work?**
 
 The `group_ingredients` function relies on being able to identify all the group headings with a single CSS selector and all the ingredients with a single CSS selector. However, this is not always possible - it depends on how the website lays out its HTML.
 

--- a/docs/in-depth-guide-scraper-functions.md
+++ b/docs/in-depth-guide-scraper-functions.md
@@ -6,15 +6,15 @@ Each website scraper has a number of functions that return information about the
 
    These functions can be expected to be available for all Scraper classes and combined provide the majority of the information for a recipe.
 
-2. Inherited functions
+1. Inherited functions
 
    These functions are always available for all Scraper classes. They are implemented in the `AbstractScraper` base class and rarely require overriding in the Scraper class.
 
-3. Optional functions
+1. Optional functions
 
    These functions provide extra information about a recipe, from the particular websites that support them.
 
-All of the examples below come from https://www.bbcgoodfood.com/recipes/monster-cupcakes.
+All of the examples below come from <https://www.bbcgoodfood.com/recipes/monster-cupcakes>.
 
 ```py
 >>> from recipe_scrapers import scrape_html
@@ -40,6 +40,7 @@ Returns the host of the website the Scraper class is for. This is a constant `st
 >>> scraper.host()
 'bbcgoodfood.com'
 ```
+
 ### `description() -> str`
 
 Returns a description of the recipe. This is normally a sentence or short paragraph describing the recipe. Often the website defines the description, but sometimes it has to be inferred from the page content.
@@ -57,6 +58,7 @@ Returns the URL to the main image associated with the recipe, usually a photogra
 >>> scraper.image()
 'https://images.immediate.co.uk/production/volatile/sites/30/2020/08/recipe-image-legacy-id-405483_12-cee017a.jpg?resize=768,574'
 ```
+
 ### `ingredients() -> List[str]`
 
 Returns the ingredients needed to make the recipe as a `list` of `str`. Each element of the list is usually a single sentence stating an ingredient, the required amount and any additional comments. The elements of the list should mirror the ingredients written on the website and should not include non-ingredient sentences such as sub-headings.
@@ -189,7 +191,7 @@ but may also include the dialect or variation, such as 'en-US' for American Engl
 
 The language code is based on BCP 47 standards.
 For a comprehensive list of BCP 47 language codes, refer to this GitHub Gist:
-https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1
+<https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1>
 
 ```py
 >>> scraper.language()


### PR DESCRIPTION
Specifically:

  - [`MD007`: Number of characters for list indentation](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md007---unordered-list-indentation)
  - [`MD014`: Don't bother with `$` prefix for no-output `shell` examples](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md014---dollar-signs-used-before-commands-without-showing-output)
  - [`MD026`: Section headings shouldn't end with punctuation](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md026---trailing-punctuation-in-header)
  - [`MD029`: Numbered list items shouldn't be manually numbered](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md029---ordered-list-item-prefix)
  - [`MD031`: Code blocks should have surrounding whitespace](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md031---fenced-code-blocks-should-be-surrounded-by-blank-lines)
  - [`MD034`: Markup shouldn't contain bare URLs](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md034---bare-url-used)