### PR TITLE
Added headers to the URLOpen Request

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -1033,5 +1033,5 @@ def scrape_html(
 
 
 def scrape_me(url: str) -> AbstractScraper:
-    html = urlopen(Request(url, headers={'User-Agent': 'Mozilla/5.0'})).read().decode("utf-8")
+    html = urlopen(Request(url, headers=HEADERS)).read().decode("utf-8")
     return scrape_html(html, org_url=url)

--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -13,7 +13,7 @@ __all__ = (
 
 import warnings
 
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
 
 try:
     # requests is an optional dependency; we can provide better error messages
@@ -1033,5 +1033,5 @@ def scrape_html(
 
 
 def scrape_me(url: str) -> AbstractScraper:
-    html = urlopen(url).read().decode("utf-8")
+    html = urlopen(Request(url, headers={'User-Agent': 'Mozilla/5.0'})).read().decode("utf-8")
     return scrape_html(html, org_url=url)


### PR DESCRIPTION
The urllib open was getting HTTP 403 (Forbidden) for some of the domains, examples https://addapinch.com/the-best-chocolate-cake-recipe-ever/ https://www.baking-sense.com/2024/03/08/coconut-layer-cake/.  Added a browser header that fixed the error