### PR TITLE
fix: detect JSON-LD injected by Next.js App Router __next_s SSR mechanism

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -2,6 +2,8 @@
 # find a package that parses https://schema.org/Recipe properly (or create one ourselves).
 from __future__ import annotations
 
+import json
+import re
 from itertools import chain
 
 import extruct
@@ -24,6 +26,50 @@ SYNTAXES = ["json-ld", "microdata"]
 
 class SchemaOrg:
     @staticmethod
+    def _normalize_nextjs_jsonld(html: str) -> str:
+        """Lift JSON-LD from Next.js App Router __next_s.push() injections.
+
+        Next.js App Router SSR pages inject JSON-LD via:
+
+            (self.__next_s=self.__next_s||[]).push([0,
+                {"type":"application/ld+json","children":"{...}"}
+            ])
+
+        instead of a static <script type="application/ld+json"> tag, so extruct
+        misses it entirely. This method detects the pattern and injects a proper
+        script tag before the HTML reaches extruct.
+
+        Returns *html* unchanged when the pattern is absent (fast path).
+        """
+        if "__next_s" not in html or "application/ld+json" not in html:
+            return html
+
+        injected: list[str] = []
+        for script_body in re.findall(r"<script[^>]*>(.*?)</script>", html, re.DOTALL):
+            if "__next_s" not in script_body or "application/ld+json" not in script_body:
+                continue
+            m = re.search(r"push\(\[0,(\{.*\})\]\)", script_body, re.DOTALL)
+            if not m:
+                continue
+            try:
+                obj = json.loads(m.group(1))
+                if obj.get("type") == "application/ld+json" and "children" in obj:
+                    injected.append(obj["children"])
+            except (json.JSONDecodeError, KeyError):
+                continue
+
+        if not injected:
+            return html
+
+        extra = "".join(
+            f'<script type="application/ld+json">{content}</script>'
+            for content in injected
+        )
+        if "</head>" in html:
+            return html.replace("</head>", extra + "</head>", 1)
+        return extra + html
+
+    @staticmethod
     def _contains_schematype(item, schematype):
         itemtype = item.get("@type", "")
         itemtypes = itemtype if isinstance(itemtype, list) else [itemtype]
@@ -40,6 +86,7 @@ class SchemaOrg:
                     return node
 
     def __init__(self, page_data):
+        page_data = self._normalize_nextjs_jsonld(page_data)
         self.format = None
         self.data = {}
         self.people = {}

--- a/tests/library/test_schemaorg.py
+++ b/tests/library/test_schemaorg.py
@@ -130,3 +130,27 @@ class TestSchemaOrg(unittest.TestCase):
             )
         finally:
             settings.BEST_IMAGE_SELECTION = original
+
+    def test_nextjs_ssr_jsonld(self):
+        """JSON-LD injected via Next.js __next_s.push() must be detected."""
+        import json as _json
+
+        ld = {
+            "@context": "https://schema.org",
+            "@type": "Recipe",
+            "name": "Test Next.js Recipe",
+            "recipeIngredient": ["500g fish"],
+            "recipeInstructions": ["Cook the fish."],
+        }
+        outer = _json.dumps(
+            {"type": "application/ld+json", "async": True, "children": _json.dumps(ld)}
+        )
+        page_data = (
+            "<html><head><title>Test</title>"
+            f"<script>(self.__next_s=self.__next_s||[]).push([0,{outer}])</script>"
+            "</head><body></body></html>"
+        )
+        parser = SchemaOrg(page_data)
+        self.assertEqual("Test Next.js Recipe", parser.title())
+        self.assertIn("500g fish", parser.ingredients())
+        self.assertEqual("Cook the fish.", parser.instructions())


### PR DESCRIPTION
## Problem

Next.js App Router SSR pages inject JSON-LD via a JavaScript push call rather than a static `<script type="application/ld+json">` tag:

```html
<script>
(self.__next_s=self.__next_s||[]).push([0,
    {"type":"application/ld+json","async":true,"children":"{...recipe JSON...}"}
])
</script>
```

`extruct` (which recipe-scrapers uses for JSON-LD extraction) only finds static script tags, so it misses this markup entirely. The result is that `SchemaOrg` finds no recipe data and scraping fails silently on any site built with Next.js App Router that uses structured `Recipe` markup. **meny.no** is one confirmed affected site.

## Fix

Add `SchemaOrg._normalize_nextjs_jsonld(html)` — a static pre-processing step called at the top of `__init__` that detects the `__next_s.push()` pattern and lifts the embedded `children` JSON-LD string into a proper `<script type="application/ld+json">` tag before the HTML reaches `extruct`.

### Fast path

Two cheap `in` checks (`"__next_s" not in html` and `"application/ld+json" not in html`) return the original HTML unchanged on all non-Next.js pages, so there is zero overhead for the vast majority of requests.

### No new dependencies

`json` and `re` are stdlib modules.

## Before / after (meny.no example)

**Before** — `SchemaOrg` finds no Recipe data → scraping raises `SchemaOrgException`.

**After** — the injected JSON-LD is promoted to a static script tag before `extruct` runs → title, ingredients, and instructions are parsed correctly.

## Changes

- `recipe_scrapers/_schemaorg.py` — add `import json`, `import re`; add `_normalize_nextjs_jsonld()` static method; call it as the first line of `__init__`
- `tests/library/test_schemaorg.py` — add `test_nextjs_ssr_jsonld` to `TestSchemaOrg`

## References

- Next.js App Router injects script data via `__next_s`: https://github.com/vercel/next.js/search?q=__next_s