### PR TITLE
Fix: Add normalization for HTML entity u0026#039;

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -358,8 +358,10 @@ class SchemaOrg:
             raise SchemaOrgException("No keywords data in SchemaOrg")
         if keywords:
             if isinstance(keywords, list):
+                keywords = [normalize_string(k) for k in keywords]
                 keywords = ", ".join(keywords)
-            keywords = normalize_string(keywords)
+            else:
+                keywords = normalize_string(keywords)
             keywords = csv_to_tags(keywords)
         return keywords
 

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -254,6 +254,7 @@ def normalize_string(string):
         .replace("\r\n", " ")
         .replace("\n", " ")  # &nbsp;
         .replace("\t", " ")
+        .replace("u0026#039;", "'")
         .strip(),
     )
 

--- a/tests/test_data/abuelascounter.com/abuelascounter_2.json
+++ b/tests/test_data/abuelascounter.com/abuelascounter_2.json
@@ -73,7 +73,7 @@
   },
   "image": "https://abuelascounter.com/wp-content/uploads/2023/11/Pecan-Bars-Recipe-2.jpeg",
   "keywords": [
-    "abuelau0026#039;s",
+    "abuela's",
     "dessert",
     "dessert ideas",
     "easy recipes",


### PR DESCRIPTION
- Adds replace("u0026#039;", "'") to ensure apostrophes are properly decoded within `normalize_string`
- Pass output of `keywords` through `normalize_string`