### PR TITLE
Refactor: Optimize Equipment Helper and Simplify Logic for WPRM Equip

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -236,13 +236,7 @@ def get_yields(element):
 
 def get_equipment(equipment_items):
     # Removes duplicates from results and sorts them in order they appear on site.
-    seen = set()
-    unique_equipment = []
-    for item in equipment_items:
-        if item not in seen:
-            seen.add(item)
-            unique_equipment.append(item)
-    return unique_equipment
+    return list(dict.fromkeys(equipment_items))
 
 
 def normalize_string(string):

--- a/recipe_scrapers/abeautifulmess.py
+++ b/recipe_scrapers/abeautifulmess.py
@@ -8,12 +8,9 @@ class ABeautifulMess(AbstractScraper):
         return "abeautifulmess.com"
 
     def equipment(self):
-        equipment_container = self.soup.select_one(".wprm-recipe-equipment-container")
-        if not equipment_container:
-            return None
-
         equipment_items = [
-            item.get_text()
-            for item in equipment_container.select(".wprm-recipe-equipment-name")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/acozykitchen.py
+++ b/recipe_scrapers/acozykitchen.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class ACozyKitchen(AbstractScraper):
@@ -14,3 +15,11 @@ class ACozyKitchen(AbstractScraper):
             ".wprm-recipe-ingredient-group h4",
             ".wprm-recipe-ingredient-group li",
         )
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/aflavorjournal.py
+++ b/recipe_scrapers/aflavorjournal.py
@@ -9,9 +9,8 @@ class AFlavorJournal(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            item.get_text()
-            for item in self.soup.select(
-                "li.wprm-recipe-equipment-item div.wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/altonbrown.py
+++ b/recipe_scrapers/altonbrown.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class AltonBrown(AbstractScraper):
@@ -7,11 +8,9 @@ class AltonBrown(AbstractScraper):
         return "altonbrown.com"
 
     def equipment(self):
-        return list(
-            dict.fromkeys(
-                (equip.get_text())
-                for equip in self.soup.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            )
-        )
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/ameessavorydish.py
+++ b/recipe_scrapers/ameessavorydish.py
@@ -1,6 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
-from ._utils import get_equipment, normalize_string
+from ._utils import get_equipment
 
 
 class AmeesSavoryDish(AbstractScraper):
@@ -32,15 +32,9 @@ class AmeesSavoryDish(AbstractScraper):
         )
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            normalize_string(item.get_text())
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/bakingsense.py
+++ b/recipe_scrapers/bakingsense.py
@@ -18,8 +18,8 @@ class BakingSense(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            equip.get_text()
+            text
             for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
-            if equip.get_text()
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/bowlofdelicious.py
+++ b/recipe_scrapers/bowlofdelicious.py
@@ -9,9 +9,8 @@ class BowlOfDelicious(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            link.get_text()
-            for link in self.soup.select(
-                "div.wprm-recipe-equipment-name a.wprm-recipe-equipment-link"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/brokenovenbaking.py
+++ b/recipe_scrapers/brokenovenbaking.py
@@ -8,12 +8,9 @@ class BrokenOvenBaking(AbstractScraper):
         return "brokenovenbaking.com"
 
     def equipment(self):
-        equipment_items = self.soup.select(
-            ".wprm-recipe-equipment-container .wprm-recipe-equipment-item"
-        )
-        equipment_list = [
-            item.select_one(".wprm-recipe-equipment-name").get_text()
-            for item in equipment_items
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
-
-        return get_equipment(equipment_list)
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/budgetbytes.py
+++ b/recipe_scrapers/budgetbytes.py
@@ -9,9 +9,8 @@ class BudgetBytes(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            link.get_text()
-            for link in self.soup.select(
-                "div.wprm-recipe-equipment-name a.wprm-recipe-equipment-link"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/cakemehometonight.py
+++ b/recipe_scrapers/cakemehometonight.py
@@ -8,9 +8,9 @@ class CakeMeHomeTonight(AbstractScraper):
         return "cakemehometonight.com"
 
     def equipment(self):
-        equipment_items = self.soup.select(
-            ".wprm-recipe-equipment-container .wprm-recipe-equipment-list .wprm-recipe-equipment-item .wprm-recipe-equipment-name"
-        )
-        equipment_list = [item.get_text(strip=True) for item in equipment_items]
-
-        return get_equipment(equipment_list)
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/cambreabakes.py
+++ b/recipe_scrapers/cambreabakes.py
@@ -8,9 +8,9 @@ class CambreaBakes(AbstractScraper):
         return "cambreabakes.com"
 
     def equipment(self):
-        equipment_items = self.soup.select(
-            ".wprm-recipe-equipment.wprm-recipe-equipment-list .wprm-recipe-equipment-item .wprm-recipe-equipment-name"
-        )
-        equipment_list = [item.get_text(strip=True) for item in equipment_items]
-
-        return get_equipment(equipment_list)
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/chefjeanpierre.py
+++ b/recipe_scrapers/chefjeanpierre.py
@@ -8,15 +8,9 @@ class ChefJeanPierre(AbstractScraper):
         return "chefjeanpierre.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text(strip=True)
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/chewoutloud.py
+++ b/recipe_scrapers/chewoutloud.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class ChewOutLoud(AbstractScraper):
@@ -14,3 +15,11 @@ class ChewOutLoud(AbstractScraper):
             ".wprm-recipe-ingredient-group h4",
             ".wprm-recipe-ingredient",
         )
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/emmikochteinfach.py
+++ b/recipe_scrapers/emmikochteinfach.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class EmmiKochtEinfach(AbstractScraper):
     @classmethod
     def host(cls):
         return "emmikochteinfach.de"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/forktospoon.py
+++ b/recipe_scrapers/forktospoon.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class ForkToSpoon(AbstractScraper):
@@ -7,10 +8,9 @@ class ForkToSpoon(AbstractScraper):
         return "forktospoon.com"
 
     def equipment(self):
-        seen = set()
-        return [
-            equip.get_text()
+        equipment_items = [
+            text
             for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
-            if equip.get_text()
-            and (equip.get_text() not in seen and not seen.add(equip.get_text()))
+            if (text := equip.get_text())
         ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/fortyaprons.py
+++ b/recipe_scrapers/fortyaprons.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class FortyAprons(AbstractScraper):
@@ -53,12 +54,12 @@ class FortyAprons(AbstractScraper):
         return self.schema.ratings_count()
 
     def equipment(self):
-        equipment_elements = self.soup.select(".wprm-recipe-equipment-name")
-        return (
-            [element.get_text() for element in equipment_elements]
-            if equipment_elements
-            else None
-        )
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)
 
     def keywords(self):
         return self.schema.keywords()

--- a/recipe_scrapers/glutenfreeonashoestring.py
+++ b/recipe_scrapers/glutenfreeonashoestring.py
@@ -9,8 +9,8 @@ class GlutenFreeOnAShoeString(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            equip.get_text()
+            text
             for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
-            if equip.get_text()
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/howtofeedaloon.py
+++ b/recipe_scrapers/howtofeedaloon.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class HowToFeedALoon(AbstractScraper):
@@ -34,3 +35,11 @@ class HowToFeedALoon(AbstractScraper):
             ".wprm-recipe-ingredient-group h4",
             ".wprm-recipe-ingredient-group li",
         )
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/hungryhappens.py
+++ b/recipe_scrapers/hungryhappens.py
@@ -8,13 +8,9 @@ class HungryHappens(AbstractScraper):
         return "hungryhappens.net"
 
     def equipment(self):
-        equipment_container = self.soup.select_one(".wprm-recipe-equipment-container")
-        if not equipment_container:
-            return None
-
         equipment_items = [
-            item.select_one(".wprm-recipe-equipment-name").get_text(strip=True)
-            for item in equipment_container.select(".wprm-recipe-equipment-item")
-            if item.select_one(".wprm-recipe-equipment-name")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/jocooks.py
+++ b/recipe_scrapers/jocooks.py
@@ -9,7 +9,8 @@ class JoCooks(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            item.get_text()
-            for item in self.soup.find_all("li", class_="wprm-recipe-equipment-item")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/joyfoodsunshine.py
+++ b/recipe_scrapers/joyfoodsunshine.py
@@ -14,8 +14,8 @@ class Joyfoodsunshine(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            item.find("a", class_="wprm-recipe-equipment-link").get_text()
-            for item in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
-            if item.find("a", class_="wprm-recipe-equipment-link")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/kitchendivas.py
+++ b/recipe_scrapers/kitchendivas.py
@@ -8,15 +8,9 @@ class KitchenDivas(AbstractScraper):
         return "kitchendivas.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text(strip=True)
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/krollskorner.py
+++ b/recipe_scrapers/krollskorner.py
@@ -14,13 +14,9 @@ class KrollsKorner(AbstractScraper):
         return author_tag.get_text(strip=True)
 
     def equipment(self):
-        equipment_container = self.soup.select_one(".wprm-recipe-equipment-container")
-        if not equipment_container:
-            return None
-
         equipment_items = [
-            item.select_one(".wprm-recipe-equipment-name").get_text(strip=True)
-            for item in equipment_container.select(".wprm-recipe-equipment-item")
-            if item.select_one(".wprm-recipe-equipment-name")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/leckerschmecker.py
+++ b/recipe_scrapers/leckerschmecker.py
@@ -28,7 +28,8 @@ class LeckerSchmecker(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            item.get_text()
-            for item in self.soup.find_all("li", class_="wprm-recipe-equipment-item")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/lifestyleofafoodie.py
+++ b/recipe_scrapers/lifestyleofafoodie.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class LifestyleOfAFoodie(AbstractScraper):
@@ -16,11 +17,9 @@ class LifestyleOfAFoodie(AbstractScraper):
         )
 
     def equipment(self):
-        return list(
-            dict.fromkeys(
-                (item.get_text())
-                for item in self.soup.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            )
-        )
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/littlesunnykitchen.py
+++ b/recipe_scrapers/littlesunnykitchen.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class LittleSunnyKitchen(AbstractScraper):
     @classmethod
     def host(cls):
         return "littlesunnykitchen.com"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/madamecuisine.py
+++ b/recipe_scrapers/madamecuisine.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_yields
+from ._utils import get_yields, get_equipment
 
 
 class MadameCuisine(AbstractScraper):
@@ -58,3 +58,11 @@ class MadameCuisine(AbstractScraper):
 
     def description(self):
         return self.soup.find("div", {"class": "wprm-recipe-summary"}).get_text()
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/makeitdairyfree.py
+++ b/recipe_scrapers/makeitdairyfree.py
@@ -8,15 +8,9 @@ class MakeItDairyFree(AbstractScraper):
         return "makeitdairyfree.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text(strip=True)
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/mealprepmanual.py
+++ b/recipe_scrapers/mealprepmanual.py
@@ -8,15 +8,9 @@ class MealPrepManual(AbstractScraper):
         return "mealprepmanual.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text(strip=True)
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/melskitchencafe.py
+++ b/recipe_scrapers/melskitchencafe.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class MelsKitchenCafe(AbstractScraper):
     @classmethod
     def host(cls):
         return "melskitchencafe.com"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/ministryofcurry.py
+++ b/recipe_scrapers/ministryofcurry.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class MinistryOfCurry(AbstractScraper):
@@ -7,11 +8,9 @@ class MinistryOfCurry(AbstractScraper):
         return "ministryofcurry.com"
 
     def equipment(self):
-        return list(
-            {
-                (item.get_text())
-                for item in self.soup.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            }
-        )
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/modernhoney.py
+++ b/recipe_scrapers/modernhoney.py
@@ -9,7 +9,8 @@ class ModernHoney(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            item.get_text()
-            for item in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/momswithcrockpots.py
+++ b/recipe_scrapers/momswithcrockpots.py
@@ -9,8 +9,8 @@ class MomsWithCrockPots(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            item.find("a", class_="wprm-recipe-equipment-link").get_text()
-            for item in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
-            if item.find("a", class_="wprm-recipe-equipment-link")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/mykitchen101.py
+++ b/recipe_scrapers/mykitchen101.py
@@ -3,7 +3,7 @@ import re
 from bs4 import BeautifulSoup
 
 from ._abstract import AbstractScraper
-from ._utils import get_yields, normalize_string
+from ._utils import get_yields, normalize_string, get_equipment
 
 
 class MyKitchen101(AbstractScraper):
@@ -43,11 +43,9 @@ class MyKitchen101(AbstractScraper):
         )
 
     def equipment(self):
-        return list(
-            {
-                normalize_string("".join(item.stripped_strings).split("(")[0].strip())
-                for item in self.soup.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            }
-        )
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/mykitchen101en.py
+++ b/recipe_scrapers/mykitchen101en.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class MyKitchen101en(AbstractScraper):
@@ -7,11 +8,9 @@ class MyKitchen101en(AbstractScraper):
         return "mykitchen101en.com"
 
     def equipment(self):
-        return list(
-            {
-                ("".join(item.stripped_strings).split("(")[0].strip())
-                for item in self.soup.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            }
-        )
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/onesweetappetite.py
+++ b/recipe_scrapers/onesweetappetite.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._utils import get_equipment, normalize_string
+from ._utils import get_equipment
 
 
 class OneSweetAppetite(AbstractScraper):
@@ -9,7 +9,8 @@ class OneSweetAppetite(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            normalize_string(e.get_text())
-            for e in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/peelwithzeal.py
+++ b/recipe_scrapers/peelwithzeal.py
@@ -9,8 +9,8 @@ class PeelWithZeal(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            equip.get_text()
+            text
             for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
-            if equip.get_text()
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/persnicketyplates.py
+++ b/recipe_scrapers/persnicketyplates.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class PersnicketyPlates(AbstractScraper):
     @classmethod
     def host(cls):
         return "persnicketyplates.com"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/pinkowlkitchen.py
+++ b/recipe_scrapers/pinkowlkitchen.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class PinkOwlKitchen(AbstractScraper):
@@ -14,3 +15,11 @@ class PinkOwlKitchen(AbstractScraper):
             ".wprm-recipe-ingredient-group h4",
             ".wprm-recipe-ingredient-group li",
         )
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/plowingthroughlife.py
+++ b/recipe_scrapers/plowingthroughlife.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class PlowingThroughLife(AbstractScraper):
     @classmethod
     def host(cls):
         return "plowingthroughlife.com"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/preppykitchen.py
+++ b/recipe_scrapers/preppykitchen.py
@@ -8,15 +8,9 @@ class PreppyKitchen(AbstractScraper):
         return "preppykitchen.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text(strip=True)
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/saltpepperskillet.py
+++ b/recipe_scrapers/saltpepperskillet.py
@@ -11,15 +11,9 @@ class SaltPepperSkillet(AbstractScraper):
         return self.schema.author().title()
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text(strip=True)
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/savorynothings.py
+++ b/recipe_scrapers/savorynothings.py
@@ -9,15 +9,8 @@ class SavoryNothings(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            link.get_text()
-            for link in self.soup.select(
-                "div.wprm-recipe-equipment-name a.wprm-recipe-equipment-link"
-            )
-        ]
-        equipment_items += [
-            item.get_text()
-            for item in self.soup.select(
-                "div.wprm-recipe-equipment-name:not(:has(a.wprm-recipe-equipment-link))"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/scrummylane.py
+++ b/recipe_scrapers/scrummylane.py
@@ -1,5 +1,5 @@
 from ._abstract import AbstractScraper
-from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class ScrummyLane(AbstractScraper):
@@ -7,11 +7,10 @@ class ScrummyLane(AbstractScraper):
     def host(cls):
         return "scrummylane.com"
 
-
-def ingredient_groups(self):
-    return group_ingredients(
-        self.ingredients(),
-        self.soup,
-        ".wprm-recipe-ingredient-group h4",
-        ".wprm-recipe-ingredient-group li",
-    )
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/simplegreensmoothies.py
+++ b/recipe_scrapers/simplegreensmoothies.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class SimpleGreenSmoothies(AbstractScraper):
@@ -25,3 +26,11 @@ class SimpleGreenSmoothies(AbstractScraper):
             ingredients_list.append(ingredient)
 
         return ingredients_list
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/skinnytaste.py
+++ b/recipe_scrapers/skinnytaste.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class SkinnyTaste(AbstractScraper):
@@ -7,14 +8,9 @@ class SkinnyTaste(AbstractScraper):
         return "skinnytaste.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if equipment_container:
-            return [
-                item.get_text(strip=True)
-                for item in equipment_container.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            ]
-        return None
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/spendwithpennies.py
+++ b/recipe_scrapers/spendwithpennies.py
@@ -8,14 +8,9 @@ class SpendWithPennies(AbstractScraper):
         return "spendwithpennies.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if equipment_container:
-            equipment_items = [
-                item.get_text()
-                for item in equipment_container.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            ]
-            return get_equipment(equipment_items)
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/stacyling.py
+++ b/recipe_scrapers/stacyling.py
@@ -8,15 +8,9 @@ class StacyLing(AbstractScraper):
         return "stacyling.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text()
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/recipe_scrapers/staysnatched.py
+++ b/recipe_scrapers/staysnatched.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class StaySnatched(AbstractScraper):
@@ -14,3 +15,11 @@ class StaySnatched(AbstractScraper):
             },
         )
         return author_element.find("a").get_text() if author_element else "Unknown"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/tastesbetterfromscratch.py
+++ b/recipe_scrapers/tastesbetterfromscratch.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class TastesBetterFromScratch(AbstractScraper):
     @classmethod
     def host(cls):
         return "tastesbetterfromscratch.com"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/tastyoven.py
+++ b/recipe_scrapers/tastyoven.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class TastyOven(AbstractScraper):
@@ -7,14 +8,9 @@ class TastyOven(AbstractScraper):
         return "tastyoven.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if equipment_container:
-            return [
-                item.get_text(strip=True)
-                for item in equipment_container.find_all(
-                    "div", class_="wprm-recipe-equipment-name"
-                )
-            ]
-        return None
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/thekitchencommunity.py
+++ b/recipe_scrapers/thekitchencommunity.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class TheKitchenCommunity(AbstractScraper):
     @classmethod
     def host(cls):
         return "thekitchencommunity.org"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/themagicalslowcooker.py
+++ b/recipe_scrapers/themagicalslowcooker.py
@@ -1,7 +1,16 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class TheMagicalSlowCooker(AbstractScraper):
     @classmethod
     def host(cls):
         return "themagicalslowcooker.com"
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/theplantbasedschool.py
+++ b/recipe_scrapers/theplantbasedschool.py
@@ -9,10 +9,9 @@ class ThePlantBasedSchool(AbstractScraper):
 
     def equipment(self):
         equipment_items = [
-            item.get_text()
-            for item in self.soup.select(
-                "li.wprm-recipe-equipment-item div.wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)
 

--- a/recipe_scrapers/thespicetrain.py
+++ b/recipe_scrapers/thespicetrain.py
@@ -1,5 +1,6 @@
 from ._abstract import AbstractScraper
 from ._grouping_utils import group_ingredients
+from ._utils import get_equipment
 
 
 class TheSpiceTrain(AbstractScraper):
@@ -14,3 +15,11 @@ class TheSpiceTrain(AbstractScraper):
             ".wprm-recipe-ingredient-group h4",
             ".wprm-recipe-ingredient-group li",
         )
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/thinlicious.py
+++ b/recipe_scrapers/thinlicious.py
@@ -8,5 +8,9 @@ class Thinlicious(AbstractScraper):
         return "thinlicious.com"
 
     def equipment(self):
-        equipment_list = self.soup.select(".wprm-recipe-equipment-name")
-        return get_equipment(item.get_text() for item in equipment_list)
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/watchwhatueat.py
+++ b/recipe_scrapers/watchwhatueat.py
@@ -1,4 +1,5 @@
 from ._abstract import AbstractScraper
+from ._utils import get_equipment
 
 
 class WatchWhatUEat(AbstractScraper):
@@ -18,3 +19,11 @@ class WatchWhatUEat(AbstractScraper):
             text = " ".join(part.get_text(strip=True) for part in parts)
             ingredients.append(text.strip())
         return ingredients
+
+    def equipment(self):
+        equipment_items = [
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
+        ]
+        return get_equipment(equipment_items)

--- a/recipe_scrapers/wedishitup.py
+++ b/recipe_scrapers/wedishitup.py
@@ -8,15 +8,9 @@ class WeDishItUp(AbstractScraper):
         return "wedishitup.com"
 
     def equipment(self):
-        equipment_container = self.soup.find(
-            "div", class_="wprm-recipe-equipment-container"
-        )
-        if not equipment_container:
-            return None
         equipment_items = [
-            item.get_text(strip=True)
-            for item in equipment_container.find_all(
-                "div", class_="wprm-recipe-equipment-name"
-            )
+            text
+            for equip in self.soup.find_all("div", class_="wprm-recipe-equipment-name")
+            if (text := equip.get_text())
         ]
         return get_equipment(equipment_items)

--- a/tests/test_data/acozykitchen.com/acozykitchen_1.json
+++ b/tests/test_data/acozykitchen.com/acozykitchen_1.json
@@ -26,6 +26,9 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 1,
+  "equipment": [
+    "1 small bowl"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "50 kcal",

--- a/tests/test_data/acozykitchen.com/acozykitchen_2.json
+++ b/tests/test_data/acozykitchen.com/acozykitchen_2.json
@@ -109,6 +109,9 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 13,
+  "equipment": [
+    "1 (8×8-inch or 9×9-inch) square baking pan"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "350 kcal",

--- a/tests/test_data/chewoutloud.com/chewoutloud_2.json
+++ b/tests/test_data/chewoutloud.com/chewoutloud_2.json
@@ -54,6 +54,10 @@
   "cuisine": "American",
   "ratings": 4.75,
   "ratings_count": 316,
+  "equipment": [
+    "Splatter Screen for Frying Pan",
+    "Large Oven Proof Pan"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "241 kcal",

--- a/tests/test_data/howtofeedaloon.com/howtofeedaloon_2.json
+++ b/tests/test_data/howtofeedaloon.com/howtofeedaloon_2.json
@@ -94,6 +94,10 @@
   "cook_time": 180,
   "prep_time": 30,
   "cuisine": "Mexican",
+  "equipment": [
+    "Al Pastor Skewer for Grill",
+    "Charcoal or gas grill"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "247 kcal",

--- a/tests/test_data/kitchendivas.com/kitchendivas_1.json
+++ b/tests/test_data/kitchendivas.com/kitchendivas_1.json
@@ -37,7 +37,7 @@
   "ratings": 5.0,
   "ratings_count": 1,
   "equipment": [
-    "9 x 5 inch loaf panor bread pan",
+    "9 x 5 inch loaf pan or bread pan",
     "whisk",
     "mixing bowl",
     "wooden spoon",

--- a/tests/test_data/littlesunnykitchen.com/littlesunnykitchen.json
+++ b/tests/test_data/littlesunnykitchen.com/littlesunnykitchen.json
@@ -31,6 +31,9 @@
   "cuisine": "American,Mexican",
   "ratings": 4.95,
   "ratings_count": 57,
+  "equipment": [
+    "Gallon sized Ziploc bag"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "49 kcal",

--- a/tests/test_data/madamecuisine.de/madamecuisine_1.json
+++ b/tests/test_data/madamecuisine.de/madamecuisine_1.json
@@ -84,6 +84,11 @@
   "cuisine": "Amerikanisch, Deutsch",
   "ratings": 5.0,
   "ratings_count": 4,
+  "equipment": [
+    "1 Schneidebrett + Messer",
+    "1 großer Topf mit Deckel",
+    "1 Sieb"
+  ],
   "nutrients": {
     "servingSize": "1 Portion",
     "calories": "540 kcal"

--- a/tests/test_data/melskitchencafe.com/melskitchencafe.json
+++ b/tests/test_data/melskitchencafe.com/melskitchencafe.json
@@ -30,6 +30,11 @@
   "prep_time": 130,
   "ratings": 4.6,
   "ratings_count": 49,
+  "equipment": [
+    "8-inch Baking Pan",
+    "Cookware",
+    "Instant Read Thermometer"
+  ],
   "nutrients": {
     "servingSize": "1 Caramel",
     "calories": "100 kcal",

--- a/tests/test_data/mykitchen101en.com/mykitchen101en.json
+++ b/tests/test_data/mykitchen101en.com/mykitchen101en.json
@@ -42,7 +42,7 @@
   "ratings": 5.0,
   "ratings_count": 3,
   "equipment": [
-    "2 mini muffin pans"
+    "2 mini muffin pans  (diameter = 4.8 cm, depth = 2.2 cm) "
   ],
   "nutrients": {
     "servingSize": "1 serving",

--- a/tests/test_data/persnicketyplates.com/persnicketyplates.json
+++ b/tests/test_data/persnicketyplates.com/persnicketyplates.json
@@ -32,6 +32,9 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 2,
+  "equipment": [
+    "Slow Cooker"
+  ],
   "nutrients": {
     "servingSize": "1 g",
     "calories": "638 kcal",

--- a/tests/test_data/pinkowlkitchen.com/pinkowlkitchen_1.json
+++ b/tests/test_data/pinkowlkitchen.com/pinkowlkitchen_1.json
@@ -30,6 +30,12 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 1,
+  "equipment": [
+    "Mixing bowls",
+    "Measuring cups and spoons",
+    "9-inch pie plate",
+    "Pie server"
+  ],
   "nutrients": {
     "servingSize": "1 slice",
     "calories": "260 kcal",

--- a/tests/test_data/pinkowlkitchen.com/pinkowlkitchen_2.json
+++ b/tests/test_data/pinkowlkitchen.com/pinkowlkitchen_2.json
@@ -46,6 +46,9 @@
   "cuisine": "American",
   "ratings": 4.94,
   "ratings_count": 16,
+  "equipment": [
+    "Handheld milk frother"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "200 kcal",

--- a/tests/test_data/plowingthroughlife.com/plowingthroughlife_1.json
+++ b/tests/test_data/plowingthroughlife.com/plowingthroughlife_1.json
@@ -31,6 +31,12 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 20,
+  "equipment": [
+    "Slow Cooker",
+    "Silicone Spatula",
+    "Slow Cooker Liners",
+    "Measuring Spoons"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "306 kcal",

--- a/tests/test_data/plowingthroughlife.com/plowingthroughlife_2.json
+++ b/tests/test_data/plowingthroughlife.com/plowingthroughlife_2.json
@@ -57,6 +57,11 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 13,
+  "equipment": [
+    "1 9×13 Baking Dish",
+    "1 Mixing Bowls",
+    "1 Hand Mixer"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "951 kcal",

--- a/tests/test_data/scrummylane.com/scrummylane_1.json
+++ b/tests/test_data/scrummylane.com/scrummylane_1.json
@@ -36,6 +36,9 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 6,
+  "equipment": [
+    "Jumbo sautée pan"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "92 kcal",

--- a/tests/test_data/scrummylane.com/scrummylane_2.json
+++ b/tests/test_data/scrummylane.com/scrummylane_2.json
@@ -123,6 +123,9 @@
   "cuisine": "Greek",
   "ratings": 5.0,
   "ratings_count": 17,
+  "equipment": [
+    "Cuisinart 8 cup food processor"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "589 kcal",

--- a/tests/test_data/simplegreensmoothies.com/simplegreensmoothies_1.json
+++ b/tests/test_data/simplegreensmoothies.com/simplegreensmoothies_1.json
@@ -28,6 +28,9 @@
   "cuisine": "Plant-Based",
   "ratings": 4.85,
   "ratings_count": 1939,
+  "equipment": [
+    "high-speed blender"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "203 kcal",

--- a/tests/test_data/skinnytaste.com/skinnytaste_2.json
+++ b/tests/test_data/skinnytaste.com/skinnytaste_2.json
@@ -80,7 +80,7 @@
   "ratings": 4.74,
   "ratings_count": 19,
   "equipment": [
-    "large deep skilletor wok"
+    "large deep skillet or wok"
   ],
   "nutrients": {
     "servingSize": "3 /4 cup chicken with 3/4 cups rice",

--- a/tests/test_data/staysnatched.com/staysnatched_1.json
+++ b/tests/test_data/staysnatched.com/staysnatched_1.json
@@ -36,6 +36,11 @@
   "cook_time": 25,
   "prep_time": 10,
   "cuisine": "American",
+  "equipment": [
+    "12 inch Cast Iron Skillet",
+    "Cast Iron Skillet",
+    "Cast Iron Dutch Oven"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "545 kcal",

--- a/tests/test_data/staysnatched.com/staysnatched_2.json
+++ b/tests/test_data/staysnatched.com/staysnatched_2.json
@@ -73,6 +73,10 @@
   "cuisine": "American",
   "ratings": 4.89,
   "ratings_count": 60,
+  "equipment": [
+    "Slow Cooker",
+    "Meat Chopper"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "346 kcal",

--- a/tests/test_data/tastesbetterfromscratch.com/tastesbetterfromscratch.json
+++ b/tests/test_data/tastesbetterfromscratch.com/tastesbetterfromscratch.json
@@ -35,6 +35,9 @@
   "cuisine": "American",
   "ratings": 4.99,
   "ratings_count": 744,
+  "equipment": [
+    "Dutch Oven"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "310 kcal",

--- a/tests/test_data/thekitchencommunity.org/thekitchencommunity.json
+++ b/tests/test_data/thekitchencommunity.org/thekitchencommunity.json
@@ -34,6 +34,12 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 25,
+  "equipment": [
+    "1 slow cooker at least 6 quarts",
+    "1 Food processor",
+    "1 Measuring cup",
+    "1 Measuring spoons"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "574 kcal"

--- a/tests/test_data/themagicalslowcooker.com/themagicalslowcooker_1.json
+++ b/tests/test_data/themagicalslowcooker.com/themagicalslowcooker_1.json
@@ -28,6 +28,9 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 1,
+  "equipment": [
+    "Slow Cooker – 3 quart or larger"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "275 kcal",

--- a/tests/test_data/themagicalslowcooker.com/themagicalslowcooker_2.json
+++ b/tests/test_data/themagicalslowcooker.com/themagicalslowcooker_2.json
@@ -77,6 +77,9 @@
   "cuisine": "American",
   "ratings": 5.0,
   "ratings_count": 8,
+  "equipment": [
+    "Slow Cooker- 6 quart or larger"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "582 kcal",

--- a/tests/test_data/thespicetrain.com/thespicetrain_1.json
+++ b/tests/test_data/thespicetrain.com/thespicetrain_1.json
@@ -27,6 +27,10 @@
   "cuisine": "World",
   "ratings": 4.9,
   "ratings_count": 19,
+  "equipment": [
+    "measuring spoons",
+    "mixing bowl"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "13 kcal",

--- a/tests/test_data/thespicetrain.com/thespicetrain_2.json
+++ b/tests/test_data/thespicetrain.com/thespicetrain_2.json
@@ -62,6 +62,16 @@
   "total_time": 20,
   "cook_time": 20,
   "cuisine": "Mexican",
+  "equipment": [
+    "measuring spoons",
+    "kitchen scale",
+    "knife and cutting board",
+    "cast iron skillet or non-stick pan",
+    "wooden spoon or spatula",
+    "paper towels",
+    "kitchen tongs",
+    "cheese grater"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "616 kcal",

--- a/tests/test_data/watchwhatueat.com/watchwhatueat.json
+++ b/tests/test_data/watchwhatueat.com/watchwhatueat.json
@@ -74,6 +74,9 @@
   "cuisine": "American Inspired",
   "ratings": 4.59,
   "ratings_count": 17,
+  "equipment": [
+    "Instant Pot"
+  ],
   "nutrients": {
     "servingSize": "1 serving",
     "calories": "99 kcal",


### PR DESCRIPTION
**_`utils.py`**
- Replaced the manual loop-based deduplication in `get_equipment()` with `dict.fromkeys()`

**Equipment gathering throughout codebase**
- Removed redundant calls to `get_text()` by using a walrus operator for assignment within the list.

**Newly added equipment coverage to existing scrapers**
1. acozykitchen.py
2. chewoutloud.py
3. emmikochteinfach.py
4. howtofeedaloon.py
5. littlesunnykitchen.py
6. madamecuisine.py
7. melskitchencafe.py
8. persnicketyplates.py
9. pinkowlkitchen.py
10. plowingthroughlife.py
11. simplegreensmoothies.py
12. staysnatched.py
13. tastesbetterfromscratch.py
14. thekitchencommunity.py
15. themagicalslowcooker.py
16. thespicetrain.py
17. watchwhatueat.py