### PR TITLE
Fix __init__.py insertion bug

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -129,8 +129,8 @@ class InitScraperState(ScraperState):
         if isinstance(node, ast.Module) or isinstance(node, ast.Import):
             return True
 
-        if isinstance(node, ast.ImportFrom):
-            if node.module > self.module_name and node.level > 0:
+        if isinstance(node, ast.ImportFrom) and node.level > 0:
+            if node.module > self.module_name:
                 offset = self._offset(node)
                 import_statement = (
                     f"\nfrom .{self.module_name} import {self.class_name}"


### PR DESCRIPTION
* Currently, generate.py tries to insert new `from ... import ...` statements after the first line (See https://github.com/hhursev/recipe-scrapers/issues/1259 and https://github.com/hhursev/recipe-scrapers/pull/1427#issuecomment-2526395409).
* It looks like the `node.level > 0` condition was added to skip the first item (`from __future__ import annotations`, which the generator considers to be a valid scraper class), but unfortunately `self.last_node = node` is still reached. The second time `__import()` is called, the first line is `self.last_node` and the new import is added beneath it.
* This PR moves the `node.level > 0` condition up into the parent `if` statement to avoid `self.last_node = node` from being called. Luckily, this doesn't impact the `elif` beneath it.
* I manually validated that we can insert a new scraper class named "AAA" and "ZZZ"