### PR TITLE
ci: configure minimal permissions and disable credential persistence in GitHub Actions workflows

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   coverage:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   linters:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test_publish.yaml
+++ b/.github/workflows/test_publish.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test_publish.yaml
+++ b/.github/workflows/test_publish.yaml
@@ -11,6 +11,8 @@ on: workflow_dispatch
 
 jobs:
   test_publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Based on reading [this blog post about a recent `ultralytics` vulnerability related to GitHub Actions workflows](https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection):

  * Set `persist-credentials` to `false` during `actions/checkout` steps -- this resolves some but not all findings of [`zizmor`](https://github.com/woodruffw/zizmor) (v0.8.0).
  * Configure minimal (`contents:read`) permissions necessary.

It might also make sense to [configure](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) the default GitHub Actions token permissions to be read-only in the repository settings, if they're not already.

NB: The blogpost briefly mentions `pip` caching -- I think our use of it (#1323) is safe and worthwhile, but I'm biased.

cc @hhursev @jknndy (yes, I'm sorta taking some time out, but after reading the blogpost I thought I'd return briefly to suggest we configure these)