### PR TITLE
Add better nutrition parsing for cookwell.com

### DIFF
--- a/recipe_scrapers/cookwell.py
+++ b/recipe_scrapers/cookwell.py
@@ -1,7 +1,25 @@
 from ._abstract import AbstractScraper
+import re
 
 
 class CookWell(AbstractScraper):
     @classmethod
     def host(cls):
         return "cookwell.com"
+    
+    def nutrients(self):
+        nutrition = None
+        nutrition_pattern = re.compile(r'{\\\"calories\\\":(?P<calories>\d+),\\\"carbohydrates\\\":(?P<carbohydrates>\d+),\\\"fat\\\":(?P<fat>\d+),\\\"protein\\\":(?P<protein>\d+)}')
+        
+        nutrition_script = self.soup.find("script",string=nutrition_pattern)
+        if nutrition_script:
+            nutrition_info = nutrition_pattern.search(nutrition_script.string).groupdict()
+            if nutrition_info:
+                nutrition = {
+                    "calories": f'{nutrition_info["calories"]} calories',
+                    "carbohydrateContent": f'{nutrition_info["carbohydrates"]} g',
+                    "fatContent": f'{nutrition_info["fat"]} g',
+                    "proteinContent": f'{nutrition_info["protein"]} g'
+                }
+        
+        return nutrition if nutrition else super().nutrients()

--- a/recipe_scrapers/cookwell.py
+++ b/recipe_scrapers/cookwell.py
@@ -6,20 +6,24 @@ class CookWell(AbstractScraper):
     @classmethod
     def host(cls):
         return "cookwell.com"
-    
+
     def nutrients(self):
         nutrition = None
-        nutrition_pattern = re.compile(r'{\\\"calories\\\":(?P<calories>\d+),\\\"carbohydrates\\\":(?P<carbohydrates>\d+),\\\"fat\\\":(?P<fat>\d+),\\\"protein\\\":(?P<protein>\d+)}')
-        
-        nutrition_script = self.soup.find("script",string=nutrition_pattern)
+        nutrition_pattern = re.compile(
+            r"{\\\"calories\\\":(?P<calories>\d+),\\\"carbohydrates\\\":(?P<carbohydrates>\d+),\\\"fat\\\":(?P<fat>\d+),\\\"protein\\\":(?P<protein>\d+)}"
+        )
+
+        nutrition_script = self.soup.find("script", string=nutrition_pattern)
         if nutrition_script:
-            nutrition_info = nutrition_pattern.search(nutrition_script.string).groupdict()
+            nutrition_info = nutrition_pattern.search(
+                nutrition_script.string
+            ).groupdict()
             if nutrition_info:
                 nutrition = {
                     "calories": f'{nutrition_info["calories"]} calories',
                     "carbohydrateContent": f'{nutrition_info["carbohydrates"]} g',
                     "fatContent": f'{nutrition_info["fat"]} g',
-                    "proteinContent": f'{nutrition_info["protein"]} g'
+                    "proteinContent": f'{nutrition_info["protein"]} g',
                 }
-        
+
         return nutrition if nutrition else super().nutrients()

--- a/recipe_scrapers/cookwell.py
+++ b/recipe_scrapers/cookwell.py
@@ -10,20 +10,19 @@ class CookWell(AbstractScraper):
     def nutrients(self):
         nutrition = None
         nutrition_pattern = re.compile(
-            r"{\\\"calories\\\":(?P<calories>\d+),\\\"carbohydrates\\\":(?P<carbohydrates>\d+),\\\"fat\\\":(?P<fat>\d+),\\\"protein\\\":(?P<protein>\d+)}"
+            r'{\\"calories\\":(?P<calories>\d+),\\"carbohydrates\\":(?P<carbohydrates>\d+),\\"fat\\":(?P<fat>\d+),\\"protein\\":(?P<protein>\d+)}'
         )
 
         nutrition_script = self.soup.find("script", string=nutrition_pattern)
         if nutrition_script:
-            nutrition_info = nutrition_pattern.search(
-                nutrition_script.string
-            ).groupdict()
-            if nutrition_info:
-                nutrition = {
-                    "calories": f'{nutrition_info["calories"]} calories',
+            match = nutrition_pattern.search(nutrition_script.string)
+            if match:
+                nutrition_info = match.groupdict()
+                return {
+                    "calories": nutrition_info["calories"],
                     "carbohydrateContent": f'{nutrition_info["carbohydrates"]} g',
                     "fatContent": f'{nutrition_info["fat"]} g',
                     "proteinContent": f'{nutrition_info["protein"]} g',
                 }
 
-        return nutrition if nutrition else super().nutrients()
+        return self.schema.nutrients()

--- a/recipe_scrapers/cookwell.py
+++ b/recipe_scrapers/cookwell.py
@@ -8,7 +8,6 @@ class CookWell(AbstractScraper):
         return "cookwell.com"
 
     def nutrients(self):
-        nutrition = None
         nutrition_pattern = re.compile(
             r'{\\"calories\\":(?P<calories>\d+),\\"carbohydrates\\":(?P<carbohydrates>\d+),\\"fat\\":(?P<fat>\d+),\\"protein\\":(?P<protein>\d+)}'
         )

--- a/tests/test_data/cookwell.com/cookwell_1.json
+++ b/tests/test_data/cookwell.com/cookwell_1.json
@@ -28,7 +28,7 @@
   "total_time": 75,
   "cuisine": "American",
   "nutrients": {
-    "calories": "970 calories",
+    "calories": "970",
     "fatContent": "60 g",
     "carbohydrateContent": "100 g",
     "proteinContent": "12 g"

--- a/tests/test_data/cookwell.com/cookwell_1.json
+++ b/tests/test_data/cookwell.com/cookwell_1.json
@@ -28,7 +28,10 @@
   "total_time": 75,
   "cuisine": "American",
   "nutrients": {
-    "calories": "970 calories"
+    "calories": "970 calories",
+    "fatContent": "60 g",
+    "carbohydrateContent": "100 g",
+    "proteinContent": "12 g"
   },
   "image": "https://cdn.sanity.io/images/g1s4qnmz/production/ba9d3d0d5ff9a0f9f17f8e11df7e93b7f3806a48-1000x1000.jpg",
   "keywords": [

--- a/tests/test_data/cookwell.com/cookwell_2.json
+++ b/tests/test_data/cookwell.com/cookwell_2.json
@@ -33,7 +33,7 @@
   "total_time": 30,
   "cuisine": "Middle Eastern",
   "nutrients": {
-    "calories": "2558 calories",
+    "calories": "2558",
     "fatContent": "49 g",
     "carbohydrateContent": "402 g",
     "proteinContent": "132 g"

--- a/tests/test_data/cookwell.com/cookwell_2.json
+++ b/tests/test_data/cookwell.com/cookwell_2.json
@@ -33,7 +33,10 @@
   "total_time": 30,
   "cuisine": "Middle Eastern",
   "nutrients": {
-    "calories": "2558 calories"
+    "calories": "2558 calories",
+    "fatContent": "49 g",
+    "carbohydrateContent": "402 g",
+    "proteinContent": "132 g"
   },
   "image": "https://cdn.sanity.io/images/g1s4qnmz/production/3b2a77f0f746cf90c4f7f49a92b39885ada6e9de-3543x3543.jpg",
   "keywords": [


### PR DESCRIPTION
Cookwell.com only provides calorie information in the recipe metadata, but additional nutrition information is embedded in one of the page's scripts. This change searches the script tags for the matching information and extracts it. If it cannot find the information, it will default to the calorie only information provided in the metadata. I've tested this with a few random recipes from the site and observed it working as expected.
```
from urllib.request import urlopen
from recipe_scrapers import scrape_html
url = "https://cookwell.com/recipe/crispy-oven-fries"
html = urlopen(url).read().decode("utf-8")
scraper = scrape_html(html,url)
scraper.nutrients()
```
> {'calories': '970 calories', 'carbohydrateContent': '100 g', 'fatContent': '60 g', 'proteinContent': '12 g'}
```
...
url = "https://cookwell.com/recipe/lahmacun"
...
scraper.nutrients()
```
> {'calories': '2558 calories', 'carbohydrateContent': '402 g', 'fatContent': '49 g', 'proteinContent': '132 g'}
