### PR TITLE
Use "Trusted Publishing" instead of the manual user/pass config.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,13 @@ on:
 
 jobs:
   publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/recipe-scrapers
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -20,8 +26,6 @@ jobs:
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
       - name: Show build version used
         run: pip list | grep build


### PR DESCRIPTION
Benefits:
- Improves security by removing non-expiring token
- Automatically generates signed digital attestations for distribution files

Links with more info:
- https://docs.pypi.org/trusted-publishers/
- https://github.com/marketplace/actions/pypi-publish#trusted-publishing