### PR TITLE
Add support for velocidadcuchara.com

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -609,6 +609,7 @@ from .varechapravdask import VarechaPravdaSK
 from .vegetarbloggen import Vegetarbloggen
 from .vegolosi import Vegolosi
 from .vegrecipesofindia import VegRecipesOfIndia
+from .velocidadcuchara import VelocidadCuchara
 from .veroniquecloutier import VeroniqueCloutier
 from .waitrose import Waitrose
 from .watchwhatueat import WatchWhatUEat
@@ -1242,6 +1243,7 @@ SCRAPERS = {
     Vegetarbloggen.host(): Vegetarbloggen,
     Vegolosi.host(): Vegolosi,
     VegRecipesOfIndia.host(): VegRecipesOfIndia,
+    VelocidadCuchara.host(): VelocidadCuchara,
     VeroniqueCloutier.host(): VeroniqueCloutier,
     Waitrose.host(): Waitrose,
     WatchWhatUEat.host(): WatchWhatUEat,

--- a/recipe_scrapers/velocidadcuchara.py
+++ b/recipe_scrapers/velocidadcuchara.py
@@ -15,8 +15,7 @@ class VelocidadCuchara(AbstractScraper):
         strong = li.find("strong")
         return bool(
             strong
-            and normalize_string(li.get_text())
-            == normalize_string(strong.get_text())
+            and normalize_string(li.get_text()) == normalize_string(strong.get_text())
         )
 
     def ingredients(self):
@@ -47,7 +46,9 @@ class VelocidadCuchara(AbstractScraper):
 
         if current_ingredients:
             groups.append(
-                IngredientGroup(purpose=current_purpose, ingredients=current_ingredients)
+                IngredientGroup(
+                    purpose=current_purpose, ingredients=current_ingredients
+                )
             )
 
         return groups or [IngredientGroup(purpose=None, ingredients=self.ingredients())]

--- a/recipe_scrapers/velocidadcuchara.py
+++ b/recipe_scrapers/velocidadcuchara.py
@@ -1,0 +1,53 @@
+from ._abstract import AbstractScraper
+from ._grouping_utils import IngredientGroup
+from ._utils import normalize_string
+
+
+class VelocidadCuchara(AbstractScraper):
+    @classmethod
+    def host(cls):
+        return "velocidadcuchara.com"
+
+    def _ingredient_items(self):
+        return self.soup.select(".ERSIngredients li.ingredient")
+
+    def _is_group_header(self, li):
+        strong = li.find("strong")
+        return bool(
+            strong
+            and normalize_string(li.get_text())
+            == normalize_string(strong.get_text())
+        )
+
+    def ingredients(self):
+        return [
+            normalize_string(li.get_text())
+            for li in self._ingredient_items()
+            if not self._is_group_header(li)
+        ]
+
+    def ingredient_groups(self):
+        groups = []
+        current_purpose = None
+        current_ingredients = []
+
+        for li in self._ingredient_items():
+            text = normalize_string(li.get_text())
+            if self._is_group_header(li):
+                if current_ingredients:
+                    groups.append(
+                        IngredientGroup(
+                            purpose=current_purpose, ingredients=current_ingredients
+                        )
+                    )
+                current_purpose = text.rstrip(":")
+                current_ingredients = []
+            else:
+                current_ingredients.append(text)
+
+        if current_ingredients:
+            groups.append(
+                IngredientGroup(purpose=current_purpose, ingredients=current_ingredients)
+            )
+
+        return groups or [IngredientGroup(purpose=None, ingredients=self.ingredients())]

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_1.json
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_1.json
@@ -1,0 +1,76 @@
+{
+  "author": "Rosa Ardá",
+  "canonical_url": "https://www.velocidadcuchara.com/salsa-bolonesa/",
+  "site_name": "Velocidad Cuchara",
+  "host": "velocidadcuchara.com",
+  "language": "es",
+  "title": "Salsa boloñesa",
+  "ingredients": [
+    "150 gr de zanahoria",
+    "130 gr de cebolla",
+    "180 gr de champiñones",
+    "1 diente de ajo",
+    "500 gr de tomate natural triturado",
+    "50 gr de aceite de oliva virgen extra",
+    "500 gr de carne picada -mitad ternera, mitad cerdo-.",
+    "Sal al gusto",
+    "Una pizca de pimienta negra",
+    "Orégano seco al gusto",
+    "1000 gr de agua",
+    "1 cucharadita de sal",
+    "500 gr de espaguetis",
+    "Queso parmesano rallado"
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "150 gr de zanahoria",
+        "130 gr de cebolla",
+        "180 gr de champiñones",
+        "1 diente de ajo",
+        "500 gr de tomate natural triturado",
+        "50 gr de aceite de oliva virgen extra"
+      ],
+      "purpose": "Para el sofrito"
+    },
+    {
+      "ingredients": [
+        "500 gr de carne picada -mitad ternera, mitad cerdo-.",
+        "Sal al gusto",
+        "Una pizca de pimienta negra",
+        "Orégano seco al gusto"
+      ],
+      "purpose": "Para el resto"
+    },
+    {
+      "ingredients": [
+        "1000 gr de agua",
+        "1 cucharadita de sal",
+        "500 gr de espaguetis"
+      ],
+      "purpose": "Para cocer la pasta"
+    },
+    {
+      "ingredients": [
+        "Queso parmesano rallado"
+      ],
+      "purpose": "Para servir"
+    }
+  ],
+  "instructions_list": [
+    "Pon todos los ingredientes del sofrito en trozos dentro del vaso - excepto el aceite - y tritura 15 segundos en velocidad 5.",
+    "Baja los restos que hayan quedado en las paredes del vaso. Añade el aceite y programa 8 minutos, temperatura Varoma, velocidad 1.",
+    "Incorpora al vaso, la carne picada -rómpela un poquito con el tenedor que suele venir muy apelmazada-, sal y especias y cocina 15 minutos, Varoma, giro a la izquierda y velocidad cuchara. Comprueba punto de sal, retira y reserva.",
+    "Sin lavar el vaso, añade el agua y caliéntala unos 10-12 minutos, Varoma, velocidad 1 o hasta que hierva. Añade la pasta y programa el tiempo que recomiende el paquete, Varoma, giro a la izquierda y velocidad cuchara. Escurre y sirve acompañada con la salsa. A mi me gusta mezclar ambas cosas en una fuente para que los espaguetis se pongan del color de la boloñesa."
+  ],
+  "category": "Salsas",
+  "yields": "6 servings",
+  "description": "Con Thermomix ® se hace de forma muy sencilla y queda genial. Es otra forma de preparar una receta tan italiana como la salsa boloñesa de forma más cómoda, ahorrando tiempo.",
+  "total_time": 38,
+  "cook_time": 15,
+  "prep_time": 23,
+  "cuisine": "Italiana",
+  "ratings": 4.5,
+  "ratings_count": 10,
+  "image": "https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-768x514.jpg"
+}

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_1.testhtml
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_1.testhtml
@@ -1,0 +1,2919 @@
+<!DOCTYPE html>
+<html class="no-js" lang="es" itemscope="itemscope" itemtype="http://schema.org/WebPage">
+<head><meta charset="UTF-8"><script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script><script>(()=>{class RocketLazyLoadScripts{constructor(){this.v="2.0.5",this.userEvents=["keydown","keyup","mousedown","mouseup","mousemove","mouseover","mouseout","touchmove","touchstart","touchend","touchcancel","wheel","click","dblclick","input"],this.attributeEvents=["onblur","onclick","oncontextmenu","ondblclick","onfocus","onmousedown","onmouseenter","onmouseleave","onmousemove","onmouseout","onmouseover","onmouseup","onmousewheel","onscroll","onsubmit"]}async t(){this.i(),this.o(),/iP(ad|hone)/.test(navigator.userAgent)&&this.h(),this.u(),this.l(this),this.m(),this.k(this),this.p(this),this._(),await Promise.all([this.R(),this.L()]),this.lastBreath=Date.now(),this.S(this),this.P(),this.D(),this.O(),this.M(),await this.C(this.delayedScripts.normal),await this.C(this.delayedScripts.defer),await this.C(this.delayedScripts.async),await this.T(),await this.F(),await this.j(),await this.A(),window.dispatchEvent(new Event("rocket-allScriptsLoaded")),this.everythingLoaded=!0,this.lastTouchEnd&&await new Promise(t=>setTimeout(t,500-Date.now()+this.lastTouchEnd)),this.I(),this.H(),this.U(),this.W()}i(){this.CSPIssue=sessionStorage.getItem("rocketCSPIssue"),document.addEventListener("securitypolicyviolation",t=>{this.CSPIssue||"script-src-elem"!==t.violatedDirective||"data"!==t.blockedURI||(this.CSPIssue=!0,sessionStorage.setItem("rocketCSPIssue",!0))},{isRocket:!0})}o(){window.addEventListener("pageshow",t=>{this.persisted=t.persisted,this.realWindowLoadedFired=!0},{isRocket:!0}),window.addEventListener("pagehide",()=>{this.onFirstUserAction=null},{isRocket:!0})}h(){let t;function e(e){t=e}window.addEventListener("touchstart",e,{isRocket:!0}),window.addEventListener("touchend",function i(o){o.changedTouches[0]&&t.changedTouches[0]&&Math.abs(o.changedTouches[0].pageX-t.changedTouches[0].pageX)<10&&Math.abs(o.changedTouches[0].pageY-t.changedTouches[0].pageY)<10&&o.timeStamp-t.timeStamp<200&&(window.removeEventListener("touchstart",e,{isRocket:!0}),window.removeEventListener("touchend",i,{isRocket:!0}),"INPUT"===o.target.tagName&&"text"===o.target.type||(o.target.dispatchEvent(new TouchEvent("touchend",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new MouseEvent("mouseover",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new PointerEvent("click",{target:o.target,bubbles:!0,cancelable:!0,detail:1,clientX:o.changedTouches[0].clientX,clientY:o.changedTouches[0].clientY})),event.preventDefault()))},{isRocket:!0})}q(t){this.userActionTriggered||("mousemove"!==t.type||this.firstMousemoveIgnored?"keyup"===t.type||"mouseover"===t.type||"mouseout"===t.type||(this.userActionTriggered=!0,this.onFirstUserAction&&this.onFirstUserAction()):this.firstMousemoveIgnored=!0),"click"===t.type&&t.preventDefault(),t.stopPropagation(),t.stopImmediatePropagation(),"touchstart"===this.lastEvent&&"touchend"===t.type&&(this.lastTouchEnd=Date.now()),"click"===t.type&&(this.lastTouchEnd=0),this.lastEvent=t.type,t.composedPath&&t.composedPath()[0].getRootNode()instanceof ShadowRoot&&(t.rocketTarget=t.composedPath()[0]),this.savedUserEvents.push(t)}u(){this.savedUserEvents=[],this.userEventHandler=this.q.bind(this),this.userEvents.forEach(t=>window.addEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.addEventListener("visibilitychange",this.userEventHandler,{isRocket:!0})}U(){this.userEvents.forEach(t=>window.removeEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.removeEventListener("visibilitychange",this.userEventHandler,{isRocket:!0}),this.savedUserEvents.forEach(t=>{(t.rocketTarget||t.target).dispatchEvent(new window[t.constructor.name](t.type,t))})}m(){const t="return false",e=Array.from(this.attributeEvents,t=>"data-rocket-"+t),i="["+this.attributeEvents.join("],[")+"]",o="[data-rocket-"+this.attributeEvents.join("],[data-rocket-")+"]",s=(e,i,o)=>{o&&o!==t&&(e.setAttribute("data-rocket-"+i,o),e["rocket"+i]=new Function("event",o),e.setAttribute(i,t))};new MutationObserver(t=>{for(const n of t)"attributes"===n.type&&(n.attributeName.startsWith("data-rocket-")||this.everythingLoaded?n.attributeName.startsWith("data-rocket-")&&this.everythingLoaded&&this.N(n.target,n.attributeName.substring(12)):s(n.target,n.attributeName,n.target.getAttribute(n.attributeName))),"childList"===n.type&&n.addedNodes.forEach(t=>{if(t.nodeType===Node.ELEMENT_NODE)if(this.everythingLoaded)for(const i of[t,...t.querySelectorAll(o)])for(const t of i.getAttributeNames())e.includes(t)&&this.N(i,t.substring(12));else for(const e of[t,...t.querySelectorAll(i)])for(const t of e.getAttributeNames())this.attributeEvents.includes(t)&&s(e,t,e.getAttribute(t))})}).observe(document,{subtree:!0,childList:!0,attributeFilter:[...this.attributeEvents,...e]})}I(){this.attributeEvents.forEach(t=>{document.querySelectorAll("[data-rocket-"+t+"]").forEach(e=>{this.N(e,t)})})}N(t,e){const i=t.getAttribute("data-rocket-"+e);i&&(t.setAttribute(e,i),t.removeAttribute("data-rocket-"+e))}k(t){Object.defineProperty(HTMLElement.prototype,"onclick",{get(){return this.rocketonclick||null},set(e){this.rocketonclick=e,this.setAttribute(t.everythingLoaded?"onclick":"data-rocket-onclick","this.rocketonclick(event)")}})}S(t){function e(e,i){let o=e[i];e[i]=null,Object.defineProperty(e,i,{get:()=>o,set(s){t.everythingLoaded?o=s:e["rocket"+i]=o=s}})}e(document,"onreadystatechange"),e(window,"onload"),e(window,"onpageshow");try{Object.defineProperty(document,"readyState",{get:()=>t.rocketReadyState,set(e){t.rocketReadyState=e},configurable:!0}),document.readyState="loading"}catch(t){console.log("WPRocket DJE readyState conflict, bypassing")}}l(t){this.originalAddEventListener=EventTarget.prototype.addEventListener,this.originalRemoveEventListener=EventTarget.prototype.removeEventListener,this.savedEventListeners=[],EventTarget.prototype.addEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalAddEventListener.call(this,e,i,o):(t.savedEventListeners.push({target:this,remove:!1,type:e,func:i,options:o}),"mouseenter"!==e&&"mouseleave"!==e||t.originalAddEventListener.call(this,e,t.savedUserEvents.push,o))},EventTarget.prototype.removeEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalRemoveEventListener.call(this,e,i,o):t.savedEventListeners.push({target:this,remove:!0,type:e,func:i,options:o})}}J(t,e){this.savedEventListeners=this.savedEventListeners.filter(i=>{let o=i.type,s=i.target||window;return e!==o||t!==s||(this.B(o,s)&&(i.type="rocket-"+o),this.$(i),!1)})}H(){EventTarget.prototype.addEventListener=this.originalAddEventListener,EventTarget.prototype.removeEventListener=this.originalRemoveEventListener,this.savedEventListeners.forEach(t=>this.$(t))}$(t){t.remove?this.originalRemoveEventListener.call(t.target,t.type,t.func,t.options):this.originalAddEventListener.call(t.target,t.type,t.func,t.options)}p(t){let e;function i(e){return t.everythingLoaded?e:e.split(" ").map(t=>"load"===t||t.startsWith("load.")?"rocket-jquery-load":t).join(" ")}function o(o){function s(e){const s=o.fn[e];o.fn[e]=o.fn.init.prototype[e]=function(){return this[0]===window&&t.userActionTriggered&&("string"==typeof arguments[0]||arguments[0]instanceof String?arguments[0]=i(arguments[0]):"object"==typeof arguments[0]&&Object.keys(arguments[0]).forEach(t=>{const e=arguments[0][t];delete arguments[0][t],arguments[0][i(t)]=e})),s.apply(this,arguments),this}}if(o&&o.fn&&!t.allJQueries.includes(o)){const e={DOMContentLoaded:[],"rocket-DOMContentLoaded":[]};for(const t in e)document.addEventListener(t,()=>{e[t].forEach(t=>t())},{isRocket:!0});o.fn.ready=o.fn.init.prototype.ready=function(i){function s(){parseInt(o.fn.jquery)>2?setTimeout(()=>i.bind(document)(o)):i.bind(document)(o)}return"function"==typeof i&&(t.realDomReadyFired?!t.userActionTriggered||t.fauxDomReadyFired?s():e["rocket-DOMContentLoaded"].push(s):e.DOMContentLoaded.push(s)),this},s("on"),s("one"),s("off"),t.allJQueries.push(o)}e=o}t.allJQueries=[],o(window.jQuery),Object.defineProperty(window,"jQuery",{get:()=>e,set(t){o(t)}})}P(){const t=new Map;document.write=document.writeln=function(e){const i=document.currentScript,o=document.createRange(),s=i.parentElement;let n=t.get(i);void 0===n&&(n=i.nextSibling,t.set(i,n));const c=document.createDocumentFragment();o.setStart(c,0),c.appendChild(o.createContextualFragment(e)),s.insertBefore(c,n)}}async R(){return new Promise(t=>{this.userActionTriggered?t():this.onFirstUserAction=t})}async L(){return new Promise(t=>{document.addEventListener("DOMContentLoaded",()=>{this.realDomReadyFired=!0,t()},{isRocket:!0})})}async j(){return this.realWindowLoadedFired?Promise.resolve():new Promise(t=>{window.addEventListener("load",t,{isRocket:!0})})}M(){this.pendingScripts=[];this.scriptsMutationObserver=new MutationObserver(t=>{for(const e of t)e.addedNodes.forEach(t=>{"SCRIPT"!==t.tagName||!t.src||t.noModule||t.isWPRocket||this.pendingScripts.push({script:t,promise:new Promise(e=>{const i=()=>{const i=this.pendingScripts.findIndex(e=>e.script===t);i>=0&&this.pendingScripts.splice(i,1),e()};t.addEventListener("load",i,{isRocket:!0}),t.addEventListener("error",i,{isRocket:!0}),setTimeout(i,1e3)})})})}),this.scriptsMutationObserver.observe(document,{childList:!0,subtree:!0})}async F(){await this.X(),this.pendingScripts.length?(await this.pendingScripts[0].promise,await this.F()):this.scriptsMutationObserver.disconnect()}D(){this.delayedScripts={normal:[],async:[],defer:[]},document.querySelectorAll("script[type$=rocketlazyloadscript]").forEach(t=>{t.hasAttribute("data-rocket-src")?t.hasAttribute("async")&&!1!==t.async?this.delayedScripts.async.push(t):t.hasAttribute("defer")&&!1!==t.defer||"module"===t.getAttribute("data-rocket-type")?this.delayedScripts.defer.push(t):this.delayedScripts.normal.push(t):this.delayedScripts.normal.push(t)})}async _(){await this.L();let t=[];document.querySelectorAll("script[type$=rocketlazyloadscript][data-rocket-src]").forEach(e=>{let i=e.getAttribute("data-rocket-src");if(i&&!i.startsWith("data:")){i.startsWith("//")&&(i=location.protocol+i);try{const o=new URL(i).origin;o!==location.origin&&t.push({src:o,crossOrigin:e.crossOrigin||"module"===e.getAttribute("data-rocket-type")})}catch(t){}}}),t=[...new Map(t.map(t=>[JSON.stringify(t),t])).values()],this.Y(t,"preconnect")}async G(t){if(await this.K(),!0!==t.noModule||!("noModule"in HTMLScriptElement.prototype))return new Promise(e=>{let i;function o(){(i||t).setAttribute("data-rocket-status","executed"),e()}try{if(navigator.userAgent.includes("Firefox/")||""===navigator.vendor||this.CSPIssue)i=document.createElement("script"),[...t.attributes].forEach(t=>{let e=t.nodeName;"type"!==e&&("data-rocket-type"===e&&(e="type"),"data-rocket-src"===e&&(e="src"),i.setAttribute(e,t.nodeValue))}),t.text&&(i.text=t.text),t.nonce&&(i.nonce=t.nonce),i.hasAttribute("src")?(i.addEventListener("load",o,{isRocket:!0}),i.addEventListener("error",()=>{i.setAttribute("data-rocket-status","failed-network"),e()},{isRocket:!0}),setTimeout(()=>{i.isConnected||e()},1)):(i.text=t.text,o()),i.isWPRocket=!0,t.parentNode.replaceChild(i,t);else{const i=t.getAttribute("data-rocket-type"),s=t.getAttribute("data-rocket-src");i?(t.type=i,t.removeAttribute("data-rocket-type")):t.removeAttribute("type"),t.addEventListener("load",o,{isRocket:!0}),t.addEventListener("error",i=>{this.CSPIssue&&i.target.src.startsWith("data:")?(console.log("WPRocket: CSP fallback activated"),t.removeAttribute("src"),this.G(t).then(e)):(t.setAttribute("data-rocket-status","failed-network"),e())},{isRocket:!0}),s?(t.fetchPriority="high",t.removeAttribute("data-rocket-src"),t.src=s):t.src="data:text/javascript;base64,"+window.btoa(unescape(encodeURIComponent(t.text)))}}catch(i){t.setAttribute("data-rocket-status","failed-transform"),e()}});t.setAttribute("data-rocket-status","skipped")}async C(t){const e=t.shift();return e?(e.isConnected&&await this.G(e),this.C(t)):Promise.resolve()}O(){this.Y([...this.delayedScripts.normal,...this.delayedScripts.defer,...this.delayedScripts.async],"preload")}Y(t,e){this.trash=this.trash||[];let i=!0;var o=document.createDocumentFragment();t.forEach(t=>{const s=t.getAttribute&&t.getAttribute("data-rocket-src")||t.src;if(s&&!s.startsWith("data:")){const n=document.createElement("link");n.href=s,n.rel=e,"preconnect"!==e&&(n.as="script",n.fetchPriority=i?"high":"low"),t.getAttribute&&"module"===t.getAttribute("data-rocket-type")&&(n.crossOrigin=!0),t.crossOrigin&&(n.crossOrigin=t.crossOrigin),t.integrity&&(n.integrity=t.integrity),t.nonce&&(n.nonce=t.nonce),o.appendChild(n),this.trash.push(n),i=!1}}),document.head.appendChild(o)}W(){this.trash.forEach(t=>t.remove())}async T(){try{document.readyState="interactive"}catch(t){}this.fauxDomReadyFired=!0;try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(document,"DOMContentLoaded"),document.dispatchEvent(new Event("rocket-DOMContentLoaded")),await this.K(),this.J(window,"DOMContentLoaded"),window.dispatchEvent(new Event("rocket-DOMContentLoaded"))}catch(t){console.error(t)}}async A(){try{document.readyState="complete"}catch(t){}try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(window,"load"),window.dispatchEvent(new Event("rocket-load")),await this.K(),window.rocketonload&&window.rocketonload(),await this.K(),this.allJQueries.forEach(t=>t(window).trigger("rocket-jquery-load")),await this.K(),this.J(window,"pageshow");const t=new Event("rocket-pageshow");t.persisted=this.persisted,window.dispatchEvent(t),await this.K(),window.rocketonpageshow&&window.rocketonpageshow({persisted:this.persisted})}catch(t){console.error(t)}}async K(){Date.now()-this.lastBreath>45&&(await this.X(),this.lastBreath=Date.now())}async X(){return document.hidden?new Promise(t=>setTimeout(t)):new Promise(t=>requestAnimationFrame(t))}B(t,e=window){return e===document&&"readystatechange"===t||(e===document&&"DOMContentLoaded"===t||(e===window&&"DOMContentLoaded"===t||(e===window&&"load"===t||e===window&&"pageshow"===t)))}static run(){(new RocketLazyLoadScripts).t()}}RocketLazyLoadScripts.run()})();
+</script>
+
+<!--
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-++-+
+	|v|e|l|o|c|i|d|a|d| |c|u|c|h|a|r|a|
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-+ +- -->
+
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="copyright" content="Velocidad Cuchara"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta property="fb:pages" content="117162944985048" />
+  <link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &#8211; El primer blog de recetas para Thermomix RSS Feed" href="https://www.velocidadcuchara.com/feed/" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000">
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="sitemap" href="https://www.velocidadcuchara.com/sitemap.xml" />
+  <link href="https://fonts.googleapis.com/css?family=Kaushan+Script" rel="stylesheet">
+
+  <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+	
+	<!-- This site is optimized with the Yoast SEO plugin v27.0 - https://yoast.com/product/yoast-seo-wordpress/ -->
+	<title>Salsa boloñesa | Velocidad Cuchara</title>
+<link data-rocket-prefetch href="https://fonts.googleapis.com" rel="dns-prefetch"><link rel="preload" data-rocket-preload as="image" imagesrcset="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC.jpg.webp 1000w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-300x201.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-768x514.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-272x182.jpg.webp 272w" imagesizes="(max-width: 1000px) 100vw, 1000px" fetchpriority="high">
+	<meta name="description" content="Receta de Salsa boloñesa con Thermomix, una forma sencilla de hacer una receta italiana con carne y tomate." />
+	<link rel="canonical" href="https://www.velocidadcuchara.com/salsa-bolonesa/" />
+	<meta property="og:locale" content="es_ES" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Salsa boloñesa | Velocidad Cuchara" />
+	<meta property="og:description" content="Receta de Salsa boloñesa con Thermomix, una forma sencilla de hacer una receta italiana con carne y tomate." />
+	<meta property="og:url" content="https://www.velocidadcuchara.com/salsa-bolonesa/" />
+	<meta property="og:site_name" content="Velocidad Cuchara" />
+	<meta property="article:publisher" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:author" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:published_time" content="2009-09-05T16:40:00+00:00" />
+	<meta property="article:modified_time" content="2017-08-26T09:49:52+00:00" />
+	<meta property="og:image" content="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-768x514.jpg" />
+	<meta property="og:image:width" content="768" />
+	<meta property="og:image:height" content="514" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="author" content="Rosa Ardá" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:creator" content="@rosaarda" />
+	<meta name="twitter:site" content="@rosaarda" />
+	<meta name="twitter:label1" content="Escrito por" />
+	<meta name="twitter:data1" content="Rosa Ardá" />
+	<meta name="twitter:label2" content="Tiempo de lectura" />
+	<meta name="twitter:data2" content="2 minutos" />
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//static.addtoany.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed" href="https://www.velocidadcuchara.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed de los comentarios" href="https://www.velocidadcuchara.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Comentario Salsa boloñesa del feed" href="https://www.velocidadcuchara.com/salsa-bolonesa/feed/" />
+<link rel="shortcut icon" type="image/x-icon" href="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/favicon.png" /><!-- www.velocidadcuchara.com is managing ads with Advanced Ads 2.0.17 – https://wpadvancedads.com/ --><!--noptimize--><script type="rocketlazyloadscript" id="local-ready">
+			window.advanced_ads_ready=function(e,a){a=a||"complete";var d=function(e){return"interactive"===a?"loading"!==e:"complete"===e};d(document.readyState)?e():document.addEventListener("readystatechange",(function(a){d(a.target.readyState)&&e()}),{once:"interactive"===a})},window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[];		</script>
+		<!--/noptimize--><style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.velocidadcuchara.com/wp-includes/css/dist/block-library/style.min.css?ver=6.8.2' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+:root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
+</style>
+<link data-minify="1" rel='stylesheet' id='mostrar-comentarios-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='post_grid_style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-new.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='owl.carousel-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/owl.carousel.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='font-awesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/font-awesome.min.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style-woocommerce-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-woocommerce.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.skins-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.skins.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.layout-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.layout.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-17bc2272b535-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-17bc2272b535.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-654ee1169f99-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-654ee1169f99.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-b136017e055b-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-b136017e055b.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-7877d6771435-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-7877d6771435.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-d6014b76747a-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-d6014b76747a.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-base-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/widgets/button/css/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-a0517016730c-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-a0517016730c.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-b763d6af42b8-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-b763d6af42b8.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wpos-slick-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/slick.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wtpsw-public-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/wtpsw-public.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='cmplz-general-css' href='https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/assets/css/cookieblocker.min.css?ver=1768420286' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='megamenu-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/maxmegamenu/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='dashicons-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-includes/css/dashicons.min.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='easyrecipestyle-reset-css' href='https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/css/easyrecipe-style-reset-min.css?ver=3.5.3251' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipebuttonUI-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/ui/easyrecipe-buttonUI.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipestyle-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/styles/style002a/style.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='addtoany-css' href='https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.css?ver=1.16' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='kadence_theme-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/virtue.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='virtue_skin-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/skins/default.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='virtue_child-css' href='https://www.velocidadcuchara.com/wp-content/themes/velocidad/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='redux-google-fonts-virtue-css' href='https://fonts.googleapis.com/css?family=Lato%3A400%2C700%7CJosefin+Sans%3A400%2C600%2C300%7COpen+Sans%3A300%2C400%2C600%2C700%2C800%2C300italic%2C400italic%2C600italic%2C700italic%2C800italic&#038;subset=latin-ext&#038;ver=1774857236' type='text/css' media='all' />
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf-stub/build/index.js?ver=1773428753" id="cmplz-tcf-stub-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/vendor/DOMPurify/DOMPurify.min.js?ver=2.5.8" id="bodhi-dompurify-library-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="addtoany-core-js-before">
+/* <![CDATA[ */
+window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_localize = {
+	Share: "Compartir",
+	Save: "Guardar",
+	Subscribe: "Suscribir",
+	Email: "Correo electrónico",
+	Bookmark: "Marcador",
+	ShowAll: "Mostrar todo",
+	ShowLess: "Mostrar menos",
+	FindServices: "Encontrar servicio(s)",
+	FindAnyServiceToAddTo: "Encuentra al instante cualquier servicio para añadir a",
+	PoweredBy: "Funciona con",
+	ShareViaEmail: "Compartir por correo electrónico",
+	SubscribeViaEmail: "Suscribirse a través de correo electrónico",
+	BookmarkInYourBrowser: "Añadir a marcadores de tu navegador",
+	BookmarkInstructions: "Presiona «Ctrl+D» o «\u2318+D» para añadir esta página a marcadores",
+	AddToYourFavorites: "Añadir a tus favoritos",
+	SendFromWebOrProgram: "Enviar desde cualquier dirección o programa de correo electrónico ",
+	EmailProgram: "Programa de correo electrónico",
+	More: "Más&#8230;",
+	ThanksForSharing: "¡Gracias por compartir!",
+	ThanksForFollowing: "¡Gracias por seguirnos!"
+};
+
+a2a_config.icon_color = "#bdbeb2";
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://static.addtoany.com/menu/page.js" id="addtoany-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.js?ver=1.1" id="addtoany-jquery-js"></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.js?ver=1773428753" id="mostrar-comentarios-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="post_grid_scripts-js-extra">
+/* <![CDATA[ */
+var post_grid_ajax = {"post_grid_ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/scripts.js?ver=1773428753" id="post_grid_scripts-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/masonry.pkgd.min.js?ver=6.8.2" id="masonry.pkgd.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/owl.carousel.min.js?ver=6.8.2" id="owl.carousel.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/imagesloaded.pkgd.js?ver=1773428753" id="imagesloaded.pkgd.js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="bodhi_svg_inline-js-extra">
+/* <![CDATA[ */
+var svgSettings = {"skipNested":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/js/min/svgs-inline-min.js" id="bodhi_svg_inline-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="bodhi_svg_inline-js-after">
+/* <![CDATA[ */
+cssTarget={"Bodhi":"img.style-svg","ForceInlineSVG":"style-svg"};ForceInlineSVGActive="false";frontSanitizationEnabled="on";
+/* ]]> */
+</script>
+<script type="text/javascript" id="cmplz-tcf-js-extra">
+/* <![CDATA[ */
+var cmplz_tcf = {"cmp_url":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/","retention_string":"Retenci\u00f3n en d\u00edas","undeclared_string":"No declarado","isServiceSpecific":"1","excludedVendors":{"15":15,"66":66,"119":119,"139":139,"141":141,"174":174,"192":192,"262":262,"375":375,"377":377,"387":387,"427":427,"435":435,"512":512,"527":527,"569":569,"581":581,"587":587,"626":626,"644":644,"667":667,"713":713,"733":733,"736":736,"748":748,"776":776,"806":806,"822":822,"830":830,"836":836,"856":856,"879":879,"882":882,"888":888,"909":909,"970":970,"986":986,"1015":1015,"1018":1018,"1022":1022,"1039":1039,"1078":1078,"1079":1079,"1094":1094,"1149":1149,"1156":1156,"1167":1167,"1173":1173,"1199":1199,"1211":1211,"1216":1216,"1252":1252,"1263":1263,"1298":1298,"1305":1305,"1342":1342,"1343":1343,"1355":1355,"1365":1365,"1366":1366,"1368":1368,"1371":1371,"1373":1373,"1391":1391,"1405":1405,"1418":1418,"1423":1423,"1425":1425,"1440":1440,"1442":1442,"1482":1482,"1492":1492,"1496":1496,"1503":1503,"1508":1508,"1509":1509,"1510":1510,"1519":1519,"1529":1529,"1537":1537,"1541":1541,"1549":1549,"1550":1550,"1558":1558,"1564":1564,"1579":1579,"1580":1580},"purposes":[1,2,3,4,5,6,7,8,9,10],"specialPurposes":[1,2,3],"features":[1,2],"specialFeatures":[],"publisherCountryCode":"ES","lspact":"N","ccpa_applies":"","ac_mode":"1","debug":"","prefix":"cmplz_"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf/build/index.js?ver=1773428753" id="cmplz-tcf-js"></script>
+<script type="text/javascript" id="advanced-ads-advanced-js-js-extra">
+/* <![CDATA[ */
+var advads_options = {"blog_id":"1","privacy":{"enabled":true,"custom-cookie-name":"euconsent-v2","custom-cookie-value":"CO49HGNO49HGNAKALAESA1CsAP_AAH_AAAiQGatd_X9fb2vj-_5999t0eY1f9_63v-wzjgeNs-8NyZ_X_L4Xr2MyvB36pq4KmR4Eu3LBAQFlHOHcTQmQwIkVqTLsbk2Mq7NKJ7LEilMbM2dYGG9Pn8XTuZCY70_sf__z_3-_-___67bgYIQSYKl4BAkJYQEk2aUQogAhHEBUA4AKCEICBSw0ABATsCgI9QAAAEBgABAAAACCCAgEAAAAASEQAAACAgEABEAgABACNAQgAIkAAWAEgQBAAKAaEgBFEEIAhBgYBRygBAUAAAAA.fmAAAAAAAAAA","consent-method":"iab_tcf_20","state":"unknown"}};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/advanced-ads/public/assets/js/advanced.min.js?ver=2.0.17" id="advanced-ads-advanced-js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="utils-js-extra">
+/* <![CDATA[ */
+var userSettings = {"url":"\/","uid":"0","time":"1776938193","secure":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/utils.min.js?ver=6.8.2" id="utils-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/controlgroup.min.js?ver=1.13.3" id="jquery-ui-controlgroup-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/checkboxradio.min.js?ver=1.13.3" id="jquery-ui-checkboxradio-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/button.min.js?ver=1.13.3" id="jquery-ui-button-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/js/easyrecipe-min.js?ver=3.5.3251" id="EasyRecipePlus-js" data-rocket-defer defer></script>
+<link rel="https://api.w.org/" href="https://www.velocidadcuchara.com/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://www.velocidadcuchara.com/wp-json/wp/v2/posts/254" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.velocidadcuchara.com/xmlrpc.php?rsd" />
+<meta name="generator" content="WordPress 6.8.2" />
+<link rel='shortlink' href='https://www.velocidadcuchara.com/?p=254' />
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-bolonesa%2F" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-bolonesa%2F&#038;format=xml" />
+			<style>.cmplz-hidden {
+					display: none !important;
+				}</style><style type="text/css">#logo {padding-top:20px;}#logo {padding-bottom:20px;}#logo {margin-left:0px;}#logo {margin-right:0px;}#nav-main {margin-top:25px;}#nav-main {margin-bottom:10px;}.headerfont, .tp-caption {font-family:Josefin Sans;} 
+  .topbarmenu ul li {font-family:Josefin Sans;}
+  #kadbreadcrumbs {font-family:Open Sans;}.home-message:hover {background-color:#8faa8f; background-color: rgba(143, 170, 143, 0.6);}
+  nav.woocommerce-pagination ul li a:hover, .wp-pagenavi a:hover, .panel-heading .accordion-toggle, .variations .kad_radio_variations label:hover, .variations .kad_radio_variations label.selectedValue {border-color: #8faa8f;}
+  a, #nav-main ul.sf-menu ul li a:hover, .product_price ins .amount, .price ins .amount, .color_primary, .primary-color, #logo a.brand, #nav-main ul.sf-menu a:hover,
+  .woocommerce-message:before, .woocommerce-info:before, #nav-second ul.sf-menu a:hover, .footerclass a:hover, .posttags a:hover, .subhead a:hover, .nav-trigger-case:hover .kad-menu-name, 
+  .nav-trigger-case:hover .kad-navbtn, #kadbreadcrumbs a:hover, #wp-calendar a, .star-rating {color: #8faa8f;}
+.widget_price_filter .ui-slider .ui-slider-handle, .product_item .kad_add_to_cart:hover, .product_item:hover a.button:hover, .product_item:hover .kad_add_to_cart:hover, .kad-btn-primary, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li a:hover, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li.chosen a,
+.product-category.grid_item a:hover h5, .woocommerce-message .button, .widget_layered_nav_filters ul li a, .widget_layered_nav ul li.chosen a, .wpcf7 input.wpcf7-submit, .yith-wcan .yith-wcan-reset-navigation,
+#containerfooter .menu li a:hover, .bg_primary, .portfolionav a:hover, .home-iconmenu a:hover, p.demo_store, .topclass, #commentform .form-submit #submit, .kad-hover-bg-primary:hover, .widget_shopping_cart_content .checkout,
+.login .form-row .button, .variations .kad_radio_variations label.selectedValue, #payment #place_order, .wpcf7 input.wpcf7-back, .shop_table .actions input[type=submit].checkout-button, .cart_totals .checkout-button, input[type="submit"].button, .order-actions .button  {background: #8faa8f;}a:hover {color: #b7bfaf;} .kad-btn-primary:hover, .login .form-row .button:hover, #payment #place_order:hover, .yith-wcan .yith-wcan-reset-navigation:hover, .widget_shopping_cart_content .checkout:hover,
+.woocommerce-message .button:hover, #commentform .form-submit #submit:hover, .wpcf7 input.wpcf7-submit:hover, .widget_layered_nav_filters ul li a:hover, .cart_totals .checkout-button:hover,
+.widget_layered_nav ul li.chosen a:hover, .shop_table .actions input[type=submit].checkout-button:hover, .wpcf7 input.wpcf7-back:hover, .order-actions .button:hover, input[type="submit"].button:hover, .product_item:hover .kad_add_to_cart, .product_item:hover a.button {background: #b7bfaf;}input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; } input[type=number] {-moz-appearance: textfield;}.quantity input::-webkit-outer-spin-button,.quantity input::-webkit-inner-spin-button {display: none;}#containerfooter h3, #containerfooter, .footercredits p, .footerclass a, .footernav ul li a {color:#c6c6c6;}.topclass {background:transparent    ;}.navclass {background:#23282d    ;}.mobileclass {background:#23282d    ;}.footerclass {background:#23282d    ;}.product_item .product_details h5 {text-transform: none;} @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {#logo .kad-standard-logo {display: none;} #logo .kad-retina-logo {display: block;}}.product_item .product_details h5 {min-height:40px;}[class*="wp-image"] {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}[class*="wp-image"]:hover {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}.light-dropshaddow {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;}/*::::::::::::::::::::::::::::::::::::::::: PÁGINA LIBRO VC ::::::::::::::::::::::::::::::::::*/
+
+#textolibrovc {
+    font-family: "Open Sans";
+    line-height: 28px;
+    font-weight: 400;
+    font-style: normal;
+    font-size: 20px;
+}
+
+#titulibrovc {
+    font-family: "Josefin Sans";
+    line-height: 40px;
+    font-weight: 600;
+    font-style: normal;
+    font-size: 30px;
+}
+
+.page-id-56361 .titleclass { background-color: #c08993; } 
+.page-id-58566 .titleclass { background-color: #757575; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO PODCAST ::::::::::::::::::::::::::::::::::*/
+
+.page-id-59933 .titleclass { 
+background-image: url("https://velocidadcuchara.com/recursos/fondo_cabecera_pvc.png");
+margin-top: -15px; 
+background-color: #ad6b77; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO RADIO  ::::::::::::::::::::::::::::::::::*/
+    
+.page-id-57235 .titleclass { 
+background-color: #2d2f39; 
+;} 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESTILOS RELACIONADOS ::::::::::::::::::::::::::::::::::*/
+
+.bcarousellink>header>h5 {
+    padding: 0;
+    margin: 0;
+font-size:18px;
+font-weight: bold;
+}
+
+.bcarousellink>header .subhead {
+    text-align: right;
+display:none;
+}
+
+.post-grid .item .layer-media img {
+    border-radius: 50;
+    box-shadow: none;
+    width: 100%;
+    border-radius: 15px;
+}
+
+
+/*::::::::::::::::::::::::::::::::::::::::: CASILLA RGPD COMENTARIOS ::::::::::::::::::::::::::::::::::*/
+
+#commentform input {
+    display: inline-grid;
+}
+
+/*:::::::::::::::::::::::::::::::::::::::::  ELIMINAR ADMIN BAR WP ::::::::::::::::::::::::::::::::::*/
+
+#wpadminbar { display:none; }
+
+/*::::::::::::::::::::::::::::::::::::::::: CABECERA 10 ANIVERSARIO ::::::::::::::::::::::::::::::::::*/
+
+#thelogo .kad-standard-logo  {max-height: 100%}
+#thelogo .kad-retina-logo  {max-height: 100%}
+
+@media (min-width: 1024px) {NAV
+    #thelogo { width: 120%}
+}
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL HALLOWEEN ::::::::::::::::::::::::::::::::::*/
+
+.page-id-7832 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/10/fondo_cabecera_halloween_trans.png");
+    margin-top: -15px; background-color: #363636; background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-7832 .page-header .entry-title {  color: #ffa200; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CABECERA ::::::::::::::::::::::::::::::::::*/
+
+.page-id-8160 .titleclass { 
+background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; 
+background-color: #F3F3F3; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-8160 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700;} 
+
+.page-id-8160 .page-header > p {
+    color: #aa0000 } 
+
+.page-id-8160 .sidebar a {
+    color: #aa0000 } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-781 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+
+.category-781 .page-header .entry-title { 
+font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+
+.category-781 .page-header > p {
+    color: #aa0000 } 
+.category-781 .sidebar a {
+    color: #aa0000 } 
+
+.category-778 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-778 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-778 .page-header > p {
+    color: #aa0000 } 
+.category-778 .sidebar a {
+    color: #aa0000 } 
+
+.category-779 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-779 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-779 .page-header > p {
+    color: #aa0000 } 
+.category-779 .sidebar a {
+    color: #aa0000 } 
+
+.category-780 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-780 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-780 .page-header > p {
+    color: #aa0000 }
+.category-780 .sidebar a {
+    color: #aa0000 }  
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL SSANTA CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-121 .titleclass { background-color: #444560; } 
+
+/*:::::::::::::::::::::::::::::::::::::::::GENERAL ::::::::::::::::::::::::::::::::::*/
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+/*TOPBAR */
+
+/*iconos redes */
+.so-widget-sow-social-media-buttons .sow-social-media-button {
+padding:0.2em !important;}
+
+/* color del buscador textos y labels*/
+#topbar .form-search {border: 1px solid #000;}
+#topbar .form-search .search-icon {color: #000;}
+#topbar .form-search input[type="text"] {color: #000;}
+#topbar .topbar-widget {color: #000;}
+#topbar .form-search input[type="text"]::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]::-moz-placeholder { /* Firefox 19+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-ms-input-placeholder { /* IE 10+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-moz-placeholder { /* Firefox 18- */
+  color: #bdbeb2;
+}
+
+/*MENU FIJO PRINCIPAL*/
+.navclass.stickytop {
+   z-index: 9999; 
+   position: fixed; 
+   left: 0; 
+   top: 0; 
+   width: 100%
+}
+
+/*BREADCRUMBS*/
+#breadcrumbs {
+    color: #f2f2f2;
+    font-size: 0.8em;
+}
+#breadcrumbs a {
+    color: #f1f1f1;
+    text-decoration: underline;
+}
+
+/* margen superior de la página de resultado de búsquedas*/
+.search-results .wrap.contentclass .main.col-lg-9.col-md-8.postlist {
+ 	margin-top: 50px;
+}
+/* margen superior de página "estilo" blog*/
+.page-template-page-blog .main.col-lg-9.col-md-8.postlist {
+    margin-top: 50px;
+}
+
+/* etiqueta "publicidad" bloques de publicidad*/
+.local-adlabel {
+    color: #bdbeb2;
+    font-size: 14px;
+    font-style: italic;
+   text-align:center;
+}
+
+/* :::::::::::::::::::::::::::: HEADER ::::::::::::::::::::::::::::::: */
+/*tag line*/
+.kad_tagline {
+ margin-top: 20px;
+    padding-left: 0.1em;
+}
+
+/*títulos páginas*/
+.page-header{
+border-top: 0 solid rgba(0, 0, 0, 0);
+border-bottom: 0 solid rgba(0, 0, 0, 0);
+margin-bottom:0;
+}
+.titleclass {
+    background-color: #bdbeb2;
+margin-top:-15px;
+}
+.page-header .entry-title {
+padding:0.5em;
+text-transform: uppercase;
+color:#fff;
+}
+
+/*titulos páginas - visión móvil*/
+@media (max-width: 768px){
+.page-header {text-align:center;
+}
+}
+
+/* textos descripción categorias*/
+
+/* Menú principal*/
+#nav-second ul.sf-menu .menu-inicio.current-menu-item > a{
+   background-color: #fff;
+    color: #d36a5f ;
+}
+
+/* :::::: COLUMNA ::::: SIDEBAR :::::: */
+.sidebar .menu{
+font-family: "Josefin Sans";
+font-weight:600;
+margin-top: 30px;
+text-transform:uppercase;
+}
+.sidebar .widget-inner li {
+    border-bottom: 1px solid rgba(189, 190, 178, 0.5);
+    line-height: 40px;
+   }
+
+.sidebar .widget-title {
+    text-align: center;
+}
+
+/* títulos enlaces de videos en sidebar columna*/
+
+.titulovideo h3 { font-family:"Open Sans";
+font-size: 1em; 
+font-weight:600;
+text-align: center;
+
+}
+
+.sidebar .widget-inner .so-widget-sow-image > h3 {
+    text-align: center;
+}
+
+.so-widget-image {
+    border-radius: 15px;
+}
+
+/* botón suscripción*/
+#submitbox input[type="submit"] {
+    background-color: #bdbeb2;
+    color: #fff;
+    font-size: 0.9em;
+    font-style: italic;
+}
+
+/* Tïtulos de "Los más leídos"*/
+.wtpsw-post-thumb-right {
+    display: table-cell;
+    vertical-align: middle;
+}
+.wtpsw-post-thumb-right h6 a.wtpsw-post-title {
+    color: #555;
+    font-family: "Josefin Sans";
+    font-size: 1.3em;
+    line-height: 1.4em;
+    text-transform: uppercase;
+}
+
+/* fondo y bordes "Los más leídos"*/
+.wtpsw-post-items {
+    background-color: #e7e8e1;
+    border-radius: 12px;
+    padding-right: 0.5em;
+}
+
+/* botones categorías blog Te Cuento*/
+.sidebar .widget_sow-button {
+margin-bottom:-20px;
+}
+
+
+
+/*::::::::::::::::::::::::: POST GRID en páginas internas :::::::::::::::::::::::::::*/
+.post-grid .item {
+border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+/* navegadores entre páginas <<    >>*/
+.pagination.dark br {
+    display: none;
+}
+
+/* botones números  paginación */
+
+.post-grid .pagination.dark .page-numbers {
+color:#8faa8f;
+font-weight:700;
+margin:5px;
+background:#fff none repeat scroll 0 0;
+border: 2px solid rgba(0, 0, 0, 0.05);
+padding: 4px 10px;
+line-height: 37px;
+transition: border 0.2s ease-in-out 0s;
+
+}
+
+.post-grid .pagination.dark .page-numbers:hover{
+background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+border-color:#b7bfaf;
+}
+.post-grid .pagination.dark .current {
+    color:#222222;
+    background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+   border: 2px solid rgba(0, 0, 0, 0.05) !important;
+
+}
+
+
+/* mensaje de ERROR 404*/
+.alert {text-align:center; margin-top:50px;}
+.onomatopeya { font-size:2.5em; font-family:"Josefin Sans"; font-weight:600;}
+.error{font-size:1.6em; font-weight:300; line-height:1.3em;}
+
+.alert .form-search {
+margin-bottom:10px;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 303px;
+}
+
+
+/*:::::::::::::::::::::::::::::::::::::::::HOME:::::::::::::::::::::::::::::::::::::::*/
+
+.home-padding {
+padding-top:0;
+}
+.hometitle{
+padding-bottom:15px;
+}
+
+/*slide textos*/
+
+.kt-full-slider .flex-caption-case .captiontitle {
+    background: #c08993b0;
+    padding-top: 15px;
+    color: #ffffff;
+    font-size: 40px;
+    text-transform: uppercase;
+    text-shadow: 1px 1px 4px rgba(0, 0, 0, 0);
+    font-weight: 700;
+    letter-spacing: -1.5px;
+}
+
+.kt-full-slider .flex-caption-case .captiontext {
+    background: #ffffffc2;
+    color: #444;
+    text-shadow: 1px 1px 4px #eee;
+    font-size: 35px;
+    font-weight: 300;
+    letter-spacing: -2px;
+
+}
+
+/* receta principal destacada ocultar foto destacada */
+#post-grid-44850 .item .layer-media img {
+display:none;}
+
+/* receta principal destacada quitar borde recuadro*/
+#post-grid-44850 .item {
+border:none;}
+
+/* publicidad en el cuerpo de la home*/
+.publicidad{
+	margin-top:-40px;
+}
+
+/* imagenes de enlaces e iconos */
+.sow-masonry-grid-item:hover{
+opacity:0.7;
+}
+
+/*carrusel*/
+.sow-carousel-title a.sow-carousel-next {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+.sow-carousel-title a.sow-carousel-previous {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-wrapper ul.sow-carousel-items li.sow-carousel-item .sow-carousel-thumbnail a span.overlay {
+    background: #bebdbd none repeat scroll 0 0;}
+
+/* :::::::::::::::::::::::::::::::::::::::: RECETAS :::::::::::::::::::::::::::::::::::::::::::*/
+
+/* índice de recetas*/
+
+.azindex .head {
+    color: #000;
+}
+
+.azindex h4 {
+    border-bottom: 1px solid #ccc;
+    width: 90%;
+}
+.azindex h2 >a {
+color: #000;
+}
+.azlinks .azlink{
+display:inline-flex
+}
+.azlinks .azlink >a {
+      color: #000;
+    font-family: "josefin sans";
+    font-size: 1.2em;
+    font-weight: 700;
+    margin: 0.15em;
+    text-align: center;
+}
+
+
+/*visión movil*/
+@media (max-width: 600px){
+.azindex{width:100% !important;}
+}
+
+/* ::::::::::::::::::::  PÁGINAS INTERIORES DE RECETAS ::::::::::::::::::::::::*/
+.pagrecetcab {
+    margin-bottom: -30px;
+    margin-top: -30px;
+}
+
+/* :::::::::::::::::::::::::: CATEGORIAS RECETAS ::::::::::::::::::::::::::::::::::::::::::*/
+/* div del menu de tipos de recetas*/
+.recetnav {
+    margin-bottom: 40px;
+    margin-top: 40px;
+}
+
+/* texto descripción de la categoría*/
+.page-header > p {
+    color: #fff;
+    font-family:Open Sans;  /*"Josefin Sans";*/
+    font-size: 1.3em;
+    font-weight: 300;
+    padding-left: 1em;
+    margin-top: -20px;
+  padding-bottom:0.5em;
+line-height: 1.3em;
+
+}
+
+@media (max-width: 768px){
+.page-header > p {font-size:1em;
+}
+}
+
+/* ::::::::::::::::::::::::::::::::: POST RECETA :::::::::::::::::::::::::::*/
+.single-article article h1 { font-family:"Open Sans";
+/*border-bottom:1px solid #24292e;
+width:85%;*/
+text-decoration:none;
+padding-bottom:5px;}
+.postedintop{display:none}
+.single-footer .posttags a {
+font-size:16px;
+}
+
+/* Línea autora y comentarios*/
+.subhead {
+    margin-top: -12px;
+}
+/* ocultar divisor de más  entre "autora" "comentarios" post */
+.kad-hidepostedin {
+    display: none;
+}
+.postcommentscount {
+    margin-left: -2px;
+}
+
+/* Línea iconos redes*/
+.addtoany_share_save_container.addtoany_content_top {
+    margin-left: -5px;
+    margin-top: -5px;
+}
+
+/* etiquetas de ingredientes ocultas*/
+.single-footer .posttags {
+    display: none;
+}
+
+/* recetas plugin recipe en movil*/
+@media (max-width: 560px){
+.easyrecipe .ERSTimes .ERSTime {
+    float: left;
+    font-weight: bold;
+    min-width: 120px;
+    text-align: center;
+    width: 100%;
+    border:1px dotted #bdbeb2;}
+}
+
+easyrecipe-styl…ver=3.2.2708.1
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+
+/* ::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD :::::::::::::::::::::::::::: */
+.desnavidad {
+    border: 3px solid #bdbeb2;
+    border-radius: 20px;
+    padding: 1.5em  0.5em  0.2em 0.5em;
+  }
+
+.desnavidad h3 {
+   text-align:center;
+  font-family: 'Josefin Sans';
+  text-transform: uppercase; 
+ margin-bottom: 40px;
+ font-size:2.0em;
+color:#aa0000;
+}
+
+/* ::::::::::::::::::::::::::::::::::: VISIÓN TABLET :::::::::::::::::::::::::::::::::::::*/
+.iconhover{ width:80%;}
+/* Tablet APAISADA*/
+@media (min-width: 1020px) and (max-width: 1025px){
+.container{width:1010px;}
+}
+/* ajuste de padding izquierdo de receta en resultdos de búqueda 
+o visión tipo categorias para tablet apaisada*/
+@media (min-width: 768px) and (max-width: 1025px){
+.col-md-7.post-text-container.postcontent {
+padding-left:32px;
+}
+}
+/* whatsapp*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_whatsapp {
+display:none;}
+}
+
+/* telegram*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_telegram {
+display:none;}
+}
+
+
+/* ::::::::::::::::::::::::::: ELIMINAR BORDE AVATAR COMENT :::::::::::::::::::::::::: */
+
+.comment .avatar { border: 0px solid #f0eef0;
+}
+
+/* :::::::::::::::::::::::::::::::::: BOTONES CARRUSEL PORTADA ::::::::::::::::::::::::::::::::::::::::::::::: */
+
+.sow-carousel-title a.sow-carousel-next {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-title a.sow-carousel-previous {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-right: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+
+/* :::::::::::::::::::::::::::::::::: FOOTER ::::::::::::::::::::::::::::::::::::::::::::::: */
+/*Créditos*/
+.footercredits.clearfix {
+float:right;
+}
+.footercredits.clearfix > p {
+    font-size: 0.85em;
+    line-height: 1.5em;
+}
+
+.freehare {
+    font-size: 0.86em;
+}
+
+/* :::::::::::::::::::::::::::::::::: CHECKBOX ::::::::::::::::::::::::::::::::::::::::::::::: */
+.form-check {
+  width: 1em;
+  height: 1em;
+  vertical-align: top;
+}
+</style>
+<!-- Matomo -->
+<script type="rocketlazyloadscript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://estadisticas.mediasector.es/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '34']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
+		<script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+			var advadsCfpQueue = [];
+			var advadsCfpAd = function( adID ) {
+				if ( 'undefined' === typeof advadsProCfp ) {
+					advadsCfpQueue.push( adID )
+				} else {
+					advadsProCfp.addElement( adID )
+				}
+			}
+		</script>
+		<!--[if lt IE 9]>
+<script src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/vendor/respond.min.js"></script>
+<![endif]-->
+<style type="text/css">
+html body div.easyrecipe .ERSNotesDiv .ERSNotesHeader { font-size: 18px!important;font-style: italic!important;margin-top: 21px!important;margin-bottom: 1px!important;margin-left: 41px!important; }
+html body div.easyrecipe .ERSNotesDiv .ERSNotes { font-style: italic!important;font-size: 15px!important;padding-left: 39px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe .ERSName { font-family: inherit!important;color: rgb(5, 5, 5)!important;font-weight: bold!important;font-size: 27px!important;margin-top: 31px!important;margin-bottom: 16px!important;margin-left: 1px!important;padding-top: 1px!important;padding-left: 2px!important; }
+html body div.easyrecipe .ERSTimes { color: rgb(5, 5, 5)!important;margin-top: 10px!important;margin-bottom: 9px!important;padding-top: 8px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSTimes .ERSTimeItem { color: rgb(5, 5, 5)!important;font-size: 14px!important;margin-bottom: 9px!important;margin-left: -4px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSSummary { font-family: inherit!important;font-weight: bold!important;font-size: 18px!important;margin-top: 10px!important;margin-bottom: 8px!important;margin-left: 1px!important;padding-top: 6px!important;padding-right: 2px!important; }
+html body div.easyrecipe .ERSAuthor { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important;margin-left: 0px!important; }
+html body div.easyrecipe .ERSCategory { padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSCuisine { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSServes { font-size: 15px!important;padding-left: 0px!important; }
+html body div.easyrecipe .ERSPrintBtnSpan .ERSPrintBtn { font-family: inherit!important;background-color: rgb(189, 190, 178)!important;font-weight: bold!important;font-size: 14px!important;margin-top: -10px!important;margin-bottom: -11px!important;margin-right: 2px!important;padding: 8px!important; }
+html body div.easyrecipe .ERSIngredientsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;margin: 24px -3px 20px 0px!important;padding-left: 21px!important;font-weight: normal!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSIngredients li.ingredient { font-size: 15px!important;list-style-type: circle!important;margin: -4px -10px 8px 13px!important;padding-left: 3px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructionsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;font-weight: normal!important;margin-top: 24px!important;margin-bottom: 9px!important;margin-right: -2px!important;padding-left: 21px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructions .instruction { font-size: 15px!important;margin: 12px -6px 12px 32px!important;padding: 0px 20px 6px 9px!important;font-family: inherit!important; }
+div.easyrecipe { border-radius:18px; font-family: 'Open Sans' !important;}
+.ERSRatingOuter .review {
+margin-top:0.5em;
+}
+
+div.easyrecipe div.ERSSavePrint span.ERSPrintBtnSpan a.ERSPrintBtn span.ERSPrintIcon {
+background-image: url(images/printicon.png);
+width: 16px;
+height: 16px;
+display: none;
+/* padding-top: 20px; */
+}</style>
+<style type="text/css" class="options-output">header #logo a.brand,.logofont{font-family:Lato;line-height:40px;font-weight:400;font-style:normal;font-size:32px;}.kad_tagline{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;color:#444444;font-size:20px;}.product_item .product_details h5{font-family:Lato;line-height:20px;font-weight:700;font-style:normal;font-size:16px;}h1{font-family:"Josefin Sans";line-height:40px;font-weight:600;font-style:normal;font-size:32px;}h2{font-family:"Josefin Sans";line-height:32px;font-weight:400;font-style:normal;font-size:28px;}h3{font-family:"Josefin Sans";line-height:28px;font-weight:400;font-style:normal;font-size:24px;}h4{font-family:"Open Sans";line-height:24px;font-weight:400;font-style:normal;font-size:20px;}h5{font-family:"Josefin Sans";line-height:22px;font-weight:300;font-style:normal;font-size:18px;}body{font-family:"Open Sans";line-height:25px;font-weight:400;font-style:normal;font-size:16px;}#nav-main ul.sf-menu a{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;font-size:22px;}#nav-second ul.sf-menu a{font-family:"Josefin Sans";line-height:20px;font-weight:600;font-style:normal;font-size:16px;}.kad-nav-inner .kad-mnav, .kad-mobile-nav .kad-nav-inner li a,.nav-trigger-case{font-family:"Josefin Sans";line-height:22px;font-weight:600;font-style:normal;font-size:16px;}</style><style type="text/css">/** Mega Menu CSS Disabled **/</style>
+
+    <!-- Custom scripts -->
+
+
+<!-- Menú fijo-->
+
+<script type="rocketlazyloadscript">jQuery("document").ready(function($){
+
+	var nav = $('.navclass');
+
+	$(window).scroll(function () {
+		if ($(this).scrollTop() > 173) {
+			nav.addClass("stickytop");
+		} else {
+			nav.removeClass("stickytop");
+		}
+	});
+
+});
+
+</script>
+
+<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style><meta name="generator" content="WP Rocket 3.20.4" data-wpr-features="wpr_delay_js wpr_defer_js wpr_minify_js wpr_preconnect_external_domains wpr_automatic_lazy_rendering wpr_oci wpr_minify_css wpr_preload_links wpr_desktop" /></head>
+  	
+  	<body data-cmplz=1 class="wp-singular post-template-default single single-post postid-254 single-format-standard wp-theme-virtue wp-child-theme-velocidad mega-menu-secondary-navigation mega-menu-max-mega-menu-1 mega-menu-max-mega-menu-2 mega-menu-max-mega-menu-3 mega-menu-max-mega-menu-4 mega-menu-max-mega-menu-6 mega-menu-max-mega-menu-7 mega-menu-max-mega-menu-8 mega-menu-max-mega-menu-9 mega-menu-max-mega-menu-10 mega-menu-max-mega-menu-11 mega-menu-max-mega-menu-12 wide salsa-bolonesa aa-prefix-local- er-recipe">
+  	<div  id="kt-skip-link"><a href="#content">Skip to Main Content</a></div>
+    <div  id="wrapper" class="container">
+    <header  class="banner headerclass" itemscope itemtype="http://schema.org/WPHeader">
+  <div  id="topbar" class="topclass">
+    <div  class="container">
+      <div class="row">
+        <div class="col-md-6 col-sm-6 kad-topbar-left">
+          <div class="topbarmenu clearfix">
+                                </div>
+        </div><!-- close col-md-6 --> 
+        <div class="col-md-6 col-sm-6 kad-topbar-right">
+          <div id="topbar-search" class="topbar-widget">
+            <form role="search" method="get" class="form-search" action="https://www.velocidadcuchara.com/">
+  <label>
+  	<span class="screen-reader-text">Búsqueda para:</span>
+  	<input type="text" value="" name="s" class="search-query" placeholder="Busca tu receta">
+  </label>
+  <button type="submit" class="search-icon"><i class="icon-search"></i></button>
+</form>        </div>
+        </div> <!-- close col-md-6-->
+      </div> <!-- Close Row -->
+    </div> <!-- Close Container -->
+  </div><div  class="container">
+  <div class="row">
+      <div class="col-md-4 clearfix kad-header-left">
+            <div id="logo" class="logocase">
+              <a class="brand logofont" href="https://www.velocidadcuchara.com/">
+                                  <div id="thelogo">
+                    <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-standard-logo" />
+                                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-retina-logo" style="max-height:121px" />                   </div>
+                              </a>
+                         </div> <!-- Close #logo -->
+       </div><!-- close logo span -->
+              
+    </div> <!-- Close Row -->
+     
+</div> <!-- Close Container -->
+    <section id="cat_nav" class="navclass">
+    <div class="container">
+      <nav id="nav-second" class="clearfix" itemscope itemtype="http://schema.org/SiteNavigationElement">
+        <div id="mega-menu-wrap-secondary_navigation" class="mega-menu-wrap"><div class="mega-menu-toggle" tabindex="0"><div class='mega-toggle-block mega-menu-toggle-block mega-toggle-block-right mega-toggle-block-1' id='mega-toggle-block-1'></div></div><ul id="mega-menu-secondary_navigation" class="mega-menu mega-menu-horizontal mega-no-js" data-event="hover_intent" data-effect="fade_up" data-effect-speed="200" data-second-click="close" data-document-click="collapse" data-vertical-behaviour="accordion" data-breakpoint="768" data-unbind="true"><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-58762' id='mega-menu-item-58762'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/indice-recetas-thermomix/" tabindex="0">Índice</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58774' id='mega-menu-item-58774'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/todas-las-recetas/" aria-haspopup="true" tabindex="0">Recetas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-custom mega-menu-item-object-custom mega-menu-item-58775' id='mega-menu-item-58775'><a class="mega-menu-link" href="https://velocidadcuchara.com/todas-las-recetas/">Todas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58778' id='mega-menu-item-58778'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/carnes/">Carnes</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58779' id='mega-menu-item-58779'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/pescados-y-marisco/">Pescados y mariscos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58780' id='mega-menu-item-58780'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/ensaladas/">Ensaladas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58781' id='mega-menu-item-58781'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/legumbres-y-verduras/">Legumbres y verduras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58782' id='mega-menu-item-58782'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/arroces-y-pastas/">Arroces y pastas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58783' id='mega-menu-item-58783'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sopas-y-cremas/">Sopas y cremas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58784' id='mega-menu-item-58784'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/masas-y-pan/">Masas y pan</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58785' id='mega-menu-item-58785'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/reposteria/">Repostería</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58786' id='mega-menu-item-58786'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/postres-y-dulces/">Postres y dulces</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58787' id='mega-menu-item-58787'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/conservas-y-confituras/">Conservas y confituras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-59720' id='mega-menu-item-59720'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/desayuno/">Desayunos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58788' id='mega-menu-item-58788'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/bebidas/">Bebidas y cócteles</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58789' id='mega-menu-item-58789'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetarios/">Recetarios</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58803' id='mega-menu-item-58803'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dos-en-uno/">Dos en uno</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58776' id='mega-menu-item-58776'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/dietas/" aria-haspopup="true" tabindex="0">Dietas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58790' id='mega-menu-item-58790'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-gluten/">Sin gluten</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58791' id='mega-menu-item-58791'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-lactosa/">Sin lactosa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58792' id='mega-menu-item-58792'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-huevo/">Sin huevo</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58793' id='mega-menu-item-58793'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-azucar/">Sin azúcar</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58794' id='mega-menu-item-58794'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/vegetariana/">Vegetariana</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58795' id='mega-menu-item-58795'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/hipocalorica/">Hipocalórica</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58777' id='mega-menu-item-58777'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas-sin-thermomix/" aria-haspopup="true" tabindex="0">Sin TMX</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58798' id='mega-menu-item-58798'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/olla-rapida/">Olla rápida</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58797' id='mega-menu-item-58797'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/cocotte/">Cocotte</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-60222' id='mega-menu-item-60222'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/freidora-de-aire/">Freidora de aire</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58799' id='mega-menu-item-58799'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/crock-pot/">Crock Pot</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58796' id='mega-menu-item-58796'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/kitchenaid/">Kitchenaid</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58801' id='mega-menu-item-58801'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/al-vacio/">Al vacío</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58800' id='mega-menu-item-58800'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/barbacoa/">Barbacoa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58802' id='mega-menu-item-58802'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/otros/">Otros</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58763' id='mega-menu-item-58763'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" aria-haspopup="true" tabindex="0">Libros</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58765' id='mega-menu-item-58765'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-cocina-rico-todos-los-dias-thermomix/">Cocina rico todos los días</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58764' id='mega-menu-item-58764'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-mis-recetas-imprescindibles-thermomix/">Mis recetas imprescindibles</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-60105' id='mega-menu-item-60105'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/podcast-velocidad-cuchara/" tabindex="0">🎧 Pódcast</a></li></ul></div>      </nav>
+    </div><!--close container-->
+  </section>
+  </header>
+      <div  class="wrap contentclass" role="document">
+
+        <div  id="content" class="container">
+    <div class="row single-article" itemscope itemtype="http://schema.org/BlogPosting">
+        <div class="main col-lg-9 col-md-8" role="main">
+                    <article class="post-254 post type-post status-publish format-standard has-post-thumbnail hentry category-30-minutos category-guarniciones-y-salsas category-recetas tag-ajos tag-carne-picada tag-cebollas tag-champinones tag-oregano tag-pimienta tag-pimiento-rojo tag-tomate-natural-triturado tag-zanahorias course-salsas cuisine-italiana">
+            <div class="meta_post_image" itemprop="image" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC.jpg"><meta itemprop="width" content="1000"><meta itemprop="height" content="669"></div>
+                <div class="postmeta updated color_gray">
+      <div class="postdate bg-lightgray headerfont" itemprop="datePublished">
+      <span class="postday">5</span>
+      Sep 2009    </div>
+</div>                <header>
+                    <h1 class="entry-title" itemprop="name headline">Salsa boloñesa</h1><div class="subhead">
+    <span class="postauthortop author vcard">
+    <i class="icon-user"></i> por  <span itemprop="author"><a href="https://www.velocidadcuchara.com/author/admin/" class="fn" rel="author">Rosa Ardá</a></span> |</span>
+      
+    <span class="postedintop"><i class="icon-folder-open"></i> publicado en: <a href="https://www.velocidadcuchara.com/tiempo/30-minutos/" rel="category tag">30 minutos</a>, <a href="https://www.velocidadcuchara.com/recetas/guarniciones-y-salsas/" rel="category tag">Guarniciones y salsas</a>, <a href="https://www.velocidadcuchara.com/recetas/" rel="category tag">Recetas</a></span>     <span class="kad-hidepostedin">|</span>
+    <span class="postcommentscount">
+    <i class="icon-comments-alt"></i> 62    </span>
+</div>                </header>
+
+                <div class="entry-content" itemprop="articleBody">
+                    <p><a href="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC.jpg"><picture fetchpriority="high" decoding="async" class="aligncenter wp-image-48344 size-full" title="Salsa Boloñesa">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC.jpg.webp 1000w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-300x201.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-768x514.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-272x182.jpg.webp 272w" sizes="(max-width: 1000px) 100vw, 1000px"/>
+<img fetchpriority="high" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC.jpg" alt="Salsa Boloñesa" width="1000" height="669" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC.jpg 1000w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-300x201.jpg 300w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-768x514.jpg 768w, https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC-272x182.jpg 272w" sizes="(max-width: 1000px) 100vw, 1000px"/>
+</picture>
+</a></p>
+<p><strong>Sirve para todo&#8230;</strong> para poner con <a title="Espaguetis boloñesa" href="https://www.velocidadcuchara.com/espaguetis-a-la-bolonesa/" target="_blank" rel="noopener"><strong>espaguetis</strong></a> o cualquier tipo de pasta seca o fresca, para usar dentro de unas <a title="Berenjenas rellenas de boloñesa" href="https://www.velocidadcuchara.com/berenjenas-rellenas-de-bolonesa/" target="_blank" rel="noopener"><strong>berenjenas</strong> </a>cocidas al vapor, unos<a title="Calabacines rellenos" href="https://www.velocidadcuchara.com/calabacines-rellenos-paso-a-paso/" target="_blank" rel="noopener"><strong> calabacines</strong></a>, para poner sobre una <a title="Pizzas" href="https://www.velocidadcuchara.com/category/recetas/masas-y-pan/pizza/" target="_blank" rel="noopener"><strong>masa de pizza</strong></a>, para rellenar unas<a title="Empanadillas" href="https://www.velocidadcuchara.com/empanadillas-faciles-y-rapidas-paso-a-paso-con-thermomix/" target="_blank" rel="noopener"><strong> empanadillas</strong></a> o una<a title="Empanadas" href="https://www.velocidadcuchara.com/category/recetas/masas-y-pan/empanadas/" target="_blank" rel="noopener"><strong> empanada</strong></a>&#8230; siempre queda bien.</p><script type="text/plain" data-tcf="waiting-for-consent" data-id="45718" data-bid="1" data-placement="61266">PGRpdiBpZD0ibG9jYWwtNTQ3NjMxOTkzIiBjbGFzcz0iZ2FzX2ZhbGxiYWNrLWFkXzQ1NzE4LS1wbGFjZW1lbnRfNjEyNjYiIHN0eWxlPSJtYXJnaW4tdG9wOiAyMHB4O21hcmdpbi1ib3R0b206IDIwcHg7Ij48c2NyaXB0IGFzeW5jIHNyYz0iLy9wYWdlYWQyLmdvb2dsZXN5bmRpY2F0aW9uLmNvbS9wYWdlYWQvanMvYWRzYnlnb29nbGUuanM/Y2xpZW50PWNhLXB1Yi0wNDMyNzI2MDQwMDA5Njc2IiBjcm9zc29yaWdpbj0iYW5vbnltb3VzIj48L3NjcmlwdD48aW5zIGNsYXNzPSJhZHNieWdvb2dsZSIgc3R5bGU9ImRpc3BsYXk6YmxvY2s7IiBkYXRhLWFkLWNsaWVudD0iY2EtcHViLTA0MzI3MjYwNDAwMDk2NzYiIApkYXRhLWFkLXNsb3Q9Ijk4OTU0ODA5NDgiIApkYXRhLWFkLWZvcm1hdD0iYXV0byI+PC9pbnM+CjxzY3JpcHQ+IAooYWRzYnlnb29nbGUgPSB3aW5kb3cuYWRzYnlnb29nbGUgfHwgW10pLnB1c2goe30pOyAKPC9zY3JpcHQ+CjwvZGl2Pg==</script>
+<p><strong>Lo podéis preparar con antelación y guardar o congelar&#8230;</strong> al final, cuando terminéis esta receta tendréis una cantidad importante de salsa boloñesa, como un litro y medio aproximadamente :DD</p>
+<p>A por ella&#8230; os va a cundir!</p><div  class="local-2e3004518adda224bf6858aae4e50cc9 local-contenido-2" id="local-2e3004518adda224bf6858aae4e50cc9"></div>
+<p><span id="more-254"></span><br />
+<div id="easyrecipe-254-0" class="easyrecipe" itemscope itemtype="http://schema.org/Recipe"> <link itemprop="image" href="https://www.velocidadcuchara.com/wp-content/uploads/2009/09/Salsa-bolonesa-VC.jpg"/> <div class="ERSRatings" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"> <div class="ERSRatingOuter"> <div class="ERSRatingInner" style="width: 90%"></div> <div class="review"><span class="rating"><span class="average" itemprop="ratingValue">4.5</span> de <span class="count" itemprop="ratingCount">10</span> opiniones</span></div> </div> </div> <div itemprop="name" class="ERSName">Salsa boloñesa</div> <div class="ERSClear">&nbsp;</div> <div class="ERSTopRight"> <div class="ERSSavePrint"> <span class="ERSPrintBtnSpan"><a class="ERSPrintBtn" href="https://www.velocidadcuchara.com/easyrecipe-print/254-0/" rel="nofollow" target="_blank">Imprimir</a></span> </div> </div> <div class="ERSTimes"> <div class="ERSTime"> <div class="ERSTimeHeading">Preparación</div> <div class="ERSTimeItem"> <time itemprop="prepTime" datetime="PT23M">23 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Cocción</div> <div class="ERSTimeItem"> <time itemprop="cookTime" datetime="PT15M">15 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Tiempo total</div> <div class="ERSTimeItem"> <time itemprop="totalTime" datetime="PT38M">38 min</time> </div> </div> <div class="ERSClearLeft">&nbsp;</div> </div> <div itemprop="description" class="ERSSummary">Con Thermomix ® se hace de forma muy sencilla y queda genial. Es otra forma de preparar una receta tan italiana como la salsa boloñesa de forma más cómoda, ahorrando tiempo.</div> <div class="divERSHeadItems"> <div class="ERSAuthor">Autor: <span itemprop="author">Rosa Ardá</span></div> <div class="ERSCategory">Tipo de receta: <span itemprop="recipeCategory">Salsas</span></div> <div class="ERSCuisine">Cocina: <span itemprop="recipeCuisine">Italiana</span></div> <div class="ERSServes">Raciones: <span itemprop="recipeYield">6</span></div> </div> <div class="ERSIngredients"> <div class="ERSIngredientsHeader ERSHeading">Ingredientes</div> <ul> <li class="ingredient" itemprop="ingredients"><strong>Para el sofrito:</strong></li> <li class="ingredient" itemprop="ingredients">150 gr de zanahoria</li> <li class="ingredient" itemprop="ingredients">130 gr de cebolla</li> <li class="ingredient" itemprop="ingredients">180 gr de champiñones</li> <li class="ingredient" itemprop="ingredients">1 diente de ajo</li> <li class="ingredient" itemprop="ingredients">500 gr de tomate natural triturado</li> <li class="ingredient" itemprop="ingredients">50 gr de aceite de oliva virgen extra</li> <li class="ingredient" itemprop="ingredients"><strong>Para el resto:</strong></li> <li class="ingredient" itemprop="ingredients">500 gr de carne picada -mitad ternera, mitad cerdo-.</li> <li class="ingredient" itemprop="ingredients">Sal al gusto</li> <li class="ingredient" itemprop="ingredients">Una pizca de pimienta negra</li> <li class="ingredient" itemprop="ingredients">Orégano seco al gusto</li> <li class="ingredient" itemprop="ingredients"><strong>Para cocer la pasta:</strong></li> <li class="ingredient" itemprop="ingredients">1000 gr de agua</li> <li class="ingredient" itemprop="ingredients">1 cucharadita de sal</li> <li class="ingredient" itemprop="ingredients">500 gr de espaguetis</li> <li class="ingredient" itemprop="ingredients"><strong>Para servir:</strong></li> <li class="ingredient" itemprop="ingredients">Queso parmesano rallado</li> </ul> <div class="ERSClear"></div> </div> <div class="ERSInstructions"> <div class="ERSInstructionsHeader ERSHeading">Pasos a seguir</div> <ol> <li class="instruction" itemprop="recipeInstructions">Pon todos los ingredientes del sofrito en trozos dentro del vaso -<em>excepto el aceite</em>- y <strong>tritura 15 segundos en velocidad 5.</strong></li> <li class="instruction" itemprop="recipeInstructions"><strong>Baja los restos que hayan quedado en las paredes </strong>del vaso. <strong>Añade el aceite</strong> y programa <strong>8 minutos, temperatura Varoma, velocidad 1</strong>.</li> <li class="instruction" itemprop="recipeInstructions">Incorpora al vaso, la carne picada -rómpela un poquito con el tenedor que suele venir muy apelmazada-, sal y especias y<strong> cocina 15 minutos, Varoma, giro a la izquierda y velocidad cuchara</strong>. Comprueba<strong> punto de sal, retira y reserva</strong>.</li> <li class="instruction" itemprop="recipeInstructions">Sin lavar el vaso, <strong>añade el agua y caliéntala unos 10-12 minutos, Varoma, velocidad 1 o hasta que hierva</strong>. <strong>Añade la pasta </strong>y programa el <strong>tiempo que recomiende el paquete, Varoma, giro a la izquierda y velocidad cuchara</strong>. Escurre y sirve acompañada con la salsa. A mi me gusta mezclar ambas cosas en una fuente para que los espaguetis se pongan del color de la boloñesa.</li> </ol> <div class="ERSClear"></div> </div> <div class="ERSNotesDiv"> <div class="ERSNotesHeader">Notas:</div> <div class="ERSNotes">-Si te gusta la boloñesa con más tropezones de las verduras, en lugar de triturar 15 segundos en velocidad 5, baja el tiempo a 6-8 segundos en velocidad 4.<br>-Necesitarás algo más de tomate, unos 100 gr más para que quede más líquido.<br>Prueba a ponerle 50 gr de leche evaporada, ya verás que toque rico.</div> <div class="ERSClear"></div> </div> <div class="endeasyrecipe" title="style002a" style="display: none">3.2.2708</div> </div>
+<div class="addtoany_share_save_container addtoany_content addtoany_content_bottom"><div class="a2a_kit a2a_kit_size_32 addtoany_list" data-a2a-url="https://www.velocidadcuchara.com/salsa-bolonesa/" data-a2a-title="Salsa boloñesa"><a class="a2a_button_facebook" href="https://www.addtoany.com/add_to/facebook?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-bolonesa%2F&amp;linkname=Salsa%20bolo%C3%B1esa" title="Facebook" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_x" href="https://www.addtoany.com/add_to/x?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-bolonesa%2F&amp;linkname=Salsa%20bolo%C3%B1esa" title="X" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_pinterest" href="https://www.addtoany.com/add_to/pinterest?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-bolonesa%2F&amp;linkname=Salsa%20bolo%C3%B1esa" title="Pinterest" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_whatsapp" href="https://www.addtoany.com/add_to/whatsapp?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-bolonesa%2F&amp;linkname=Salsa%20bolo%C3%B1esa" title="WhatsApp" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_telegram" href="https://www.addtoany.com/add_to/telegram?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-bolonesa%2F&amp;linkname=Salsa%20bolo%C3%B1esa" title="Telegram" rel="nofollow noopener" target="_blank"></a></div></div>                </div>
+
+                <footer class="single-footer">
+                <span class="posttags"><i class="icon-tag"></i><a href="https://www.velocidadcuchara.com/tag/ajos/" rel="tag">Ajos</a>, <a href="https://www.velocidadcuchara.com/tag/carne-picada/" rel="tag">Carne picada</a>, <a href="https://www.velocidadcuchara.com/tag/cebollas/" rel="tag">Cebollas</a>, <a href="https://www.velocidadcuchara.com/tag/champinones/" rel="tag">Champiñones</a>, <a href="https://www.velocidadcuchara.com/tag/oregano/" rel="tag">Orégano</a>, <a href="https://www.velocidadcuchara.com/tag/pimienta/" rel="tag">Pimienta</a>, <a href="https://www.velocidadcuchara.com/tag/pimiento-rojo/" rel="tag">Pimiento rojo</a>, <a href="https://www.velocidadcuchara.com/tag/tomate-natural-triturado/" rel="tag">Tomate natural triturado</a>, <a href="https://www.velocidadcuchara.com/tag/zanahorias/" rel="tag">Zanahorias</a></span><meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/salsa-bolonesa/"><meta itemprop="dateModified" content="2017-08-26T11:49:52+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div>                </footer>
+            </article>
+            <div id="blog_carousel_container" class="carousel_outerrim">
+    <h3 class="title">Publicaciones Recientes</h3>    <div class="blog-carouselcase fredcarousel">
+    		<div id="carouselcontainer-blog" class="rowtight">
+		<div id="blog_carousel" class="blog_carousel caroufedselclass initcaroufedsel clearfix" data-carousel-container="#carouselcontainer-blog" data-carousel-transition="300" data-carousel-scroll="1" data-carousel-auto="true" data-carousel-speed="9000" data-carousel-id="blog" data-carousel-md="3" data-carousel-sm="3" data-carousel-xs="2" data-carousel-ss="1">
+            				<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61247 post type-post status-publish format-standard has-post-thumbnail hentry category-cocina-para-ninos category-dietas category-dulces-para-ninos category-postres-de-cuchara category-postres-y-dulces category-recetas category-sin-gluten category-sin-lactosa tag-azucar-blanquilla tag-esencia-de-vainilla tag-galletas-tipo-maria tag-huevos tag-leche-sin-lactosa course-postres-reposteria cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" title="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg" alt="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">23 octubre, 2025</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Cocina para todos una receta sin gluten y sin lactosa. Este Pudin te va a...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/"><meta itemprop="dateModified" content="2025-10-24T18:03:21+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-274 post type-post status-publish format-standard has-post-thumbnail hentry category-30-minutos category-dietas category-ensaladas category-estaciones category-frias category-hipocalorica category-pescado-azul category-pescados-y-marisco category-primeros-dieta category-recetas category-sin-azucar category-sin-gluten category-sin-lactosa category-verano category-verduras-y-hortalizas tag-aceitunas-negras tag-aceitunas-rellenas-de-anchoa tag-atun tag-cebollas-tomates tag-huevos tag-patatas tag-pimiento-rojo tag-pimiento-verde course-ensaladas cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/ensalada-campera/" title="Ensalada campera">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg" alt="Ensalada campera" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/ensalada-campera/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Ensalada campera</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">7 junio, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>En días de calor no hay nada más apetecible que una ensalada. Te propongo que...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/ensalada-campera/"><meta itemprop="dateModified" content="2025-11-30T17:58:48+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61149 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-estaciones category-invierno category-otono category-otros category-pescado-blanco category-pescados-y-marisco category-primavera category-recetas category-sin-thermomix category-tiempo category-tupper tag-ajos tag-bacalao tag-cebollas tag-guindillas tag-harina tag-perejil tag-pimienta-negra tag-sal tag-tomate-natural-triturado course-segundos-pescados cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" title="Bacalao en salsa de tomate">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg" alt="Bacalao en salsa de tomate" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Bacalao en salsa de tomate</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 abril, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Hoy quiero compartir con vosotros esta receta. ¿Sabéis lo buenísima que está? Es deliciosaaaaaaa. En...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/"><meta itemprop="dateModified" content="2025-11-30T18:03:39+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-10498 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-dulces category-fiestas category-masas-y-pan category-pan category-postres-de-cuchara category-postres-y-dulces category-recetas category-semana-santa tag-canela tag-cointreau tag-huevos tag-leche-entera tag-naranjas tag-pan course-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" title="Torrijas fritas de Semana Santa con Thermomix">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg" alt="Torrijas fritas de Semana Santa con Thermomix" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-730x730.jpg 730w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-365x365.jpg 365w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Torrijas fritas de Semana Santa con Thermomix</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">27 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¿Estáis listos para la segunda parte del &#8220;Pan para torrijas&#8221;? Pues agarraros a la silla...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/"><meta itemprop="dateModified" content="2024-03-27T11:23:07+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-60562 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-desayuno category-dulces category-estaciones category-fiestas category-freidora-de-aire category-masas-dulces category-postres-de-cuchara category-postres-y-dulces category-primavera category-recetas category-reposteria category-semana-santa category-sin-thermomix category-tiempo tag-azucar tag-azucar-blanquilla tag-canela tag-huevos tag-leche-entera tag-limones tag-pan course-reposteria-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" title="Mis primeras Torrijas en Freidora de aire o Airfryer">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg" alt="Mis primeras Torrijas en Freidora de aire o Airfryer" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-150x150.jpeg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-532x532.jpeg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Mis primeras Torrijas en Freidora de aire o Airfryer</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">5 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Receta de Torrijas de Semana Santa en freidora de aire o Airfryer. Prepáralas en pocos...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/"><meta itemprop="dateModified" content="2024-04-06T10:23:15+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61100 post type-post status-publish format-standard has-post-thumbnail hentry category-carne-de-pollo category-carnes category-cocina-del-mundo category-estaciones category-india category-invierno category-otono category-otros category-primavera category-recetas category-sin-thermomix category-tupper tag-aguacates tag-ajos tag-carne-de-pollo tag-fideos-de-arroz tag-jengibre tag-lima tag-miel tag-pimienta-negra tag-sal tag-salsa-de-soja tag-semillas-de-sesamo course-carnes-segundos" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" title="Pollo con soja y jengibre">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg" alt="Pollo con soja y jengibre" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pollo con soja y jengibre</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 enero, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¡Que se nota dicen!! Que si, que estoy feliz. Sobre todo estoy tranquila y este...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/"><meta itemprop="dateModified" content="2024-12-23T09:15:20+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+					</div>
+     <div class="clearfix"></div>
+            <a id="prevport-blog" class="prev_carousel icon-chevron-left" href="#"></a>
+			<a id="nextport-blog" class="next_carousel icon-chevron-right" href="#"></a>
+            </div>
+            </div>
+</div><!-- Carousel Container-->  <section id="comments">
+    <h3>62 Comentarios</h3>
+
+      <button class="mostrar-comentarios antes button" style="cursor:pointer">Mostrar comentarios</button>
+
+    <ol class="media-list">
+      
+  <li id="comment-238205" class="comment even thread-even depth-1 media comment-238205">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f46a8c888d16e62da3373be6a82b717e38c0cc3e08e1133449df448bb8358ad?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f46a8c888d16e62da3373be6a82b717e38c0cc3e08e1133449df448bb8358ad?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Pau</h5>
+        <div class="comment-meta">
+        <time datetime="2026-04-02T13:39:28+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-238205">
+          2 abril, 2026</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-238205" data-commentid="238205" data-postid="254" data-belowelement="comment-238205" data-respondelement="respond" data-replyto="Responder a Pau" aria-label="Responder a Pau">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>-que locura de boloñesa      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-238096" class="comment odd alt thread-odd thread-alt depth-1 media comment-238096">
+    <img alt='' src='https://secure.gravatar.com/avatar/e584fbf953b4e413a0297be1e9e7a8ffac08fdb564fce8af1a10bd22aaf6cf0a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e584fbf953b4e413a0297be1e9e7a8ffac08fdb564fce8af1a10bd22aaf6cf0a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Yo</h5>
+        <div class="comment-meta">
+        <time datetime="2026-03-02T19:44:33+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-238096">
+          2 marzo, 2026</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-238096" data-commentid="238096" data-postid="254" data-belowelement="comment-238096" data-respondelement="respond" data-replyto="Responder a Yo" aria-label="Responder a Yo">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>En las notas pones que necesitarás algo ma más de tomate&#8230;&#8230;. Claro&#8230;.. Como que en la receta no dices cuándo agregar el tomate. Jjj</p>
+      
+  </div></li>
+
+  <li id="comment-238095" class="comment even thread-even depth-1 media comment-238095">
+    <img alt='' src='https://secure.gravatar.com/avatar/e584fbf953b4e413a0297be1e9e7a8ffac08fdb564fce8af1a10bd22aaf6cf0a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e584fbf953b4e413a0297be1e9e7a8ffac08fdb564fce8af1a10bd22aaf6cf0a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Yo</h5>
+        <div class="comment-meta">
+        <time datetime="2026-03-02T19:44:16+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-238095">
+          2 marzo, 2026</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-238095" data-commentid="238095" data-postid="254" data-belowelement="comment-238095" data-respondelement="respond" data-replyto="Responder a Yo" aria-label="Responder a Yo">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>En las notas pones que necesitarás algo ma más de tomate&#8230;&#8230;. Claro&#8230;.. Como que en la receta no dices cuándo agregar el tomate.</p>
+      
+  </div></li>
+
+  <li id="comment-237338" class="comment odd alt thread-odd thread-alt depth-1 media comment-237338">
+    <img alt='' src='https://secure.gravatar.com/avatar/4a3031a8c51f9ebeaf96d5240a7154566188e9cc22ab5c2c5845c879b138cff7?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/4a3031a8c51f9ebeaf96d5240a7154566188e9cc22ab5c2c5845c879b138cff7?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Silvia</h5>
+        <div class="comment-meta">
+        <time datetime="2025-07-16T18:15:19+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-237338">
+          16 julio, 2025</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-237338" data-commentid="237338" data-postid="254" data-belowelement="comment-237338" data-respondelement="respond" data-replyto="Responder a Silvia" aria-label="Responder a Silvia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Alguna receta de boloñesa que no lleve tomate? Mi hija no lo soporta y no se como hacerlo, gracias</p>
+      
+  </div></li>
+
+  <li id="comment-235317" class="comment even thread-even depth-1 media comment-235317">
+    <img alt='' src='https://secure.gravatar.com/avatar/55efcb34dffcdd70007477f2f4cf40158f355ba952af616a239b090153feb2b6?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/55efcb34dffcdd70007477f2f4cf40158f355ba952af616a239b090153feb2b6?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">maribel</h5>
+        <div class="comment-meta">
+        <time datetime="2024-02-01T08:39:30+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-235317">
+          1 febrero, 2024</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-235317" data-commentid="235317" data-postid="254" data-belowelement="comment-235317" data-respondelement="respond" data-replyto="Responder a maribel" aria-label="Responder a maribel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenas, en que paso le hecho la leche evaporada?, gracias</p>
+      
+  </div></li>
+
+  <li id="comment-234912" class="comment odd alt thread-odd thread-alt depth-1 media comment-234912">
+    <img alt='' src='https://secure.gravatar.com/avatar/8462ef4a5f10928586aa1ec2c73a5a268e706285da16f7bd728636005e4de49a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/8462ef4a5f10928586aa1ec2c73a5a268e706285da16f7bd728636005e4de49a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carmen</h5>
+        <div class="comment-meta">
+        <time datetime="2023-09-01T12:51:19+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-234912">
+          1 septiembre, 2023</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-234912" data-commentid="234912" data-postid="254" data-belowelement="comment-234912" data-respondelement="respond" data-replyto="Responder a Carmen" aria-label="Responder a Carmen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Cuando se pone el tomate 🍅 está incompleta. El resto me gusta. Gracias</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-234912">
+    
+  <li id="comment-237997" class="comment odd alt depth-2 media comment-237997">
+    <img alt='' src='https://secure.gravatar.com/avatar/7b1e8b72ea12ab166642682c358d3883cdbf48d10110942ca4737ac0864d5333?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/7b1e8b72ea12ab166642682c358d3883cdbf48d10110942ca4737ac0864d5333?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Loli</h5>
+        <div class="comment-meta">
+        <time datetime="2026-01-29T00:58:51+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-237997">
+          29 enero, 2026</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Lo pone en la receta, con todo lo del sofrito.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-233821" class="comment even thread-odd thread-alt depth-1 media comment-233821">
+    <img alt='' src='https://secure.gravatar.com/avatar/59e4a2d2b4f4fd0f042a5c94cc764f08c722e13592cd02910a5bbf926321a7e0?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/59e4a2d2b4f4fd0f042a5c94cc764f08c722e13592cd02910a5bbf926321a7e0?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Esther</h5>
+        <div class="comment-meta">
+        <time datetime="2022-09-21T13:55:47+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-233821">
+          21 septiembre, 2022</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-233821" data-commentid="233821" data-postid="254" data-belowelement="comment-233821" data-respondelement="respond" data-replyto="Responder a Esther" aria-label="Responder a Esther">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola,<br />
+Entiendo que en el paso del sofrito se hace con el vaso sin tapar, ¿y los 15 minutos con la carne? ¿Se deja destapado también?</p>
+      
+  </div></li>
+
+  <li id="comment-233764" class="comment odd alt thread-even depth-1 media comment-233764">
+    <img alt='' src='https://secure.gravatar.com/avatar/056e07d422fb3ca35e7160326ecf55dbd889768a69014793674f35a4fe514865?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/056e07d422fb3ca35e7160326ecf55dbd889768a69014793674f35a4fe514865?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Miguel</h5>
+        <div class="comment-meta">
+        <time datetime="2022-09-01T13:30:41+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-233764">
+          1 septiembre, 2022</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-233764" data-commentid="233764" data-postid="254" data-belowelement="comment-233764" data-respondelement="respond" data-replyto="Responder a Miguel" aria-label="Responder a Miguel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>En qué momento pone en la receta donde se añade el tomate??</p>
+      
+  </div></li>
+
+  <li id="comment-232442" class="comment even thread-odd thread-alt depth-1 media comment-232442">
+    <img alt='' src='https://secure.gravatar.com/avatar/69d3f3184ac992ae858a5da58b159985207107b83bd35967cd95dfe5cb3cdee1?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/69d3f3184ac992ae858a5da58b159985207107b83bd35967cd95dfe5cb3cdee1?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">isabela</h5>
+        <div class="comment-meta">
+        <time datetime="2021-10-01T08:54:54+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-232442">
+          1 octubre, 2021</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-232442" data-commentid="232442" data-postid="254" data-belowelement="comment-232442" data-respondelement="respond" data-replyto="Responder a isabela" aria-label="Responder a isabela">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>el toque de la leche evaporada me parece genial      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-232442">
+    
+  <li id="comment-232549" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-232549">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2021-10-30T12:14:41+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-232549">
+          30 octubre, 2021</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>👏👏👏</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-230561" class="comment odd alt thread-odd thread-alt depth-1 media comment-230561">
+    <img alt='' src='https://secure.gravatar.com/avatar/ac45dfaebdffda8736888c8c64a4e3b3903807f37485d02c24a8def220aa5214?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ac45dfaebdffda8736888c8c64a4e3b3903807f37485d02c24a8def220aa5214?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Frank</h5>
+        <div class="comment-meta">
+        <time datetime="2021-01-28T16:21:06+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-230561">
+          28 enero, 2021</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-230561" data-commentid="230561" data-postid="254" data-belowelement="comment-230561" data-respondelement="respond" data-replyto="Responder a Frank" aria-label="Responder a Frank">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hecha en mcc de lidl.<br />
+Muy rica. Gracias!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-230481" class="comment even thread-even depth-1 media comment-230481">
+    <img alt='' src='https://secure.gravatar.com/avatar/68a9a5b2bbf3a588f41bce9e69f279ff350e082e8da11dd81934296a1dc5f0c4?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/68a9a5b2bbf3a588f41bce9e69f279ff350e082e8da11dd81934296a1dc5f0c4?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Willie</h5>
+        <div class="comment-meta">
+        <time datetime="2021-01-20T11:58:23+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-230481">
+          20 enero, 2021</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-230481" data-commentid="230481" data-postid="254" data-belowelement="comment-230481" data-respondelement="respond" data-replyto="Responder a Willie" aria-label="Responder a Willie">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Siempre hago las recetas  vuestras. Siempre velocidad cuchara.</p>
+      
+  </div></li>
+
+  <li id="comment-227594" class="comment odd alt thread-odd thread-alt depth-1 media comment-227594">
+    <img alt='' src='https://secure.gravatar.com/avatar/4f343d1f889403e2bd1bdb1f5bf4efd4c0159a17abc02118eb8849d392cf2db4?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/4f343d1f889403e2bd1bdb1f5bf4efd4c0159a17abc02118eb8849d392cf2db4?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">MARIA JESÚS</h5>
+        <div class="comment-meta">
+        <time datetime="2020-02-15T15:15:29+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-227594">
+          15 febrero, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-227594" data-commentid="227594" data-postid="254" data-belowelement="comment-227594" data-respondelement="respond" data-replyto="Responder a MARIA JESÚS" aria-label="Responder a MARIA JESÚS">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Cuando busco una receta siempre me gusta leer los comentarios de los demás para ver qué tal. Si el mío os sirve de algo os invito a que hagáis esta con los ojos cerrados. Sale buenísima, en realidad todas las que he hecho de velocidadcuchara salen bien.      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-227402" class="comment even thread-even depth-1 media comment-227402">
+    <img alt='' src='https://secure.gravatar.com/avatar/7d882e3895810b86aa8d0836b030d2e178ebf0f8533d8221345feb5acea4ef75?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/7d882e3895810b86aa8d0836b030d2e178ebf0f8533d8221345feb5acea4ef75?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Kali</h5>
+        <div class="comment-meta">
+        <time datetime="2020-01-26T03:52:27+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-227402">
+          26 enero, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-227402" data-commentid="227402" data-postid="254" data-belowelement="comment-227402" data-respondelement="respond" data-replyto="Responder a Kali" aria-label="Responder a Kali">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Me encanta Velocidad  Cuchara! Haces un trabajo fantástico. Ninguna receta me ha fallado :)<br />
+Soy novata en la cocina en general. </p>
+<p>Estoy preparando Batch Cooking. Así que mi idea es preparar el máximo de cantidad al mismo tiempo. </p>
+<p>Sí deseo doblar  cantidades, el tiempo será el mismo?  Solamente para la salsa. </p>
+<p>Muchísimas gracias por adelantado.</p>
+      
+  </div></li>
+
+  <li id="comment-226559" class="comment odd alt thread-odd thread-alt depth-1 media comment-226559">
+    <img alt='' src='https://secure.gravatar.com/avatar/009dd212d867b0e18b725ba2b20c8cb12e0f3c98b870e6486fd1b0247cfbdf1d?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/009dd212d867b0e18b725ba2b20c8cb12e0f3c98b870e6486fd1b0247cfbdf1d?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">LIDIA</h5>
+        <div class="comment-meta">
+        <time datetime="2019-11-18T20:42:29+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-226559">
+          18 noviembre, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-226559" data-commentid="226559" data-postid="254" data-belowelement="comment-226559" data-respondelement="respond" data-replyto="Responder a LIDIA" aria-label="Responder a LIDIA">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>En qué momento echas el tomate??? Me pierdo&#8230;</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-226559">
+    
+  <li id="comment-230562" class="comment odd alt depth-2 media comment-230562">
+    <img alt='' src='https://secure.gravatar.com/avatar/a0594faa9bdb23e146e3b6612025630831a217e896a98cf33c5f74f384e6339e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/a0594faa9bdb23e146e3b6612025630831a217e896a98cf33c5f74f384e6339e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Frank</h5>
+        <div class="comment-meta">
+        <time datetime="2021-01-28T16:22:32+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-230562">
+          28 enero, 2021</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Todo lo del sofrito en el primer paso. Menos el aceite. Esta escrito</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-226257" class="comment even thread-odd thread-alt depth-1 media comment-226257">
+    <img alt='' src='https://secure.gravatar.com/avatar/8d501e3d26dc1d1f7b591d8912328868327214bcee3d8e00a3c706b0bf845a19?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/8d501e3d26dc1d1f7b591d8912328868327214bcee3d8e00a3c706b0bf845a19?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Teresa</h5>
+        <div class="comment-meta">
+        <time datetime="2019-10-17T13:24:44+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-226257">
+          17 octubre, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-226257" data-commentid="226257" data-postid="254" data-belowelement="comment-226257" data-respondelement="respond" data-replyto="Responder a Teresa" aria-label="Responder a Teresa">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hago siempre esta boloñesa pòrque sale muy bien y facil con Thermomix.A veces cuando no me apetece con carne la hago igual con soja texturizada puesta a remojo unos 10 min.Muchas gracias por la receta!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-225401" class="comment odd alt thread-even depth-1 media comment-225401">
+    <img alt='' src='https://secure.gravatar.com/avatar/ba3fc0c04890b13fe704af6cff2ca463b6c9734dd153194e10b0c75d0941eeec?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ba3fc0c04890b13fe704af6cff2ca463b6c9734dd153194e10b0c75d0941eeec?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://miherenciablogspotcom.blogspot.com.es/" class="url" rel="ugc external nofollow">Eugenio Gancedo</a></h5>
+        <div class="comment-meta">
+        <time datetime="2019-06-16T13:56:35+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-225401">
+          16 junio, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-225401" data-commentid="225401" data-postid="254" data-belowelement="comment-225401" data-respondelement="respond" data-replyto="Responder a Eugenio Gancedo" aria-label="Responder a Eugenio Gancedo">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>No tengo ni idea que es la velocidad cuchara, ni Varoma, así que no puedo usar la receta, una pena porque me gusta, voy a ver si averiguo esos conceptos, supongo que serán de una máquina.<br />
+Saludos</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-225401">
+    
+  <li id="comment-226256" class="comment odd alt depth-2 media comment-226256">
+    <img alt='' src='https://secure.gravatar.com/avatar/8d501e3d26dc1d1f7b591d8912328868327214bcee3d8e00a3c706b0bf845a19?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/8d501e3d26dc1d1f7b591d8912328868327214bcee3d8e00a3c706b0bf845a19?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Teresa</h5>
+        <div class="comment-meta">
+        <time datetime="2019-10-17T13:21:39+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-226256">
+          17 octubre, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>son para thermomix.      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-230563" class="comment even depth-2 media comment-230563">
+    <img alt='' src='https://secure.gravatar.com/avatar/19913e02a47e0814238e17a89bcabcd15580483c05b88e6d0acb1b2408941809?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/19913e02a47e0814238e17a89bcabcd15580483c05b88e6d0acb1b2408941809?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Frank</h5>
+        <div class="comment-meta">
+        <time datetime="2021-01-28T16:23:51+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-230563">
+          28 enero, 2021</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>En mcc de lidl. Velocidad cuchara es velocidad 1 giro inverso.<br />
+Varoma es 130 grados</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-225287" class="comment odd alt thread-even depth-1 media comment-225287">
+    <img alt='' src='https://secure.gravatar.com/avatar/d84cea0e2a427a611a9ecb8027e77dc6bc053a6321d806d7c37562499b80280e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/d84cea0e2a427a611a9ecb8027e77dc6bc053a6321d806d7c37562499b80280e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">MarBorrull</h5>
+        <div class="comment-meta">
+        <time datetime="2019-05-19T11:25:49+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-225287">
+          19 mayo, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-225287" data-commentid="225287" data-postid="254" data-belowelement="comment-225287" data-respondelement="respond" data-replyto="Responder a MarBorrull" aria-label="Responder a MarBorrull">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>La he hecho y queda riquísima ???? Gracias por tu blog! Hace poquito que compramos la Monsieur cuisine plus y me eres de mucha ayuda!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-223824" class="comment even thread-odd thread-alt depth-1 media comment-223824">
+    <img alt='' src='https://secure.gravatar.com/avatar/3c66cdbcc040f8d282c86abfe6bacd205a42bd481efd82aea05527af8e981e55?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/3c66cdbcc040f8d282c86abfe6bacd205a42bd481efd82aea05527af8e981e55?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Cristina</h5>
+        <div class="comment-meta">
+        <time datetime="2018-10-18T13:54:07+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-223824">
+          18 octubre, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223824" data-commentid="223824" data-postid="254" data-belowelement="comment-223824" data-respondelement="respond" data-replyto="Responder a Cristina" aria-label="Responder a Cristina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Yo también añadi azúcar, esta riquísimo</p>
+      
+  </div></li>
+
+  <li id="comment-223771" class="comment odd alt thread-even depth-1 media comment-223771">
+    <img alt='' src='https://secure.gravatar.com/avatar/61a61edb34878046687bc7158b34a49c89f6cd49d5a0fe7593fb55e2f3a25dd3?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/61a61edb34878046687bc7158b34a49c89f6cd49d5a0fe7593fb55e2f3a25dd3?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">María Isabel</h5>
+        <div class="comment-meta">
+        <time datetime="2018-10-09T12:49:20+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-223771">
+          9 octubre, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223771" data-commentid="223771" data-postid="254" data-belowelement="comment-223771" data-respondelement="respond" data-replyto="Responder a María Isabel" aria-label="Responder a María Isabel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Riquísima. Yo le añadí algo de azúcar al sofrito, pues quedaba algo ácido para nuestro gusto. Por lo demás, dan ganas de comérsela a cucharadas????.<br />
+Muchas gracias.      </p>
+<div class="ERRatingComment">
+<div style="width:80%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-220666" class="comment even thread-odd thread-alt depth-1 media comment-220666">
+    <img alt='' src='https://secure.gravatar.com/avatar/abad5fb6baf1930cc815b792d581a3e4b7dd54756310389fe3186203dbd1f888?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/abad5fb6baf1930cc815b792d581a3e4b7dd54756310389fe3186203dbd1f888?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Elena</h5>
+        <div class="comment-meta">
+        <time datetime="2018-03-17T12:11:28+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-220666">
+          17 marzo, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-220666" data-commentid="220666" data-postid="254" data-belowelement="comment-220666" data-respondelement="respond" data-replyto="Responder a Elena" aria-label="Responder a Elena">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Por favor a quien pone que está incompleta, lee bien, el tomate es un ingrediente del sofrito&#8230;Yo siempre la hago y sale estupenda</p>
+      
+  </div></li>
+
+  <li id="comment-220452" class="comment odd alt thread-even depth-1 media comment-220452">
+    <img alt='' src='https://secure.gravatar.com/avatar/39072643c37365aa6144aec55b56b2e2f69f3fe40e5b5f264bf47385b0dc6bf2?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/39072643c37365aa6144aec55b56b2e2f69f3fe40e5b5f264bf47385b0dc6bf2?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">marina</h5>
+        <div class="comment-meta">
+        <time datetime="2018-03-10T14:58:49+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-220452">
+          10 marzo, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-220452" data-commentid="220452" data-postid="254" data-belowelement="comment-220452" data-respondelement="respond" data-replyto="Responder a marina" aria-label="Responder a marina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>INCOMPLETA NO PONE CUANDO HAY QUE AÑADIR EL TOMATE , NI TIEMPO NI MODO.      </p>
+<div class="ERRatingComment">
+<div style="width:20%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-220452">
+    
+  <li id="comment-221571" class="comment odd alt depth-2 media comment-221571">
+    <img alt='' src='https://secure.gravatar.com/avatar/07ad1717dc463849eed122f6e6bffcd4be528cd7a4f2692b75b0e4f37d4637eb?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/07ad1717dc463849eed122f6e6bffcd4be528cd7a4f2692b75b0e4f37d4637eb?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Soledad</h5>
+        <div class="comment-meta">
+        <time datetime="2018-04-14T16:36:09+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-221571">
+          14 abril, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Repasa bien la receta mejor</p>
+      
+  </div></li>
+
+  <li id="comment-221572" class="comment even depth-2 media comment-221572">
+    <img alt='' src='https://secure.gravatar.com/avatar/07ad1717dc463849eed122f6e6bffcd4be528cd7a4f2692b75b0e4f37d4637eb?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/07ad1717dc463849eed122f6e6bffcd4be528cd7a4f2692b75b0e4f37d4637eb?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Soledad</h5>
+        <div class="comment-meta">
+        <time datetime="2018-04-14T16:37:02+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-221572">
+          14 abril, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>El tomate va con el sofrito y se incorpora con los demás ingredientes del sofrito</p>
+      
+  </div></li>
+
+  <li id="comment-230564" class="comment odd alt depth-2 media comment-230564">
+    <img alt='' src='https://secure.gravatar.com/avatar/7040c10487a35c3ce0b9878043749bb1983bd204653756c96c2230b30da6d5f2?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/7040c10487a35c3ce0b9878043749bb1983bd204653756c96c2230b30da6d5f2?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Frank</h5>
+        <div class="comment-meta">
+        <time datetime="2021-01-28T16:25:09+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-230564">
+          28 enero, 2021</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>No se escribe en mayúsculas. Molesta</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-218459" class="comment even thread-even depth-1 media comment-218459">
+    <img alt='' src='https://secure.gravatar.com/avatar/2ba4e2e4c44f455cbb02376c9116c6745b9e8461ff21f4b125fead4972664611?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2ba4e2e4c44f455cbb02376c9116c6745b9e8461ff21f4b125fead4972664611?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Pilar</h5>
+        <div class="comment-meta">
+        <time datetime="2018-02-10T12:25:16+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-218459">
+          10 febrero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-218459" data-commentid="218459" data-postid="254" data-belowelement="comment-218459" data-respondelement="respond" data-replyto="Responder a Pilar" aria-label="Responder a Pilar">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Es excelente! Gracias</p>
+      
+  </div></li>
+
+  <li id="comment-126603" class="comment odd alt thread-odd thread-alt depth-1 media comment-126603">
+    <img alt='' src='https://secure.gravatar.com/avatar/f52d77646127850a7a2ca2a88fa84864b771a3e382f7bcaa105e02ac1176cd94?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f52d77646127850a7a2ca2a88fa84864b771a3e382f7bcaa105e02ac1176cd94?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anabel</h5>
+        <div class="comment-meta">
+        <time datetime="2016-08-12T11:47:16+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-126603">
+          12 agosto, 2016</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-126603" data-commentid="126603" data-postid="254" data-belowelement="comment-126603" data-respondelement="respond" data-replyto="Responder a Anabel" aria-label="Responder a Anabel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, una pregunta de novata total, tengo preparada la salsa boloñesa, exquisita, si quiero hacer arroz como sería?, cantidad de agua, temperatura tiempo?? un saludo</p>
+      
+  </div></li>
+
+  <li id="comment-123116" class="comment even thread-even depth-1 media comment-123116">
+    <img alt='' src='https://secure.gravatar.com/avatar/5ed24a36d91253b05a090794ccf121d47d9aba1d309d16db5be107111a198290?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/5ed24a36d91253b05a090794ccf121d47d9aba1d309d16db5be107111a198290?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mari marin</h5>
+        <div class="comment-meta">
+        <time datetime="2016-05-31T10:57:42+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-123116">
+          31 mayo, 2016</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-123116" data-commentid="123116" data-postid="254" data-belowelement="comment-123116" data-respondelement="respond" data-replyto="Responder a Mari marin" aria-label="Responder a Mari marin">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola guapa! Super contenta de seguirte!<br />
+Estoy haciendo la receta. Si quiero ponerle el toque de leche evaporado,cuando se lo he de echar?<br />
+Gracias besitos</p>
+      
+  </div></li>
+
+  <li id="comment-121943" class="pingback odd alt thread-odd thread-alt depth-1 media comment-121943">
+        <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://receptesmagali.wordpress.com/2016/04/11/blog-post-title-6/" class="url" rel="ugc external nofollow">Pasta fresca amb salsa bolonyesa &#8211; receptes maggi</a></h5>
+        <div class="comment-meta">
+        <time datetime="2016-04-12T23:01:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-121943">
+          12 abril, 2016</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-121943" data-commentid="121943" data-postid="254" data-belowelement="comment-121943" data-respondelement="respond" data-replyto="Responder a Pasta fresca amb salsa bolonyesa &#8211; receptes maggi" aria-label="Responder a Pasta fresca amb salsa bolonyesa &#8211; receptes maggi">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>[&#8230;] <a href="https://www.velocidadcuchara.com/salsa-bolonesa/" rel="ugc">https://www.velocidadcuchara.com/salsa-bolonesa/</a> [&#8230;]</p>
+      
+  </div></li>
+
+  <li id="comment-117692" class="pingback even thread-even depth-1 media comment-117692">
+        <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://enchiladadelunares.com/2015/10/13/mis-recetas-favoritas-de-thermomix/" class="url" rel="ugc external nofollow">Mis recetas favoritas de Thermomix | Enchilada de Lunares</a></h5>
+        <div class="comment-meta">
+        <time datetime="2015-10-25T14:43:32+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-117692">
+          25 octubre, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-117692" data-commentid="117692" data-postid="254" data-belowelement="comment-117692" data-respondelement="respond" data-replyto="Responder a Mis recetas favoritas de Thermomix | Enchilada de Lunares" aria-label="Responder a Mis recetas favoritas de Thermomix | Enchilada de Lunares">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>[&#8230;] Salsa Boloñesa [&#8230;]</p>
+      
+  </div></li>
+
+  <li id="comment-116264" class="comment odd alt thread-odd thread-alt depth-1 media comment-116264">
+    <img alt='' src='https://secure.gravatar.com/avatar/91a732ad9f175ce25f334e200aabe1119bf4c5062793e3a136be99f00bbaa235?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/91a732ad9f175ce25f334e200aabe1119bf4c5062793e3a136be99f00bbaa235?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Jos</h5>
+        <div class="comment-meta">
+        <time datetime="2015-08-16T14:10:49+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-116264">
+          16 agosto, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-116264" data-commentid="116264" data-postid="254" data-belowelement="comment-116264" data-respondelement="respond" data-replyto="Responder a Jos" aria-label="Responder a Jos">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Y el tomate cuando se echa?</p>
+      
+  </div></li>
+
+  <li id="comment-115971" class="comment even thread-even depth-1 media comment-115971">
+    <img alt='' src='https://secure.gravatar.com/avatar/df0a6d75db150370e839d19e834abdbfb414b45ff736059c22cd32ac66d71ef6?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/df0a6d75db150370e839d19e834abdbfb414b45ff736059c22cd32ac66d71ef6?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Lou.</h5>
+        <div class="comment-meta">
+        <time datetime="2015-07-30T12:44:50+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-115971">
+          30 julio, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-115971" data-commentid="115971" data-postid="254" data-belowelement="comment-115971" data-respondelement="respond" data-replyto="Responder a Lou." aria-label="Responder a Lou.">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenísima.  Gracias Rosa !</p>
+      
+  </div></li>
+
+  <li id="comment-113289" class="comment odd alt thread-odd thread-alt depth-1 media comment-113289">
+    <img alt='' src='https://secure.gravatar.com/avatar/9ec0486286a28c27ef9874845b563c8d54e6265465e771906d87886d0b12f20f?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/9ec0486286a28c27ef9874845b563c8d54e6265465e771906d87886d0b12f20f?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://www.cocinandoconbejico.blogspot.com.es" class="url" rel="ugc external nofollow">Beatriz</a></h5>
+        <div class="comment-meta">
+        <time datetime="2015-04-09T15:31:02+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-113289">
+          9 abril, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-113289" data-commentid="113289" data-postid="254" data-belowelement="comment-113289" data-respondelement="respond" data-replyto="Responder a Beatriz" aria-label="Responder a Beatriz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hoy he hecho tu receta, ummm, nos ha encantado. He modificado un poco los ingredientes, pero la base es la misma. Simplemente algunas cantidades.<br />
+Te aseguro que la repetiré.</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-113289">
+    
+  <li id="comment-114716" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-114716">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2015-06-05T10:22:26+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-114716">
+          5 junio, 2015</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>:DD      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-111715" class="comment even thread-odd thread-alt depth-1 media comment-111715">
+    <img alt='' src='https://secure.gravatar.com/avatar/59e551f7e85e4f353176f0e44cef308d33c139ef58754fc52aac052973a7ddcd?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/59e551f7e85e4f353176f0e44cef308d33c139ef58754fc52aac052973a7ddcd?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mariló Ruiz</h5>
+        <div class="comment-meta">
+        <time datetime="2015-02-23T14:19:15+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-111715">
+          23 febrero, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-111715" data-commentid="111715" data-postid="254" data-belowelement="comment-111715" data-respondelement="respond" data-replyto="Responder a Mariló Ruiz" aria-label="Responder a Mariló Ruiz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, ¿Qué tal, Rosa? Hace varios meses que te leo, y cada receta tuya que me he aventurado a elaborar ha sido todo un éxito. En tu salsa boloñesa, ¿puedo usar una lata de tomate natural sin triturar (como en la salsa de tomate italiana de tu blog)?<br />
+Gracias de antemano por tu respuesta.</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-111715">
+    
+  <li id="comment-111716" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-111716">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2015-02-23T14:22:59+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-111716">
+          23 febrero, 2015</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Si&#8230; de hecho a veces lo hago así. No añadas el caldo, solo los tomates y si puedes espachurrarlos y sacarle el líquido que tienen dentro mejor, porque sinó habrá que evaporar y colocar el cestillo en lugar del cubilete :D<br />
+Muaccc.</p>
+      
+  </div></li>
+
+  <li id="comment-111932" class="comment odd alt depth-2 media comment-111932">
+    <img alt='' src='https://secure.gravatar.com/avatar/59e551f7e85e4f353176f0e44cef308d33c139ef58754fc52aac052973a7ddcd?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/59e551f7e85e4f353176f0e44cef308d33c139ef58754fc52aac052973a7ddcd?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mariló Ruiz</h5>
+        <div class="comment-meta">
+        <time datetime="2015-02-26T12:42:49+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-111932">
+          26 febrero, 2015</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Muchas gracias. Me he vuelto thermoadicta. Ya no cocino sin ella&#8230; ¡Tu blog es genial! Gracias por ayudarnos tanto. Un beso</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-105700" class="comment even thread-odd thread-alt depth-1 media comment-105700">
+    <img alt='' src='https://secure.gravatar.com/avatar/6f48a374080f93ca6250dc24db8b92fbbac992397270cfc8d8e002af2b6977a9?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/6f48a374080f93ca6250dc24db8b92fbbac992397270cfc8d8e002af2b6977a9?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://velocidadcuchara" class="url" rel="ugc external nofollow">zuriñe Incera</a></h5>
+        <div class="comment-meta">
+        <time datetime="2014-11-23T11:27:40+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-105700">
+          23 noviembre, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-105700" data-commentid="105700" data-postid="254" data-belowelement="comment-105700" data-respondelement="respond" data-replyto="Responder a zuriñe Incera" aria-label="Responder a zuriñe Incera">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hoy la he hecho para mi lasaña estupenda receta graciasss</p>
+      
+  </div></li>
+
+  <li id="comment-101807" class="comment odd alt thread-even depth-1 media comment-101807">
+    <img alt='' src='https://secure.gravatar.com/avatar/3f4c54175bb03c34b612e5b8454a6cc82c0baf1d7eaf1a4a269493135c3b8e34?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/3f4c54175bb03c34b612e5b8454a6cc82c0baf1d7eaf1a4a269493135c3b8e34?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Isabel</h5>
+        <div class="comment-meta">
+        <time datetime="2014-10-23T07:10:16+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-101807">
+          23 octubre, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-101807" data-commentid="101807" data-postid="254" data-belowelement="comment-101807" data-respondelement="respond" data-replyto="Responder a Isabel" aria-label="Responder a Isabel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola rosa lo primero que quiero decirte es FELICIDADES y gracias aunque va hacer un año que tengo la maquina la verdad es que no la he utilizado mucho hasta que te he descubierto y estoy muy contenta<br />
+me encanta tus recetas.</p>
+      
+  </div></li>
+
+  <li id="comment-92887" class="comment even thread-odd thread-alt depth-1 media comment-92887">
+    <img alt='' src='https://secure.gravatar.com/avatar/b2249fd323d8714cced04dcd95ab21cc6a50409f8952592691dcedf2bdb46873?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b2249fd323d8714cced04dcd95ab21cc6a50409f8952592691dcedf2bdb46873?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Sabrina</h5>
+        <div class="comment-meta">
+        <time datetime="2014-09-05T21:14:45+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-92887">
+          5 septiembre, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-92887" data-commentid="92887" data-postid="254" data-belowelement="comment-92887" data-respondelement="respond" data-replyto="Responder a Sabrina" aria-label="Responder a Sabrina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Otro éxito.<br />
+Gracias por tanta dedicación. .!!!</p>
+      
+  </div></li>
+
+  <li id="comment-88668" class="comment odd alt thread-even depth-1 media comment-88668">
+    <img alt='' src='https://secure.gravatar.com/avatar/1129376743287da4da553d5dfc09632c379ba24c2bf9dc06086dc1c1564451ab?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/1129376743287da4da553d5dfc09632c379ba24c2bf9dc06086dc1c1564451ab?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Letizia</h5>
+        <div class="comment-meta">
+        <time datetime="2014-07-07T09:54:36+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-88668">
+          7 julio, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-88668" data-commentid="88668" data-postid="254" data-belowelement="comment-88668" data-respondelement="respond" data-replyto="Responder a Letizia" aria-label="Responder a Letizia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>&#8230;hola!!!&#8230;.boloñesa&#8230;.rápida y éxito seguro con esta recetita!!!!&#8230;.gracias de nuevo!!!!</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-88668">
+    
+  <li id="comment-88697" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-88697">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2014-07-07T14:28:41+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-88697">
+          7 julio, 2014</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>:D</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-75245" class="comment even thread-even depth-1 media comment-75245">
+    <img alt='' src='https://secure.gravatar.com/avatar/fa24c782c15327a048ec3e58566f8c18cc8395160d25fbfe40bfebfa7805dd71?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/fa24c782c15327a048ec3e58566f8c18cc8395160d25fbfe40bfebfa7805dd71?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Erica</h5>
+        <div class="comment-meta">
+        <time datetime="2014-05-29T11:25:45+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-75245">
+          29 mayo, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-75245" data-commentid="75245" data-postid="254" data-belowelement="comment-75245" data-respondelement="respond" data-replyto="Responder a Erica" aria-label="Responder a Erica">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Una pregunta si quiero hacer el doble de cantidad???? Doblo ingredientes y tiempo? Gracias!!!!</p>
+      
+  </div></li>
+
+  <li id="comment-54771" class="comment odd alt thread-odd thread-alt depth-1 media comment-54771">
+    <img alt='' src='https://secure.gravatar.com/avatar/b3414886117406db8b8b4e63e6e691644133cad616f9cb4bae0f9c212d9a55df?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b3414886117406db8b8b4e63e6e691644133cad616f9cb4bae0f9c212d9a55df?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mª del Mar</h5>
+        <div class="comment-meta">
+        <time datetime="2014-03-13T09:06:47+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-54771">
+          13 marzo, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-54771" data-commentid="54771" data-postid="254" data-belowelement="comment-54771" data-respondelement="respond" data-replyto="Responder a Mª del Mar" aria-label="Responder a Mª del Mar">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, y la pregunta del millón, porque nunca se como hacerlo.</p>
+<p>¿Y si quiero hacer la receta doble? ¿Doblo ingredientes y tiempo?</p>
+<p>Muchísimas gracias.<br />
+Mª del Mar</p>
+      
+  </div></li>
+
+  <li id="comment-50249" class="comment even thread-even depth-1 media comment-50249">
+    <img alt='' src='https://secure.gravatar.com/avatar/e779e39e68bb1ee9ac492f31f2024d8033de859f47c3a7067e9d1f64252b3c58?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e779e39e68bb1ee9ac492f31f2024d8033de859f47c3a7067e9d1f64252b3c58?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://cuinarpergust.blogspot.com.es" class="url" rel="ugc external nofollow">Joana</a></h5>
+        <div class="comment-meta">
+        <time datetime="2014-01-24T12:03:14+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-50249">
+          24 enero, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-50249" data-commentid="50249" data-postid="254" data-belowelement="comment-50249" data-respondelement="respond" data-replyto="Responder a Joana" aria-label="Responder a Joana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Me encanta!!! Una pregunta tonta&#8230;se pueden poner en caliente en potes de cristal y hacerlos al vacío, como si fuese mermelada??<br />
+Graciasss</p>
+      
+  </div></li>
+
+  <li id="comment-40635" class="comment odd alt thread-odd thread-alt depth-1 media comment-40635">
+    <img alt='' src='https://secure.gravatar.com/avatar/95922263eb06a6a67b2f90dac58b5a93d8121eaa6ef1f9d51cfdcf799a8dc707?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/95922263eb06a6a67b2f90dac58b5a93d8121eaa6ef1f9d51cfdcf799a8dc707?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Joana</h5>
+        <div class="comment-meta">
+        <time datetime="2013-05-11T15:12:07+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-40635">
+          11 mayo, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-40635" data-commentid="40635" data-postid="254" data-belowelement="comment-40635" data-respondelement="respond" data-replyto="Responder a Joana" aria-label="Responder a Joana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola,<br />
+Después de tener esta receta muuuuuuuuucho tiempo en pendientes, hoy me he decidido a hacerla: es-tu-pen-da!!!<br />
+Lástima haber tardado tanto!<br />
+Ademàs me ha dado para la pasta de hoy, y he podido congelar para otro dia: Perfecto!<br />
+Muchas gracias por todas tus recetas. Un beso</p>
+      
+  </div></li>
+
+  <li id="comment-37604" class="comment even thread-even depth-1 media comment-37604">
+    <img alt='' src='https://secure.gravatar.com/avatar/ca89dfb757c73d5cbbc71ba7346d71a7db42d353999b3ca5f6542f9638bbe912?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ca89dfb757c73d5cbbc71ba7346d71a7db42d353999b3ca5f6542f9638bbe912?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carme</h5>
+        <div class="comment-meta">
+        <time datetime="2013-02-10T11:41:42+01:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-37604">
+          10 febrero, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-37604" data-commentid="37604" data-postid="254" data-belowelement="comment-37604" data-respondelement="respond" data-replyto="Responder a Carme" aria-label="Responder a Carme">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, soy nueva, pero si puedo decir que he hecho varias recetas con la thermomix 21 y como somos dos, lo que sobra su es bastante lo congelo por raciones y siempre me ha quedado bien.</p>
+      
+  </div></li>
+
+  <li id="comment-30852" class="comment odd alt thread-odd thread-alt depth-1 media comment-30852">
+    <img alt='' src='https://secure.gravatar.com/avatar/6023de0eb89ef26ad2469549eaed714b2f75f56fd89ab779619a6472b357f204?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/6023de0eb89ef26ad2469549eaed714b2f75f56fd89ab779619a6472b357f204?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Beatriz</h5>
+        <div class="comment-meta">
+        <time datetime="2012-10-04T16:21:06+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-30852">
+          4 octubre, 2012</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-30852" data-commentid="30852" data-postid="254" data-belowelement="comment-30852" data-respondelement="respond" data-replyto="Responder a Beatriz" aria-label="Responder a Beatriz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Q tipo de champiñones de lata o naturales?muchas gracias</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-30852">
+    
+  <li id="comment-30859" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-30859">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2012-10-04T18:37:26+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-30859">
+          4 octubre, 2012</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Yo siempre uso naturales a no ser que ponga expecificamente que son de lata</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-29654" class="comment even thread-odd thread-alt depth-1 media comment-29654">
+    <img alt='' src='https://secure.gravatar.com/avatar/5a73fc20846c80903e19da2fa03112b51a009816248f69fc79488b11231a1c0f?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/5a73fc20846c80903e19da2fa03112b51a009816248f69fc79488b11231a1c0f?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Novata en la cocina</h5>
+        <div class="comment-meta">
+        <time datetime="2012-08-08T23:17:25+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-29654">
+          8 agosto, 2012</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-29654" data-commentid="29654" data-postid="254" data-belowelement="comment-29654" data-respondelement="respond" data-replyto="Responder a Novata en la cocina" aria-label="Responder a Novata en la cocina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>La acabo de hacer y sale buenísima de sabor. Diferente a la del libro tm31. Asi que otra manera diferente de hacerla. Lo unico no me ha quedado tan roja, la mia tira mas a marron. Por que sera?<br />
+Muchas gracias Rosa. Otra vez mas.</p>
+      
+  </div></li>
+
+  <li id="comment-1993" class="comment odd alt thread-even depth-1 media comment-1993">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">laviana ( Fely)</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-14T20:20:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1993">
+          14 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1993" data-commentid="1993" data-postid="254" data-belowelement="comment-1993" data-respondelement="respond" data-replyto="Responder a laviana ( Fely)" aria-label="Responder a laviana ( Fely)">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>muy rica..yo la hago para la lasagna&#8230;y espagetti y la verdad sale muy rica.<br />Un besín.</p>
+      
+  </div></li>
+
+  <li id="comment-1991" class="comment even thread-odd thread-alt depth-1 media comment-1991">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Luisi</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-14T18:18:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1991">
+          14 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1991" data-commentid="1991" data-postid="254" data-belowelement="comment-1991" data-respondelement="respond" data-replyto="Responder a Luisi" aria-label="Responder a Luisi">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Esta salsa sale buenisima, para cualquier tipo de pasta, muy buena.<br />besos</p>
+      
+  </div></li>
+
+  <li id="comment-1989" class="comment odd alt thread-even depth-1 media comment-1989">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Juanfra</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-13T19:39:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1989">
+          13 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1989" data-commentid="1989" data-postid="254" data-belowelement="comment-1989" data-respondelement="respond" data-replyto="Responder a Juanfra" aria-label="Responder a Juanfra">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Esta salsa es para los canelones y lasañas??? No la he hecho nunca y tampoco lasaña, así k me interesa algo así, pero si es sin carne mejor, que tengo uno a mi lado que es medio vegetariano!!!</p>
+      
+  </div></li>
+
+  <li id="comment-1988" class="comment even thread-odd thread-alt depth-1 media comment-1988">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">LOLA</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-13T16:48:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1988">
+          13 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1988" data-commentid="1988" data-postid="254" data-belowelement="comment-1988" data-respondelement="respond" data-replyto="Responder a LOLA" aria-label="Responder a LOLA">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Sale riquisima,yo doy fe de ello y tambien la he congelado y no pierde nada de sabor,besitos</p>
+      
+  </div></li>
+
+  <li id="comment-1987" class="comment odd alt thread-even depth-1 media comment-1987">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Lala</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-13T15:14:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1987">
+          13 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1987" data-commentid="1987" data-postid="254" data-belowelement="comment-1987" data-respondelement="respond" data-replyto="Responder a Lala" aria-label="Responder a Lala">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>.. deliciosa .. que rica &#8230; un saludo!!!!!!</p>
+      
+  </div></li>
+
+  <li id="comment-1986" class="comment even thread-odd thread-alt depth-1 media comment-1986">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Vicky Ortiz</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-13T14:31:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1986">
+          13 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1986" data-commentid="1986" data-postid="254" data-belowelement="comment-1986" data-respondelement="respond" data-replyto="Responder a Vicky Ortiz" aria-label="Responder a Vicky Ortiz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Está muy rica. Yo la he hecho varias veces. Nunca la había congelado. Lo probaré.</p>
+      
+  </div></li>
+
+  <li id="comment-1984" class="comment odd alt thread-even depth-1 media comment-1984">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-13T13:35:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1984">
+          13 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1984" data-commentid="1984" data-postid="254" data-belowelement="comment-1984" data-respondelement="respond" data-replyto="Responder a Rosa Ardá" aria-label="Responder a Rosa Ardá">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Si se puede congelar, yo lo he hecho varias veces y sin ningún problema&#8230; Un saludo<br />Rosa</p>
+      
+  </div></li>
+
+  <li id="comment-1983" class="comment even thread-odd thread-alt depth-1 media comment-1983">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Natalia</h5>
+        <div class="comment-meta">
+        <time datetime="2009-04-13T12:55:00+02:00"><a href="https://www.velocidadcuchara.com/salsa-bolonesa/#comment-1983">
+          13 abril, 2009</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-1983" data-commentid="1983" data-postid="254" data-belowelement="comment-1983" data-respondelement="respond" data-replyto="Responder a Natalia" aria-label="Responder a Natalia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa,</p>
+<p>Menuda pinta que tiene!!! Tengo que hacerla, desde luego :)</p>
+<p>¿Sabes si luego la puedes congelar?</p>
+<p>Un beso</p>
+<p>Natalia</p>
+      
+  </div></li>
+    </ol>
+
+    
+      </section><!-- /#comments -->
+  
+
+<button class="mostrar-comentarios despues button" style="cursor:pointer">Mostrar comentarios</button>
+
+  <section id="respond">
+  	<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Dejar una opinión <small><a rel="nofollow" id="cancel-comment-reply-link" href="/salsa-bolonesa/#respond" style="display:none;">Cancelar la respuesta</a></small></h3><form action="https://www.velocidadcuchara.com/wp-comments-post.php" method="post" id="commentform" class="comment-form"><p class="comment-form-comment"><label for="comment">Comentarios</label> <textarea id="comment" name="comment" cols="45" rows="8" class="input-xlarge" aria-required="true" required="required"></textarea></p><p class="pprivacy"><input type="checkbox" class="form-check" name="privacy" value="privacy-key" class="privacyBox" aria-req="true">&nbsp;&nbsp;Acepto la <a target="blank" href="https://velocidadcuchara.com/politica-de-privacidad">política de privacidad</a><p><div class="row"><div class="col-md-4"><label for="author">Nombre <span class="comment-required">*</span></label> <input id="author" name="author" type="text" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="email">Email (no será publicado) <span class="comment-required">*</span></label> <input type="email" class="text" name="email" id="email" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="url">Sitio Web</label> <input id="url" name="url" type="url" value="" /></div>
+</div><p class="form-submit"><input name="submit" type="submit" id="submit" class="kad-btn kad-btn-primary" value="Enviar" /> <input type='hidden' name='comment_post_ID' value='254' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><span class="ERComment">
+<span style="float:left">Valora esta receta: </span>
+<span class="ERRateBG">
+<span class="ERRateStars"></span>
+</span>
+<input type="hidden" class="inpERRating" name="ERRating" value="0" />
+&nbsp;
+</span><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="3d37a132af" /></p><p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="74"/><script type="rocketlazyloadscript">document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );</script></p></form>	</div><!-- #respond -->
+	
+  </section><!-- /#respond -->
+        </div>
+                    
+          	            <aside class="col-lg-3 col-md-4 kad-sidebar" role="complementary" itemscope itemtype="http://schema.org/WPSideBar">
+	              <div class="sidebar">
+	                <section class="widget-2 widget local-widget"><div class="widget-inner"><div id="local-1347472164" style="margin-bottom: 25px;margin-left: auto;margin-right: auto;text-align: center;"><picture style="display: inline-block; max-width: 100%; height: auto;">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg.webp"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg" alt="Claudia &amp; Julia: Utensilios para una cocina tradicional y saludable" width="300" height="100"/>
+</picture>
+</div></div></section><section id="siteorigin-panels-builder-28" class="widget-4 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w64208d0f963d5"  class="panel-layout" ><div id="pg-w64208d0f963d5-0"  class="panel-grid panel-no-style" ><div id="pgc-w64208d0f963d5-0-0"  class="panel-grid-cell" ><div id="panel-w64208d0f963d5-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://newsletter.velocidadcuchara.com/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Suscribete.svg" width="300" height="45" sizes="(max-width: 300px) 100vw, 300px" title="Suscríbete Newsletter" alt="Suscríbete a Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div><div id="panel-w64208d0f963d5-0-0-1" class="so-panel widget widget_sow-editor panel-last-child" data-index="1" ><div class="panel-widget-style panel-widget-style-for-w64208d0f963d5-0-0-1" ><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p style="text-align: center;"><a href="https://newsletter.velocidadcuchara.com/" target="_blank" rel="noopener"><em>Recibe nuestra Newsletter<br />
+en tu correo electrónico</em></a></p>
+</div>
+</div></div></div></div></div></div></div></section><section id="sow-image-26" class="widget-5 widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/todas-las-recetas/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2018/07/descubre_todas_nuestras_recetas-1.svg" width="1" height="1" sizes="(max-width: 1px) 100vw, 1px" title="Todas las recetas Thermomix" alt="Todas las recetas Thermomix" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section><section id="custom_html-5" class="widget_text widget-6 widget widget_custom_html"><div class="widget_text widget-inner"><div class="textwidget custom-html-widget"><script type="rocketlazyloadscript" async data-rocket-src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0432726040009676"
+     crossorigin="anonymous"></script>
+<!-- PRUEBA 23 -->
+<ins class="adsbygoogle"
+     style="display:block"
+     data-ad-client="ca-pub-0432726040009676"
+     data-ad-slot="7485608005"
+     data-ad-format="auto"
+     data-full-width-responsive="true"></ins>
+<script type="rocketlazyloadscript">
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script></div></div></section><section id="siteorigin-panels-builder-29" class="widget-7 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w5f89a361017dd"  class="panel-layout" ><div id="pg-w5f89a361017dd-0"  class="panel-grid panel-has-style" ><div class="panel-row-style panel-row-style-for-w5f89a361017dd-0" ><div id="pgc-w5f89a361017dd-0-0"  class="panel-grid-cell" ><div id="panel-w5f89a361017dd-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.youtube.com/user/velocidadcuchara" target="_blank" rel="noopener noreferrer" >	<picture class="so-widget-image">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png.webp 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png.webp 600w" sizes="(max-width: 300px) 100vw, 300px"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png 600w" sizes="(max-width: 300px) 100vw, 300px" alt=""/>
+</picture>
+
+</a></div>
+
+</div></div></div><div id="panel-w5f89a361017dd-0-0-1" class="so-panel widget widget_sow-image" data-index="1" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-1" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/tarta-sacher-paso-a-paso-con-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Tarta Sacher" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Tarta Sacher</h3></div></div></div><div id="panel-w5f89a361017dd-0-0-2" class="so-panel widget widget_sow-image panel-last-child" data-index="2" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-2" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/como-preparar-yogur-en-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Yogurt casero" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Yogurt casero</h3></div></div></div></div></div></div></div></div></section><section id="sow-image-18" class="widget-8 widget-last widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Podcast-Caratula-cuadrados-1080-×-1920-px-1000-×-1000-px.svg" width="300" height="300" sizes="(max-width: 300px) 100vw, 300px" title="Promo libros Velocidad Cuchara" alt="Promo libros Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section>	              </div><!-- /.sidebar -->
+	            </aside><!-- /aside -->
+                    </div><!-- /.row-->
+        </div><!-- /.content -->
+      </div><!-- /.wrap -->
+      <footer data-wpr-lazyrender="1" id="containerfooter" class="footerclass" itemscope itemtype="http://schema.org/WPFooter">
+  <div class="container">
+  	<div class="row">
+  							<div class="col-md-4 footercol1">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-5" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="https://www.velocidadcuchara.com"><img loading="lazy" decoding="async" class="alignnone wp-image-45320" src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/footer_vc.svg" alt="" width="171" height="53" /></a></p>
+<p>Desde 2008 cocinamos con (y sin) el robot de cocina más famoso del mundo</p>
+<div class="space_20 clearfix"></div>
+<figure id="attachment_43492" class="thumbnail wp-caption alignnone" style="width: 176px"><picture loading="lazy" decoding="async" class="size-full wp-image-43492">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png.webp 176w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+<img loading="lazy" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png" alt="" width="176" height="46" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png 176w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-140x36.png 140w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-24x6.png 24w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-36x9.png 36w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-48x12.png 48w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+</picture>
+<figcaption class="caption wp-caption-text">Ganadores en la XII edición</figcaption></figure>
+<figure id="attachment_45318" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45318" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/gastroblogs.png" alt="" width="176" height="52" /><figcaption class="caption wp-caption-text">Ganador Gastroblogs</figcaption></figure>
+<figure id="attachment_45319" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45319" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/bitacoras.png" alt="" width="176" height="46" /><figcaption class="caption wp-caption-text">Finalista en Gastronomía</figcaption></figure>
+</div>
+</div></aside></div>					</div>
+            										<div class="col-md-4 footercol2">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-social-media-buttons-4" class="widget widget_sow-social-media-buttons"><div class="so-widget-sow-social-media-buttons so-widget-sow-social-media-buttons-flat-3af2f923c85f"><h3>EN LAS REDES</h3>
+<div class="social-media-button-container">
+	
+		<a class="ow-button-hover sow-social-media-button-facebook sow-social-media-button" title="Velocidad Cuchara en Facebook" aria-label="Velocidad Cuchara en Facebook" target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf39e;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-instagram sow-social-media-button" title="Velocidad Cuchara en Instagram" aria-label="Velocidad Cuchara en Instagram" target="_blank" rel="noopener noreferrer" href="https://www.instagram.com/velocidadcuchara/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf16d;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-youtube sow-social-media-button" title="Velocidad Cuchara en Youtube" aria-label="Velocidad Cuchara en Youtube" target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/user/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf167;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-twitter sow-social-media-button" title="Velocidad Cuchara en Twitter" aria-label="Velocidad Cuchara en Twitter" target="_blank" rel="noopener noreferrer" href="https://twitter.com/rosaarda" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf099;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-pinterest sow-social-media-button" title="Velocidad Cuchara en Pinterest" aria-label="Velocidad Cuchara en Pinterest" target="_blank" rel="noopener noreferrer" href="https://es.pinterest.com/rosaarda/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf0d2;" ></span>							</span>
+		</a>
+	</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-6" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>ROSA ARDÁ</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>Enganchada a la Thermomix, uno de los grandes inventos de la historia :D</p>
+</div>
+</div></aside></div><div class="widget-3 widget-last footer-widget"><aside id="media_image-2" class="widget widget_media_image"><h3>NUESTROS LIBROS</h3><a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/"><picture class="image wp-image-58705  attachment-full size-full" style="max-width: 100%; height: auto;" title="NUESTRO LIBRO" decoding="async" loading="lazy">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png.webp 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png.webp 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+<img width="241" height="148" src="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png" alt="" decoding="async" loading="lazy" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+</picture>
+</a></aside></div>					</div>
+		        		        					<div class="col-md-4 footercol3">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-7" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>AVISO LEGAL</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>VelocidadCuchara.com y Velocidad Cuchara <a href="https://www.velocidadcuchara.com/aviso-legal/">son marcas registradas</a>. Consulta la <a href="https://www.velocidadcuchara.com/declaracion-de-privacidad-ue/" target="_blank" rel="noopener">Política de privacidad</a> y la <a href="https://www.velocidadcuchara.com/politica-de-cookies-ue/" target="_blank" rel="noopener">Política de Cookies</a></p>
+</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-8" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>NOS ENCANTA LEER</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="http://www.averquecocinamoshoy.com/" target="_blank" rel="noopener noreferrer">A ver qué cocinamos hoy</a><br />
+<a href="http://www.crockpotting.es/" target="_blank" rel="noopener">Crockpotting</a><br />
+<a href="https://elcomidista.elpais.com/" target="_blank" rel="noopener noreferrer">El Comidista</a><br />
+<a href="http://www.misthermorecetas.com/" target="_blank" rel="noopener noreferrer">Mis thermorecetas</a><br />
+<a href="http://pepacooks.com/" target="_blank" rel="noopener noreferrer">Pepa Cooks </a><br />
+<a href="http://www.recetasderechupete.com/" target="_blank" rel="noopener noreferrer">Recetas de Rechupete </a><br />
+<a href="https://webosfritos.es/" target="_blank" rel="noopener noreferrer">Webos Fritos</a></p>
+</div>
+</div></aside></div><div class="widget_text widget-3 widget-last footer-widget"><aside id="custom_html-3" class="widget_text widget widget_custom_html"><div class="textwidget custom-html-widget"></div></aside></div>					</div>
+	            			        </div>
+        <div class="footercredits clearfix">
+
+    		        	<p>&copy; 2008 - 2026 Velocidad Cuchara</p>
+    	</div>
+
+  </div>
+
+</footer>
+</div><!--Wrapper-->
+
+<script type="rocketlazyloadscript" data-rocket-type='text/javascript'>
+/* <![CDATA[ */
+var advancedAds = {"adHealthNotice":{"enabled":true,"pattern":"AdSense fallback was loaded for empty AdSense ad \"[ad_title]\""},"frontendPrefix":"local-"};
+
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript">(function(){var advanced_ads_ga_UID="rosaarda",advanced_ads_ga_anonymIP=!!1;window.advanced_ads_check_adblocker=function(){var t=[],n=null;function e(t){var n=window.requestAnimationFrame||window.mozRequestAnimationFrame||window.webkitRequestAnimationFrame||function(t){return setTimeout(t,16)};n.call(window,t)}return e((function(){var a=document.createElement("div");a.innerHTML="&nbsp;",a.setAttribute("class","ad_unit ad-unit text-ad text_ad pub_300x250"),a.setAttribute("style","width: 1px !important; height: 1px !important; position: absolute !important; left: 0px !important; top: 0px !important; overflow: hidden !important;"),document.body.appendChild(a),e((function(){var e,o,i=null===(e=(o=window).getComputedStyle)||void 0===e?void 0:e.call(o,a),d=null==i?void 0:i.getPropertyValue("-moz-binding");n=i&&"none"===i.getPropertyValue("display")||"string"==typeof d&&-1!==d.indexOf("about:");for(var c=0,r=t.length;c<r;c++)t[c](n);t=[]}))})),function(e){"undefined"==typeof advanced_ads_adblocker_test&&(n=!0),null!==n?e(n):t.push(e)}}(),(()=>{function t(t){this.UID=t,this.analyticsObject="function"==typeof gtag;var n=this;return this.count=function(){gtag("event","AdBlock",{event_category:"Advanced Ads",event_label:"Yes",non_interaction:!0,send_to:n.UID})},function(){if(!n.analyticsObject){var e=document.createElement("script");e.src="https://www.googletagmanager.com/gtag/js?id="+t,e.async=!0,document.body.appendChild(e),window.dataLayer=window.dataLayer||[],window.gtag=function(){dataLayer.push(arguments)},n.analyticsObject=!0,gtag("js",new Date)}var a={send_page_view:!1,transport_type:"beacon"};window.advanced_ads_ga_anonymIP&&(a.anonymize_ip=!0),gtag("config",t,a)}(),this}advanced_ads_check_adblocker((function(n){n&&new t(advanced_ads_ga_UID).count()}))})();})();</script><script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"\/*"},{"not":{"href_matches":["\/wp-*.php","\/wp-admin\/*","\/wp-content\/uploads\/*","\/wp-content\/*","\/wp-content\/plugins\/*","\/wp-content\/themes\/velocidad\/*","\/wp-content\/themes\/virtue\/*","\/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+
+<!-- Consent Management powered by Complianz | GDPR/CCPA Cookie Consent https://wordpress.org/plugins/complianz-gdpr -->
+<div id="cmplz-cookiebanner-container"><div class="cmplz-cookiebanner cmplz-hidden banner-1 velocidad-cuchara optin cmplz-bottom cmplz-categories-type-view-preferences" aria-modal="true" data-nosnippet="true" role="dialog" aria-live="polite" aria-labelledby="cmplz-header-1-optin" aria-describedby="cmplz-message-1-optin">
+	<div class="cmplz-header">
+		<div class="cmplz-logo"><img width="350" height="100" src="https://www.velocidadcuchara.com/wp-content/uploads/2024/03/cookies-350x100.png" class="attachment-cmplz_banner_image size-cmplz_banner_image" alt="Velocidad Cuchara" decoding="async" loading="lazy" /></div>
+		<div class="cmplz-title" id="cmplz-header-1-optin">Gestiona tu privacidad</div>
+		<div class="cmplz-close" tabindex="0" role="button" aria-label="Cerrar diálogo">
+			<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>
+		</div>
+	</div>
+
+	<div class="cmplz-divider cmplz-divider-header"></div>
+	<div class="cmplz-body">
+		<div class="cmplz-message" id="cmplz-message-1-optin"><p>Para ofrecer las mejores experiencias, nosotros y nuestros socios utilizamos tecnologías como cookies para almacenar y/o acceder a la información del dispositivo. La aceptación de estas tecnologías nos permitirá a nosotros y a nuestros socios procesar datos personales como el comportamiento de navegación o identificaciones únicas (IDs) en este sitio y mostrar anuncios (no-) personalizados. No consentir o retirar el consentimiento, puede afectar negativamente a ciertas características y funciones.</p><p>Haz clic a continuación para aceptar lo anterior o realizar elecciones más detalladas.&nbsp;Tus elecciones se aplicarán solo en este sitio.&nbsp;Puedes cambiar tus ajustes en cualquier momento, incluso retirar tu consentimiento, utilizando los botones de la Política de cookies o haciendo clic en el icono de Privacidad situado en la parte inferior de la pantalla.</p></div>
+		<!-- categories start -->
+		<div class="cmplz-categories">
+			<details class="cmplz-category cmplz-functional" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Funcional</span>
+							<span class='cmplz-always-active'>
+								<span class="cmplz-banner-checkbox">
+									<input type="checkbox"
+										   id="cmplz-functional-optin"
+										   data-category="cmplz_functional"
+										   class="cmplz-consent-checkbox cmplz-functional"
+										   size="40"
+										   value="1"/>
+									<label class="cmplz-label" for="cmplz-functional-optin"><span class="screen-reader-text">Funcional</span></label>
+								</span>
+								Siempre activo							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-functional">El almacenamiento o acceso técnico es estrictamente necesario para el propósito legítimo de permitir el uso de un servicio específico explícitamente solicitado por el abonado o usuario, o con el único propósito de llevar a cabo la transmisión de una comunicación a través de una red de comunicaciones electrónicas.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-preferences" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Preferencias</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-preferences-optin"
+									   data-category="cmplz_preferences"
+									   class="cmplz-consent-checkbox cmplz-preferences"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-preferences-optin"><span class="screen-reader-text">Preferencias</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-preferences">El almacenamiento o acceso técnico es necesario para la finalidad legítima de almacenar preferencias no solicitadas por el abonado o usuario.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-statistics" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Estadísticas</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-statistics-optin"
+									   data-category="cmplz_statistics"
+									   class="cmplz-consent-checkbox cmplz-statistics"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-statistics-optin"><span class="screen-reader-text">Estadísticas</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-statistics">El almacenamiento o acceso técnico que es utilizado exclusivamente con fines estadísticos.</span>
+					<span class="cmplz-description-statistics-anonymous">El almacenamiento o acceso técnico que se utiliza exclusivamente con fines estadísticos anónimos. Sin un requerimiento, el cumplimiento voluntario por parte de tu Proveedor de servicios de Internet, o los registros adicionales de un tercero, la información almacenada o recuperada sólo para este propósito no se puede utilizar para identificarte.</span>
+				</div>
+			</details>
+			<details class="cmplz-category cmplz-marketing" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Marketing</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-marketing-optin"
+									   data-category="cmplz_marketing"
+									   class="cmplz-consent-checkbox cmplz-marketing"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-marketing-optin"><span class="screen-reader-text">Marketing</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-marketing">El almacenamiento o acceso técnico es necesario para crear perfiles de usuario para enviar publicidad, o para rastrear al usuario en una web o en varias web con fines de marketing similares.</span>
+				</div>
+			</details>
+		</div><!-- categories end -->
+		
+<div class="cmplz-categories cmplz-tcf">
+
+	<div class="cmplz-category cmplz-statistics">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Estadísticas</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-marketing">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Marketing</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-features">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Características</div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialfeatures">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'></div>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialpurposes">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+		</div>
+	</div>
+
+</div>
+	</div>
+
+	<div class="cmplz-links cmplz-information">
+		<ul>
+			<li><a class="cmplz-link cmplz-manage-options cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a></li>
+			<li><a class="cmplz-link cmplz-manage-third-parties cookie-statement" href="#" data-relative_url="#cmplz-cookies-overview">Gestionar los servicios</a></li>
+			<li><a class="cmplz-link cmplz-manage-vendors tcf cookie-statement" href="#" data-relative_url="#cmplz-tcf-wrapper">Gestionar {vendor_count} proveedores</a></li>
+			<li><a class="cmplz-link cmplz-external cmplz-read-more-purposes tcf" target="_blank" rel="noopener noreferrer nofollow" href="https://cookiedatabase.org/tcf/purposes/" aria-label="Read more about TCF purposes on Cookie Database">Leer más sobre estos propósitos</a></li>
+		</ul>
+			</div>
+
+	<div class="cmplz-divider cmplz-footer"></div>
+
+	<div class="cmplz-buttons">
+		<button class="cmplz-btn cmplz-accept">Aceptar</button>
+		<button class="cmplz-btn cmplz-deny">Rechazar</button>
+		<button class="cmplz-btn cmplz-view-preferences">Administrar opciones</button>
+		<button class="cmplz-btn cmplz-save-preferences">Guardar preferencias</button>
+		<a class="cmplz-btn cmplz-manage-options tcf cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a>
+			</div>
+
+	
+	<div class="cmplz-documents cmplz-links">
+		<ul>
+			<li><a class="cmplz-link cookie-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link privacy-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link impressum" href="#" data-relative_url="">{title}</a></li>
+		</ul>
+			</div>
+</div>
+</div>
+					<div id="cmplz-manage-consent" data-nosnippet="true"><button class="cmplz-btn cmplz-hidden cmplz-manage-consent manage-consent-1">Privacidad</button>
+
+</div>        <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        jQuery(document).ready(function($){
+            $("#submit").click(function(e)){
+                if (!$('.privacyBox').prop('checked')){
+                    e.preventDefault();
+                    alert('Debes aceptar nuestra política de privacidad <p><a href="javascript:history.back()">' . __('&laquo; Volver') . '</a></p>');
+                    return false;
+                }
+            }
+        });
+        </script>
+                        <style type="text/css" media="all"
+                       id="siteorigin-panels-layouts-footer">/* Layout w64208d0f963d5 */ #pgc-w64208d0f963d5-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-0 , #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-1 {  } #pl-w64208d0f963d5 .so-panel { margin-bottom:30px } #pl-w64208d0f963d5 .so-panel:last-child { margin-bottom:0px } #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w64208d0f963d5-0-0-1> .panel-widget-style { color:#bdbeb2;margin-top:-18px;font-size:1.2em;font-weight:400;line-height:1.2em } @media (max-width:780px){ #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w64208d0f963d5-0 > .panel-grid-cell , #pg-w64208d0f963d5-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w64208d0f963d5 .panel-grid-cell { padding:0 } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-empty { display:none } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } /* Layout w5f89a361017dd */ #pgc-w5f89a361017dd-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-0 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-1 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-2 {  } #pl-w5f89a361017dd .so-panel { margin-bottom:30px } #pl-w5f89a361017dd .so-panel:last-child { margin-bottom:0px } #pg-w5f89a361017dd-0> .panel-row-style { background-color:#e7e8e1;padding:0.5em } #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w5f89a361017dd-0-0-0> .panel-widget-style { margin-bottom:20px } @media (max-width:780px){ #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w5f89a361017dd-0 > .panel-grid-cell , #pg-w5f89a361017dd-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w5f89a361017dd .panel-grid-cell { padding:0 } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-empty { display:none } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } </style><link rel='stylesheet' id='siteorigin-panels-front-css' href='https://www.velocidadcuchara.com/wp-content/plugins/siteorigin-panels/css/front-flex.min.css?ver=2.10.9' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-3af2f923c85f-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-3af2f923c85f.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='siteorigin-widget-icon-font-fontawesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/icons/fontawesome/style.css?ver=1773428753' type='text/css' media='all' />
+<script type="text/javascript" id="wtpsw-public-script-js-extra">
+/* <![CDATA[ */
+var Wtpsw = {"elementor_preview":"0","ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","is_mobile":"0","is_avada":"0","is_rtl":"0","post_view_count":"254","data_nonce":"aca6b40d34"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/js/wtpsw-public.js?ver=1773428753" id="wtpsw-public-script-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-browser-checker-js-after">
+/* <![CDATA[ */
+"use strict";var _createClass=function(){function defineProperties(target,props){for(var i=0;i<props.length;i++){var descriptor=props[i];descriptor.enumerable=descriptor.enumerable||!1,descriptor.configurable=!0,"value"in descriptor&&(descriptor.writable=!0),Object.defineProperty(target,descriptor.key,descriptor)}}return function(Constructor,protoProps,staticProps){return protoProps&&defineProperties(Constructor.prototype,protoProps),staticProps&&defineProperties(Constructor,staticProps),Constructor}}();function _classCallCheck(instance,Constructor){if(!(instance instanceof Constructor))throw new TypeError("Cannot call a class as a function")}var RocketBrowserCompatibilityChecker=function(){function RocketBrowserCompatibilityChecker(options){_classCallCheck(this,RocketBrowserCompatibilityChecker),this.passiveSupported=!1,this._checkPassiveOption(this),this.options=!!this.passiveSupported&&options}return _createClass(RocketBrowserCompatibilityChecker,[{key:"_checkPassiveOption",value:function(self){try{var options={get passive(){return!(self.passiveSupported=!0)}};window.addEventListener("test",null,options),window.removeEventListener("test",null,options)}catch(err){self.passiveSupported=!1}}},{key:"initRequestIdleCallback",value:function(){!1 in window&&(window.requestIdleCallback=function(cb){var start=Date.now();return setTimeout(function(){cb({didTimeout:!1,timeRemaining:function(){return Math.max(0,50-(Date.now()-start))}})},1)}),!1 in window&&(window.cancelIdleCallback=function(id){return clearTimeout(id)})}},{key:"isDataSaverModeOn",value:function(){return"connection"in navigator&&!0===navigator.connection.saveData}},{key:"supportsLinkPrefetch",value:function(){var elem=document.createElement("link");return elem.relList&&elem.relList.supports&&elem.relList.supports("prefetch")&&window.IntersectionObserver&&"isIntersecting"in IntersectionObserverEntry.prototype}},{key:"isSlowConnection",value:function(){return"connection"in navigator&&"effectiveType"in navigator.connection&&("2g"===navigator.connection.effectiveType||"slow-2g"===navigator.connection.effectiveType)}}]),RocketBrowserCompatibilityChecker}();
+/* ]]> */
+</script>
+<script type="text/javascript" id="rocket-preload-links-js-extra">
+/* <![CDATA[ */
+var RocketPreloadLinksConfig = {"excludeUris":"\/(?:.+\/)?feed(?:\/(?:.+\/?)?)?$|\/(?:.+\/)?embed\/|\/(index.php\/)?(.*)wp-json(\/.*|$)|\/refer\/|\/go\/|\/recommend\/|\/recommends\/","usesTrailingSlash":"1","imageExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php","fileExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php|html|htm","siteUrl":"https:\/\/www.velocidadcuchara.com","onHoverDelay":"100","rateThrottle":"3"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-preload-links-js-after">
+/* <![CDATA[ */
+(function() {
+"use strict";var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},e=function(){function i(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}return function(e,t,n){return t&&i(e.prototype,t),n&&i(e,n),e}}();function i(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var t=function(){function n(e,t){i(this,n),this.browser=e,this.config=t,this.options=this.browser.options,this.prefetched=new Set,this.eventTime=null,this.threshold=1111,this.numOnHover=0}return e(n,[{key:"init",value:function(){!this.browser.supportsLinkPrefetch()||this.browser.isDataSaverModeOn()||this.browser.isSlowConnection()||(this.regex={excludeUris:RegExp(this.config.excludeUris,"i"),images:RegExp(".("+this.config.imageExt+")$","i"),fileExt:RegExp(".("+this.config.fileExt+")$","i")},this._initListeners(this))}},{key:"_initListeners",value:function(e){-1<this.config.onHoverDelay&&document.addEventListener("mouseover",e.listener.bind(e),e.listenerOptions),document.addEventListener("mousedown",e.listener.bind(e),e.listenerOptions),document.addEventListener("touchstart",e.listener.bind(e),e.listenerOptions)}},{key:"listener",value:function(e){var t=e.target.closest("a"),n=this._prepareUrl(t);if(null!==n)switch(e.type){case"mousedown":case"touchstart":this._addPrefetchLink(n);break;case"mouseover":this._earlyPrefetch(t,n,"mouseout")}}},{key:"_earlyPrefetch",value:function(t,e,n){var i=this,r=setTimeout(function(){if(r=null,0===i.numOnHover)setTimeout(function(){return i.numOnHover=0},1e3);else if(i.numOnHover>i.config.rateThrottle)return;i.numOnHover++,i._addPrefetchLink(e)},this.config.onHoverDelay);t.addEventListener(n,function e(){t.removeEventListener(n,e,{passive:!0}),null!==r&&(clearTimeout(r),r=null)},{passive:!0})}},{key:"_addPrefetchLink",value:function(i){return this.prefetched.add(i.href),new Promise(function(e,t){var n=document.createElement("link");n.rel="prefetch",n.href=i.href,n.onload=e,n.onerror=t,document.head.appendChild(n)}).catch(function(){})}},{key:"_prepareUrl",value:function(e){if(null===e||"object"!==(void 0===e?"undefined":r(e))||!1 in e||-1===["http:","https:"].indexOf(e.protocol))return null;var t=e.href.substring(0,this.config.siteUrl.length),n=this._getPathname(e.href,t),i={original:e.href,protocol:e.protocol,origin:t,pathname:n,href:t+n};return this._isLinkOk(i)?i:null}},{key:"_getPathname",value:function(e,t){var n=t?e.substring(this.config.siteUrl.length):e;return n.startsWith("/")||(n="/"+n),this._shouldAddTrailingSlash(n)?n+"/":n}},{key:"_shouldAddTrailingSlash",value:function(e){return this.config.usesTrailingSlash&&!e.endsWith("/")&&!this.regex.fileExt.test(e)}},{key:"_isLinkOk",value:function(e){return null!==e&&"object"===(void 0===e?"undefined":r(e))&&(!this.prefetched.has(e.href)&&e.origin===this.config.siteUrl&&-1===e.href.indexOf("?")&&-1===e.href.indexOf("#")&&!this.regex.excludeUris.test(e.href)&&!this.regex.images.test(e.href))}}],[{key:"run",value:function(){"undefined"!=typeof RocketPreloadLinksConfig&&new n(new RocketBrowserCompatibilityChecker({capture:!0,passive:!0}),RocketPreloadLinksConfig).init()}}]),n}();t.run();
+}());
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads/admin/assets/js/advertisement.js?ver=1773428753" id="advanced-ads-find-adblocker-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro-main-js-extra">
+/* <![CDATA[ */
+var advanced_ads_cookies = {"cookie_path":"\/","cookie_domain":""};
+var advadsCfpInfo = {"cfpExpHours":"3","cfpClickLimit":"3","cfpBan":"7","cfpPath":"","cfpDomain":"www.velocidadcuchara.com","cfpEnabled":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/advanced-ads-pro.js?ver=1773428753" id="advanced-ads-pro-main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/js/postscribe.js?ver=1773428753" id="advanced-ads-pro/postscribe-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro/cache_busting-js-extra">
+/* <![CDATA[ */
+var advanced_ads_pro_ajax_object = {"ajax_url":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","lazy_load_module_enabled":"1","lazy_load":{"default_offset":0,"offsets":[]},"moveintohidden":"","wp_timezone_offset":"7200","the_id":"254","is_singular":"1"};
+var advanced_ads_responsive = {"reload_on_resize":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/front.js?ver=1773428753" id="advanced-ads-pro/cache_busting-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/comment-reply.min.js?ver=6.8.2" id="comment-reply-js" async="async" data-wp-strategy="async"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/imagesloaded.min.js?ver=5.0.0" id="imagesloaded-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/masonry.min.js?ver=4.2.2" id="masonry-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/min/plugins-min.js?ver=303" id="kadence_plugins-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/js/main.js?ver=1773428753" id="kadence_main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/hoverIntent.min.js?ver=1.10.2" id="hoverIntent-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="megamenu-js-extra">
+/* <![CDATA[ */
+var megamenu = {"timeout":"300","interval":"100"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/megamenu/js/maxmegamenu.js?ver=1773428753" id="megamenu-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="cmplz-cookiebanner-js-extra">
+/* <![CDATA[ */
+var complianz = {"prefix":"cmplz_","user_banner_id":"1","set_cookies":[],"block_ajax_content":"0","banner_version":"48","version":"7.5.6.1","store_consent":"1","do_not_track_enabled":"","consenttype":"optin","region":"eu","geoip":"1","dismiss_timeout":"","disable_cookiebanner":"","soft_cookiewall":"","dismiss_on_scroll":"","cookie_expiry":"365","url":"https:\/\/www.velocidadcuchara.com\/wp-json\/complianz\/v1\/","locale":"lang=es&locale=es_ES","set_cookies_on_root":"0","cookie_domain":"","current_policy_id":"44","cookie_path":"\/","categories":{"statistics":"estad\u00edsticas","marketing":"m\u00e1rketing"},"tcf_active":"1","placeholdertext":"Haz clic para aceptar {category} cookies y habilitar este contenido","css_file":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/css\/banner-{banner_id}-{type}.css?v=48","page_links":{"eu":{"cookie-statement":{"title":"Pol\u00edtica de cookies ","url":"https:\/\/www.velocidadcuchara.com\/politica-de-cookies-ue\/"},"privacy-statement":{"title":"Declaraci\u00f3n de privacidad ","url":"https:\/\/www.velocidadcuchara.com\/declaracion-de-privacidad-ue\/"}}},"tm_categories":"1","forceEnableStats":"","preview":"","clean_cookies":"","aria_label":"Haz clic para aceptar {category} cookies y habilitar este contenido","tcf_regions":["us","ca","eu","uk","au","za","br"]};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/cookiebanner/js/complianz.min.js?ver=1768420286" id="cmplz-cookiebanner-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="cmplz-cookiebanner-js-after">
+/* <![CDATA[ */
+	let cmplzBlockedContent = document.querySelector('.cmplz-blocked-content-notice');
+	if ( cmplzBlockedContent) {
+	        cmplzBlockedContent.addEventListener('click', function(event) {
+            event.stopPropagation();
+        });
+	}
+    
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1773428753" id="akismet-frontend-js"></script>
+<!-- Statistics script Complianz GDPR/CCPA -->
+						<script type="rocketlazyloadscript" data-category="functional">
+							(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MBHRNJL');
+
+const revokeListeners = [];
+window.addRevokeListener = (callback) => {
+	revokeListeners.push(callback);
+};
+document.addEventListener("cmplz_revoke", function (e) {
+	cmplz_set_cookie('cmplz_consent_mode', 'revoked', false );
+	revokeListeners.forEach((callback) => {
+		callback();
+	});
+});
+
+const consentListeners = [];
+/**
+ * Called from GTM template to set callback to be executed when user consent is provided.
+ * @param callback
+ */
+window.addConsentUpdateListener = (callback) => {
+	consentListeners.push(callback);
+};
+document.addEventListener("cmplz_fire_categories", function (e) {
+	var consentedCategories = e.detail.categories;
+	const consent = {
+		'security_storage': "granted",
+		'functionality_storage': "granted",
+		'personalization_storage':  cmplz_in_array( 'preferences', consentedCategories ) ? 'granted' : 'denied',
+		'analytics_storage':  cmplz_in_array( 'statistics', consentedCategories ) ? 'granted' : 'denied',
+		'ad_storage': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_user_data': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_personalization': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+	};
+
+	//don't use automatic prefixing, as the TM template needs to be sure it's cmplz_.
+	let consented = [];
+	for (const [key, value] of Object.entries(consent)) {
+		if (value === 'granted') {
+			consented.push(key);
+		}
+	}
+	cmplz_set_cookie('cmplz_consent_mode', consented.join(','), false );
+	consentListeners.forEach((callback) => {
+		callback(consent);
+	});
+});
+						</script><!--noptimize--><script type="rocketlazyloadscript">window.advads_admin_bar_items = [{"title":"ADS RECETA P\u00c1RRAFO 1","type":"ad","count":1},{"title":"Contenido","type":"placement","count":1},{"title":"Contenido 2","type":"placement","count":1},{"title":"ADS RECETA P\u00c1RRAFO 3","type":"ad","count":0},{"title":"PRP C&amp;J ESCRITORIO","type":"ad","count":1}];</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">window.advads_passive_placements = {"61268_1":{"elementid":["local-2e3004518adda224bf6858aae4e50cc9"],"ads":{"47608":{"id":47608,"title":"ADS RECETA P\u00c1RRAFO 3","expiry_date":0,"visitors":[{"type":"geo_targeting","geo_mode":"classic","operator":"is_not","country":"ES","region":"","city":"","distance_condition":"lte","distance":"","distance_unit":"km","lat":"","lon":"","latlon_city":""}],"content":"<script type=\"text\/plain\" data-tcf=\"waiting-for-consent\" data-id=\"47608\" data-bid=\"1\" data-placement=\"61268\">PGRpdiBpZD0ibG9jYWwtMzQ2NDI1Mjk4IiBjbGFzcz0iZ2FzX2ZhbGxiYWNrLWFkXzQ3NjA4LS1wbGFjZW1lbnRfNjEyNjgiIHN0eWxlPSJtYXJnaW4tdG9wOiAyMHB4O21hcmdpbi1ib3R0b206IDIwcHg7Ij48c2NyaXB0IGFzeW5jIHNyYz0iLy9wYWdlYWQyLmdvb2dsZXN5bmRpY2F0aW9uLmNvbS9wYWdlYWQvanMvYWRzYnlnb29nbGUuanM\/Y2xpZW50PWNhLXB1Yi0wNDMyNzI2MDQwMDA5Njc2IiBjcm9zc29yaWdpbj0iYW5vbnltb3VzIj48L3NjcmlwdD48aW5zIGNsYXNzPSJhZHNieWdvb2dsZSIgc3R5bGU9ImRpc3BsYXk6YmxvY2s7IiBkYXRhLWFkLWNsaWVudD0iY2EtcHViLTA0MzI3MjYwNDAwMDk2NzYiIApkYXRhLWFkLXNsb3Q9IjIwMjk2MTA5NzgiIApkYXRhLWFkLWZvcm1hdD0iYXV0byI+PC9pbnM+CjxzY3JpcHQ+IAooYWRzYnlnb29nbGUgPSB3aW5kb3cuYWRzYnlnb29nbGUgfHwgW10pLnB1c2goe30pOyAKPC9zY3JpcHQ+CjwvZGl2Pg==<\/script>","once_per_page":0,"debugmode":false,"blog_id":1,"type":"adsense","position":"center_nofloat","day_indexes":false,"privacy":{"ignore":false,"needs_consent":false}}},"type":"ad","id":47608,"placement_info":{"id":"61268","title":"Contenido 2","content":"New placement content goes here","type":"post_content","slug":"contenido-2","status":"publish","item":"ad_47608","display":[],"visitors":[],"ad_label":"disabled","placement_position":"","inline-css":"","parallax":{"height":{"value":"200","unit":"px"}},"pro_minimum_length":"0","words_between_repeats":"0","position":"after","index":3,"tag":"p","xpath":"","lazy_load":"disabled","cache-busting":"auto"},"test_id":null,"ajax_query":{"id":61268,"method":"placement","params":{"title":"Contenido 2","content":"New placement content goes here","type":"post_content","slug":"contenido-2","status":"publish","item":"ad_47608","display":[],"visitors":[],"ad_label":"disabled","inline-css":"","parallax":{"height":{"value":"200","unit":"px"}},"position":"after","index":3,"tag":"p","xpath":"","cache-busting":"auto","previous_id":61268,"previous_method":"placement","post":"r0","url_parameter":"\/salsa-bolonesa\/","placement_type":"post_content","output":{"class":["local-contenido-2"],"placement_id":61268},"cache_busting_elementid":"local-2e3004518adda224bf6858aae4e50cc9"},"elementid":"local-2e3004518adda224bf6858aae4e50cc9","server_conditions":{"fb0761cc21":{"type":"geo_targeting"}},"blog_id":1},"server_info_duration":2592000,"server_conditions":{"fb0761cc21":{"type":"geo_targeting"}},"inject_before":[""]}};
+window.advads_has_ads = [["45718","ad","ADS RECETA P\u00c1RRAFO 1","off"],["49235","ad","PRP C&J ESCRITORIO","off"]];
+window.advads_ajax_queries_args = {"r0":{"id":254,"author":"1","post_type":"post"}};
+( window.advanced_ads_ready || jQuery( document ).ready ).call( null, function() {if ( !window.advanced_ads_pro ) {console.log("Advanced Ads Pro: cache-busting can not be initialized");} });</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">!function(){window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[],advanced_ads_ready_queue.push=window.advanced_ads_ready;for(var d=0,a=advanced_ads_ready_queue.length;d<a;d++)advanced_ads_ready(advanced_ads_ready_queue[d])}();</script><!--/noptimize-->
+      <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        window._taboola = window._taboola || [];
+        _taboola.push({flush: true});
+      </script>
+
+  </body>
+</html>
+
+<!-- This website is like a Rocket, isn't it? Performance optimized by WP Rocket. Learn more: https://wp-rocket.me - Debug: cached@1776938193 -->

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_2.json
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_2.json
@@ -1,0 +1,70 @@
+{
+  "author": "Rosa Ardá",
+  "canonical_url": "https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/",
+  "site_name": "Velocidad Cuchara",
+  "host": "velocidadcuchara.com",
+  "language": "es",
+  "title": "Albóndigas de berenjena con salsa de tomate",
+  "ingredients": [
+    "4 dientes de ajo",
+    "600 g de berenjena con piel en trozos de 2-3 cm",
+    "30 g de aceite de oliva virgen extra",
+    "60 g de agua -opcional-",
+    "180 g de pan duro",
+    "4 ramitas de perejil fresco",
+    "unas hojas de albahaca fresca troceada",
+    "1 huevo",
+    "1 pizca de sal o al gusto",
+    "1 pizca de Pimienta negra recién molida",
+    "Un bote de 800 g de tomate entero pelado",
+    "50 g de aceite de oliva virgen extra",
+    "2 cucharadas de azúcar",
+    "1 cucharadita de sal",
+    "Albahaca fresca troceada para espolvorear"
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "4 dientes de ajo",
+        "600 g de berenjena con piel en trozos de 2-3 cm",
+        "30 g de aceite de oliva virgen extra",
+        "60 g de agua -opcional-",
+        "180 g de pan duro",
+        "4 ramitas de perejil fresco",
+        "unas hojas de albahaca fresca troceada",
+        "1 huevo",
+        "1 pizca de sal o al gusto",
+        "1 pizca de Pimienta negra recién molida"
+      ],
+      "purpose": "Para las albóndigas"
+    },
+    {
+      "ingredients": [
+        "Un bote de 800 g de tomate entero pelado",
+        "50 g de aceite de oliva virgen extra",
+        "2 cucharadas de azúcar",
+        "1 cucharadita de sal",
+        "Albahaca fresca troceada para espolvorear"
+      ],
+      "purpose": "Para la salsa de tomate"
+    }
+  ],
+  "instructions_list": [
+    "Para las albóndigas: Pon 2 dientes de ajo en el vaso y pica 3 segundos en velocidad 7. Incorpora los 600 gr de berenjena en trozos -yo corto en rodajas de 2 dedos de ancho y estos en 4 trozos-, trocea 6 segundos en velocidad 4. Baja los restos de las paredes añade el aceite y sofríe 6 minutos, 120ºC o Varoma en velocidad 1.",
+    "Incorpora el agua y programa otros 6 minutos, 100ºC, velocidad 1. Después trocea 3 segundos en velocidad 5 y vierte la mezcla en una fuente o un bol para que atempere. Deja reposar unos 20 minutos.",
+    "Sin lavar el vaso y con este vacío, pon dentro el pan en trozos, 2 dientes de ajo, el perejil y la albahaca y tritura 10 segundos en velocidad 10. Baja los restos de las paredes.",
+    "Añade el huevo, la sal, la pimienta y las carne de las berenjenas reservada y mezcla 15 segundos, giro a la izquierda y velocidad 3. Acaba de mezclar con la espátula y pasa a un cuenco. Precalienta el horno a 200ºC.",
+    "Engrasa un molde apto para horno y ve formando bolitas con la masa y colocándolas en esta, te saldrán unas 20-24 en total de unos 30 gr unidad. Usa una cuchara para coger siempre la misma cantidad. Hornea 20 minutos a 180ºC con calor arriba y abajo y mientras haz la salsa de tomate.",
+    "Para la salsa de tomate: Pon todos los ingredientes en el vaso, incluido el jugo de los tomates y programa 30 minutos, 120ºC o Varoma en velocidad 2. Una vez lista vierte sobre las albóndigas ya horneadas y decora con albahaca picada."
+  ],
+  "category": "Verduras",
+  "yields": "6 servings",
+  "description": "Receta de Albóndigas de berenjena con salsa de tomate en Thermomix. Sorprende su sabor por las especias. No tendrás que freírlas, bastará con hornearlas.",
+  "total_time": 60,
+  "cook_time": 30,
+  "prep_time": 30,
+  "cuisine": "Española",
+  "ratings": 4.6,
+  "ratings_count": 44,
+  "image": "https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-1024x684.jpg"
+}

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_2.testhtml
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_2.testhtml
@@ -1,0 +1,3885 @@
+<!DOCTYPE html>
+<html class="no-js" lang="es" itemscope="itemscope" itemtype="http://schema.org/WebPage">
+<head><meta charset="UTF-8"><script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script><script>(()=>{class RocketLazyLoadScripts{constructor(){this.v="2.0.5",this.userEvents=["keydown","keyup","mousedown","mouseup","mousemove","mouseover","mouseout","touchmove","touchstart","touchend","touchcancel","wheel","click","dblclick","input"],this.attributeEvents=["onblur","onclick","oncontextmenu","ondblclick","onfocus","onmousedown","onmouseenter","onmouseleave","onmousemove","onmouseout","onmouseover","onmouseup","onmousewheel","onscroll","onsubmit"]}async t(){this.i(),this.o(),/iP(ad|hone)/.test(navigator.userAgent)&&this.h(),this.u(),this.l(this),this.m(),this.k(this),this.p(this),this._(),await Promise.all([this.R(),this.L()]),this.lastBreath=Date.now(),this.S(this),this.P(),this.D(),this.O(),this.M(),await this.C(this.delayedScripts.normal),await this.C(this.delayedScripts.defer),await this.C(this.delayedScripts.async),await this.T(),await this.F(),await this.j(),await this.A(),window.dispatchEvent(new Event("rocket-allScriptsLoaded")),this.everythingLoaded=!0,this.lastTouchEnd&&await new Promise(t=>setTimeout(t,500-Date.now()+this.lastTouchEnd)),this.I(),this.H(),this.U(),this.W()}i(){this.CSPIssue=sessionStorage.getItem("rocketCSPIssue"),document.addEventListener("securitypolicyviolation",t=>{this.CSPIssue||"script-src-elem"!==t.violatedDirective||"data"!==t.blockedURI||(this.CSPIssue=!0,sessionStorage.setItem("rocketCSPIssue",!0))},{isRocket:!0})}o(){window.addEventListener("pageshow",t=>{this.persisted=t.persisted,this.realWindowLoadedFired=!0},{isRocket:!0}),window.addEventListener("pagehide",()=>{this.onFirstUserAction=null},{isRocket:!0})}h(){let t;function e(e){t=e}window.addEventListener("touchstart",e,{isRocket:!0}),window.addEventListener("touchend",function i(o){o.changedTouches[0]&&t.changedTouches[0]&&Math.abs(o.changedTouches[0].pageX-t.changedTouches[0].pageX)<10&&Math.abs(o.changedTouches[0].pageY-t.changedTouches[0].pageY)<10&&o.timeStamp-t.timeStamp<200&&(window.removeEventListener("touchstart",e,{isRocket:!0}),window.removeEventListener("touchend",i,{isRocket:!0}),"INPUT"===o.target.tagName&&"text"===o.target.type||(o.target.dispatchEvent(new TouchEvent("touchend",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new MouseEvent("mouseover",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new PointerEvent("click",{target:o.target,bubbles:!0,cancelable:!0,detail:1,clientX:o.changedTouches[0].clientX,clientY:o.changedTouches[0].clientY})),event.preventDefault()))},{isRocket:!0})}q(t){this.userActionTriggered||("mousemove"!==t.type||this.firstMousemoveIgnored?"keyup"===t.type||"mouseover"===t.type||"mouseout"===t.type||(this.userActionTriggered=!0,this.onFirstUserAction&&this.onFirstUserAction()):this.firstMousemoveIgnored=!0),"click"===t.type&&t.preventDefault(),t.stopPropagation(),t.stopImmediatePropagation(),"touchstart"===this.lastEvent&&"touchend"===t.type&&(this.lastTouchEnd=Date.now()),"click"===t.type&&(this.lastTouchEnd=0),this.lastEvent=t.type,t.composedPath&&t.composedPath()[0].getRootNode()instanceof ShadowRoot&&(t.rocketTarget=t.composedPath()[0]),this.savedUserEvents.push(t)}u(){this.savedUserEvents=[],this.userEventHandler=this.q.bind(this),this.userEvents.forEach(t=>window.addEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.addEventListener("visibilitychange",this.userEventHandler,{isRocket:!0})}U(){this.userEvents.forEach(t=>window.removeEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.removeEventListener("visibilitychange",this.userEventHandler,{isRocket:!0}),this.savedUserEvents.forEach(t=>{(t.rocketTarget||t.target).dispatchEvent(new window[t.constructor.name](t.type,t))})}m(){const t="return false",e=Array.from(this.attributeEvents,t=>"data-rocket-"+t),i="["+this.attributeEvents.join("],[")+"]",o="[data-rocket-"+this.attributeEvents.join("],[data-rocket-")+"]",s=(e,i,o)=>{o&&o!==t&&(e.setAttribute("data-rocket-"+i,o),e["rocket"+i]=new Function("event",o),e.setAttribute(i,t))};new MutationObserver(t=>{for(const n of t)"attributes"===n.type&&(n.attributeName.startsWith("data-rocket-")||this.everythingLoaded?n.attributeName.startsWith("data-rocket-")&&this.everythingLoaded&&this.N(n.target,n.attributeName.substring(12)):s(n.target,n.attributeName,n.target.getAttribute(n.attributeName))),"childList"===n.type&&n.addedNodes.forEach(t=>{if(t.nodeType===Node.ELEMENT_NODE)if(this.everythingLoaded)for(const i of[t,...t.querySelectorAll(o)])for(const t of i.getAttributeNames())e.includes(t)&&this.N(i,t.substring(12));else for(const e of[t,...t.querySelectorAll(i)])for(const t of e.getAttributeNames())this.attributeEvents.includes(t)&&s(e,t,e.getAttribute(t))})}).observe(document,{subtree:!0,childList:!0,attributeFilter:[...this.attributeEvents,...e]})}I(){this.attributeEvents.forEach(t=>{document.querySelectorAll("[data-rocket-"+t+"]").forEach(e=>{this.N(e,t)})})}N(t,e){const i=t.getAttribute("data-rocket-"+e);i&&(t.setAttribute(e,i),t.removeAttribute("data-rocket-"+e))}k(t){Object.defineProperty(HTMLElement.prototype,"onclick",{get(){return this.rocketonclick||null},set(e){this.rocketonclick=e,this.setAttribute(t.everythingLoaded?"onclick":"data-rocket-onclick","this.rocketonclick(event)")}})}S(t){function e(e,i){let o=e[i];e[i]=null,Object.defineProperty(e,i,{get:()=>o,set(s){t.everythingLoaded?o=s:e["rocket"+i]=o=s}})}e(document,"onreadystatechange"),e(window,"onload"),e(window,"onpageshow");try{Object.defineProperty(document,"readyState",{get:()=>t.rocketReadyState,set(e){t.rocketReadyState=e},configurable:!0}),document.readyState="loading"}catch(t){console.log("WPRocket DJE readyState conflict, bypassing")}}l(t){this.originalAddEventListener=EventTarget.prototype.addEventListener,this.originalRemoveEventListener=EventTarget.prototype.removeEventListener,this.savedEventListeners=[],EventTarget.prototype.addEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalAddEventListener.call(this,e,i,o):(t.savedEventListeners.push({target:this,remove:!1,type:e,func:i,options:o}),"mouseenter"!==e&&"mouseleave"!==e||t.originalAddEventListener.call(this,e,t.savedUserEvents.push,o))},EventTarget.prototype.removeEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalRemoveEventListener.call(this,e,i,o):t.savedEventListeners.push({target:this,remove:!0,type:e,func:i,options:o})}}J(t,e){this.savedEventListeners=this.savedEventListeners.filter(i=>{let o=i.type,s=i.target||window;return e!==o||t!==s||(this.B(o,s)&&(i.type="rocket-"+o),this.$(i),!1)})}H(){EventTarget.prototype.addEventListener=this.originalAddEventListener,EventTarget.prototype.removeEventListener=this.originalRemoveEventListener,this.savedEventListeners.forEach(t=>this.$(t))}$(t){t.remove?this.originalRemoveEventListener.call(t.target,t.type,t.func,t.options):this.originalAddEventListener.call(t.target,t.type,t.func,t.options)}p(t){let e;function i(e){return t.everythingLoaded?e:e.split(" ").map(t=>"load"===t||t.startsWith("load.")?"rocket-jquery-load":t).join(" ")}function o(o){function s(e){const s=o.fn[e];o.fn[e]=o.fn.init.prototype[e]=function(){return this[0]===window&&t.userActionTriggered&&("string"==typeof arguments[0]||arguments[0]instanceof String?arguments[0]=i(arguments[0]):"object"==typeof arguments[0]&&Object.keys(arguments[0]).forEach(t=>{const e=arguments[0][t];delete arguments[0][t],arguments[0][i(t)]=e})),s.apply(this,arguments),this}}if(o&&o.fn&&!t.allJQueries.includes(o)){const e={DOMContentLoaded:[],"rocket-DOMContentLoaded":[]};for(const t in e)document.addEventListener(t,()=>{e[t].forEach(t=>t())},{isRocket:!0});o.fn.ready=o.fn.init.prototype.ready=function(i){function s(){parseInt(o.fn.jquery)>2?setTimeout(()=>i.bind(document)(o)):i.bind(document)(o)}return"function"==typeof i&&(t.realDomReadyFired?!t.userActionTriggered||t.fauxDomReadyFired?s():e["rocket-DOMContentLoaded"].push(s):e.DOMContentLoaded.push(s)),this},s("on"),s("one"),s("off"),t.allJQueries.push(o)}e=o}t.allJQueries=[],o(window.jQuery),Object.defineProperty(window,"jQuery",{get:()=>e,set(t){o(t)}})}P(){const t=new Map;document.write=document.writeln=function(e){const i=document.currentScript,o=document.createRange(),s=i.parentElement;let n=t.get(i);void 0===n&&(n=i.nextSibling,t.set(i,n));const c=document.createDocumentFragment();o.setStart(c,0),c.appendChild(o.createContextualFragment(e)),s.insertBefore(c,n)}}async R(){return new Promise(t=>{this.userActionTriggered?t():this.onFirstUserAction=t})}async L(){return new Promise(t=>{document.addEventListener("DOMContentLoaded",()=>{this.realDomReadyFired=!0,t()},{isRocket:!0})})}async j(){return this.realWindowLoadedFired?Promise.resolve():new Promise(t=>{window.addEventListener("load",t,{isRocket:!0})})}M(){this.pendingScripts=[];this.scriptsMutationObserver=new MutationObserver(t=>{for(const e of t)e.addedNodes.forEach(t=>{"SCRIPT"!==t.tagName||!t.src||t.noModule||t.isWPRocket||this.pendingScripts.push({script:t,promise:new Promise(e=>{const i=()=>{const i=this.pendingScripts.findIndex(e=>e.script===t);i>=0&&this.pendingScripts.splice(i,1),e()};t.addEventListener("load",i,{isRocket:!0}),t.addEventListener("error",i,{isRocket:!0}),setTimeout(i,1e3)})})})}),this.scriptsMutationObserver.observe(document,{childList:!0,subtree:!0})}async F(){await this.X(),this.pendingScripts.length?(await this.pendingScripts[0].promise,await this.F()):this.scriptsMutationObserver.disconnect()}D(){this.delayedScripts={normal:[],async:[],defer:[]},document.querySelectorAll("script[type$=rocketlazyloadscript]").forEach(t=>{t.hasAttribute("data-rocket-src")?t.hasAttribute("async")&&!1!==t.async?this.delayedScripts.async.push(t):t.hasAttribute("defer")&&!1!==t.defer||"module"===t.getAttribute("data-rocket-type")?this.delayedScripts.defer.push(t):this.delayedScripts.normal.push(t):this.delayedScripts.normal.push(t)})}async _(){await this.L();let t=[];document.querySelectorAll("script[type$=rocketlazyloadscript][data-rocket-src]").forEach(e=>{let i=e.getAttribute("data-rocket-src");if(i&&!i.startsWith("data:")){i.startsWith("//")&&(i=location.protocol+i);try{const o=new URL(i).origin;o!==location.origin&&t.push({src:o,crossOrigin:e.crossOrigin||"module"===e.getAttribute("data-rocket-type")})}catch(t){}}}),t=[...new Map(t.map(t=>[JSON.stringify(t),t])).values()],this.Y(t,"preconnect")}async G(t){if(await this.K(),!0!==t.noModule||!("noModule"in HTMLScriptElement.prototype))return new Promise(e=>{let i;function o(){(i||t).setAttribute("data-rocket-status","executed"),e()}try{if(navigator.userAgent.includes("Firefox/")||""===navigator.vendor||this.CSPIssue)i=document.createElement("script"),[...t.attributes].forEach(t=>{let e=t.nodeName;"type"!==e&&("data-rocket-type"===e&&(e="type"),"data-rocket-src"===e&&(e="src"),i.setAttribute(e,t.nodeValue))}),t.text&&(i.text=t.text),t.nonce&&(i.nonce=t.nonce),i.hasAttribute("src")?(i.addEventListener("load",o,{isRocket:!0}),i.addEventListener("error",()=>{i.setAttribute("data-rocket-status","failed-network"),e()},{isRocket:!0}),setTimeout(()=>{i.isConnected||e()},1)):(i.text=t.text,o()),i.isWPRocket=!0,t.parentNode.replaceChild(i,t);else{const i=t.getAttribute("data-rocket-type"),s=t.getAttribute("data-rocket-src");i?(t.type=i,t.removeAttribute("data-rocket-type")):t.removeAttribute("type"),t.addEventListener("load",o,{isRocket:!0}),t.addEventListener("error",i=>{this.CSPIssue&&i.target.src.startsWith("data:")?(console.log("WPRocket: CSP fallback activated"),t.removeAttribute("src"),this.G(t).then(e)):(t.setAttribute("data-rocket-status","failed-network"),e())},{isRocket:!0}),s?(t.fetchPriority="high",t.removeAttribute("data-rocket-src"),t.src=s):t.src="data:text/javascript;base64,"+window.btoa(unescape(encodeURIComponent(t.text)))}}catch(i){t.setAttribute("data-rocket-status","failed-transform"),e()}});t.setAttribute("data-rocket-status","skipped")}async C(t){const e=t.shift();return e?(e.isConnected&&await this.G(e),this.C(t)):Promise.resolve()}O(){this.Y([...this.delayedScripts.normal,...this.delayedScripts.defer,...this.delayedScripts.async],"preload")}Y(t,e){this.trash=this.trash||[];let i=!0;var o=document.createDocumentFragment();t.forEach(t=>{const s=t.getAttribute&&t.getAttribute("data-rocket-src")||t.src;if(s&&!s.startsWith("data:")){const n=document.createElement("link");n.href=s,n.rel=e,"preconnect"!==e&&(n.as="script",n.fetchPriority=i?"high":"low"),t.getAttribute&&"module"===t.getAttribute("data-rocket-type")&&(n.crossOrigin=!0),t.crossOrigin&&(n.crossOrigin=t.crossOrigin),t.integrity&&(n.integrity=t.integrity),t.nonce&&(n.nonce=t.nonce),o.appendChild(n),this.trash.push(n),i=!1}}),document.head.appendChild(o)}W(){this.trash.forEach(t=>t.remove())}async T(){try{document.readyState="interactive"}catch(t){}this.fauxDomReadyFired=!0;try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(document,"DOMContentLoaded"),document.dispatchEvent(new Event("rocket-DOMContentLoaded")),await this.K(),this.J(window,"DOMContentLoaded"),window.dispatchEvent(new Event("rocket-DOMContentLoaded"))}catch(t){console.error(t)}}async A(){try{document.readyState="complete"}catch(t){}try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(window,"load"),window.dispatchEvent(new Event("rocket-load")),await this.K(),window.rocketonload&&window.rocketonload(),await this.K(),this.allJQueries.forEach(t=>t(window).trigger("rocket-jquery-load")),await this.K(),this.J(window,"pageshow");const t=new Event("rocket-pageshow");t.persisted=this.persisted,window.dispatchEvent(t),await this.K(),window.rocketonpageshow&&window.rocketonpageshow({persisted:this.persisted})}catch(t){console.error(t)}}async K(){Date.now()-this.lastBreath>45&&(await this.X(),this.lastBreath=Date.now())}async X(){return document.hidden?new Promise(t=>setTimeout(t)):new Promise(t=>requestAnimationFrame(t))}B(t,e=window){return e===document&&"readystatechange"===t||(e===document&&"DOMContentLoaded"===t||(e===window&&"DOMContentLoaded"===t||(e===window&&"load"===t||e===window&&"pageshow"===t)))}static run(){(new RocketLazyLoadScripts).t()}}RocketLazyLoadScripts.run()})();
+</script>
+
+<!--
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-++-+
+	|v|e|l|o|c|i|d|a|d| |c|u|c|h|a|r|a|
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-+ +- -->
+
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="copyright" content="Velocidad Cuchara"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta property="fb:pages" content="117162944985048" />
+  <link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &#8211; El primer blog de recetas para Thermomix RSS Feed" href="https://www.velocidadcuchara.com/feed/" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000">
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="sitemap" href="https://www.velocidadcuchara.com/sitemap.xml" />
+  <link href="https://fonts.googleapis.com/css?family=Kaushan+Script" rel="stylesheet">
+
+  <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+	
+	<!-- This site is optimized with the Yoast SEO plugin v27.0 - https://yoast.com/product/yoast-seo-wordpress/ -->
+	<title>Albóndigas de berenjena con tomate | Velocidad Cuchara</title>
+<link data-rocket-prefetch href="https://fonts.googleapis.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://static.addtoany.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://pagead2.googlesyndication.com" rel="dns-prefetch"><link rel="preload" data-rocket-preload as="image" imagesrcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-1024x684.jpg.webp 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-300x200.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-768x513.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-272x182.jpg.webp 272w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1.jpg.webp 1200w" imagesizes="(max-width: 1024px) 100vw, 1024px" fetchpriority="high">
+	<meta name="description" content="Receta de Albóndigas de berenjena con salsa de tomate en Thermomix. Sorprende su sabor por las especias. No tendrás que freírlas, bastará con hornearlas." />
+	<link rel="canonical" href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/" />
+	<meta property="og:locale" content="es_ES" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Albóndigas de berenjena con tomate | Velocidad Cuchara" />
+	<meta property="og:description" content="Receta de Albóndigas de berenjena con salsa de tomate en Thermomix. Sorprende su sabor por las especias. No tendrás que freírlas, bastará con hornearlas." />
+	<meta property="og:url" content="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/" />
+	<meta property="og:site_name" content="Velocidad Cuchara" />
+	<meta property="article:publisher" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:author" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:published_time" content="2017-04-26T14:48:01+00:00" />
+	<meta property="article:modified_time" content="2018-02-21T06:14:02+00:00" />
+	<meta property="og:image" content="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-768x513.jpg" />
+	<meta property="og:image:width" content="768" />
+	<meta property="og:image:height" content="513" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="author" content="Rosa Ardá" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:creator" content="@rosaarda" />
+	<meta name="twitter:site" content="@rosaarda" />
+	<meta name="twitter:label1" content="Escrito por" />
+	<meta name="twitter:data1" content="Rosa Ardá" />
+	<meta name="twitter:label2" content="Tiempo de lectura" />
+	<meta name="twitter:data2" content="3 minutos" />
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//static.addtoany.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed" href="https://www.velocidadcuchara.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed de los comentarios" href="https://www.velocidadcuchara.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Comentario Albóndigas de berenjena con tomate del feed" href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/feed/" />
+<link rel="shortcut icon" type="image/x-icon" href="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/favicon.png" /><!-- www.velocidadcuchara.com is managing ads with Advanced Ads 2.0.17 – https://wpadvancedads.com/ --><!--noptimize--><script type="rocketlazyloadscript" id="local-ready">
+			window.advanced_ads_ready=function(e,a){a=a||"complete";var d=function(e){return"interactive"===a?"loading"!==e:"complete"===e};d(document.readyState)?e():document.addEventListener("readystatechange",(function(a){d(a.target.readyState)&&e()}),{once:"interactive"===a})},window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[];		</script>
+		<!--/noptimize--><style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.velocidadcuchara.com/wp-includes/css/dist/block-library/style.min.css?ver=6.8.2' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+:root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
+</style>
+<link data-minify="1" rel='stylesheet' id='mostrar-comentarios-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='post_grid_style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-new.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='owl.carousel-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/owl.carousel.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='font-awesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/font-awesome.min.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style-woocommerce-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-woocommerce.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.skins-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.skins.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.layout-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.layout.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-17bc2272b535-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-17bc2272b535.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-654ee1169f99-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-654ee1169f99.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-b136017e055b-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-b136017e055b.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-7877d6771435-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-7877d6771435.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-d6014b76747a-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-d6014b76747a.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-base-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/widgets/button/css/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-a0517016730c-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-a0517016730c.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-b763d6af42b8-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-b763d6af42b8.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wpos-slick-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/slick.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wtpsw-public-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/wtpsw-public.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='cmplz-general-css' href='https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/assets/css/cookieblocker.min.css?ver=1768420286' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='megamenu-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/maxmegamenu/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='dashicons-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-includes/css/dashicons.min.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='easyrecipestyle-reset-css' href='https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/css/easyrecipe-style-reset-min.css?ver=3.5.3251' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipebuttonUI-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/ui/easyrecipe-buttonUI.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipestyle-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/styles/style002a/style.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='addtoany-css' href='https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.css?ver=1.16' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='kadence_theme-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/virtue.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='virtue_skin-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/skins/default.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='virtue_child-css' href='https://www.velocidadcuchara.com/wp-content/themes/velocidad/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='redux-google-fonts-virtue-css' href='https://fonts.googleapis.com/css?family=Lato%3A400%2C700%7CJosefin+Sans%3A400%2C600%2C300%7COpen+Sans%3A300%2C400%2C600%2C700%2C800%2C300italic%2C400italic%2C600italic%2C700italic%2C800italic&#038;subset=latin-ext&#038;ver=1774857236' type='text/css' media='all' />
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf-stub/build/index.js?ver=1773428753" id="cmplz-tcf-stub-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/vendor/DOMPurify/DOMPurify.min.js?ver=2.5.8" id="bodhi-dompurify-library-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="addtoany-core-js-before">
+/* <![CDATA[ */
+window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_localize = {
+	Share: "Compartir",
+	Save: "Guardar",
+	Subscribe: "Suscribir",
+	Email: "Correo electrónico",
+	Bookmark: "Marcador",
+	ShowAll: "Mostrar todo",
+	ShowLess: "Mostrar menos",
+	FindServices: "Encontrar servicio(s)",
+	FindAnyServiceToAddTo: "Encuentra al instante cualquier servicio para añadir a",
+	PoweredBy: "Funciona con",
+	ShareViaEmail: "Compartir por correo electrónico",
+	SubscribeViaEmail: "Suscribirse a través de correo electrónico",
+	BookmarkInYourBrowser: "Añadir a marcadores de tu navegador",
+	BookmarkInstructions: "Presiona «Ctrl+D» o «\u2318+D» para añadir esta página a marcadores",
+	AddToYourFavorites: "Añadir a tus favoritos",
+	SendFromWebOrProgram: "Enviar desde cualquier dirección o programa de correo electrónico ",
+	EmailProgram: "Programa de correo electrónico",
+	More: "Más&#8230;",
+	ThanksForSharing: "¡Gracias por compartir!",
+	ThanksForFollowing: "¡Gracias por seguirnos!"
+};
+
+a2a_config.icon_color = "#bdbeb2";
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://static.addtoany.com/menu/page.js" id="addtoany-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.js?ver=1.1" id="addtoany-jquery-js"></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.js?ver=1773428753" id="mostrar-comentarios-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="post_grid_scripts-js-extra">
+/* <![CDATA[ */
+var post_grid_ajax = {"post_grid_ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/scripts.js?ver=1773428753" id="post_grid_scripts-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/masonry.pkgd.min.js?ver=6.8.2" id="masonry.pkgd.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/owl.carousel.min.js?ver=6.8.2" id="owl.carousel.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/imagesloaded.pkgd.js?ver=1773428753" id="imagesloaded.pkgd.js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="bodhi_svg_inline-js-extra">
+/* <![CDATA[ */
+var svgSettings = {"skipNested":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/js/min/svgs-inline-min.js" id="bodhi_svg_inline-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="bodhi_svg_inline-js-after">
+/* <![CDATA[ */
+cssTarget={"Bodhi":"img.style-svg","ForceInlineSVG":"style-svg"};ForceInlineSVGActive="false";frontSanitizationEnabled="on";
+/* ]]> */
+</script>
+<script type="text/javascript" id="cmplz-tcf-js-extra">
+/* <![CDATA[ */
+var cmplz_tcf = {"cmp_url":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/","retention_string":"Retenci\u00f3n en d\u00edas","undeclared_string":"No declarado","isServiceSpecific":"1","excludedVendors":{"15":15,"66":66,"119":119,"139":139,"141":141,"174":174,"192":192,"262":262,"375":375,"377":377,"387":387,"427":427,"435":435,"512":512,"527":527,"569":569,"581":581,"587":587,"626":626,"644":644,"667":667,"713":713,"733":733,"736":736,"748":748,"776":776,"806":806,"822":822,"830":830,"836":836,"856":856,"879":879,"882":882,"888":888,"909":909,"970":970,"986":986,"1015":1015,"1018":1018,"1022":1022,"1039":1039,"1078":1078,"1079":1079,"1094":1094,"1149":1149,"1156":1156,"1167":1167,"1173":1173,"1199":1199,"1211":1211,"1216":1216,"1252":1252,"1263":1263,"1298":1298,"1305":1305,"1342":1342,"1343":1343,"1355":1355,"1365":1365,"1366":1366,"1368":1368,"1371":1371,"1373":1373,"1391":1391,"1405":1405,"1418":1418,"1423":1423,"1425":1425,"1440":1440,"1442":1442,"1482":1482,"1492":1492,"1496":1496,"1503":1503,"1508":1508,"1509":1509,"1510":1510,"1519":1519,"1529":1529,"1537":1537,"1541":1541,"1549":1549,"1550":1550,"1558":1558,"1564":1564,"1579":1579,"1580":1580},"purposes":[1,2,3,4,5,6,7,8,9,10],"specialPurposes":[1,2,3],"features":[1,2],"specialFeatures":[],"publisherCountryCode":"ES","lspact":"N","ccpa_applies":"","ac_mode":"1","debug":"","prefix":"cmplz_"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf/build/index.js?ver=1773428753" id="cmplz-tcf-js"></script>
+<script type="text/javascript" id="advanced-ads-advanced-js-js-extra">
+/* <![CDATA[ */
+var advads_options = {"blog_id":"1","privacy":{"enabled":true,"custom-cookie-name":"euconsent-v2","custom-cookie-value":"CO49HGNO49HGNAKALAESA1CsAP_AAH_AAAiQGatd_X9fb2vj-_5999t0eY1f9_63v-wzjgeNs-8NyZ_X_L4Xr2MyvB36pq4KmR4Eu3LBAQFlHOHcTQmQwIkVqTLsbk2Mq7NKJ7LEilMbM2dYGG9Pn8XTuZCY70_sf__z_3-_-___67bgYIQSYKl4BAkJYQEk2aUQogAhHEBUA4AKCEICBSw0ABATsCgI9QAAAEBgABAAAACCCAgEAAAAASEQAAACAgEABEAgABACNAQgAIkAAWAEgQBAAKAaEgBFEEIAhBgYBRygBAUAAAAA.fmAAAAAAAAAA","consent-method":"iab_tcf_20","state":"unknown"}};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/advanced-ads/public/assets/js/advanced.min.js?ver=2.0.17" id="advanced-ads-advanced-js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="utils-js-extra">
+/* <![CDATA[ */
+var userSettings = {"url":"\/","uid":"0","time":"1776938850","secure":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/utils.min.js?ver=6.8.2" id="utils-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/controlgroup.min.js?ver=1.13.3" id="jquery-ui-controlgroup-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/checkboxradio.min.js?ver=1.13.3" id="jquery-ui-checkboxradio-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/button.min.js?ver=1.13.3" id="jquery-ui-button-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/js/easyrecipe-min.js?ver=3.5.3251" id="EasyRecipePlus-js" data-rocket-defer defer></script>
+<link rel="https://api.w.org/" href="https://www.velocidadcuchara.com/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://www.velocidadcuchara.com/wp-json/wp/v2/posts/44981" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.velocidadcuchara.com/xmlrpc.php?rsd" />
+<meta name="generator" content="WordPress 6.8.2" />
+<link rel='shortlink' href='https://www.velocidadcuchara.com/?p=44981' />
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Falbondigas-de-berenjena-con-tomate%2F" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Falbondigas-de-berenjena-con-tomate%2F&#038;format=xml" />
+			<style>.cmplz-hidden {
+					display: none !important;
+				}</style><style type="text/css">#logo {padding-top:20px;}#logo {padding-bottom:20px;}#logo {margin-left:0px;}#logo {margin-right:0px;}#nav-main {margin-top:25px;}#nav-main {margin-bottom:10px;}.headerfont, .tp-caption {font-family:Josefin Sans;} 
+  .topbarmenu ul li {font-family:Josefin Sans;}
+  #kadbreadcrumbs {font-family:Open Sans;}.home-message:hover {background-color:#8faa8f; background-color: rgba(143, 170, 143, 0.6);}
+  nav.woocommerce-pagination ul li a:hover, .wp-pagenavi a:hover, .panel-heading .accordion-toggle, .variations .kad_radio_variations label:hover, .variations .kad_radio_variations label.selectedValue {border-color: #8faa8f;}
+  a, #nav-main ul.sf-menu ul li a:hover, .product_price ins .amount, .price ins .amount, .color_primary, .primary-color, #logo a.brand, #nav-main ul.sf-menu a:hover,
+  .woocommerce-message:before, .woocommerce-info:before, #nav-second ul.sf-menu a:hover, .footerclass a:hover, .posttags a:hover, .subhead a:hover, .nav-trigger-case:hover .kad-menu-name, 
+  .nav-trigger-case:hover .kad-navbtn, #kadbreadcrumbs a:hover, #wp-calendar a, .star-rating {color: #8faa8f;}
+.widget_price_filter .ui-slider .ui-slider-handle, .product_item .kad_add_to_cart:hover, .product_item:hover a.button:hover, .product_item:hover .kad_add_to_cart:hover, .kad-btn-primary, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li a:hover, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li.chosen a,
+.product-category.grid_item a:hover h5, .woocommerce-message .button, .widget_layered_nav_filters ul li a, .widget_layered_nav ul li.chosen a, .wpcf7 input.wpcf7-submit, .yith-wcan .yith-wcan-reset-navigation,
+#containerfooter .menu li a:hover, .bg_primary, .portfolionav a:hover, .home-iconmenu a:hover, p.demo_store, .topclass, #commentform .form-submit #submit, .kad-hover-bg-primary:hover, .widget_shopping_cart_content .checkout,
+.login .form-row .button, .variations .kad_radio_variations label.selectedValue, #payment #place_order, .wpcf7 input.wpcf7-back, .shop_table .actions input[type=submit].checkout-button, .cart_totals .checkout-button, input[type="submit"].button, .order-actions .button  {background: #8faa8f;}a:hover {color: #b7bfaf;} .kad-btn-primary:hover, .login .form-row .button:hover, #payment #place_order:hover, .yith-wcan .yith-wcan-reset-navigation:hover, .widget_shopping_cart_content .checkout:hover,
+.woocommerce-message .button:hover, #commentform .form-submit #submit:hover, .wpcf7 input.wpcf7-submit:hover, .widget_layered_nav_filters ul li a:hover, .cart_totals .checkout-button:hover,
+.widget_layered_nav ul li.chosen a:hover, .shop_table .actions input[type=submit].checkout-button:hover, .wpcf7 input.wpcf7-back:hover, .order-actions .button:hover, input[type="submit"].button:hover, .product_item:hover .kad_add_to_cart, .product_item:hover a.button {background: #b7bfaf;}input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; } input[type=number] {-moz-appearance: textfield;}.quantity input::-webkit-outer-spin-button,.quantity input::-webkit-inner-spin-button {display: none;}#containerfooter h3, #containerfooter, .footercredits p, .footerclass a, .footernav ul li a {color:#c6c6c6;}.topclass {background:transparent    ;}.navclass {background:#23282d    ;}.mobileclass {background:#23282d    ;}.footerclass {background:#23282d    ;}.product_item .product_details h5 {text-transform: none;} @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {#logo .kad-standard-logo {display: none;} #logo .kad-retina-logo {display: block;}}.product_item .product_details h5 {min-height:40px;}[class*="wp-image"] {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}[class*="wp-image"]:hover {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}.light-dropshaddow {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;}/*::::::::::::::::::::::::::::::::::::::::: PÁGINA LIBRO VC ::::::::::::::::::::::::::::::::::*/
+
+#textolibrovc {
+    font-family: "Open Sans";
+    line-height: 28px;
+    font-weight: 400;
+    font-style: normal;
+    font-size: 20px;
+}
+
+#titulibrovc {
+    font-family: "Josefin Sans";
+    line-height: 40px;
+    font-weight: 600;
+    font-style: normal;
+    font-size: 30px;
+}
+
+.page-id-56361 .titleclass { background-color: #c08993; } 
+.page-id-58566 .titleclass { background-color: #757575; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO PODCAST ::::::::::::::::::::::::::::::::::*/
+
+.page-id-59933 .titleclass { 
+background-image: url("https://velocidadcuchara.com/recursos/fondo_cabecera_pvc.png");
+margin-top: -15px; 
+background-color: #ad6b77; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO RADIO  ::::::::::::::::::::::::::::::::::*/
+    
+.page-id-57235 .titleclass { 
+background-color: #2d2f39; 
+;} 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESTILOS RELACIONADOS ::::::::::::::::::::::::::::::::::*/
+
+.bcarousellink>header>h5 {
+    padding: 0;
+    margin: 0;
+font-size:18px;
+font-weight: bold;
+}
+
+.bcarousellink>header .subhead {
+    text-align: right;
+display:none;
+}
+
+.post-grid .item .layer-media img {
+    border-radius: 50;
+    box-shadow: none;
+    width: 100%;
+    border-radius: 15px;
+}
+
+
+/*::::::::::::::::::::::::::::::::::::::::: CASILLA RGPD COMENTARIOS ::::::::::::::::::::::::::::::::::*/
+
+#commentform input {
+    display: inline-grid;
+}
+
+/*:::::::::::::::::::::::::::::::::::::::::  ELIMINAR ADMIN BAR WP ::::::::::::::::::::::::::::::::::*/
+
+#wpadminbar { display:none; }
+
+/*::::::::::::::::::::::::::::::::::::::::: CABECERA 10 ANIVERSARIO ::::::::::::::::::::::::::::::::::*/
+
+#thelogo .kad-standard-logo  {max-height: 100%}
+#thelogo .kad-retina-logo  {max-height: 100%}
+
+@media (min-width: 1024px) {NAV
+    #thelogo { width: 120%}
+}
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL HALLOWEEN ::::::::::::::::::::::::::::::::::*/
+
+.page-id-7832 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/10/fondo_cabecera_halloween_trans.png");
+    margin-top: -15px; background-color: #363636; background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-7832 .page-header .entry-title {  color: #ffa200; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CABECERA ::::::::::::::::::::::::::::::::::*/
+
+.page-id-8160 .titleclass { 
+background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; 
+background-color: #F3F3F3; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-8160 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700;} 
+
+.page-id-8160 .page-header > p {
+    color: #aa0000 } 
+
+.page-id-8160 .sidebar a {
+    color: #aa0000 } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-781 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+
+.category-781 .page-header .entry-title { 
+font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+
+.category-781 .page-header > p {
+    color: #aa0000 } 
+.category-781 .sidebar a {
+    color: #aa0000 } 
+
+.category-778 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-778 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-778 .page-header > p {
+    color: #aa0000 } 
+.category-778 .sidebar a {
+    color: #aa0000 } 
+
+.category-779 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-779 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-779 .page-header > p {
+    color: #aa0000 } 
+.category-779 .sidebar a {
+    color: #aa0000 } 
+
+.category-780 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-780 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-780 .page-header > p {
+    color: #aa0000 }
+.category-780 .sidebar a {
+    color: #aa0000 }  
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL SSANTA CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-121 .titleclass { background-color: #444560; } 
+
+/*:::::::::::::::::::::::::::::::::::::::::GENERAL ::::::::::::::::::::::::::::::::::*/
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+/*TOPBAR */
+
+/*iconos redes */
+.so-widget-sow-social-media-buttons .sow-social-media-button {
+padding:0.2em !important;}
+
+/* color del buscador textos y labels*/
+#topbar .form-search {border: 1px solid #000;}
+#topbar .form-search .search-icon {color: #000;}
+#topbar .form-search input[type="text"] {color: #000;}
+#topbar .topbar-widget {color: #000;}
+#topbar .form-search input[type="text"]::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]::-moz-placeholder { /* Firefox 19+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-ms-input-placeholder { /* IE 10+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-moz-placeholder { /* Firefox 18- */
+  color: #bdbeb2;
+}
+
+/*MENU FIJO PRINCIPAL*/
+.navclass.stickytop {
+   z-index: 9999; 
+   position: fixed; 
+   left: 0; 
+   top: 0; 
+   width: 100%
+}
+
+/*BREADCRUMBS*/
+#breadcrumbs {
+    color: #f2f2f2;
+    font-size: 0.8em;
+}
+#breadcrumbs a {
+    color: #f1f1f1;
+    text-decoration: underline;
+}
+
+/* margen superior de la página de resultado de búsquedas*/
+.search-results .wrap.contentclass .main.col-lg-9.col-md-8.postlist {
+ 	margin-top: 50px;
+}
+/* margen superior de página "estilo" blog*/
+.page-template-page-blog .main.col-lg-9.col-md-8.postlist {
+    margin-top: 50px;
+}
+
+/* etiqueta "publicidad" bloques de publicidad*/
+.local-adlabel {
+    color: #bdbeb2;
+    font-size: 14px;
+    font-style: italic;
+   text-align:center;
+}
+
+/* :::::::::::::::::::::::::::: HEADER ::::::::::::::::::::::::::::::: */
+/*tag line*/
+.kad_tagline {
+ margin-top: 20px;
+    padding-left: 0.1em;
+}
+
+/*títulos páginas*/
+.page-header{
+border-top: 0 solid rgba(0, 0, 0, 0);
+border-bottom: 0 solid rgba(0, 0, 0, 0);
+margin-bottom:0;
+}
+.titleclass {
+    background-color: #bdbeb2;
+margin-top:-15px;
+}
+.page-header .entry-title {
+padding:0.5em;
+text-transform: uppercase;
+color:#fff;
+}
+
+/*titulos páginas - visión móvil*/
+@media (max-width: 768px){
+.page-header {text-align:center;
+}
+}
+
+/* textos descripción categorias*/
+
+/* Menú principal*/
+#nav-second ul.sf-menu .menu-inicio.current-menu-item > a{
+   background-color: #fff;
+    color: #d36a5f ;
+}
+
+/* :::::: COLUMNA ::::: SIDEBAR :::::: */
+.sidebar .menu{
+font-family: "Josefin Sans";
+font-weight:600;
+margin-top: 30px;
+text-transform:uppercase;
+}
+.sidebar .widget-inner li {
+    border-bottom: 1px solid rgba(189, 190, 178, 0.5);
+    line-height: 40px;
+   }
+
+.sidebar .widget-title {
+    text-align: center;
+}
+
+/* títulos enlaces de videos en sidebar columna*/
+
+.titulovideo h3 { font-family:"Open Sans";
+font-size: 1em; 
+font-weight:600;
+text-align: center;
+
+}
+
+.sidebar .widget-inner .so-widget-sow-image > h3 {
+    text-align: center;
+}
+
+.so-widget-image {
+    border-radius: 15px;
+}
+
+/* botón suscripción*/
+#submitbox input[type="submit"] {
+    background-color: #bdbeb2;
+    color: #fff;
+    font-size: 0.9em;
+    font-style: italic;
+}
+
+/* Tïtulos de "Los más leídos"*/
+.wtpsw-post-thumb-right {
+    display: table-cell;
+    vertical-align: middle;
+}
+.wtpsw-post-thumb-right h6 a.wtpsw-post-title {
+    color: #555;
+    font-family: "Josefin Sans";
+    font-size: 1.3em;
+    line-height: 1.4em;
+    text-transform: uppercase;
+}
+
+/* fondo y bordes "Los más leídos"*/
+.wtpsw-post-items {
+    background-color: #e7e8e1;
+    border-radius: 12px;
+    padding-right: 0.5em;
+}
+
+/* botones categorías blog Te Cuento*/
+.sidebar .widget_sow-button {
+margin-bottom:-20px;
+}
+
+
+
+/*::::::::::::::::::::::::: POST GRID en páginas internas :::::::::::::::::::::::::::*/
+.post-grid .item {
+border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+/* navegadores entre páginas <<    >>*/
+.pagination.dark br {
+    display: none;
+}
+
+/* botones números  paginación */
+
+.post-grid .pagination.dark .page-numbers {
+color:#8faa8f;
+font-weight:700;
+margin:5px;
+background:#fff none repeat scroll 0 0;
+border: 2px solid rgba(0, 0, 0, 0.05);
+padding: 4px 10px;
+line-height: 37px;
+transition: border 0.2s ease-in-out 0s;
+
+}
+
+.post-grid .pagination.dark .page-numbers:hover{
+background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+border-color:#b7bfaf;
+}
+.post-grid .pagination.dark .current {
+    color:#222222;
+    background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+   border: 2px solid rgba(0, 0, 0, 0.05) !important;
+
+}
+
+
+/* mensaje de ERROR 404*/
+.alert {text-align:center; margin-top:50px;}
+.onomatopeya { font-size:2.5em; font-family:"Josefin Sans"; font-weight:600;}
+.error{font-size:1.6em; font-weight:300; line-height:1.3em;}
+
+.alert .form-search {
+margin-bottom:10px;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 303px;
+}
+
+
+/*:::::::::::::::::::::::::::::::::::::::::HOME:::::::::::::::::::::::::::::::::::::::*/
+
+.home-padding {
+padding-top:0;
+}
+.hometitle{
+padding-bottom:15px;
+}
+
+/*slide textos*/
+
+.kt-full-slider .flex-caption-case .captiontitle {
+    background: #c08993b0;
+    padding-top: 15px;
+    color: #ffffff;
+    font-size: 40px;
+    text-transform: uppercase;
+    text-shadow: 1px 1px 4px rgba(0, 0, 0, 0);
+    font-weight: 700;
+    letter-spacing: -1.5px;
+}
+
+.kt-full-slider .flex-caption-case .captiontext {
+    background: #ffffffc2;
+    color: #444;
+    text-shadow: 1px 1px 4px #eee;
+    font-size: 35px;
+    font-weight: 300;
+    letter-spacing: -2px;
+
+}
+
+/* receta principal destacada ocultar foto destacada */
+#post-grid-44850 .item .layer-media img {
+display:none;}
+
+/* receta principal destacada quitar borde recuadro*/
+#post-grid-44850 .item {
+border:none;}
+
+/* publicidad en el cuerpo de la home*/
+.publicidad{
+	margin-top:-40px;
+}
+
+/* imagenes de enlaces e iconos */
+.sow-masonry-grid-item:hover{
+opacity:0.7;
+}
+
+/*carrusel*/
+.sow-carousel-title a.sow-carousel-next {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+.sow-carousel-title a.sow-carousel-previous {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-wrapper ul.sow-carousel-items li.sow-carousel-item .sow-carousel-thumbnail a span.overlay {
+    background: #bebdbd none repeat scroll 0 0;}
+
+/* :::::::::::::::::::::::::::::::::::::::: RECETAS :::::::::::::::::::::::::::::::::::::::::::*/
+
+/* índice de recetas*/
+
+.azindex .head {
+    color: #000;
+}
+
+.azindex h4 {
+    border-bottom: 1px solid #ccc;
+    width: 90%;
+}
+.azindex h2 >a {
+color: #000;
+}
+.azlinks .azlink{
+display:inline-flex
+}
+.azlinks .azlink >a {
+      color: #000;
+    font-family: "josefin sans";
+    font-size: 1.2em;
+    font-weight: 700;
+    margin: 0.15em;
+    text-align: center;
+}
+
+
+/*visión movil*/
+@media (max-width: 600px){
+.azindex{width:100% !important;}
+}
+
+/* ::::::::::::::::::::  PÁGINAS INTERIORES DE RECETAS ::::::::::::::::::::::::*/
+.pagrecetcab {
+    margin-bottom: -30px;
+    margin-top: -30px;
+}
+
+/* :::::::::::::::::::::::::: CATEGORIAS RECETAS ::::::::::::::::::::::::::::::::::::::::::*/
+/* div del menu de tipos de recetas*/
+.recetnav {
+    margin-bottom: 40px;
+    margin-top: 40px;
+}
+
+/* texto descripción de la categoría*/
+.page-header > p {
+    color: #fff;
+    font-family:Open Sans;  /*"Josefin Sans";*/
+    font-size: 1.3em;
+    font-weight: 300;
+    padding-left: 1em;
+    margin-top: -20px;
+  padding-bottom:0.5em;
+line-height: 1.3em;
+
+}
+
+@media (max-width: 768px){
+.page-header > p {font-size:1em;
+}
+}
+
+/* ::::::::::::::::::::::::::::::::: POST RECETA :::::::::::::::::::::::::::*/
+.single-article article h1 { font-family:"Open Sans";
+/*border-bottom:1px solid #24292e;
+width:85%;*/
+text-decoration:none;
+padding-bottom:5px;}
+.postedintop{display:none}
+.single-footer .posttags a {
+font-size:16px;
+}
+
+/* Línea autora y comentarios*/
+.subhead {
+    margin-top: -12px;
+}
+/* ocultar divisor de más  entre "autora" "comentarios" post */
+.kad-hidepostedin {
+    display: none;
+}
+.postcommentscount {
+    margin-left: -2px;
+}
+
+/* Línea iconos redes*/
+.addtoany_share_save_container.addtoany_content_top {
+    margin-left: -5px;
+    margin-top: -5px;
+}
+
+/* etiquetas de ingredientes ocultas*/
+.single-footer .posttags {
+    display: none;
+}
+
+/* recetas plugin recipe en movil*/
+@media (max-width: 560px){
+.easyrecipe .ERSTimes .ERSTime {
+    float: left;
+    font-weight: bold;
+    min-width: 120px;
+    text-align: center;
+    width: 100%;
+    border:1px dotted #bdbeb2;}
+}
+
+easyrecipe-styl…ver=3.2.2708.1
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+
+/* ::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD :::::::::::::::::::::::::::: */
+.desnavidad {
+    border: 3px solid #bdbeb2;
+    border-radius: 20px;
+    padding: 1.5em  0.5em  0.2em 0.5em;
+  }
+
+.desnavidad h3 {
+   text-align:center;
+  font-family: 'Josefin Sans';
+  text-transform: uppercase; 
+ margin-bottom: 40px;
+ font-size:2.0em;
+color:#aa0000;
+}
+
+/* ::::::::::::::::::::::::::::::::::: VISIÓN TABLET :::::::::::::::::::::::::::::::::::::*/
+.iconhover{ width:80%;}
+/* Tablet APAISADA*/
+@media (min-width: 1020px) and (max-width: 1025px){
+.container{width:1010px;}
+}
+/* ajuste de padding izquierdo de receta en resultdos de búqueda 
+o visión tipo categorias para tablet apaisada*/
+@media (min-width: 768px) and (max-width: 1025px){
+.col-md-7.post-text-container.postcontent {
+padding-left:32px;
+}
+}
+/* whatsapp*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_whatsapp {
+display:none;}
+}
+
+/* telegram*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_telegram {
+display:none;}
+}
+
+
+/* ::::::::::::::::::::::::::: ELIMINAR BORDE AVATAR COMENT :::::::::::::::::::::::::: */
+
+.comment .avatar { border: 0px solid #f0eef0;
+}
+
+/* :::::::::::::::::::::::::::::::::: BOTONES CARRUSEL PORTADA ::::::::::::::::::::::::::::::::::::::::::::::: */
+
+.sow-carousel-title a.sow-carousel-next {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-title a.sow-carousel-previous {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-right: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+
+/* :::::::::::::::::::::::::::::::::: FOOTER ::::::::::::::::::::::::::::::::::::::::::::::: */
+/*Créditos*/
+.footercredits.clearfix {
+float:right;
+}
+.footercredits.clearfix > p {
+    font-size: 0.85em;
+    line-height: 1.5em;
+}
+
+.freehare {
+    font-size: 0.86em;
+}
+
+/* :::::::::::::::::::::::::::::::::: CHECKBOX ::::::::::::::::::::::::::::::::::::::::::::::: */
+.form-check {
+  width: 1em;
+  height: 1em;
+  vertical-align: top;
+}
+</style>
+<!-- Matomo -->
+<script type="rocketlazyloadscript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://estadisticas.mediasector.es/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '34']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
+		<script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+			var advadsCfpQueue = [];
+			var advadsCfpAd = function( adID ) {
+				if ( 'undefined' === typeof advadsProCfp ) {
+					advadsCfpQueue.push( adID )
+				} else {
+					advadsProCfp.addElement( adID )
+				}
+			}
+		</script>
+		<!--[if lt IE 9]>
+<script src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/vendor/respond.min.js"></script>
+<![endif]-->
+<style type="text/css">
+html body div.easyrecipe .ERSNotesDiv .ERSNotesHeader { font-size: 18px!important;font-style: italic!important;margin-top: 21px!important;margin-bottom: 1px!important;margin-left: 41px!important; }
+html body div.easyrecipe .ERSNotesDiv .ERSNotes { font-style: italic!important;font-size: 15px!important;padding-left: 39px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe .ERSName { font-family: inherit!important;color: rgb(5, 5, 5)!important;font-weight: bold!important;font-size: 27px!important;margin-top: 31px!important;margin-bottom: 16px!important;margin-left: 1px!important;padding-top: 1px!important;padding-left: 2px!important; }
+html body div.easyrecipe .ERSTimes { color: rgb(5, 5, 5)!important;margin-top: 10px!important;margin-bottom: 9px!important;padding-top: 8px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSTimes .ERSTimeItem { color: rgb(5, 5, 5)!important;font-size: 14px!important;margin-bottom: 9px!important;margin-left: -4px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSSummary { font-family: inherit!important;font-weight: bold!important;font-size: 18px!important;margin-top: 10px!important;margin-bottom: 8px!important;margin-left: 1px!important;padding-top: 6px!important;padding-right: 2px!important; }
+html body div.easyrecipe .ERSAuthor { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important;margin-left: 0px!important; }
+html body div.easyrecipe .ERSCategory { padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSCuisine { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSServes { font-size: 15px!important;padding-left: 0px!important; }
+html body div.easyrecipe .ERSPrintBtnSpan .ERSPrintBtn { font-family: inherit!important;background-color: rgb(189, 190, 178)!important;font-weight: bold!important;font-size: 14px!important;margin-top: -10px!important;margin-bottom: -11px!important;margin-right: 2px!important;padding: 8px!important; }
+html body div.easyrecipe .ERSIngredientsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;margin: 24px -3px 20px 0px!important;padding-left: 21px!important;font-weight: normal!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSIngredients li.ingredient { font-size: 15px!important;list-style-type: circle!important;margin: -4px -10px 8px 13px!important;padding-left: 3px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructionsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;font-weight: normal!important;margin-top: 24px!important;margin-bottom: 9px!important;margin-right: -2px!important;padding-left: 21px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructions .instruction { font-size: 15px!important;margin: 12px -6px 12px 32px!important;padding: 0px 20px 6px 9px!important;font-family: inherit!important; }
+div.easyrecipe { border-radius:18px; font-family: 'Open Sans' !important;}
+.ERSRatingOuter .review {
+margin-top:0.5em;
+}
+
+div.easyrecipe div.ERSSavePrint span.ERSPrintBtnSpan a.ERSPrintBtn span.ERSPrintIcon {
+background-image: url(images/printicon.png);
+width: 16px;
+height: 16px;
+display: none;
+/* padding-top: 20px; */
+}</style>
+<style type="text/css" class="options-output">header #logo a.brand,.logofont{font-family:Lato;line-height:40px;font-weight:400;font-style:normal;font-size:32px;}.kad_tagline{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;color:#444444;font-size:20px;}.product_item .product_details h5{font-family:Lato;line-height:20px;font-weight:700;font-style:normal;font-size:16px;}h1{font-family:"Josefin Sans";line-height:40px;font-weight:600;font-style:normal;font-size:32px;}h2{font-family:"Josefin Sans";line-height:32px;font-weight:400;font-style:normal;font-size:28px;}h3{font-family:"Josefin Sans";line-height:28px;font-weight:400;font-style:normal;font-size:24px;}h4{font-family:"Open Sans";line-height:24px;font-weight:400;font-style:normal;font-size:20px;}h5{font-family:"Josefin Sans";line-height:22px;font-weight:300;font-style:normal;font-size:18px;}body{font-family:"Open Sans";line-height:25px;font-weight:400;font-style:normal;font-size:16px;}#nav-main ul.sf-menu a{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;font-size:22px;}#nav-second ul.sf-menu a{font-family:"Josefin Sans";line-height:20px;font-weight:600;font-style:normal;font-size:16px;}.kad-nav-inner .kad-mnav, .kad-mobile-nav .kad-nav-inner li a,.nav-trigger-case{font-family:"Josefin Sans";line-height:22px;font-weight:600;font-style:normal;font-size:16px;}</style><style type="text/css">/** Mega Menu CSS Disabled **/</style>
+
+    <!-- Custom scripts -->
+
+
+<!-- Menú fijo-->
+
+<script type="rocketlazyloadscript">jQuery("document").ready(function($){
+
+	var nav = $('.navclass');
+
+	$(window).scroll(function () {
+		if ($(this).scrollTop() > 173) {
+			nav.addClass("stickytop");
+		} else {
+			nav.removeClass("stickytop");
+		}
+	});
+
+});
+
+</script>
+
+<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style><meta name="generator" content="WP Rocket 3.20.4" data-wpr-features="wpr_delay_js wpr_defer_js wpr_minify_js wpr_preconnect_external_domains wpr_automatic_lazy_rendering wpr_oci wpr_minify_css wpr_preload_links wpr_desktop" /></head>
+  	
+  	<body data-cmplz=1 class="wp-singular post-template-default single single-post postid-44981 single-format-standard wp-theme-virtue wp-child-theme-velocidad mega-menu-secondary-navigation mega-menu-max-mega-menu-1 mega-menu-max-mega-menu-2 mega-menu-max-mega-menu-3 mega-menu-max-mega-menu-4 mega-menu-max-mega-menu-6 mega-menu-max-mega-menu-7 mega-menu-max-mega-menu-8 mega-menu-max-mega-menu-9 mega-menu-max-mega-menu-10 mega-menu-max-mega-menu-11 mega-menu-max-mega-menu-12 wide albondigas-de-berenjena-con-tomate aa-prefix-local- er-recipe">
+  	<div  id="kt-skip-link"><a href="#content">Skip to Main Content</a></div>
+    <div  id="wrapper" class="container">
+    <header  class="banner headerclass" itemscope itemtype="http://schema.org/WPHeader">
+  <div  id="topbar" class="topclass">
+    <div  class="container">
+      <div class="row">
+        <div class="col-md-6 col-sm-6 kad-topbar-left">
+          <div class="topbarmenu clearfix">
+                                </div>
+        </div><!-- close col-md-6 --> 
+        <div class="col-md-6 col-sm-6 kad-topbar-right">
+          <div id="topbar-search" class="topbar-widget">
+            <form role="search" method="get" class="form-search" action="https://www.velocidadcuchara.com/">
+  <label>
+  	<span class="screen-reader-text">Búsqueda para:</span>
+  	<input type="text" value="" name="s" class="search-query" placeholder="Busca tu receta">
+  </label>
+  <button type="submit" class="search-icon"><i class="icon-search"></i></button>
+</form>        </div>
+        </div> <!-- close col-md-6-->
+      </div> <!-- Close Row -->
+    </div> <!-- Close Container -->
+  </div><div  class="container">
+  <div class="row">
+      <div class="col-md-4 clearfix kad-header-left">
+            <div id="logo" class="logocase">
+              <a class="brand logofont" href="https://www.velocidadcuchara.com/">
+                                  <div id="thelogo">
+                    <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-standard-logo" />
+                                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-retina-logo" style="max-height:121px" />                   </div>
+                              </a>
+                         </div> <!-- Close #logo -->
+       </div><!-- close logo span -->
+              
+    </div> <!-- Close Row -->
+     
+</div> <!-- Close Container -->
+    <section id="cat_nav" class="navclass">
+    <div class="container">
+      <nav id="nav-second" class="clearfix" itemscope itemtype="http://schema.org/SiteNavigationElement">
+        <div id="mega-menu-wrap-secondary_navigation" class="mega-menu-wrap"><div class="mega-menu-toggle" tabindex="0"><div class='mega-toggle-block mega-menu-toggle-block mega-toggle-block-right mega-toggle-block-1' id='mega-toggle-block-1'></div></div><ul id="mega-menu-secondary_navigation" class="mega-menu mega-menu-horizontal mega-no-js" data-event="hover_intent" data-effect="fade_up" data-effect-speed="200" data-second-click="close" data-document-click="collapse" data-vertical-behaviour="accordion" data-breakpoint="768" data-unbind="true"><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-58762' id='mega-menu-item-58762'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/indice-recetas-thermomix/" tabindex="0">Índice</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58774' id='mega-menu-item-58774'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/todas-las-recetas/" aria-haspopup="true" tabindex="0">Recetas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-custom mega-menu-item-object-custom mega-menu-item-58775' id='mega-menu-item-58775'><a class="mega-menu-link" href="https://velocidadcuchara.com/todas-las-recetas/">Todas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58778' id='mega-menu-item-58778'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/carnes/">Carnes</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58779' id='mega-menu-item-58779'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/pescados-y-marisco/">Pescados y mariscos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58780' id='mega-menu-item-58780'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/ensaladas/">Ensaladas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-menu-item-58781' id='mega-menu-item-58781'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/legumbres-y-verduras/">Legumbres y verduras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58782' id='mega-menu-item-58782'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/arroces-y-pastas/">Arroces y pastas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58783' id='mega-menu-item-58783'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sopas-y-cremas/">Sopas y cremas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58784' id='mega-menu-item-58784'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/masas-y-pan/">Masas y pan</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58785' id='mega-menu-item-58785'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/reposteria/">Repostería</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58786' id='mega-menu-item-58786'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/postres-y-dulces/">Postres y dulces</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58787' id='mega-menu-item-58787'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/conservas-y-confituras/">Conservas y confituras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-59720' id='mega-menu-item-59720'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/desayuno/">Desayunos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58788' id='mega-menu-item-58788'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/bebidas/">Bebidas y cócteles</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58789' id='mega-menu-item-58789'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetarios/">Recetarios</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58803' id='mega-menu-item-58803'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dos-en-uno/">Dos en uno</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58776' id='mega-menu-item-58776'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/dietas/" aria-haspopup="true" tabindex="0">Dietas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58790' id='mega-menu-item-58790'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-gluten/">Sin gluten</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58791' id='mega-menu-item-58791'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-lactosa/">Sin lactosa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58792' id='mega-menu-item-58792'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-huevo/">Sin huevo</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58793' id='mega-menu-item-58793'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-azucar/">Sin azúcar</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58794' id='mega-menu-item-58794'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/vegetariana/">Vegetariana</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58795' id='mega-menu-item-58795'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/hipocalorica/">Hipocalórica</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58777' id='mega-menu-item-58777'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas-sin-thermomix/" aria-haspopup="true" tabindex="0">Sin TMX</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58798' id='mega-menu-item-58798'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/olla-rapida/">Olla rápida</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58797' id='mega-menu-item-58797'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/cocotte/">Cocotte</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-60222' id='mega-menu-item-60222'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/freidora-de-aire/">Freidora de aire</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58799' id='mega-menu-item-58799'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/crock-pot/">Crock Pot</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58796' id='mega-menu-item-58796'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/kitchenaid/">Kitchenaid</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58801' id='mega-menu-item-58801'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/al-vacio/">Al vacío</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58800' id='mega-menu-item-58800'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/barbacoa/">Barbacoa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58802' id='mega-menu-item-58802'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/otros/">Otros</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58763' id='mega-menu-item-58763'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" aria-haspopup="true" tabindex="0">Libros</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58765' id='mega-menu-item-58765'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-cocina-rico-todos-los-dias-thermomix/">Cocina rico todos los días</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58764' id='mega-menu-item-58764'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-mis-recetas-imprescindibles-thermomix/">Mis recetas imprescindibles</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-60105' id='mega-menu-item-60105'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/podcast-velocidad-cuchara/" tabindex="0">🎧 Pódcast</a></li></ul></div>      </nav>
+    </div><!--close container-->
+  </section>
+  </header>
+      <div  class="wrap contentclass" role="document">
+
+        <div  id="content" class="container">
+    <div class="row single-article" itemscope itemtype="http://schema.org/BlogPosting">
+        <div class="main col-lg-9 col-md-8" role="main">
+                    <article class="post-44981 post type-post status-publish format-standard has-post-thumbnail hentry category-60-minutos category-dietas category-guarniciones-y-salsas category-hipocalorica category-otono category-primavera category-recetas category-segundos-dieta category-sin-azucar category-sin-lactosa category-tupper category-vegetariana category-verduras-y-hortalizas tag-ajos tag-albahaca tag-azucar-blanquilla tag-berenjenas tag-huevos tag-pan tag-perejil tag-pimienta-negra tag-tomates-enteros-pelados course-verduras cuisine-espanola">
+            <div class="meta_post_image" itemprop="image" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1.jpg"><meta itemprop="width" content="1200"><meta itemprop="height" content="801"></div>
+                <div class="postmeta updated color_gray">
+      <div class="postdate bg-lightgray headerfont" itemprop="datePublished">
+      <span class="postday">26</span>
+      Abr 2017    </div>
+</div>                <header>
+                    <h1 class="entry-title" itemprop="name headline">Albóndigas de berenjena con tomate</h1><div class="subhead">
+    <span class="postauthortop author vcard">
+    <i class="icon-user"></i> por  <span itemprop="author"><a href="https://www.velocidadcuchara.com/author/admin/" class="fn" rel="author">Rosa Ardá</a></span> |</span>
+      
+    <span class="postedintop"><i class="icon-folder-open"></i> publicado en: <a href="https://www.velocidadcuchara.com/tiempo/60-minutos/" rel="category tag">60 minutos</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/" rel="category tag">Dietas</a>, <a href="https://www.velocidadcuchara.com/recetas/guarniciones-y-salsas/" rel="category tag">Guarniciones y salsas</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/hipocalorica/" rel="category tag">Hipocalórica</a>, <a href="https://www.velocidadcuchara.com/recetas/estaciones/otono/" rel="category tag">Otoño</a>, <a href="https://www.velocidadcuchara.com/recetas/estaciones/primavera/" rel="category tag">Primavera</a>, <a href="https://www.velocidadcuchara.com/recetas/" rel="category tag">Recetas</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/hipocalorica/segundos-dieta/" rel="category tag">Segundos dieta</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/sin-azucar/" rel="category tag">Sin azúcar</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/sin-lactosa/" rel="category tag">Sin lactosa</a>, <a href="https://www.velocidadcuchara.com/recetas/tupper/" rel="category tag">Tupper</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/vegetariana/" rel="category tag">Vegetariana</a>, <a href="https://www.velocidadcuchara.com/recetas/legumbres-y-verduras/verduras-y-hortalizas/" rel="category tag">Verduras y hortalizas</a></span>     <span class="kad-hidepostedin">|</span>
+    <span class="postcommentscount">
+    <i class="icon-comments-alt"></i> 107    </span>
+</div>                </header>
+
+                <div class="entry-content" itemprop="articleBody">
+                    <p><a href="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1.jpg"><picture fetchpriority="high" decoding="async" class="aligncenter size-large wp-image-45776">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-1024x684.jpg.webp 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-300x200.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-768x513.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-272x182.jpg.webp 272w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1.jpg.webp 1200w" sizes="(max-width: 1024px) 100vw, 1024px"/>
+<img fetchpriority="high" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-1024x684.jpg" alt="" width="1024" height="684" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-1024x684.jpg 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-300x200.jpg 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-768x513.jpg 768w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-272x182.jpg 272w, https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px"/>
+</picture>
+</a></p>
+<div class="space_20 clearfix"></div>
+<p><strong>¡Albóndigassss de berenjenas al horno!!!! Más sano imposible</strong>. Me enamoré de la receta en cuanto la vi en la última revista de Thermomix®. Ya sabéis que hace poco os hice unos <a title="Canelones de berenjenas" href="https://www.velocidadcuchara.com/canelones-de-berenjena-para-dieta/" target="_blank" rel="noopener noreferrer"><em><strong>canelones de berenjena</strong></em></a> que quedan buenísimos, y me apetecía probar esta receta y no me ha defraudado.</p><script type="text/plain" data-tcf="waiting-for-consent" data-id="45718" data-bid="1" data-placement="61266">PGRpdiBpZD0ibG9jYWwtMjAwODkxNzcwMCIgY2xhc3M9Imdhc19mYWxsYmFjay1hZF80NTcxOC0tcGxhY2VtZW50XzYxMjY2IiBzdHlsZT0ibWFyZ2luLXRvcDogMjBweDttYXJnaW4tYm90dG9tOiAyMHB4OyI+PHNjcmlwdCBhc3luYyBzcmM9Ii8vcGFnZWFkMi5nb29nbGVzeW5kaWNhdGlvbi5jb20vcGFnZWFkL2pzL2Fkc2J5Z29vZ2xlLmpzP2NsaWVudD1jYS1wdWItMDQzMjcyNjA0MDAwOTY3NiIgY3Jvc3NvcmlnaW49ImFub255bW91cyI+PC9zY3JpcHQ+PGlucyBjbGFzcz0iYWRzYnlnb29nbGUiIHN0eWxlPSJkaXNwbGF5OmJsb2NrOyIgZGF0YS1hZC1jbGllbnQ9ImNhLXB1Yi0wNDMyNzI2MDQwMDA5Njc2IiAKZGF0YS1hZC1zbG90PSI5ODk1NDgwOTQ4IiAKZGF0YS1hZC1mb3JtYXQ9ImF1dG8iPjwvaW5zPgo8c2NyaXB0PiAKKGFkc2J5Z29vZ2xlID0gd2luZG93LmFkc2J5Z29vZ2xlIHx8IFtdKS5wdXNoKHt9KTsgCjwvc2NyaXB0Pgo8L2Rpdj4=</script>
+<p><strong>La berenjena se cocina previamente con la Thermomix®</strong>, se hace un ligero sofrito y se consigue una pasta a medio triturar que se mezcla con pan rallado o pan troceado, huevo y especias. Una vez hecha la mezcla y tras darle forma de albóndiga,<strong> se hornean 20 minutos. No es necesario freír.</strong> Solo falta hacer una salsa de tomate y por favor, no comáis demasiado pan :D El día que preparéis esta receta probar con una pan integral en vez de uno blanco o un arroz integral, un poco de<a title="Recetas con Quinoa" href="https://www.velocidadcuchara.com/tag/quinoa/" target="_blank" rel="noopener noreferrer"><strong> quinoa</strong></a>, un <a title="Recetas con Cuscús" href="https://www.velocidadcuchara.com/tag/cuscus/" target="_blank" rel="noopener noreferrer"><strong>cuscús</strong></a>.</p>
+<p><span id="more-44981"></span><br />
+<div id="easyrecipe-44981-0" class="easyrecipe" itemscope itemtype="http://schema.org/Recipe"> <link itemprop="image" href="https://www.velocidadcuchara.com/wp-content/uploads/2017/04/Albondigas-de-berenjena-1-1024x684.jpg"/> <div class="ERSRatings" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"> <div class="ERSRatingOuter"> <div class="ERSRatingInner" style="width: 92%"></div> <div class="review"><span class="rating"><span class="average" itemprop="ratingValue">4.6</span> de <span class="count" itemprop="ratingCount">44</span> opiniones</span></div> </div> </div> <div itemprop="name" class="ERSName">Albóndigas de berenjena con salsa de tomate</div> <div class="ERSClear">&nbsp;</div> <div class="ERSTopRight"> <div class="ERSSavePrint"> <span class="ERSPrintBtnSpan"><a class="ERSPrintBtn" href="https://www.velocidadcuchara.com/easyrecipe-print/44981-0/" rel="nofollow" target="_blank">Imprimir</a></span> </div> </div> <div class="ERSTimes"> <div class="ERSTime"> <div class="ERSTimeHeading">Preparación</div> <div class="ERSTimeItem"> <time itemprop="prepTime" datetime="PT30M">30 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Cocción</div> <div class="ERSTimeItem"> <time itemprop="cookTime" datetime="PT30M">30 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Tiempo total</div> <div class="ERSTimeItem"> <time itemprop="totalTime" datetime="PT1H">1 h</time> </div> </div> <div class="ERSClearLeft">&nbsp;</div> </div> <div itemprop="description" class="ERSSummary">Receta de Albóndigas de berenjena con salsa de tomate en Thermomix. Sorprende su sabor por las especias. No tendrás que freírlas, bastará con hornearlas.</div> <div class="divERSHeadItems"> <div class="ERSAuthor">Autor: <span itemprop="author">Rosa Ardá</span></div> <div class="ERSCategory">Tipo de receta: <span itemprop="recipeCategory">Verduras</span></div> <div class="ERSCuisine">Cocina: <span itemprop="recipeCuisine">Española</span></div> <div class="ERSServes">Raciones: <span itemprop="recipeYield">6</span></div> </div> <div class="ERSIngredients"> <div class="ERSIngredientsHeader ERSHeading">Ingredientes</div> <ul> <li class="ingredient" itemprop="ingredients"><strong>Para las albóndigas:</strong></li> <li class="ingredient" itemprop="ingredients">4 dientes de ajo</li> <li class="ingredient" itemprop="ingredients">600 g de berenjena con piel en trozos de 2-3 cm</li> <li class="ingredient" itemprop="ingredients">30 g de aceite de oliva virgen extra</li> <li class="ingredient" itemprop="ingredients">60 g de agua -opcional-</li> <li class="ingredient" itemprop="ingredients">180 g de pan duro</li> <li class="ingredient" itemprop="ingredients">4 ramitas de perejil fresco</li> <li class="ingredient" itemprop="ingredients">unas hojas de albahaca fresca troceada</li> <li class="ingredient" itemprop="ingredients">1 huevo</li> <li class="ingredient" itemprop="ingredients">1 pizca de sal o al gusto</li> <li class="ingredient" itemprop="ingredients">1 pizca de Pimienta negra recién molida</li> <li class="ingredient" itemprop="ingredients"><strong>Para la salsa de tomate:</strong></li> <li class="ingredient" itemprop="ingredients">Un bote de 800 g de tomate entero pelado</li> <li class="ingredient" itemprop="ingredients">50 g de aceite de oliva virgen extra</li> <li class="ingredient" itemprop="ingredients">2 cucharadas de azúcar</li> <li class="ingredient" itemprop="ingredients">1 cucharadita de sal</li> <li class="ingredient" itemprop="ingredients">Albahaca fresca troceada para espolvorear</li> </ul> <div class="ERSClear"></div> </div> <div class="ERSInstructions"> <div class="ERSInstructionsHeader ERSHeading">Pasos a seguir</div> <ol> <li class="instruction" itemprop="recipeInstructions"><strong>Para las albóndigas:</strong> Pon 2 dientes de <strong>ajo en el vaso y pica 3 segundos en velocidad 7</strong>.<strong> Incorpora los 600 gr de berenjena</strong> en trozos <em>-yo corto en rodajas de 2 dedos de ancho y estos en 4 trozos-</em>, <strong>trocea 6 segundos en velocidad 4</strong>. Baja los restos de las paredes <strong>añade el aceite </strong>y<strong> sofríe 6 minutos, 120ºC o Varoma en velocidad 1.</strong></li> <li class="instruction" itemprop="recipeInstructions"><strong>Incorpora el agua y programa otros 6 minutos, 100ºC, velocidad 1.</strong> Después <strong>trocea 3 segundos en velocidad 5 </strong>y <strong>vierte la mezcla en una fuente</strong> o un bol para que atempere. <strong>Deja reposar unos 20 minutos.</strong></li> <li class="instruction" itemprop="recipeInstructions"><strong>Sin lavar el vaso</strong> y con este vacío, pon dentro el <strong>pan en trozos, 2 dientes de ajo, el perejil y la albahaca</strong> y<strong> tritura 10 segundos en velocidad 10</strong>. Baja los restos de las paredes.</li> <li class="instruction" itemprop="recipeInstructions">Añade el <strong>huevo, la sal, la pimienta y las carne de las berenjenas reservada</strong> y <strong>mezcla 15 segundos, giro a la izquierda y velocidad 3</strong>. <strong>Acaba de mezclar con la espátula</strong> y pasa a un cuenco. <strong>Precalienta el horno a 200ºC</strong>.</li> <li class="instruction" itemprop="recipeInstructions">Engrasa un<strong> molde apto para horno y ve formando bolitas con la masa y colocándolas en esta</strong>, te saldrán unas <strong>20-24 en total</strong> de unos 30 gr unidad. Usa una cuchara para coger siempre la misma cantidad. <strong>Hornea 20 minutos a 180ºC con calor arriba y abajo</strong> y mientras haz la salsa de tomate.</li> <li class="instruction" itemprop="recipeInstructions"><strong>Para la salsa de tomate:</strong> Pon<strong> todos los ingredientes</strong> en el vaso, incluido el jugo de los tomates y programa <strong>30 minutos, 120ºC o Varoma en velocidad 2</strong>. Una vez lista vierte sobre las albóndigas ya horneadas y <strong>decora con albahaca</strong> picada.</li> </ol> <div class="ERSClear"></div> </div> <div class="endeasyrecipe" title="style002a" style="display: none">3.5.3229</div> </div>
+Fuente: <span style="color: #808080;"><strong>Revista Thermomix nº 103.</strong></span></p>
+<div class="addtoany_share_save_container addtoany_content addtoany_content_bottom"><div class="a2a_kit a2a_kit_size_32 addtoany_list" data-a2a-url="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/" data-a2a-title="Albóndigas de berenjena con tomate"><a class="a2a_button_facebook" href="https://www.addtoany.com/add_to/facebook?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Falbondigas-de-berenjena-con-tomate%2F&amp;linkname=Alb%C3%B3ndigas%20de%20berenjena%20con%20tomate" title="Facebook" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_x" href="https://www.addtoany.com/add_to/x?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Falbondigas-de-berenjena-con-tomate%2F&amp;linkname=Alb%C3%B3ndigas%20de%20berenjena%20con%20tomate" title="X" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_pinterest" href="https://www.addtoany.com/add_to/pinterest?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Falbondigas-de-berenjena-con-tomate%2F&amp;linkname=Alb%C3%B3ndigas%20de%20berenjena%20con%20tomate" title="Pinterest" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_whatsapp" href="https://www.addtoany.com/add_to/whatsapp?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Falbondigas-de-berenjena-con-tomate%2F&amp;linkname=Alb%C3%B3ndigas%20de%20berenjena%20con%20tomate" title="WhatsApp" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_telegram" href="https://www.addtoany.com/add_to/telegram?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Falbondigas-de-berenjena-con-tomate%2F&amp;linkname=Alb%C3%B3ndigas%20de%20berenjena%20con%20tomate" title="Telegram" rel="nofollow noopener" target="_blank"></a></div></div>                </div>
+
+                <footer class="single-footer">
+                <span class="posttags"><i class="icon-tag"></i><a href="https://www.velocidadcuchara.com/tag/ajos/" rel="tag">Ajos</a>, <a href="https://www.velocidadcuchara.com/tag/albahaca/" rel="tag">Albahaca</a>, <a href="https://www.velocidadcuchara.com/tag/azucar-blanquilla/" rel="tag">Azúcar blanquilla</a>, <a href="https://www.velocidadcuchara.com/tag/berenjenas/" rel="tag">Berenjenas</a>, <a href="https://www.velocidadcuchara.com/tag/huevos/" rel="tag">Huevos</a>, <a href="https://www.velocidadcuchara.com/tag/pan/" rel="tag">Pan</a>, <a href="https://www.velocidadcuchara.com/tag/perejil/" rel="tag">Perejil</a>, <a href="https://www.velocidadcuchara.com/tag/pimienta-negra/" rel="tag">Pimienta negra</a>, <a href="https://www.velocidadcuchara.com/tag/tomates-enteros-pelados/" rel="tag">Tomates enteros pelados</a></span><meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/"><meta itemprop="dateModified" content="2018-02-21T07:14:02+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div>                </footer>
+            </article>
+            <div id="blog_carousel_container" class="carousel_outerrim">
+    <h3 class="title">Publicaciones Recientes</h3>    <div class="blog-carouselcase fredcarousel">
+    		<div id="carouselcontainer-blog" class="rowtight">
+		<div id="blog_carousel" class="blog_carousel caroufedselclass initcaroufedsel clearfix" data-carousel-container="#carouselcontainer-blog" data-carousel-transition="300" data-carousel-scroll="1" data-carousel-auto="true" data-carousel-speed="9000" data-carousel-id="blog" data-carousel-md="3" data-carousel-sm="3" data-carousel-xs="2" data-carousel-ss="1">
+            				<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61247 post type-post status-publish format-standard has-post-thumbnail hentry category-cocina-para-ninos category-dietas category-dulces-para-ninos category-postres-de-cuchara category-postres-y-dulces category-recetas category-sin-gluten category-sin-lactosa tag-azucar-blanquilla tag-esencia-de-vainilla tag-galletas-tipo-maria tag-huevos tag-leche-sin-lactosa course-postres-reposteria cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" title="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg" alt="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">23 octubre, 2025</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Cocina para todos una receta sin gluten y sin lactosa. Este Pudin te va a...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/"><meta itemprop="dateModified" content="2025-10-24T18:03:21+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-274 post type-post status-publish format-standard has-post-thumbnail hentry category-30-minutos category-dietas category-ensaladas category-estaciones category-frias category-hipocalorica category-pescado-azul category-pescados-y-marisco category-primeros-dieta category-recetas category-sin-azucar category-sin-gluten category-sin-lactosa category-verano category-verduras-y-hortalizas tag-aceitunas-negras tag-aceitunas-rellenas-de-anchoa tag-atun tag-cebollas-tomates tag-huevos tag-patatas tag-pimiento-rojo tag-pimiento-verde course-ensaladas cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/ensalada-campera/" title="Ensalada campera">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg" alt="Ensalada campera" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/ensalada-campera/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Ensalada campera</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">7 junio, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>En días de calor no hay nada más apetecible que una ensalada. Te propongo que...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/ensalada-campera/"><meta itemprop="dateModified" content="2025-11-30T17:58:48+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61149 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-estaciones category-invierno category-otono category-otros category-pescado-blanco category-pescados-y-marisco category-primavera category-recetas category-sin-thermomix category-tiempo category-tupper tag-ajos tag-bacalao tag-cebollas tag-guindillas tag-harina tag-perejil tag-pimienta-negra tag-sal tag-tomate-natural-triturado course-segundos-pescados cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" title="Bacalao en salsa de tomate">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg" alt="Bacalao en salsa de tomate" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Bacalao en salsa de tomate</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 abril, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Hoy quiero compartir con vosotros esta receta. ¿Sabéis lo buenísima que está? Es deliciosaaaaaaa. En...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/"><meta itemprop="dateModified" content="2025-11-30T18:03:39+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-10498 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-dulces category-fiestas category-masas-y-pan category-pan category-postres-de-cuchara category-postres-y-dulces category-recetas category-semana-santa tag-canela tag-cointreau tag-huevos tag-leche-entera tag-naranjas tag-pan course-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" title="Torrijas fritas de Semana Santa con Thermomix">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg" alt="Torrijas fritas de Semana Santa con Thermomix" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-730x730.jpg 730w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-365x365.jpg 365w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Torrijas fritas de Semana Santa con Thermomix</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">27 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¿Estáis listos para la segunda parte del &#8220;Pan para torrijas&#8221;? Pues agarraros a la silla...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/"><meta itemprop="dateModified" content="2024-03-27T11:23:07+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-60562 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-desayuno category-dulces category-estaciones category-fiestas category-freidora-de-aire category-masas-dulces category-postres-de-cuchara category-postres-y-dulces category-primavera category-recetas category-reposteria category-semana-santa category-sin-thermomix category-tiempo tag-azucar tag-azucar-blanquilla tag-canela tag-huevos tag-leche-entera tag-limones tag-pan course-reposteria-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" title="Mis primeras Torrijas en Freidora de aire o Airfryer">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg" alt="Mis primeras Torrijas en Freidora de aire o Airfryer" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-150x150.jpeg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-532x532.jpeg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Mis primeras Torrijas en Freidora de aire o Airfryer</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">5 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Receta de Torrijas de Semana Santa en freidora de aire o Airfryer. Prepáralas en pocos...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/"><meta itemprop="dateModified" content="2024-04-06T10:23:15+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61100 post type-post status-publish format-standard has-post-thumbnail hentry category-carne-de-pollo category-carnes category-cocina-del-mundo category-estaciones category-india category-invierno category-otono category-otros category-primavera category-recetas category-sin-thermomix category-tupper tag-aguacates tag-ajos tag-carne-de-pollo tag-fideos-de-arroz tag-jengibre tag-lima tag-miel tag-pimienta-negra tag-sal tag-salsa-de-soja tag-semillas-de-sesamo course-carnes-segundos" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" title="Pollo con soja y jengibre">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg" alt="Pollo con soja y jengibre" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pollo con soja y jengibre</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 enero, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¡Que se nota dicen!! Que si, que estoy feliz. Sobre todo estoy tranquila y este...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/"><meta itemprop="dateModified" content="2024-12-23T09:15:20+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+					</div>
+     <div class="clearfix"></div>
+            <a id="prevport-blog" class="prev_carousel icon-chevron-left" href="#"></a>
+			<a id="nextport-blog" class="next_carousel icon-chevron-right" href="#"></a>
+            </div>
+            </div>
+</div><!-- Carousel Container-->  <section id="comments">
+    <h3>107 Comentarios</h3>
+
+      <button class="mostrar-comentarios antes button" style="cursor:pointer">Mostrar comentarios</button>
+
+    <ol class="media-list">
+      
+  <li id="comment-238188" class="comment even thread-even depth-1 media comment-238188">
+    <img alt='' src='https://secure.gravatar.com/avatar/5e58627c4c05d6ce372a1fea5336642b579479305d9f5a79cf63610cb5ba7699?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/5e58627c4c05d6ce372a1fea5336642b579479305d9f5a79cf63610cb5ba7699?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Vanessa</h5>
+        <div class="comment-meta">
+        <time datetime="2026-03-26T10:50:43+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-238188">
+          26 marzo, 2026</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-238188" data-commentid="238188" data-postid="44981" data-belowelement="comment-238188" data-respondelement="respond" data-replyto="Responder a Vanessa" aria-label="Responder a Vanessa">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Riquísima una forma diferente de comer berenjenas y albóndigas<br />
+La recomiendo es unos de mis basicos      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-234840" class="comment odd alt thread-odd thread-alt depth-1 media comment-234840">
+    <img alt='' src='https://secure.gravatar.com/avatar/2d03e6a7fa4adc2a98cbf6e745e11780cad708150fc20442ea973c63bc14c13a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2d03e6a7fa4adc2a98cbf6e745e11780cad708150fc20442ea973c63bc14c13a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Esther</h5>
+        <div class="comment-meta">
+        <time datetime="2023-07-24T16:43:59+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-234840">
+          24 julio, 2023</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-234840" data-commentid="234840" data-postid="44981" data-belowelement="comment-234840" data-respondelement="respond" data-replyto="Responder a Esther" aria-label="Responder a Esther">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa, con que se podria sustituir el pan? Estoy eliminando el glúten y ya las hice una vez y me encantaron,pero no se com que podria sustituir el pan.<br />
+Gracias!!!</p>
+      
+  </div></li>
+
+  <li id="comment-234377" class="comment even thread-even depth-1 media comment-234377">
+    <img alt='' src='https://secure.gravatar.com/avatar/133db7ccae71b40c955abb65b61ad533e4be1d4fba9f5a85e8898db5e8bd492f?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/133db7ccae71b40c955abb65b61ad533e4be1d4fba9f5a85e8898db5e8bd492f?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Gemma</h5>
+        <div class="comment-meta">
+        <time datetime="2023-03-03T12:01:26+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-234377">
+          3 marzo, 2023</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-234377" data-commentid="234377" data-postid="44981" data-belowelement="comment-234377" data-respondelement="respond" data-replyto="Responder a Gemma" aria-label="Responder a Gemma">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Se podria hacer en airfyer?</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-234377">
+    
+  <li id="comment-234378" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-234378">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2023-03-03T14:03:29+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-234378">
+          3 marzo, 2023</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hay que probarla. A ver si me llega a casa y empiezo a usarla</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-232271" class="comment odd alt thread-even depth-1 media comment-232271">
+    <img alt='' src='https://secure.gravatar.com/avatar/2c935a85dd1f4a5c36bae0fc0c88ed7488b1cb2c33765c1e5610b3bb0a3c3ec4?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2c935a85dd1f4a5c36bae0fc0c88ed7488b1cb2c33765c1e5610b3bb0a3c3ec4?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Charo Sáiz</h5>
+        <div class="comment-meta">
+        <time datetime="2021-08-20T14:04:37+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-232271">
+          20 agosto, 2021</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-232271" data-commentid="232271" data-postid="44981" data-belowelement="comment-232271" data-respondelement="respond" data-replyto="Responder a Charo Sáiz" aria-label="Responder a Charo Sáiz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Mil gracias por esta superreceta, las he hecho hoy y son deliciosas!</p>
+      
+  </div></li>
+
+  <li id="comment-228974" class="comment even thread-odd thread-alt depth-1 media comment-228974">
+    <img alt='' src='https://secure.gravatar.com/avatar/e98a5f1856964b3f73f1d741af8333d0e5cd8de3a8ac734a54366bcceecc1d8f?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e98a5f1856964b3f73f1d741af8333d0e5cd8de3a8ac734a54366bcceecc1d8f?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">isabel Abel</h5>
+        <div class="comment-meta">
+        <time datetime="2020-07-15T18:02:24+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-228974">
+          15 julio, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-228974" data-commentid="228974" data-postid="44981" data-belowelement="comment-228974" data-respondelement="respond" data-replyto="Responder a isabel Abel" aria-label="Responder a isabel Abel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>deliciosas      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-228369" class="comment odd alt thread-even depth-1 media comment-228369">
+    <img alt='' src='https://secure.gravatar.com/avatar/2e7770c3e7595a3744ac252f22d860e198801710efdcd605f9d5cd2a3e697aca?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2e7770c3e7595a3744ac252f22d860e198801710efdcd605f9d5cd2a3e697aca?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Fresna</h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-21T18:12:34+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-228369">
+          21 abril, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-228369" data-commentid="228369" data-postid="44981" data-belowelement="comment-228369" data-respondelement="respond" data-replyto="Responder a Fresna" aria-label="Responder a Fresna">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>hola, segui los pasos que describes tal cual y la receta no esta mal pero sale muy poquita salsa para las 25 albondigas.      </p>
+<div class="ERRatingComment">
+<div style="width:60%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-228149" class="comment even thread-odd thread-alt depth-1 media comment-228149">
+    <img alt='' src='https://secure.gravatar.com/avatar/50fe8560bd42e8cd88e084ed2cf2ac64a24be402ea7ebec7d3743202597a290a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/50fe8560bd42e8cd88e084ed2cf2ac64a24be402ea7ebec7d3743202597a290a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ana</h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-10T15:43:22+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-228149">
+          10 abril, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-228149" data-commentid="228149" data-postid="44981" data-belowelement="comment-228149" data-respondelement="respond" data-replyto="Responder a Ana" aria-label="Responder a Ana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Riquísimasss. Nosotros las hemos acompañado con salmorejo, en vez de salsa de tomate      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-228149">
+    
+  <li id="comment-228288" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-228288">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-16T19:01:29+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-228288">
+          16 abril, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Ole!! Me gusta de acompañamiento!</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-227897" class="comment odd alt thread-odd thread-alt depth-1 media comment-227897">
+    <img alt='' src='https://secure.gravatar.com/avatar/928ff17882b42de48b06b72935739f032c4fb9e57435c803ef523fe9b3569c4d?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/928ff17882b42de48b06b72935739f032c4fb9e57435c803ef523fe9b3569c4d?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rebeca</h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-03T21:01:32+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-227897">
+          3 abril, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-227897" data-commentid="227897" data-postid="44981" data-belowelement="comment-227897" data-respondelement="respond" data-replyto="Responder a Rebeca" aria-label="Responder a Rebeca">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Se pueden freir en vez de meterlas en el horno?      </p>
+<div class="ERRatingComment">
+<div style="width:60%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-227897">
+    
+  <li id="comment-228011" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-228011">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-07T13:31:05+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-228011">
+          7 abril, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>No he probado pero si!</p>
+      
+  </div></li>
+
+  <li id="comment-228226" class="comment even depth-2 media comment-228226">
+    <img alt='' src='https://secure.gravatar.com/avatar/02eabe06dd9c53511c31eb6a4b887eaeb6f41fa94ec7350d66812e329eb2d5bc?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/02eabe06dd9c53511c31eb6a4b887eaeb6f41fa94ec7350d66812e329eb2d5bc?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ana</h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-16T15:07:21+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-228226">
+          16 abril, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Solo sabe a pan, sólo ????      </p>
+<div class="ERRatingComment">
+<div style="width:20%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-228234" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-228234">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-16T18:27:57+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-228234">
+          16 abril, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Que va!!! A mi me gustan&#8230;</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-226862" class="comment even thread-odd thread-alt depth-1 media comment-226862">
+    <img alt='' src='https://secure.gravatar.com/avatar/b5e04398965d375eb3fe61535c1fc0911d62f8387238d32780bc17d7f92ffbf9?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b5e04398965d375eb3fe61535c1fc0911d62f8387238d32780bc17d7f92ffbf9?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Sara J.</h5>
+        <div class="comment-meta">
+        <time datetime="2019-12-13T15:01:34+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-226862">
+          13 diciembre, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-226862" data-commentid="226862" data-postid="44981" data-belowelement="comment-226862" data-respondelement="respond" data-replyto="Responder a Sara J." aria-label="Responder a Sara J.">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Tienen una pinta tremenda. Mi pregunto si en vez de horno, se pueden freír. ¡Gracias por compartir y hacernos más fácil la cocina! :-)</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-226862">
+    
+  <li id="comment-226882" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-226882">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2019-12-14T21:02:39+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-226882">
+          14 diciembre, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Claro, y también las puedes hacer al vapor&#8230; no pasa nada. Tu decides que te va mejor.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-224844" class="comment odd alt thread-odd thread-alt depth-1 media comment-224844">
+    <img alt='' src='https://secure.gravatar.com/avatar/085964f95ff2c0d9db48fc6c7d02128798ea42873c506795847c4af601d4e357?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/085964f95ff2c0d9db48fc6c7d02128798ea42873c506795847c4af601d4e357?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Agustín</h5>
+        <div class="comment-meta">
+        <time datetime="2019-03-13T18:47:59+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-224844">
+          13 marzo, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-224844" data-commentid="224844" data-postid="44981" data-belowelement="comment-224844" data-respondelement="respond" data-replyto="Responder a Agustín" aria-label="Responder a Agustín">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola! Soy inexperto y quisiera preguntar si es posible dejarlas en un punto determinado de la receta para hacerlas un día antes de comerlas. Muchas gracias!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-224844">
+    
+  <li id="comment-224923" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-224923">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2019-03-24T18:44:09+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-224923">
+          24 marzo, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Claro&#8230; puedes cocinarlas y recalentarlas al día siguiente&#8230; no las termines del todo para que no se te quede la carne seca.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-224678" class="comment even thread-odd thread-alt depth-1 media comment-224678">
+    <img alt='' src='https://secure.gravatar.com/avatar/f8545f80474f58fb3f8f3176f9e0a771b307316ccf24ef32163a08324f7eb62d?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f8545f80474f58fb3f8f3176f9e0a771b307316ccf24ef32163a08324f7eb62d?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Elena</h5>
+        <div class="comment-meta">
+        <time datetime="2019-02-06T15:24:13+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-224678">
+          6 febrero, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-224678" data-commentid="224678" data-postid="44981" data-belowelement="comment-224678" data-respondelement="respond" data-replyto="Responder a Elena" aria-label="Responder a Elena">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa, me ha encantado esta receta, pero la salsa de tomate me quedó corta, me parece que en la foto hay más cantidad, y el bote de tomates enteros de 800 gr, no sé  que hice mal.<br />
+También me quedó el tomate un poco entero y al final tuve que triturarlo unos segundo.<br />
+Sin duda, la volveré a hacer!      </p>
+<div class="ERRatingComment">
+<div style="width:80%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-224678">
+    
+  <li id="comment-225010" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-225010">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2019-03-24T19:37:43+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-225010">
+          24 marzo, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Cuando lo repita te digo</p>
+      
+  </div></li>
+
+  <li id="comment-226311" class="comment odd alt depth-2 media comment-226311">
+    <img alt='' src='https://secure.gravatar.com/avatar/4a3b64fd2d9197d0e4e8f7e8e5c9cb3ddc79b2f75b66c1e7841c21842d34f17d?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/4a3b64fd2d9197d0e4e8f7e8e5c9cb3ddc79b2f75b66c1e7841c21842d34f17d?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Cati</h5>
+        <div class="comment-meta">
+        <time datetime="2019-10-23T22:42:27+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-226311">
+          23 octubre, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola! Me estoy iniciando en la dieta vegana. Se puede hacer sin huevo o sustituir por otro ingrediente? Gracias</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-223623" class="comment even thread-odd thread-alt depth-1 media comment-223623">
+    <img alt='' src='https://secure.gravatar.com/avatar/ad6272eabf92d9b0a67dfdbdd4e69bb747cc8774aa6b1b54bada44ff929f8202?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ad6272eabf92d9b0a67dfdbdd4e69bb747cc8774aa6b1b54bada44ff929f8202?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosario</h5>
+        <div class="comment-meta">
+        <time datetime="2018-09-21T15:15:36+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223623">
+          21 septiembre, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223623" data-commentid="223623" data-postid="44981" data-belowelement="comment-223623" data-respondelement="respond" data-replyto="Responder a Rosario" aria-label="Responder a Rosario">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa, las preparé ayer para comerlas hoy y a recalentarlas prácticamente se me han desecho! Ayer recién hechas estaban estupendas. No se pueden hacer de un día para otro?</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-223623">
+    
+  <li id="comment-223756" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-223756">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-10-06T12:29:31+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223756">
+          6 octubre, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Claro que si&#8230; caliéntalas con mimo!</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-223513" class="comment odd alt thread-odd thread-alt depth-1 media comment-223513">
+    <img alt='' src='https://secure.gravatar.com/avatar/02ccda4808c9c3125fccbd8df0a583f90375143faa5cec68a6b1a7f54806d1cf?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/02ccda4808c9c3125fccbd8df0a583f90375143faa5cec68a6b1a7f54806d1cf?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ana</h5>
+        <div class="comment-meta">
+        <time datetime="2018-09-05T21:13:22+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223513">
+          5 septiembre, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223513" data-commentid="223513" data-postid="44981" data-belowelement="comment-223513" data-respondelement="respond" data-replyto="Responder a Ana" aria-label="Responder a Ana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, me chifla esta receta pero tengo una duda&#8230; se pueden congelar?? Gracias de antemano!</p>
+      
+  </div></li>
+
+  <li id="comment-223445" class="comment even thread-even depth-1 media comment-223445">
+    <img alt='' src='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://nafrnzznfeltreja.blogspot.com" class="url" rel="ugc external nofollow">Francina</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-08-27T22:52:44+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223445">
+          27 agosto, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223445" data-commentid="223445" data-postid="44981" data-belowelement="comment-223445" data-respondelement="respond" data-replyto="Responder a Francina" aria-label="Responder a Francina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenísimas! Las repetiré seguro. Como las cociné en plena ola de calor, para no encender el horno las cocí al varoma mientras preparaba la salsa de tomate. Un éxito</p>
+      
+  </div></li>
+
+  <li id="comment-223409" class="comment odd alt thread-odd thread-alt depth-1 media comment-223409">
+    <img alt='' src='https://secure.gravatar.com/avatar/45e71eb5c222dbd5e5d0f1af815f1991c9c0cbcee6700f2b83336bfec99f0a34?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/45e71eb5c222dbd5e5d0f1af815f1991c9c0cbcee6700f2b83336bfec99f0a34?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Marisa</h5>
+        <div class="comment-meta">
+        <time datetime="2018-08-22T12:14:21+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223409">
+          22 agosto, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223409" data-commentid="223409" data-postid="44981" data-belowelement="comment-223409" data-respondelement="respond" data-replyto="Responder a Marisa" aria-label="Responder a Marisa">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa,<br />
+deliciosas,nos han encantado suaves y sorprendente, gracias.</p>
+      
+  </div></li>
+
+  <li id="comment-223385" class="comment even thread-even depth-1 media comment-223385">
+    <img alt='' src='https://secure.gravatar.com/avatar/d3d5ef489cdfc4bc732855e28a81d1d7222a26f29ac8057d361faf2a77c7b5be?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/d3d5ef489cdfc4bc732855e28a81d1d7222a26f29ac8057d361faf2a77c7b5be?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Belén</h5>
+        <div class="comment-meta">
+        <time datetime="2018-08-17T20:55:57+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223385">
+          17 agosto, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223385" data-commentid="223385" data-postid="44981" data-belowelement="comment-223385" data-respondelement="respond" data-replyto="Responder a Belén" aria-label="Responder a Belén">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Impresionantes!!!! Nunca hubiera imaginado que estarían tan ricas</p>
+      
+  </div></li>
+
+  <li id="comment-223200" class="comment odd alt thread-odd thread-alt depth-1 media comment-223200">
+    <img alt='' src='https://secure.gravatar.com/avatar/197757ed0d7dfe983422f5d6ff6f7b30b8daf0c7ac59364f0fa0d707b232a709?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/197757ed0d7dfe983422f5d6ff6f7b30b8daf0c7ac59364f0fa0d707b232a709?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Aurora</h5>
+        <div class="comment-meta">
+        <time datetime="2018-07-21T14:37:17+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223200">
+          21 julio, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223200" data-commentid="223200" data-postid="44981" data-belowelement="comment-223200" data-respondelement="respond" data-replyto="Responder a Aurora" aria-label="Responder a Aurora">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Muchas gracias por permitirme entrar en tu blog.  Aún soy novata con thermomix y tengo muchas dudas, espero aprender mucho con tus recetas.<br />
+Gracias de nuevo.</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-223200">
+    
+  <li id="comment-223207" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-223207">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-07-22T00:11:45+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223207">
+          22 julio, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Tranquila, ya verás como le vas cogiendo el gustillo poquito a poco!!! Besis y bienvenida</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-222915" class="comment even thread-odd thread-alt depth-1 media comment-222915">
+    <img alt='' src='https://secure.gravatar.com/avatar/2603bc8eeb9df3867756d7869932bb149fcf0bb614ae6b7ede4d14667c2d6f3c?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2603bc8eeb9df3867756d7869932bb149fcf0bb614ae6b7ede4d14667c2d6f3c?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carla</h5>
+        <div class="comment-meta">
+        <time datetime="2018-06-11T08:01:50+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-222915">
+          11 junio, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-222915" data-commentid="222915" data-postid="44981" data-belowelement="comment-222915" data-respondelement="respond" data-replyto="Responder a Carla" aria-label="Responder a Carla">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!<br />
+Quisiera saber si se pueden congelar las albóndigas ( sin hacer en el horno claro y) yla salsa de tomate.<br />
+Gracias!      </p>
+<div class="ERRatingComment">
+<div style="width:80%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-222915">
+    
+  <li id="comment-223446" class="comment even depth-2 media comment-223446">
+    <img alt='' src='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://nafrnzznfeltreja.blogspot.com" class="url" rel="ugc external nofollow">Francina</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-08-27T23:02:27+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223446">
+          27 agosto, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola, Carla. Yo congelé tuppers con las albóndigas y la salsa ya cocidas. Al descongelar todo estaba muy bueno. Es muy práctico para tener comida lista cuando tienes poco tiempo! Por certo, las cociné en el varoma al mismo tiempo que en el vaso preparaba la salsa de tomate, práctico ????      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-222839" class="comment odd alt thread-odd thread-alt depth-1 media comment-222839">
+    <img alt='' src='https://secure.gravatar.com/avatar/759915563baa0c3d4a6ae4fbea83feb974affb68e8c0942fe9a9eb5fe1a3b32b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/759915563baa0c3d4a6ae4fbea83feb974affb68e8c0942fe9a9eb5fe1a3b32b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">sara</h5>
+        <div class="comment-meta">
+        <time datetime="2018-06-08T01:27:09+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-222839">
+          8 junio, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-222839" data-commentid="222839" data-postid="44981" data-belowelement="comment-222839" data-respondelement="respond" data-replyto="Responder a sara" aria-label="Responder a sara">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa! Hoy he probado esta receta, al no tener albahaca la tuve que reemplazar por orégano y han quedado buenísimas! Gracias por la receta y por tu blog :) tus recetas nunca fallan!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-222789" class="comment even thread-even depth-1 media comment-222789">
+    <img alt='' src='https://secure.gravatar.com/avatar/b74cd677cfcb023161a4098cae4eb08a445a85b47fbdc57ef0a896d0e17ea73b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b74cd677cfcb023161a4098cae4eb08a445a85b47fbdc57ef0a896d0e17ea73b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Estefania</h5>
+        <div class="comment-meta">
+        <time datetime="2018-06-05T08:02:48+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-222789">
+          5 junio, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-222789" data-commentid="222789" data-postid="44981" data-belowelement="comment-222789" data-respondelement="respond" data-replyto="Responder a Estefania" aria-label="Responder a Estefania">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Espectacular! A toda la familia nos ha encantado. Delicioso</p>
+      
+  </div></li>
+
+  <li id="comment-222630" class="comment odd alt thread-odd thread-alt depth-1 media comment-222630">
+    <img alt='' src='https://secure.gravatar.com/avatar/2cd94dc38507e3cf83fbc88bcb4fc4eb787e09926dfa2d79c06c969eebbb0f88?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2cd94dc38507e3cf83fbc88bcb4fc4eb787e09926dfa2d79c06c969eebbb0f88?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Lucia</h5>
+        <div class="comment-meta">
+        <time datetime="2018-05-25T21:53:05+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-222630">
+          25 mayo, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-222630" data-commentid="222630" data-postid="44981" data-belowelement="comment-222630" data-respondelement="respond" data-replyto="Responder a Lucia" aria-label="Responder a Lucia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>No veas como se las comen los niños ,,!,,      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-222368" class="comment even thread-even depth-1 media comment-222368">
+    <img alt='' src='https://secure.gravatar.com/avatar/9de4bd4b8ce0e898e1f4c82ee4fe1202a0ff0eabc15d1bf994df0212a9c78642?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/9de4bd4b8ce0e898e1f4c82ee4fe1202a0ff0eabc15d1bf994df0212a9c78642?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Tatiana</h5>
+        <div class="comment-meta">
+        <time datetime="2018-05-06T22:24:39+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-222368">
+          6 mayo, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-222368" data-commentid="222368" data-postid="44981" data-belowelement="comment-222368" data-respondelement="respond" data-replyto="Responder a Tatiana" aria-label="Responder a Tatiana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Tengo la Termomix desde hace poco, pero de seguida descubri tu web y que tus recetas son un referente. He provado ésta y han salido buenisimas! En vez de pan le puse salvado de avena y ha ido perfecto para darles forma con una masa espesita. Ahora provaré con más verduras.      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-222368">
+    
+  <li id="comment-226045" class="comment even depth-2 media comment-226045">
+    <img alt='' src='https://secure.gravatar.com/avatar/150ddf439410ed34c5441c487a05934d45a4811cd6f67e8a06e45d5f61dad775?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/150ddf439410ed34c5441c487a05934d45a4811cd6f67e8a06e45d5f61dad775?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Araceli</h5>
+        <div class="comment-meta">
+        <time datetime="2019-09-16T21:06:15+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-226045">
+          16 septiembre, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola Tatiana, una pregunta porfa, has sustituido tanto el pan duro como el rallado por el Salvado? Qué cantidad has puesto. Gracias de ante mano.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-221719" class="comment odd alt thread-even depth-1 media comment-221719">
+    <img alt='' src='https://secure.gravatar.com/avatar/78ffc0be58ef5daac027e3c4a81af2f86d3c788eba1f1f313d08812f0421a132?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/78ffc0be58ef5daac027e3c4a81af2f86d3c788eba1f1f313d08812f0421a132?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mariona</h5>
+        <div class="comment-meta">
+        <time datetime="2018-04-16T12:43:40+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-221719">
+          16 abril, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-221719" data-commentid="221719" data-postid="44981" data-belowelement="comment-221719" data-respondelement="respond" data-replyto="Responder a Mariona" aria-label="Responder a Mariona">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa,<br />
+Hace mucho tiempo que te sigo y sin duda eres una de mis referentes para las recetas con thermomix! me encanta tu blog y tus recetas! ;)<br />
+Tengo una duda, las albóndigas se pueden preparar con antelación y congelarlas?<br />
+O primero las cocino y luego las congelo?<br />
+Muchas gracias!! :)      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-221719">
+    
+  <li id="comment-223447" class="comment odd alt depth-2 media comment-223447">
+    <img alt='' src='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://nafrnzznfeltreja.blogspot.com" class="url" rel="ugc external nofollow">Francina</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-08-27T23:05:05+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223447">
+          27 agosto, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola Mariona, yo las congelé ya cocidas, con la salsa también cocida, y perfecto. Crudas no sé si se puede</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-221216" class="comment even thread-even depth-1 media comment-221216">
+    <img alt='' src='https://secure.gravatar.com/avatar/2157a69ba8eda806c8158d9dad7407e7983d45c6a9eef8defad7ca57696f314c?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2157a69ba8eda806c8158d9dad7407e7983d45c6a9eef8defad7ca57696f314c?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://Hendaya" class="url" rel="ugc external nofollow">Gemma</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-04-02T11:07:27+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-221216">
+          2 abril, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-221216" data-commentid="221216" data-postid="44981" data-belowelement="comment-221216" data-respondelement="respond" data-replyto="Responder a Gemma" aria-label="Responder a Gemma">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Las estoy haciendo ahora mismo.</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-221216">
+    
+  <li id="comment-221710" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-221710">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-04-16T11:56:38+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-221710">
+          16 abril, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Biennn</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-220914" class="comment odd alt thread-even depth-1 media comment-220914">
+    <img alt='' src='https://secure.gravatar.com/avatar/b5c57a4cdcdcb0ae1911a5607e5659f565e3c0093a42c78bc5d59bdc92cd4810?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b5c57a4cdcdcb0ae1911a5607e5659f565e3c0093a42c78bc5d59bdc92cd4810?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mónica</h5>
+        <div class="comment-meta">
+        <time datetime="2018-03-23T15:01:17+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-220914">
+          23 marzo, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-220914" data-commentid="220914" data-postid="44981" data-belowelement="comment-220914" data-respondelement="respond" data-replyto="Responder a Mónica" aria-label="Responder a Mónica">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>A mí me encantan!!!</p>
+      
+  </div></li>
+
+  <li id="comment-219207" class="comment even thread-odd thread-alt depth-1 media comment-219207">
+    <img alt='' src='https://secure.gravatar.com/avatar/ba1e3be40640691db0f5f2f6e79d6a84a76e7ff6fcaa0c9814dff76bf70b2a9f?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ba1e3be40640691db0f5f2f6e79d6a84a76e7ff6fcaa0c9814dff76bf70b2a9f?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Pepa martinez</h5>
+        <div class="comment-meta">
+        <time datetime="2018-02-19T11:59:24+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-219207">
+          19 febrero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-219207" data-commentid="219207" data-postid="44981" data-belowelement="comment-219207" data-respondelement="respond" data-replyto="Responder a Pepa martinez" aria-label="Responder a Pepa martinez">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Tienen una pinta maravillosa, mañana mismo las preparo, gracias por tus recetas</p>
+      
+  </div></li>
+
+  <li id="comment-218456" class="comment odd alt thread-even depth-1 media comment-218456">
+    <img alt='' src='https://secure.gravatar.com/avatar/460e8d1ca923f07ef432699b0f8cc61e78c14da668bb2a7050a31d00969a629b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/460e8d1ca923f07ef432699b0f8cc61e78c14da668bb2a7050a31d00969a629b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carolina Arbasetti</h5>
+        <div class="comment-meta">
+        <time datetime="2018-02-10T12:07:51+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-218456">
+          10 febrero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-218456" data-commentid="218456" data-postid="44981" data-belowelement="comment-218456" data-respondelement="respond" data-replyto="Responder a Carolina Arbasetti" aria-label="Responder a Carolina Arbasetti">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, no quedan bien si se cocinan en el varoma mientras se hace la salsa? Gracias!!</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-218456">
+    
+  <li id="comment-223448" class="comment odd alt depth-2 media comment-223448">
+    <img alt='' src='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/060d2ec935c5e548f2792b94f507455c720721802cd660edeb3801ea70e7cf54?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://nafrnzznfeltreja.blogspot.com" class="url" rel="ugc external nofollow">Francina</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-08-27T23:06:25+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-223448">
+          27 agosto, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>sí, perfectas! yo las hice así</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-215703" class="comment even thread-even depth-1 media comment-215703">
+    <img alt='' src='https://secure.gravatar.com/avatar/bb76d49a076aa106ee3cf7889f80194cc21329df664a46f97b9134ff34624d3a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/bb76d49a076aa106ee3cf7889f80194cc21329df664a46f97b9134ff34624d3a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ana</h5>
+        <div class="comment-meta">
+        <time datetime="2018-01-03T14:58:58+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-215703">
+          3 enero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-215703" data-commentid="215703" data-postid="44981" data-belowelement="comment-215703" data-respondelement="respond" data-replyto="Responder a Ana" aria-label="Responder a Ana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola! Las he hecho hoy pero he variado un poco la receta, más bien añadido un par de zanahorias y un puerro.<br />
+Están exquisitas!! Y muy buena textura ,que era lo q más m preocupaba!!  Me han salido 20 albóndigas hermosotas  y un par de hamburguesas! Gracias por tus recetas, me encantan!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-215703">
+    
+  <li id="comment-215764" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-215764">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-01-04T16:29:31+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-215764">
+          4 enero, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Gracias a ti Ana!!! Me alegro que te gusten</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-214806" class="comment odd alt thread-even depth-1 media comment-214806">
+    <img alt='' src='https://secure.gravatar.com/avatar/f7234dd67bbb843c1d571feb90c60627658644d1733a72aeb292b848e0b1d91e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f7234dd67bbb843c1d571feb90c60627658644d1733a72aeb292b848e0b1d91e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">INMA</h5>
+        <div class="comment-meta">
+        <time datetime="2017-12-13T22:32:48+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-214806">
+          13 diciembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-214806" data-commentid="214806" data-postid="44981" data-belowelement="comment-214806" data-respondelement="respond" data-replyto="Responder a INMA" aria-label="Responder a INMA">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Pues yo siento decir que no me gustaron&#8230; ni la pinta ni la textura ni el sabor&#8230; las hice segun tu receta pero fue fracaso absoluto, ni a mi marido le gustaron y eso que se come un bocadillo de piedras&#8230; Espero no ofenderte con mi comentario&#8230; Yo creo que lo que cuenta es que por lo menos puse en practica tu receta! Gracias por todo lo que haces en este blog, que conste que me encanta!      </p>
+<div class="ERRatingComment">
+<div style="width:20%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-214806">
+    
+  <li id="comment-215205" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-215205">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-12-22T00:41:30+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-215205">
+          22 diciembre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>No todas las recetas les tienen que gustar a todo el mundo&#8230; no pasa nada. :D Esta descártala de el recetario, no a todos le gustan el sabor de la berenjena.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-214687" class="comment even thread-even depth-1 media comment-214687">
+    <img alt='' src='https://secure.gravatar.com/avatar/f5ed9662efc771031e693df36c35e84d5eb3dca9ad4fa1031a0647708d70a295?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f5ed9662efc771031e693df36c35e84d5eb3dca9ad4fa1031a0647708d70a295?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Juan</h5>
+        <div class="comment-meta">
+        <time datetime="2017-12-09T17:02:22+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-214687">
+          9 diciembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-214687" data-commentid="214687" data-postid="44981" data-belowelement="comment-214687" data-respondelement="respond" data-replyto="Responder a Juan" aria-label="Responder a Juan">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Están muy buenas y como tú dices, más sano imposible. Se agradece el apunte de acompañar con arroz, quinoa o pan integral&#8230;:)      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-213994" class="comment odd alt thread-odd thread-alt depth-1 media comment-213994">
+    <img alt='' src='https://secure.gravatar.com/avatar/2de5af41113a7d33870991a739b748ba44ba38de09396d77a05b78e1c7ad590b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2de5af41113a7d33870991a739b748ba44ba38de09396d77a05b78e1c7ad590b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa</h5>
+        <div class="comment-meta">
+        <time datetime="2017-11-17T14:16:00+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213994">
+          17 noviembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-213994" data-commentid="213994" data-postid="44981" data-belowelement="comment-213994" data-respondelement="respond" data-replyto="Responder a Rosa" aria-label="Responder a Rosa">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!!!<br />
+Hice las albóndigas para la comida, me han quedado de fotos y ahora las probaremos. Madre mía por Dios!!! Que buenas están, les encantan a mis chicos. Menos mal que practicamos deporte y nos gustan las comidas sanas y variadas,  ya que nos gusta comer y bien.<br />
+Lo hemos acompañado con lubina al vapor con jengibre y Lima. Buenísimo!!!!<br />
+Lo siento, sigo comiendo!!!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-213994">
+    
+  <li id="comment-214002" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-214002">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-11-17T21:58:36+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-214002">
+          17 noviembre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Jajajaja&#8230; pues entonces no te interrumpo. Que disfrutes de tu deliciosa comida :D</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-213910" class="comment even thread-odd thread-alt depth-1 media comment-213910">
+    <img alt='' src='https://secure.gravatar.com/avatar/556a8f32f0767ecce55453ff0b0317d7a47c5c5238579c27720fdf36873a1512?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/556a8f32f0767ecce55453ff0b0317d7a47c5c5238579c27720fdf36873a1512?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carmen</h5>
+        <div class="comment-meta">
+        <time datetime="2017-11-15T14:58:32+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213910">
+          15 noviembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-213910" data-commentid="213910" data-postid="44981" data-belowelement="comment-213910" data-respondelement="respond" data-replyto="Responder a Carmen" aria-label="Responder a Carmen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>He sorprendido a mi hijas y ya me están pidiendo que las vuelva a hacer!!!! Están riquísimas, qué receta tan original y sabrosa!!! Gracias !!</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-213910">
+    
+  <li id="comment-213935" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-213935">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-11-16T13:05:51+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213935">
+          16 noviembre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Y sanotas!!! Besos a tus hijas. Ponle retos para que te ayuden a cocinar :D<br />
+Muaccc</p>
+      
+  </div></li>
+
+  <li id="comment-226426" class="comment odd alt depth-2 media comment-226426">
+    <img alt='' src='https://secure.gravatar.com/avatar/07c3f7df6a4006713fc6119c531a4217c82e3d1e3b9d240007dc2ff15f22c92e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/07c3f7df6a4006713fc6119c531a4217c82e3d1e3b9d240007dc2ff15f22c92e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Laura</h5>
+        <div class="comment-meta">
+        <time datetime="2019-11-04T12:43:37+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-226426">
+          4 noviembre, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola a todos.<br />
+Me parece súper buena idea hacer albóndigas con vegetales!<br />
+Pero yo esta receta no lo incluiría en hipocalorica con la cantidad de aceite que llevan&#8230;<br />
+Aún así muy ricas y sobre todo naturales! Hay que ir dejando de lado los ultraprocesados!      </p>
+<div class="ERRatingComment">
+<div style="width:60%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-213852" class="comment even thread-odd thread-alt depth-1 media comment-213852">
+    <img alt='' src='https://secure.gravatar.com/avatar/c716879f740667c9ee6405e0822659186ec7dae1e09acfcdd1902e392362d83b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/c716879f740667c9ee6405e0822659186ec7dae1e09acfcdd1902e392362d83b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ángeles</h5>
+        <div class="comment-meta">
+        <time datetime="2017-11-12T22:32:14+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213852">
+          12 noviembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-213852" data-commentid="213852" data-postid="44981" data-belowelement="comment-213852" data-respondelement="respond" data-replyto="Responder a Ángeles" aria-label="Responder a Ángeles">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa quedaron buenísimas!!! En vez de pan eché avena. Otro día las hice de calabacín y zanahoria y espectaculares!!!!<br />
+Gracias por tener un blog tan bueno      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-213852">
+    
+  <li id="comment-213956" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-213956">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-11-16T13:17:11+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213956">
+          16 noviembre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>A vosotras por verlo con tan buenos ojos :D</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-213616" class="comment odd alt thread-odd thread-alt depth-1 media comment-213616">
+    <img alt='' src='https://secure.gravatar.com/avatar/09e10c9dac83b9a0b4f11cb11cc07ef2a9dfccc4a82d9ba7dc4ca30183e323cf?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/09e10c9dac83b9a0b4f11cb11cc07ef2a9dfccc4a82d9ba7dc4ca30183e323cf?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Cristina</h5>
+        <div class="comment-meta">
+        <time datetime="2017-11-07T08:29:44+01:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213616">
+          7 noviembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-213616" data-commentid="213616" data-postid="44981" data-belowelement="comment-213616" data-respondelement="respond" data-replyto="Responder a Cristina" aria-label="Responder a Cristina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Riquísimas!! No tenía hiervas frescas y les eche hiervas provenzales.</p>
+      
+  </div></li>
+
+  <li id="comment-213086" class="pingback even thread-even depth-1 media comment-213086">
+        <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://www.lacocinadeinma.com/2017/10/24/albondigas-de-berenjenas-con-mi-salsa-de-tomate-super-rica/" class="url" rel="ugc external nofollow">Albóndigas de Berenjenas con mi Salsa de Tomate Súper Rica | La Cocina de Inma López</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-24T09:00:48+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213086">
+          24 octubre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-213086" data-commentid="213086" data-postid="44981" data-belowelement="comment-213086" data-respondelement="respond" data-replyto="Responder a Albóndigas de Berenjenas con mi Salsa de Tomate Súper Rica | La Cocina de Inma López" aria-label="Responder a Albóndigas de Berenjenas con mi Salsa de Tomate Súper Rica | La Cocina de Inma López">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>[&#8230;] NO es el caso de estas albóndigas. Vi la receta en Velocidad Cuchara, tenía muchas berenjenas en el cajón de las verduras, y así como por arte de magia: albóndigas [&#8230;]</p>
+      
+  </div></li>
+
+  <li id="comment-212919" class="comment odd alt thread-odd thread-alt depth-1 media comment-212919">
+    <img alt='' src='https://secure.gravatar.com/avatar/b956e3a2e64f09c97ab3814adb49aadec360b91ba395a98ce0e011c36a61e833?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b956e3a2e64f09c97ab3814adb49aadec360b91ba395a98ce0e011c36a61e833?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">PAOLA</h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-19T10:10:49+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-212919">
+          19 octubre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-212919" data-commentid="212919" data-postid="44981" data-belowelement="comment-212919" data-respondelement="respond" data-replyto="Responder a PAOLA" aria-label="Responder a PAOLA">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>LAS HICE AYER NO PUEDEN ESTAR MÁS BUENAS !!! MUCHAS GRACIAS      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-212919">
+    
+  <li id="comment-212920" class="comment odd alt depth-2 media comment-212920">
+    <img alt='' src='https://secure.gravatar.com/avatar/b956e3a2e64f09c97ab3814adb49aadec360b91ba395a98ce0e011c36a61e833?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b956e3a2e64f09c97ab3814adb49aadec360b91ba395a98ce0e011c36a61e833?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">PAOLA</h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-19T10:12:25+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-212920">
+          19 octubre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>añadi oloroso a la salsa de tomate y menos pan en las albóndigas y perfecto !!!</p>
+      
+  </div></li>
+
+  <li id="comment-213155" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-213155">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-24T20:56:41+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213155">
+          24 octubre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Bien!!! Tuneando como debe ser :D</p>
+      
+  </div></li>
+
+  <li id="comment-213156" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-213156">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-24T20:57:05+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-213156">
+          24 octubre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Me encanta&#8230; ya leí tu tuneo!!<br />
+Besitos y gracias por comentar.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-212823" class="comment even thread-odd thread-alt depth-1 media comment-212823">
+    <img alt='' src='https://secure.gravatar.com/avatar/d06c78449bc5461c30e48325dca379f324edc3fadf739916064e50b16e205d10?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/d06c78449bc5461c30e48325dca379f324edc3fadf739916064e50b16e205d10?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Josep</h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-15T21:01:54+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-212823">
+          15 octubre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-212823" data-commentid="212823" data-postid="44981" data-belowelement="comment-212823" data-respondelement="respond" data-replyto="Responder a Josep" aria-label="Responder a Josep">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>La albóndiga están buenísimas. Yo las he hecho 2 veces. La segunda sustituí el pan por avena sin gluten y el resultado es igual de bueno.      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-212408" class="comment odd alt thread-even depth-1 media comment-212408">
+    <img alt='' src='https://secure.gravatar.com/avatar/32f1033b8b07a3260d573b86e3e164215c365183fe46eb7e73a00c5a92d12f16?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/32f1033b8b07a3260d573b86e3e164215c365183fe46eb7e73a00c5a92d12f16?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Patricia</h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-05T16:06:53+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-212408">
+          5 octubre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-212408" data-commentid="212408" data-postid="44981" data-belowelement="comment-212408" data-respondelement="respond" data-replyto="Responder a Patricia" aria-label="Responder a Patricia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa,<br />
+Primero decirte que me encanta tu blog y que lo sigo desde hace años, muchas de mis recetas favoritas las he descubierto en él, muchas gracias!<br />
+Te quería preguntar si las albóndigas se podrían también hacer en el Varoma mientras haces la salsa, como en la receta de albóndigas de carne, crees que quedarían bien?<br />
+gracias!</p>
+      
+  </div></li>
+
+  <li id="comment-212137" class="comment even thread-odd thread-alt depth-1 media comment-212137">
+    <img alt='' src='https://secure.gravatar.com/avatar/e2c71e3c6a8a0570966cda869b0a7990b045c39ae43b67e2c7d2db8a21dcc4de?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e2c71e3c6a8a0570966cda869b0a7990b045c39ae43b67e2c7d2db8a21dcc4de?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">laura</h5>
+        <div class="comment-meta">
+        <time datetime="2017-09-28T11:58:27+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-212137">
+          28 septiembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-212137" data-commentid="212137" data-postid="44981" data-belowelement="comment-212137" data-respondelement="respond" data-replyto="Responder a laura" aria-label="Responder a laura">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>No se por que me han salido amargas :( Las deje una noche en la nevera y las meti al horno al dia siguiente y es como si la hierbabuena supiera amarga&#8230; Sabeis que ha podido pasar<br />
+Gracias      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-212137">
+    
+  <li id="comment-212375" class="comment even depth-2 media comment-212375">
+    <img alt='' src='https://secure.gravatar.com/avatar/76cde4afd1907a041ede8925cd3216f73d8640db92a8367841900f36352f9b5a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/76cde4afd1907a041ede8925cd3216f73d8640db92a8367841900f36352f9b5a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.zeushosting.cl/" class="url" rel="ugc external nofollow">hosting</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-04T15:08:19+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-212375">
+          4 octubre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Habéis lavado la hierbabuena antes?&#8230;Crees que dejándola remojar en agua tibia o caliente se evite ese problema?      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-208742" class="comment odd alt thread-odd thread-alt depth-1 media comment-208742">
+    <img alt='' src='https://secure.gravatar.com/avatar/54edfb9d2fb9307d16a7197a58d0e26f13f3eb7198377aaf5101695be2bab357?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/54edfb9d2fb9307d16a7197a58d0e26f13f3eb7198377aaf5101695be2bab357?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Montse</h5>
+        <div class="comment-meta">
+        <time datetime="2017-09-22T21:47:44+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-208742">
+          22 septiembre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-208742" data-commentid="208742" data-postid="44981" data-belowelement="comment-208742" data-respondelement="respond" data-replyto="Responder a Montse" aria-label="Responder a Montse">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Sanas y deliciosas!!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-208742">
+    
+  <li id="comment-211963" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-211963">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-09-24T13:37:07+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-211963">
+          24 septiembre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>????</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-207781" class="comment even thread-odd thread-alt depth-1 media comment-207781">
+    <img alt='' src='https://secure.gravatar.com/avatar/e355abdc7fc8fa860abeb09573c3d1f55a4fe0d539f8cb08a565ea0021cce5a3?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e355abdc7fc8fa860abeb09573c3d1f55a4fe0d539f8cb08a565ea0021cce5a3?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carmen</h5>
+        <div class="comment-meta">
+        <time datetime="2017-08-17T13:19:33+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-207781">
+          17 agosto, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-207781" data-commentid="207781" data-postid="44981" data-belowelement="comment-207781" data-respondelement="respond" data-replyto="Responder a Carmen" aria-label="Responder a Carmen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa, hay alguna forma de sustituir el huevo para que sea una receta vegana?<br />
+Bss</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-207781">
+    
+  <li id="comment-207782" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-207782">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-08-17T14:21:38+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-207782">
+          17 agosto, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>No sé si con yogur de soja servirá&#8230;</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-206382" class="comment odd alt thread-odd thread-alt depth-1 media comment-206382">
+    <img alt='' src='https://secure.gravatar.com/avatar/f3104af259076a7cd4297e38c7425ab5717cd23d8dd06ede5eda2f0ceb919e2e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f3104af259076a7cd4297e38c7425ab5717cd23d8dd06ede5eda2f0ceb919e2e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">vic</h5>
+        <div class="comment-meta">
+        <time datetime="2017-08-11T00:07:01+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-206382">
+          11 agosto, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-206382" data-commentid="206382" data-postid="44981" data-belowelement="comment-206382" data-respondelement="respond" data-replyto="Responder a vic" aria-label="Responder a vic">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Esta es de las recetas que más me han gustado y sorprendido.</p>
+<p>Muy sano y sabroso. Yo lo he acompañado con quinoa y ha quedado un plato espectacular      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-206382">
+    
+  <li id="comment-207615" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-207615">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-08-15T12:33:45+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-207615">
+          15 agosto, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Deliciosas&#8230; con la quinoa se sale!!! Plato súper completo.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203591" class="comment even thread-odd thread-alt depth-1 media comment-203591">
+    <img alt='' src='https://secure.gravatar.com/avatar/47874ac1fcc163ba7f01612d77bc7cc76a6f8e9ed01ff7a7bb6b6b99aa2f0d16?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/47874ac1fcc163ba7f01612d77bc7cc76a6f8e9ed01ff7a7bb6b6b99aa2f0d16?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">monica</h5>
+        <div class="comment-meta">
+        <time datetime="2017-07-13T13:12:47+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203591">
+          13 julio, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203591" data-commentid="203591" data-postid="44981" data-belowelement="comment-203591" data-respondelement="respond" data-replyto="Responder a monica" aria-label="Responder a monica">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>me pregunto porque no lleva cebolla ni la albondiga ni la salsa&#8230; ceo que voy improvisar y ya os cuento&#8230;      </p>
+<div class="ERRatingComment">
+<div style="width:80%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-203590" class="comment odd alt thread-even depth-1 media comment-203590">
+    <img alt='' src='https://secure.gravatar.com/avatar/d002f9003073d512ec44a37dfd2d6c657de1b7a934f2178dd201a3001a353d9d?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/d002f9003073d512ec44a37dfd2d6c657de1b7a934f2178dd201a3001a353d9d?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Isa</h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-24T21:10:40+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203590">
+          24 mayo, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203590" data-commentid="203590" data-postid="44981" data-belowelement="comment-203590" data-respondelement="respond" data-replyto="Responder a Isa" aria-label="Responder a Isa">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Holaaa que tal?<br />
+Felicidades por tu blog cariño, es una pasada !!!!!<br />
+Una preguntita ? Se pueden congelar las albóndigas e ir sacando poco a poco y haciéndolas horno?????<br />
+Gracias y besos!</p>
+      
+  </div></li>
+
+  <li id="comment-203589" class="comment even thread-odd thread-alt depth-1 media comment-203589">
+    <img alt='' src='https://secure.gravatar.com/avatar/71ffedf6920add8e9a2c1c313831b8b6368df0cf3690222d48390f526710b234?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/71ffedf6920add8e9a2c1c313831b8b6368df0cf3690222d48390f526710b234?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/" class="url" rel="ugc">Charo</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-19T21:06:19+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203589">
+          19 mayo, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203589" data-commentid="203589" data-postid="44981" data-belowelement="comment-203589" data-respondelement="respond" data-replyto="Responder a Charo" aria-label="Responder a Charo">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa, en marzo entró en casa la thermomix y velocidad cuchara. Nos gusta probar cosas nuevas y contigo no paro. Estamos encantados toda la familia.</p>
+<p>Estoy preparando las albóndigas y en la cocina huele genial.<br />
+Me gusta mucho la opción de hornear en vez de freir.<br />
+Sola una pregunta, ¿paso las albóndigas por pan rayado antes de hornear?.<br />
+Un saludo a ti y tus cuchareros</p>
+      
+  </div></li>
+
+  <li id="comment-203588" class="comment odd alt thread-even depth-1 media comment-203588">
+    <img alt='' src='https://secure.gravatar.com/avatar/9441d650afc8864fa733c4696bfd9342944595106738c3f648a4edc998469208?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/9441d650afc8864fa733c4696bfd9342944595106738c3f648a4edc998469208?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Patricia</h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-16T14:35:41+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203588">
+          16 mayo, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203588" data-commentid="203588" data-postid="44981" data-belowelement="comment-203588" data-respondelement="respond" data-replyto="Responder a Patricia" aria-label="Responder a Patricia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa, este fin de semana he hecho esta receta, y como no tenia suficiente pan duro, le puse pan rallado con ajo y perejil, y quedó riquísima!!!! La siguiente la pruebo con calabacín, tiene que estar muy rica también. Ademas, en los últimos minutos, le puse queso emmental por encima para gratinar y quedó espectacular.      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-203578" class="comment even thread-odd thread-alt depth-1 media comment-203578">
+    <img alt='' src='https://secure.gravatar.com/avatar/2b0c71c50823683f9dbe1908683abb23f344c5d05b20dd699c2c4620f4a2a586?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2b0c71c50823683f9dbe1908683abb23f344c5d05b20dd699c2c4620f4a2a586?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ana Miralles</h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-05T11:08:07+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203578">
+          5 mayo, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203578" data-commentid="203578" data-postid="44981" data-belowelement="comment-203578" data-respondelement="respond" data-replyto="Responder a Ana Miralles" aria-label="Responder a Ana Miralles">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Tenía unas ganas enormes de probar esta receta, pero cuando fui al super no tenían berenjena&#8230; Las he hecho de champiñones y calabacín, siguiendo los mismos pasos y han quedado estupendas!!!!<br />
+Muchas gracias por todas las recetas!!!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-203578">
+    
+  <li id="comment-203581" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-203581">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T11:08:23+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203581">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>De nada Ana, me encanta compartir las cosas que se cocinan en casa.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203576" class="comment odd alt thread-odd thread-alt depth-1 media comment-203576">
+    <img alt='' src='https://secure.gravatar.com/avatar/3effc6a84033de25f0c4ffe1e1eda57cb81fc5080da8887fbb213b43937ea8b0?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/3effc6a84033de25f0c4ffe1e1eda57cb81fc5080da8887fbb213b43937ea8b0?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Eva</h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-03T21:43:30+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203576">
+          3 mayo, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203576" data-commentid="203576" data-postid="44981" data-belowelement="comment-203576" data-respondelement="respond" data-replyto="Responder a Eva" aria-label="Responder a Eva">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Nos han encantado!!!<br />
+Deliciosas, congelé unas cuantas pues me salieron unas 30 albóndigas. La salsa de tomate también muy rica con ese toque de albahaca. Gracias!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-203576">
+    
+  <li id="comment-203583" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-203583">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T11:18:36+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203583">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Gracias a ti Eva!!! Que compartamos muchas más      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203575" class="comment even thread-odd thread-alt depth-1 media comment-203575">
+    <img alt='' src='https://secure.gravatar.com/avatar/af65c9c15c1aa81ca9d724da0fe63dfe9e8cc16bd198d7a09bd8ef4a9c5488c4?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/af65c9c15c1aa81ca9d724da0fe63dfe9e8cc16bd198d7a09bd8ef4a9c5488c4?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Maite</h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-02T18:36:49+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203575">
+          2 mayo, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203575" data-commentid="203575" data-postid="44981" data-belowelement="comment-203575" data-respondelement="respond" data-replyto="Responder a Maite" aria-label="Responder a Maite">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, a mi la masa me ha salido muy líquida y no he podido darles forma, así que la he extendido en la bandeja del horno y la he metido así, cuando han horneado las he cortado como brownies y me ha quedado estupendo, lo comento por si le pasa a alguien.</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-203575">
+    
+  <li id="comment-203584" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-203584">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T11:19:02+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203584">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Habrán soltado mucho líquido tus berenjenas!!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203574" class="comment odd alt thread-odd thread-alt depth-1 media comment-203574">
+    <img alt='' src='https://secure.gravatar.com/avatar/f031a7b8ddc3e9bb6cc76b56a02c1c9f79b7c060bc0ee08afc7172024994363c?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f031a7b8ddc3e9bb6cc76b56a02c1c9f79b7c060bc0ee08afc7172024994363c?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Angel</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-30T21:14:36+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203574">
+          30 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203574" data-commentid="203574" data-postid="44981" data-belowelement="comment-203574" data-respondelement="respond" data-replyto="Responder a Angel" aria-label="Responder a Angel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Una receta muy buscada por mi, que por fin encuentro.<br />
+Gracias Rosa por compartirla con nosotra/os.<br />
+Un saludo</p>
+<p>Angel</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-203574">
+    
+  <li id="comment-203585" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-203585">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T11:19:31+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203585">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>De nada!!! un placer. Espero que la cocines y te guste      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203573" class="comment even thread-odd thread-alt depth-1 media comment-203573">
+    <img alt='' src='https://secure.gravatar.com/avatar/f99371a4a62a762bbfa026b67e85e7855a78862253b7ca45dd33c6ad3922350c?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f99371a4a62a762bbfa026b67e85e7855a78862253b7ca45dd33c6ad3922350c?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Jessica</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-28T19:50:51+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203573">
+          28 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203573" data-commentid="203573" data-postid="44981" data-belowelement="comment-203573" data-respondelement="respond" data-replyto="Responder a Jessica" aria-label="Responder a Jessica">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola! Si no le añades el pan que tan quedarán? Es que mi pareja es celiaca y me gustaría hacérselas. </p>
+<p>Gracias!!!!</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-203573">
+    
+  <li id="comment-203579" class="comment even depth-2 media comment-203579">
+    <img alt='' src='https://secure.gravatar.com/avatar/b2634b5ecacef197b191f3d82469209bf3b085075d398e65fe79c51ac6614f36?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b2634b5ecacef197b191f3d82469209bf3b085075d398e65fe79c51ac6614f36?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Sandra</h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-10T17:35:27+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203579">
+          10 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Y si sustituyes el pan rallado x harina de garbanzos? Ayuda a espesar y no tiene gluten.</p>
+      
+  </div></li>
+
+  <li id="comment-203580" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-203580">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T10:48:10+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203580">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Buena idea!!!</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203572" class="comment even thread-odd thread-alt depth-1 media comment-203572">
+    <img alt='' src='https://secure.gravatar.com/avatar/9e43858655261075ce416554e6b074f1afc22270e1fdcc7875bb97e79cfda2ca?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/9e43858655261075ce416554e6b074f1afc22270e1fdcc7875bb97e79cfda2ca?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Beatriz</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T21:25:25+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203572">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203572" data-commentid="203572" data-postid="44981" data-belowelement="comment-203572" data-respondelement="respond" data-replyto="Responder a Beatriz" aria-label="Responder a Beatriz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!Estoy preparando esta receta,se podrían dejar hechas en la nevera y mañana hornearlas??</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-203572">
+    
+  <li id="comment-203586" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-203586">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T11:20:01+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203586">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Déjalas bien tapaditas&#8230; o en un tupper hermético      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203571" class="comment odd alt thread-odd thread-alt depth-1 media comment-203571">
+    <img alt='' src='https://secure.gravatar.com/avatar/91d8770ee1305f4f34c37fa90df597445f5a3ee19643e13a162af930e90bc35b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/91d8770ee1305f4f34c37fa90df597445f5a3ee19643e13a162af930e90bc35b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://chalota76@gmail.com" class="url" rel="ugc external nofollow">chalota</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T19:49:37+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203571">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203571" data-commentid="203571" data-postid="44981" data-belowelement="comment-203571" data-respondelement="respond" data-replyto="Responder a chalota" aria-label="Responder a chalota">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Me encanta la berenjena y estas albóndigas tienen que estar buenísimas! Pero no tengo thermomix, como se harían de forma tradicional? Te agradecería que me lo explicaras ya que estoy deseando probarlas! Gracias</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-203571">
+    
+  <li id="comment-203577" class="comment odd alt depth-2 media comment-203577">
+    <img alt='' src='https://secure.gravatar.com/avatar/5fbe7f39ae342e52111829b4fb83e7ff5c631b68f76c90b2cda137ad8721a173?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/5fbe7f39ae342e52111829b4fb83e7ff5c631b68f76c90b2cda137ad8721a173?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://www.cocinarlight.com" class="url" rel="ugc external nofollow">Cocinarlight</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-04T08:20:21+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203577">
+          4 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hay unas cuantas alternativas si no tienes una thermomix:<br />
+Opción 1 Rallador de esos de tomate. Tomará más tiempo, pero te quedará con la textura deseada.<br />
+Opción 2 Picadora<br />
+Opción 3 Licuadora<br />
+De este modo, cuando Rosa dice en la receta: tritura, tu usas una de estas 3 opciones.<br />
+Luego con una olla vas cociendo los alimentos. Y por último, el toque de horno.<br />
+Ánimo!<br />
+Rosa, me encanta esta receta, tan sana y natural. :-P      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-203582" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-203582">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T11:17:03+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203582">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Graciassss</p>
+      
+  </div></li>
+
+  <li id="comment-203592" class="comment odd alt depth-2 media comment-203592">
+    <img alt='' src='https://secure.gravatar.com/avatar/debab1dc3d41a5a2c2493a61b30b822299c745222a13d4fba4226499ffb09c41?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/debab1dc3d41a5a2c2493a61b30b822299c745222a13d4fba4226499ffb09c41?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Miguel ángel</h5>
+        <div class="comment-meta">
+        <time datetime="2017-07-18T13:30:29+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203592">
+          18 julio, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Podria usar el microondas en vez de horno !? Gracias</p>
+      
+  </div></li>
+
+  <li id="comment-204633" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-204633">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-08-04T18:06:40+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-204633">
+          4 agosto, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Siii&#8230; yo apenas lo uso, pero claro que se puede.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203570" class="comment odd alt thread-odd thread-alt depth-1 media comment-203570">
+    <img alt='' src='https://secure.gravatar.com/avatar/ac0698df683f3386d9d3f44789ed5f6ea1ad260e071b75b39affae060b329241?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ac0698df683f3386d9d3f44789ed5f6ea1ad260e071b75b39affae060b329241?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Encarna</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T19:39:10+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203570">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203570" data-commentid="203570" data-postid="44981" data-belowelement="comment-203570" data-respondelement="respond" data-replyto="Responder a Encarna" aria-label="Responder a Encarna">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola !<br />
+Yo las hice el sábado y quedaron buenísimas<br />
+Y tb prepararé el strudel de espárragos, que viene en la revista y fue un éxito, pruébalo!<br />
+Gracias</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-203570">
+    
+  <li id="comment-203587" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-203587">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-05-15T11:20:27+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203587">
+          15 mayo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Strudel de espárragos&#8230; lo probaré      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203568" class="comment even thread-odd thread-alt depth-1 media comment-203568">
+    <img alt='' src='https://secure.gravatar.com/avatar/689226e8ec30626f8a42d98055125aeb7e33e5be53a19467150719a063d46067?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/689226e8ec30626f8a42d98055125aeb7e33e5be53a19467150719a063d46067?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Cristina</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T15:05:30+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203568">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203568" data-commentid="203568" data-postid="44981" data-belowelement="comment-203568" data-respondelement="respond" data-replyto="Responder a Cristina" aria-label="Responder a Cristina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola! yo hago prácticamente lo mismo pero con calabacín y son deliciosas. En lugar de hacer un tomate frito normal utilizo el de tu receta de tomateitaliano que suelo tener siempre congelado y le va genial. Probaré con berenjenas a ver qué tal!</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-203568">
+    
+  <li id="comment-203569" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-203569">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T16:31:59+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203569">
+          27 abril, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Y yo probaré con calabacín :DDD      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203562" class="comment odd alt thread-odd thread-alt depth-1 media comment-203562">
+    <img alt='' src='https://secure.gravatar.com/avatar/8b17e1014d01a2fbf0b93bfbe5762215c10370cca0219ff3eb5836ce48841b7b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/8b17e1014d01a2fbf0b93bfbe5762215c10370cca0219ff3eb5836ce48841b7b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">eva</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T12:27:40+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203562">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203562" data-commentid="203562" data-postid="44981" data-belowelement="comment-203562" data-respondelement="respond" data-replyto="Responder a eva" aria-label="Responder a eva">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Yo también le eché el ojo a esta receta en cuanto la ví en la revista. Las hice el otro día y quedaron buenísimas y son muy fáciles de hacer</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-203562">
+    
+  <li id="comment-203563" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-203563">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T14:04:51+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203563">
+          27 abril, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Si, son geniales y deliciosas&#8230; me han encantado :DDD      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203561" class="comment even thread-odd thread-alt depth-1 media comment-203561">
+    <img alt='' src='https://secure.gravatar.com/avatar/f07ba10890e2333ef0fc5fa1ad2d4dbf768ba678c1e8ef3cd1c47aa690ea7a6c?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f07ba10890e2333ef0fc5fa1ad2d4dbf768ba678c1e8ef3cd1c47aa690ea7a6c?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Lourdes</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T11:14:57+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203561">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203561" data-commentid="203561" data-postid="44981" data-belowelement="comment-203561" data-respondelement="respond" data-replyto="Responder a Lourdes" aria-label="Responder a Lourdes">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenos días, gracias por esta receta, yo también quiero hacerlas, una pregunta: fritas que tal quedaran?</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-203561">
+    
+  <li id="comment-203564" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-203564">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T14:05:36+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203564">
+          27 abril, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Pues seguro que ricas, pero necesitarás rebozarlas&#8230;      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203560" class="comment odd alt thread-odd thread-alt depth-1 media comment-203560">
+    <img alt='' src='https://secure.gravatar.com/avatar/cada8afc6f631c29428d4db4dd08740d1f901f128f582ea0848b1d3df4c2106c?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/cada8afc6f631c29428d4db4dd08740d1f901f128f582ea0848b1d3df4c2106c?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://artpower-ana.blogspot.com.es" class="url" rel="ugc external nofollow">AnaG</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T10:26:50+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203560">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203560" data-commentid="203560" data-postid="44981" data-belowelement="comment-203560" data-respondelement="respond" data-replyto="Responder a AnaG" aria-label="Responder a AnaG">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>¡Qué pinta más buena Rosa! ¡Muchas gracias por compartir tus maravillosas recetas! Una pregunta, la tarta que viene en la foto para el postre, ¿es la de queso japonesa?      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-203560">
+    
+  <li id="comment-203565" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-203565">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T14:05:58+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203565">
+          27 abril, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>No&#8230; es otra. Os la pongo pronto      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203559" class="comment even thread-odd thread-alt depth-1 media comment-203559">
+    <img alt='' src='https://secure.gravatar.com/avatar/cb32e801be670e1e95b482902d5fe9422397980dba3a7b3bfcd61b79d3af6876?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/cb32e801be670e1e95b482902d5fe9422397980dba3a7b3bfcd61b79d3af6876?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mercedes</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T10:01:14+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203559">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203559" data-commentid="203559" data-postid="44981" data-belowelement="comment-203559" data-respondelement="respond" data-replyto="Responder a Mercedes" aria-label="Responder a Mercedes">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa me encanta!!! En enero estuvimos en Roma y comí unas albóndigas parecidas! ahora ya no tengo excusa para hacerlas!<br />
+Un beso grande desde Copenhague :)      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-203559">
+    
+  <li id="comment-203566" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-203566">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T14:06:29+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203566">
+          27 abril, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Un beso enorme!!! A ver si se parecen a esas que probaste, por lo menos ya tenemos una base para tunear estas :D      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-203558" class="comment odd alt thread-odd thread-alt depth-1 media comment-203558">
+    <img alt='' src='https://secure.gravatar.com/avatar/ab2718cc2ce9a95afda34e0c4dd4b63557f7d76aa094a826e8204911f025c1b1?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ab2718cc2ce9a95afda34e0c4dd4b63557f7d76aa094a826e8204911f025c1b1?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">cristina mir solanas</h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T08:01:32+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203558">
+          27 abril, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-203558" data-commentid="203558" data-postid="44981" data-belowelement="comment-203558" data-respondelement="respond" data-replyto="Responder a cristina mir solanas" aria-label="Responder a cristina mir solanas">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa, me llevo la receta, mañana mismo la preparo! En casa nos encanta la berenjena , y estas albóndigas tienen que estar de lujo.<br />
+Gracias , tus recetas son éxito seguro!<br />
+Besss</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-203558">
+    
+  <li id="comment-203567" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-203567">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-04-27T14:06:54+02:00"><a href="https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/#comment-203567">
+          27 abril, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Esta receta es de la revista, pero encantada de compartirla con vosotros :D      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+    </ol>
+
+    
+      </section><!-- /#comments -->
+  
+
+<button class="mostrar-comentarios despues button" style="cursor:pointer">Mostrar comentarios</button>
+
+  <section id="respond">
+  	<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Dejar una opinión <small><a rel="nofollow" id="cancel-comment-reply-link" href="/albondigas-de-berenjena-con-tomate/#respond" style="display:none;">Cancelar la respuesta</a></small></h3><form action="https://www.velocidadcuchara.com/wp-comments-post.php" method="post" id="commentform" class="comment-form"><p class="comment-form-comment"><label for="comment">Comentarios</label> <textarea id="comment" name="comment" cols="45" rows="8" class="input-xlarge" aria-required="true" required="required"></textarea></p><p class="pprivacy"><input type="checkbox" class="form-check" name="privacy" value="privacy-key" class="privacyBox" aria-req="true">&nbsp;&nbsp;Acepto la <a target="blank" href="https://velocidadcuchara.com/politica-de-privacidad">política de privacidad</a><p><div class="row"><div class="col-md-4"><label for="author">Nombre <span class="comment-required">*</span></label> <input id="author" name="author" type="text" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="email">Email (no será publicado) <span class="comment-required">*</span></label> <input type="email" class="text" name="email" id="email" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="url">Sitio Web</label> <input id="url" name="url" type="url" value="" /></div>
+</div><p class="form-submit"><input name="submit" type="submit" id="submit" class="kad-btn kad-btn-primary" value="Enviar" /> <input type='hidden' name='comment_post_ID' value='44981' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><span class="ERComment">
+<span style="float:left">Valora esta receta: </span>
+<span class="ERRateBG">
+<span class="ERRateStars"></span>
+</span>
+<input type="hidden" class="inpERRating" name="ERRating" value="0" />
+&nbsp;
+</span><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="fdefbde713" /></p><p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="246"/><script type="rocketlazyloadscript">document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );</script></p></form>	</div><!-- #respond -->
+	
+  </section><!-- /#respond -->
+        </div>
+                    
+          	            <aside class="col-lg-3 col-md-4 kad-sidebar" role="complementary" itemscope itemtype="http://schema.org/WPSideBar">
+	              <div class="sidebar">
+	                <section class="widget-2 widget local-widget"><div class="widget-inner"><div id="local-2776184879" style="margin-bottom: 25px;margin-left: auto;margin-right: auto;text-align: center;"><picture style="display: inline-block; max-width: 100%; height: auto;">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg.webp"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg" alt="Claudia &amp; Julia: Utensilios para una cocina tradicional y saludable" width="300" height="100"/>
+</picture>
+</div></div></section><section id="siteorigin-panels-builder-28" class="widget-4 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w64208d0f963d5"  class="panel-layout" ><div id="pg-w64208d0f963d5-0"  class="panel-grid panel-no-style" ><div id="pgc-w64208d0f963d5-0-0"  class="panel-grid-cell" ><div id="panel-w64208d0f963d5-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://newsletter.velocidadcuchara.com/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Suscribete.svg" width="300" height="45" sizes="(max-width: 300px) 100vw, 300px" title="Suscríbete Newsletter" alt="Suscríbete a Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div><div id="panel-w64208d0f963d5-0-0-1" class="so-panel widget widget_sow-editor panel-last-child" data-index="1" ><div class="panel-widget-style panel-widget-style-for-w64208d0f963d5-0-0-1" ><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p style="text-align: center;"><a href="https://newsletter.velocidadcuchara.com/" target="_blank" rel="noopener"><em>Recibe nuestra Newsletter<br />
+en tu correo electrónico</em></a></p>
+</div>
+</div></div></div></div></div></div></div></section><section id="sow-image-26" class="widget-5 widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/todas-las-recetas/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2018/07/descubre_todas_nuestras_recetas-1.svg" width="1" height="1" sizes="(max-width: 1px) 100vw, 1px" title="Todas las recetas Thermomix" alt="Todas las recetas Thermomix" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section><section id="custom_html-5" class="widget_text widget-6 widget widget_custom_html"><div class="widget_text widget-inner"><div class="textwidget custom-html-widget"><script type="rocketlazyloadscript" async data-rocket-src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0432726040009676"
+     crossorigin="anonymous"></script>
+<!-- PRUEBA 23 -->
+<ins class="adsbygoogle"
+     style="display:block"
+     data-ad-client="ca-pub-0432726040009676"
+     data-ad-slot="7485608005"
+     data-ad-format="auto"
+     data-full-width-responsive="true"></ins>
+<script type="rocketlazyloadscript">
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script></div></div></section><section id="siteorigin-panels-builder-29" class="widget-7 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w5f89a361017dd"  class="panel-layout" ><div id="pg-w5f89a361017dd-0"  class="panel-grid panel-has-style" ><div class="panel-row-style panel-row-style-for-w5f89a361017dd-0" ><div id="pgc-w5f89a361017dd-0-0"  class="panel-grid-cell" ><div id="panel-w5f89a361017dd-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.youtube.com/user/velocidadcuchara" target="_blank" rel="noopener noreferrer" >	<picture class="so-widget-image">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png.webp 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png.webp 600w" sizes="(max-width: 300px) 100vw, 300px"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png 600w" sizes="(max-width: 300px) 100vw, 300px" alt=""/>
+</picture>
+
+</a></div>
+
+</div></div></div><div id="panel-w5f89a361017dd-0-0-1" class="so-panel widget widget_sow-image" data-index="1" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-1" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/tarta-sacher-paso-a-paso-con-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Tarta Sacher" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Tarta Sacher</h3></div></div></div><div id="panel-w5f89a361017dd-0-0-2" class="so-panel widget widget_sow-image panel-last-child" data-index="2" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-2" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/como-preparar-yogur-en-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Yogurt casero" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Yogurt casero</h3></div></div></div></div></div></div></div></div></section><section id="sow-image-18" class="widget-8 widget-last widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Podcast-Caratula-cuadrados-1080-×-1920-px-1000-×-1000-px.svg" width="300" height="300" sizes="(max-width: 300px) 100vw, 300px" title="Promo libros Velocidad Cuchara" alt="Promo libros Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section>	              </div><!-- /.sidebar -->
+	            </aside><!-- /aside -->
+                    </div><!-- /.row-->
+        </div><!-- /.content -->
+      </div><!-- /.wrap -->
+      <footer data-wpr-lazyrender="1" id="containerfooter" class="footerclass" itemscope itemtype="http://schema.org/WPFooter">
+  <div class="container">
+  	<div class="row">
+  							<div class="col-md-4 footercol1">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-5" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="https://www.velocidadcuchara.com"><img loading="lazy" decoding="async" class="alignnone wp-image-45320" src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/footer_vc.svg" alt="" width="171" height="53" /></a></p>
+<p>Desde 2008 cocinamos con (y sin) el robot de cocina más famoso del mundo</p>
+<div class="space_20 clearfix"></div>
+<figure id="attachment_43492" class="thumbnail wp-caption alignnone" style="width: 176px"><picture loading="lazy" decoding="async" class="size-full wp-image-43492">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png.webp 176w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+<img loading="lazy" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png" alt="" width="176" height="46" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png 176w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-140x36.png 140w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-24x6.png 24w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-36x9.png 36w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-48x12.png 48w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+</picture>
+<figcaption class="caption wp-caption-text">Ganadores en la XII edición</figcaption></figure>
+<figure id="attachment_45318" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45318" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/gastroblogs.png" alt="" width="176" height="52" /><figcaption class="caption wp-caption-text">Ganador Gastroblogs</figcaption></figure>
+<figure id="attachment_45319" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45319" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/bitacoras.png" alt="" width="176" height="46" /><figcaption class="caption wp-caption-text">Finalista en Gastronomía</figcaption></figure>
+</div>
+</div></aside></div>					</div>
+            										<div class="col-md-4 footercol2">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-social-media-buttons-4" class="widget widget_sow-social-media-buttons"><div class="so-widget-sow-social-media-buttons so-widget-sow-social-media-buttons-flat-3af2f923c85f"><h3>EN LAS REDES</h3>
+<div class="social-media-button-container">
+	
+		<a class="ow-button-hover sow-social-media-button-facebook sow-social-media-button" title="Velocidad Cuchara en Facebook" aria-label="Velocidad Cuchara en Facebook" target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf39e;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-instagram sow-social-media-button" title="Velocidad Cuchara en Instagram" aria-label="Velocidad Cuchara en Instagram" target="_blank" rel="noopener noreferrer" href="https://www.instagram.com/velocidadcuchara/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf16d;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-youtube sow-social-media-button" title="Velocidad Cuchara en Youtube" aria-label="Velocidad Cuchara en Youtube" target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/user/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf167;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-twitter sow-social-media-button" title="Velocidad Cuchara en Twitter" aria-label="Velocidad Cuchara en Twitter" target="_blank" rel="noopener noreferrer" href="https://twitter.com/rosaarda" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf099;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-pinterest sow-social-media-button" title="Velocidad Cuchara en Pinterest" aria-label="Velocidad Cuchara en Pinterest" target="_blank" rel="noopener noreferrer" href="https://es.pinterest.com/rosaarda/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf0d2;" ></span>							</span>
+		</a>
+	</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-6" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>ROSA ARDÁ</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>Enganchada a la Thermomix, uno de los grandes inventos de la historia :D</p>
+</div>
+</div></aside></div><div class="widget-3 widget-last footer-widget"><aside id="media_image-2" class="widget widget_media_image"><h3>NUESTROS LIBROS</h3><a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/"><picture class="image wp-image-58705  attachment-full size-full" style="max-width: 100%; height: auto;" title="NUESTRO LIBRO" decoding="async" loading="lazy">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png.webp 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png.webp 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+<img width="241" height="148" src="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png" alt="" decoding="async" loading="lazy" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+</picture>
+</a></aside></div>					</div>
+		        		        					<div class="col-md-4 footercol3">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-7" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>AVISO LEGAL</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>VelocidadCuchara.com y Velocidad Cuchara <a href="https://www.velocidadcuchara.com/aviso-legal/">son marcas registradas</a>. Consulta la <a href="https://www.velocidadcuchara.com/declaracion-de-privacidad-ue/" target="_blank" rel="noopener">Política de privacidad</a> y la <a href="https://www.velocidadcuchara.com/politica-de-cookies-ue/" target="_blank" rel="noopener">Política de Cookies</a></p>
+</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-8" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>NOS ENCANTA LEER</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="http://www.averquecocinamoshoy.com/" target="_blank" rel="noopener noreferrer">A ver qué cocinamos hoy</a><br />
+<a href="http://www.crockpotting.es/" target="_blank" rel="noopener">Crockpotting</a><br />
+<a href="https://elcomidista.elpais.com/" target="_blank" rel="noopener noreferrer">El Comidista</a><br />
+<a href="http://www.misthermorecetas.com/" target="_blank" rel="noopener noreferrer">Mis thermorecetas</a><br />
+<a href="http://pepacooks.com/" target="_blank" rel="noopener noreferrer">Pepa Cooks </a><br />
+<a href="http://www.recetasderechupete.com/" target="_blank" rel="noopener noreferrer">Recetas de Rechupete </a><br />
+<a href="https://webosfritos.es/" target="_blank" rel="noopener noreferrer">Webos Fritos</a></p>
+</div>
+</div></aside></div><div class="widget_text widget-3 widget-last footer-widget"><aside id="custom_html-3" class="widget_text widget widget_custom_html"><div class="textwidget custom-html-widget"></div></aside></div>					</div>
+	            			        </div>
+        <div class="footercredits clearfix">
+
+    		        	<p>&copy; 2008 - 2026 Velocidad Cuchara</p>
+    	</div>
+
+  </div>
+
+</footer>
+</div><!--Wrapper-->
+
+<script type="rocketlazyloadscript" data-rocket-type='text/javascript'>
+/* <![CDATA[ */
+var advancedAds = {"adHealthNotice":{"enabled":true,"pattern":"AdSense fallback was loaded for empty AdSense ad \"[ad_title]\""},"frontendPrefix":"local-"};
+
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript">(function(){var advanced_ads_ga_UID="rosaarda",advanced_ads_ga_anonymIP=!!1;window.advanced_ads_check_adblocker=function(){var t=[],n=null;function e(t){var n=window.requestAnimationFrame||window.mozRequestAnimationFrame||window.webkitRequestAnimationFrame||function(t){return setTimeout(t,16)};n.call(window,t)}return e((function(){var a=document.createElement("div");a.innerHTML="&nbsp;",a.setAttribute("class","ad_unit ad-unit text-ad text_ad pub_300x250"),a.setAttribute("style","width: 1px !important; height: 1px !important; position: absolute !important; left: 0px !important; top: 0px !important; overflow: hidden !important;"),document.body.appendChild(a),e((function(){var e,o,i=null===(e=(o=window).getComputedStyle)||void 0===e?void 0:e.call(o,a),d=null==i?void 0:i.getPropertyValue("-moz-binding");n=i&&"none"===i.getPropertyValue("display")||"string"==typeof d&&-1!==d.indexOf("about:");for(var c=0,r=t.length;c<r;c++)t[c](n);t=[]}))})),function(e){"undefined"==typeof advanced_ads_adblocker_test&&(n=!0),null!==n?e(n):t.push(e)}}(),(()=>{function t(t){this.UID=t,this.analyticsObject="function"==typeof gtag;var n=this;return this.count=function(){gtag("event","AdBlock",{event_category:"Advanced Ads",event_label:"Yes",non_interaction:!0,send_to:n.UID})},function(){if(!n.analyticsObject){var e=document.createElement("script");e.src="https://www.googletagmanager.com/gtag/js?id="+t,e.async=!0,document.body.appendChild(e),window.dataLayer=window.dataLayer||[],window.gtag=function(){dataLayer.push(arguments)},n.analyticsObject=!0,gtag("js",new Date)}var a={send_page_view:!1,transport_type:"beacon"};window.advanced_ads_ga_anonymIP&&(a.anonymize_ip=!0),gtag("config",t,a)}(),this}advanced_ads_check_adblocker((function(n){n&&new t(advanced_ads_ga_UID).count()}))})();})();</script><script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"\/*"},{"not":{"href_matches":["\/wp-*.php","\/wp-admin\/*","\/wp-content\/uploads\/*","\/wp-content\/*","\/wp-content\/plugins\/*","\/wp-content\/themes\/velocidad\/*","\/wp-content\/themes\/virtue\/*","\/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+
+<!-- Consent Management powered by Complianz | GDPR/CCPA Cookie Consent https://wordpress.org/plugins/complianz-gdpr -->
+<div id="cmplz-cookiebanner-container"><div class="cmplz-cookiebanner cmplz-hidden banner-1 velocidad-cuchara optin cmplz-bottom cmplz-categories-type-view-preferences" aria-modal="true" data-nosnippet="true" role="dialog" aria-live="polite" aria-labelledby="cmplz-header-1-optin" aria-describedby="cmplz-message-1-optin">
+	<div class="cmplz-header">
+		<div class="cmplz-logo"><img width="350" height="100" src="https://www.velocidadcuchara.com/wp-content/uploads/2024/03/cookies-350x100.png" class="attachment-cmplz_banner_image size-cmplz_banner_image" alt="Velocidad Cuchara" decoding="async" loading="lazy" /></div>
+		<div class="cmplz-title" id="cmplz-header-1-optin">Gestiona tu privacidad</div>
+		<div class="cmplz-close" tabindex="0" role="button" aria-label="Cerrar diálogo">
+			<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>
+		</div>
+	</div>
+
+	<div class="cmplz-divider cmplz-divider-header"></div>
+	<div class="cmplz-body">
+		<div class="cmplz-message" id="cmplz-message-1-optin"><p>Para ofrecer las mejores experiencias, nosotros y nuestros socios utilizamos tecnologías como cookies para almacenar y/o acceder a la información del dispositivo. La aceptación de estas tecnologías nos permitirá a nosotros y a nuestros socios procesar datos personales como el comportamiento de navegación o identificaciones únicas (IDs) en este sitio y mostrar anuncios (no-) personalizados. No consentir o retirar el consentimiento, puede afectar negativamente a ciertas características y funciones.</p><p>Haz clic a continuación para aceptar lo anterior o realizar elecciones más detalladas.&nbsp;Tus elecciones se aplicarán solo en este sitio.&nbsp;Puedes cambiar tus ajustes en cualquier momento, incluso retirar tu consentimiento, utilizando los botones de la Política de cookies o haciendo clic en el icono de Privacidad situado en la parte inferior de la pantalla.</p></div>
+		<!-- categories start -->
+		<div class="cmplz-categories">
+			<details class="cmplz-category cmplz-functional" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Funcional</span>
+							<span class='cmplz-always-active'>
+								<span class="cmplz-banner-checkbox">
+									<input type="checkbox"
+										   id="cmplz-functional-optin"
+										   data-category="cmplz_functional"
+										   class="cmplz-consent-checkbox cmplz-functional"
+										   size="40"
+										   value="1"/>
+									<label class="cmplz-label" for="cmplz-functional-optin"><span class="screen-reader-text">Funcional</span></label>
+								</span>
+								Siempre activo							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-functional">El almacenamiento o acceso técnico es estrictamente necesario para el propósito legítimo de permitir el uso de un servicio específico explícitamente solicitado por el abonado o usuario, o con el único propósito de llevar a cabo la transmisión de una comunicación a través de una red de comunicaciones electrónicas.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-preferences" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Preferencias</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-preferences-optin"
+									   data-category="cmplz_preferences"
+									   class="cmplz-consent-checkbox cmplz-preferences"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-preferences-optin"><span class="screen-reader-text">Preferencias</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-preferences">El almacenamiento o acceso técnico es necesario para la finalidad legítima de almacenar preferencias no solicitadas por el abonado o usuario.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-statistics" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Estadísticas</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-statistics-optin"
+									   data-category="cmplz_statistics"
+									   class="cmplz-consent-checkbox cmplz-statistics"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-statistics-optin"><span class="screen-reader-text">Estadísticas</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-statistics">El almacenamiento o acceso técnico que es utilizado exclusivamente con fines estadísticos.</span>
+					<span class="cmplz-description-statistics-anonymous">El almacenamiento o acceso técnico que se utiliza exclusivamente con fines estadísticos anónimos. Sin un requerimiento, el cumplimiento voluntario por parte de tu Proveedor de servicios de Internet, o los registros adicionales de un tercero, la información almacenada o recuperada sólo para este propósito no se puede utilizar para identificarte.</span>
+				</div>
+			</details>
+			<details class="cmplz-category cmplz-marketing" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Marketing</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-marketing-optin"
+									   data-category="cmplz_marketing"
+									   class="cmplz-consent-checkbox cmplz-marketing"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-marketing-optin"><span class="screen-reader-text">Marketing</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-marketing">El almacenamiento o acceso técnico es necesario para crear perfiles de usuario para enviar publicidad, o para rastrear al usuario en una web o en varias web con fines de marketing similares.</span>
+				</div>
+			</details>
+		</div><!-- categories end -->
+		
+<div class="cmplz-categories cmplz-tcf">
+
+	<div class="cmplz-category cmplz-statistics">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Estadísticas</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-marketing">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Marketing</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-features">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Características</div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialfeatures">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'></div>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialpurposes">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+		</div>
+	</div>
+
+</div>
+	</div>
+
+	<div class="cmplz-links cmplz-information">
+		<ul>
+			<li><a class="cmplz-link cmplz-manage-options cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a></li>
+			<li><a class="cmplz-link cmplz-manage-third-parties cookie-statement" href="#" data-relative_url="#cmplz-cookies-overview">Gestionar los servicios</a></li>
+			<li><a class="cmplz-link cmplz-manage-vendors tcf cookie-statement" href="#" data-relative_url="#cmplz-tcf-wrapper">Gestionar {vendor_count} proveedores</a></li>
+			<li><a class="cmplz-link cmplz-external cmplz-read-more-purposes tcf" target="_blank" rel="noopener noreferrer nofollow" href="https://cookiedatabase.org/tcf/purposes/" aria-label="Read more about TCF purposes on Cookie Database">Leer más sobre estos propósitos</a></li>
+		</ul>
+			</div>
+
+	<div class="cmplz-divider cmplz-footer"></div>
+
+	<div class="cmplz-buttons">
+		<button class="cmplz-btn cmplz-accept">Aceptar</button>
+		<button class="cmplz-btn cmplz-deny">Rechazar</button>
+		<button class="cmplz-btn cmplz-view-preferences">Administrar opciones</button>
+		<button class="cmplz-btn cmplz-save-preferences">Guardar preferencias</button>
+		<a class="cmplz-btn cmplz-manage-options tcf cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a>
+			</div>
+
+	
+	<div class="cmplz-documents cmplz-links">
+		<ul>
+			<li><a class="cmplz-link cookie-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link privacy-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link impressum" href="#" data-relative_url="">{title}</a></li>
+		</ul>
+			</div>
+</div>
+</div>
+					<div id="cmplz-manage-consent" data-nosnippet="true"><button class="cmplz-btn cmplz-hidden cmplz-manage-consent manage-consent-1">Privacidad</button>
+
+</div>        <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        jQuery(document).ready(function($){
+            $("#submit").click(function(e)){
+                if (!$('.privacyBox').prop('checked')){
+                    e.preventDefault();
+                    alert('Debes aceptar nuestra política de privacidad <p><a href="javascript:history.back()">' . __('&laquo; Volver') . '</a></p>');
+                    return false;
+                }
+            }
+        });
+        </script>
+                        <style type="text/css" media="all"
+                       id="siteorigin-panels-layouts-footer">/* Layout w64208d0f963d5 */ #pgc-w64208d0f963d5-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-0 , #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-1 {  } #pl-w64208d0f963d5 .so-panel { margin-bottom:30px } #pl-w64208d0f963d5 .so-panel:last-child { margin-bottom:0px } #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w64208d0f963d5-0-0-1> .panel-widget-style { color:#bdbeb2;margin-top:-18px;font-size:1.2em;font-weight:400;line-height:1.2em } @media (max-width:780px){ #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w64208d0f963d5-0 > .panel-grid-cell , #pg-w64208d0f963d5-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w64208d0f963d5 .panel-grid-cell { padding:0 } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-empty { display:none } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } /* Layout w5f89a361017dd */ #pgc-w5f89a361017dd-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-0 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-1 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-2 {  } #pl-w5f89a361017dd .so-panel { margin-bottom:30px } #pl-w5f89a361017dd .so-panel:last-child { margin-bottom:0px } #pg-w5f89a361017dd-0> .panel-row-style { background-color:#e7e8e1;padding:0.5em } #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w5f89a361017dd-0-0-0> .panel-widget-style { margin-bottom:20px } @media (max-width:780px){ #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w5f89a361017dd-0 > .panel-grid-cell , #pg-w5f89a361017dd-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w5f89a361017dd .panel-grid-cell { padding:0 } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-empty { display:none } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } </style><link rel='stylesheet' id='siteorigin-panels-front-css' href='https://www.velocidadcuchara.com/wp-content/plugins/siteorigin-panels/css/front-flex.min.css?ver=2.10.9' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-3af2f923c85f-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-3af2f923c85f.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='siteorigin-widget-icon-font-fontawesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/icons/fontawesome/style.css?ver=1773428753' type='text/css' media='all' />
+<script type="text/javascript" id="wtpsw-public-script-js-extra">
+/* <![CDATA[ */
+var Wtpsw = {"elementor_preview":"0","ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","is_mobile":"0","is_avada":"0","is_rtl":"0","post_view_count":"44981","data_nonce":"aca6b40d34"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/js/wtpsw-public.js?ver=1773428753" id="wtpsw-public-script-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-browser-checker-js-after">
+/* <![CDATA[ */
+"use strict";var _createClass=function(){function defineProperties(target,props){for(var i=0;i<props.length;i++){var descriptor=props[i];descriptor.enumerable=descriptor.enumerable||!1,descriptor.configurable=!0,"value"in descriptor&&(descriptor.writable=!0),Object.defineProperty(target,descriptor.key,descriptor)}}return function(Constructor,protoProps,staticProps){return protoProps&&defineProperties(Constructor.prototype,protoProps),staticProps&&defineProperties(Constructor,staticProps),Constructor}}();function _classCallCheck(instance,Constructor){if(!(instance instanceof Constructor))throw new TypeError("Cannot call a class as a function")}var RocketBrowserCompatibilityChecker=function(){function RocketBrowserCompatibilityChecker(options){_classCallCheck(this,RocketBrowserCompatibilityChecker),this.passiveSupported=!1,this._checkPassiveOption(this),this.options=!!this.passiveSupported&&options}return _createClass(RocketBrowserCompatibilityChecker,[{key:"_checkPassiveOption",value:function(self){try{var options={get passive(){return!(self.passiveSupported=!0)}};window.addEventListener("test",null,options),window.removeEventListener("test",null,options)}catch(err){self.passiveSupported=!1}}},{key:"initRequestIdleCallback",value:function(){!1 in window&&(window.requestIdleCallback=function(cb){var start=Date.now();return setTimeout(function(){cb({didTimeout:!1,timeRemaining:function(){return Math.max(0,50-(Date.now()-start))}})},1)}),!1 in window&&(window.cancelIdleCallback=function(id){return clearTimeout(id)})}},{key:"isDataSaverModeOn",value:function(){return"connection"in navigator&&!0===navigator.connection.saveData}},{key:"supportsLinkPrefetch",value:function(){var elem=document.createElement("link");return elem.relList&&elem.relList.supports&&elem.relList.supports("prefetch")&&window.IntersectionObserver&&"isIntersecting"in IntersectionObserverEntry.prototype}},{key:"isSlowConnection",value:function(){return"connection"in navigator&&"effectiveType"in navigator.connection&&("2g"===navigator.connection.effectiveType||"slow-2g"===navigator.connection.effectiveType)}}]),RocketBrowserCompatibilityChecker}();
+/* ]]> */
+</script>
+<script type="text/javascript" id="rocket-preload-links-js-extra">
+/* <![CDATA[ */
+var RocketPreloadLinksConfig = {"excludeUris":"\/(?:.+\/)?feed(?:\/(?:.+\/?)?)?$|\/(?:.+\/)?embed\/|\/(index.php\/)?(.*)wp-json(\/.*|$)|\/refer\/|\/go\/|\/recommend\/|\/recommends\/","usesTrailingSlash":"1","imageExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php","fileExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php|html|htm","siteUrl":"https:\/\/www.velocidadcuchara.com","onHoverDelay":"100","rateThrottle":"3"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-preload-links-js-after">
+/* <![CDATA[ */
+(function() {
+"use strict";var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},e=function(){function i(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}return function(e,t,n){return t&&i(e.prototype,t),n&&i(e,n),e}}();function i(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var t=function(){function n(e,t){i(this,n),this.browser=e,this.config=t,this.options=this.browser.options,this.prefetched=new Set,this.eventTime=null,this.threshold=1111,this.numOnHover=0}return e(n,[{key:"init",value:function(){!this.browser.supportsLinkPrefetch()||this.browser.isDataSaverModeOn()||this.browser.isSlowConnection()||(this.regex={excludeUris:RegExp(this.config.excludeUris,"i"),images:RegExp(".("+this.config.imageExt+")$","i"),fileExt:RegExp(".("+this.config.fileExt+")$","i")},this._initListeners(this))}},{key:"_initListeners",value:function(e){-1<this.config.onHoverDelay&&document.addEventListener("mouseover",e.listener.bind(e),e.listenerOptions),document.addEventListener("mousedown",e.listener.bind(e),e.listenerOptions),document.addEventListener("touchstart",e.listener.bind(e),e.listenerOptions)}},{key:"listener",value:function(e){var t=e.target.closest("a"),n=this._prepareUrl(t);if(null!==n)switch(e.type){case"mousedown":case"touchstart":this._addPrefetchLink(n);break;case"mouseover":this._earlyPrefetch(t,n,"mouseout")}}},{key:"_earlyPrefetch",value:function(t,e,n){var i=this,r=setTimeout(function(){if(r=null,0===i.numOnHover)setTimeout(function(){return i.numOnHover=0},1e3);else if(i.numOnHover>i.config.rateThrottle)return;i.numOnHover++,i._addPrefetchLink(e)},this.config.onHoverDelay);t.addEventListener(n,function e(){t.removeEventListener(n,e,{passive:!0}),null!==r&&(clearTimeout(r),r=null)},{passive:!0})}},{key:"_addPrefetchLink",value:function(i){return this.prefetched.add(i.href),new Promise(function(e,t){var n=document.createElement("link");n.rel="prefetch",n.href=i.href,n.onload=e,n.onerror=t,document.head.appendChild(n)}).catch(function(){})}},{key:"_prepareUrl",value:function(e){if(null===e||"object"!==(void 0===e?"undefined":r(e))||!1 in e||-1===["http:","https:"].indexOf(e.protocol))return null;var t=e.href.substring(0,this.config.siteUrl.length),n=this._getPathname(e.href,t),i={original:e.href,protocol:e.protocol,origin:t,pathname:n,href:t+n};return this._isLinkOk(i)?i:null}},{key:"_getPathname",value:function(e,t){var n=t?e.substring(this.config.siteUrl.length):e;return n.startsWith("/")||(n="/"+n),this._shouldAddTrailingSlash(n)?n+"/":n}},{key:"_shouldAddTrailingSlash",value:function(e){return this.config.usesTrailingSlash&&!e.endsWith("/")&&!this.regex.fileExt.test(e)}},{key:"_isLinkOk",value:function(e){return null!==e&&"object"===(void 0===e?"undefined":r(e))&&(!this.prefetched.has(e.href)&&e.origin===this.config.siteUrl&&-1===e.href.indexOf("?")&&-1===e.href.indexOf("#")&&!this.regex.excludeUris.test(e.href)&&!this.regex.images.test(e.href))}}],[{key:"run",value:function(){"undefined"!=typeof RocketPreloadLinksConfig&&new n(new RocketBrowserCompatibilityChecker({capture:!0,passive:!0}),RocketPreloadLinksConfig).init()}}]),n}();t.run();
+}());
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads/admin/assets/js/advertisement.js?ver=1773428753" id="advanced-ads-find-adblocker-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro-main-js-extra">
+/* <![CDATA[ */
+var advanced_ads_cookies = {"cookie_path":"\/","cookie_domain":""};
+var advadsCfpInfo = {"cfpExpHours":"3","cfpClickLimit":"3","cfpBan":"7","cfpPath":"","cfpDomain":"www.velocidadcuchara.com","cfpEnabled":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/advanced-ads-pro.js?ver=1773428753" id="advanced-ads-pro-main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/js/postscribe.js?ver=1773428753" id="advanced-ads-pro/postscribe-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro/cache_busting-js-extra">
+/* <![CDATA[ */
+var advanced_ads_pro_ajax_object = {"ajax_url":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","lazy_load_module_enabled":"1","lazy_load":{"default_offset":0,"offsets":[]},"moveintohidden":"","wp_timezone_offset":"7200","the_id":"44981","is_singular":"1"};
+var advanced_ads_responsive = {"reload_on_resize":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/front.js?ver=1773428753" id="advanced-ads-pro/cache_busting-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/comment-reply.min.js?ver=6.8.2" id="comment-reply-js" async="async" data-wp-strategy="async"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/imagesloaded.min.js?ver=5.0.0" id="imagesloaded-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/masonry.min.js?ver=4.2.2" id="masonry-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/min/plugins-min.js?ver=303" id="kadence_plugins-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/js/main.js?ver=1773428753" id="kadence_main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/hoverIntent.min.js?ver=1.10.2" id="hoverIntent-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="megamenu-js-extra">
+/* <![CDATA[ */
+var megamenu = {"timeout":"300","interval":"100"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/megamenu/js/maxmegamenu.js?ver=1773428753" id="megamenu-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="cmplz-cookiebanner-js-extra">
+/* <![CDATA[ */
+var complianz = {"prefix":"cmplz_","user_banner_id":"1","set_cookies":[],"block_ajax_content":"0","banner_version":"48","version":"7.5.6.1","store_consent":"1","do_not_track_enabled":"","consenttype":"optin","region":"eu","geoip":"1","dismiss_timeout":"","disable_cookiebanner":"","soft_cookiewall":"","dismiss_on_scroll":"","cookie_expiry":"365","url":"https:\/\/www.velocidadcuchara.com\/wp-json\/complianz\/v1\/","locale":"lang=es&locale=es_ES","set_cookies_on_root":"0","cookie_domain":"","current_policy_id":"44","cookie_path":"\/","categories":{"statistics":"estad\u00edsticas","marketing":"m\u00e1rketing"},"tcf_active":"1","placeholdertext":"Haz clic para aceptar {category} cookies y habilitar este contenido","css_file":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/css\/banner-{banner_id}-{type}.css?v=48","page_links":{"eu":{"cookie-statement":{"title":"Pol\u00edtica de cookies ","url":"https:\/\/www.velocidadcuchara.com\/politica-de-cookies-ue\/"},"privacy-statement":{"title":"Declaraci\u00f3n de privacidad ","url":"https:\/\/www.velocidadcuchara.com\/declaracion-de-privacidad-ue\/"}}},"tm_categories":"1","forceEnableStats":"","preview":"","clean_cookies":"","aria_label":"Haz clic para aceptar {category} cookies y habilitar este contenido","tcf_regions":["us","ca","eu","uk","au","za","br"]};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/cookiebanner/js/complianz.min.js?ver=1768420286" id="cmplz-cookiebanner-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="cmplz-cookiebanner-js-after">
+/* <![CDATA[ */
+	let cmplzBlockedContent = document.querySelector('.cmplz-blocked-content-notice');
+	if ( cmplzBlockedContent) {
+	        cmplzBlockedContent.addEventListener('click', function(event) {
+            event.stopPropagation();
+        });
+	}
+    
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1773428753" id="akismet-frontend-js"></script>
+<!-- Statistics script Complianz GDPR/CCPA -->
+						<script type="rocketlazyloadscript" data-category="functional">
+							(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MBHRNJL');
+
+const revokeListeners = [];
+window.addRevokeListener = (callback) => {
+	revokeListeners.push(callback);
+};
+document.addEventListener("cmplz_revoke", function (e) {
+	cmplz_set_cookie('cmplz_consent_mode', 'revoked', false );
+	revokeListeners.forEach((callback) => {
+		callback();
+	});
+});
+
+const consentListeners = [];
+/**
+ * Called from GTM template to set callback to be executed when user consent is provided.
+ * @param callback
+ */
+window.addConsentUpdateListener = (callback) => {
+	consentListeners.push(callback);
+};
+document.addEventListener("cmplz_fire_categories", function (e) {
+	var consentedCategories = e.detail.categories;
+	const consent = {
+		'security_storage': "granted",
+		'functionality_storage': "granted",
+		'personalization_storage':  cmplz_in_array( 'preferences', consentedCategories ) ? 'granted' : 'denied',
+		'analytics_storage':  cmplz_in_array( 'statistics', consentedCategories ) ? 'granted' : 'denied',
+		'ad_storage': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_user_data': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_personalization': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+	};
+
+	//don't use automatic prefixing, as the TM template needs to be sure it's cmplz_.
+	let consented = [];
+	for (const [key, value] of Object.entries(consent)) {
+		if (value === 'granted') {
+			consented.push(key);
+		}
+	}
+	cmplz_set_cookie('cmplz_consent_mode', consented.join(','), false );
+	consentListeners.forEach((callback) => {
+		callback(consent);
+	});
+});
+						</script><!--noptimize--><script type="rocketlazyloadscript">window.advads_admin_bar_items = [{"title":"ADS RECETA P\u00c1RRAFO 1","type":"ad","count":1},{"title":"Contenido","type":"placement","count":1},{"title":"PRP C&amp;J ESCRITORIO","type":"ad","count":1}];</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">window.advads_has_ads = [["45718","ad","ADS RECETA P\u00c1RRAFO 1","off"],["49235","ad","PRP C&J ESCRITORIO","off"]];
+( window.advanced_ads_ready || jQuery( document ).ready ).call( null, function() {if ( !window.advanced_ads_pro ) {console.log("Advanced Ads Pro: cache-busting can not be initialized");} });</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">!function(){window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[],advanced_ads_ready_queue.push=window.advanced_ads_ready;for(var d=0,a=advanced_ads_ready_queue.length;d<a;d++)advanced_ads_ready(advanced_ads_ready_queue[d])}();</script><!--/noptimize-->
+      <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        window._taboola = window._taboola || [];
+        _taboola.push({flush: true});
+      </script>
+
+  </body>
+</html>
+
+<!-- This website is like a Rocket, isn't it? Performance optimized by WP Rocket. Learn more: https://wp-rocket.me - Debug: cached@1776938850 -->

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_3.json
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_3.json
@@ -1,0 +1,31 @@
+{
+  "author": "Rosa Ardá",
+  "canonical_url": "https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/",
+  "site_name": "Velocidad Cuchara",
+  "host": "velocidadcuchara.com",
+  "language": "es",
+  "title": "Bizcocho de naranja",
+  "ingredients": [
+    "1 naranja de zumo entera con o sin piel - a veces la piel puede amargar, así que ralla la piel de la naranja para el bizcocho y luego quita toda la parte blanca-",
+    "200 gr de azúcar o al gusto o su equivalente en edulcorante acalórico",
+    "3 huevos medianos",
+    "100 gr de aceite de girasol o aceite de oliva tipo arberquina",
+    "1 yogur natural de 125 gr",
+    "250 gr de harina de repostería",
+    "1 sobre o 16 gr de levadura Royal®",
+    "Una pizca de sal"
+  ],
+  "instructions_list": [
+    "Pon en el vaso el azúcar, la naranja troceada en cuartos y los huevos y programa 3 minutos, 37º, velocidad 5.",
+    "Añade el aceite y el yogur y mezcla 15 segundos en velocidad 2 y medio.",
+    "Incorpora la harina, la levadura y la sal y mezcla 15 segundos en velocidad 3. Termina de envolver con la espátula.",
+    "Engrasa el molde que prefieras y vierte la mezcla. Hornea a 180º durante 30 minutos calor arriba y abajo. Deja enfriar sobre una rejilla y decora al gusto."
+  ],
+  "yields": "8 servings",
+  "total_time": 40,
+  "cook_time": 30,
+  "prep_time": 10,
+  "ratings": 4.6,
+  "ratings_count": 13,
+  "image": "https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-768x513.jpg"
+}

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_3.testhtml
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_3.testhtml
@@ -1,0 +1,4411 @@
+<!DOCTYPE html>
+<html class="no-js" lang="es" itemscope="itemscope" itemtype="http://schema.org/WebPage">
+<head><meta charset="UTF-8"><script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script><script>(()=>{class RocketLazyLoadScripts{constructor(){this.v="2.0.5",this.userEvents=["keydown","keyup","mousedown","mouseup","mousemove","mouseover","mouseout","touchmove","touchstart","touchend","touchcancel","wheel","click","dblclick","input"],this.attributeEvents=["onblur","onclick","oncontextmenu","ondblclick","onfocus","onmousedown","onmouseenter","onmouseleave","onmousemove","onmouseout","onmouseover","onmouseup","onmousewheel","onscroll","onsubmit"]}async t(){this.i(),this.o(),/iP(ad|hone)/.test(navigator.userAgent)&&this.h(),this.u(),this.l(this),this.m(),this.k(this),this.p(this),this._(),await Promise.all([this.R(),this.L()]),this.lastBreath=Date.now(),this.S(this),this.P(),this.D(),this.O(),this.M(),await this.C(this.delayedScripts.normal),await this.C(this.delayedScripts.defer),await this.C(this.delayedScripts.async),await this.T(),await this.F(),await this.j(),await this.A(),window.dispatchEvent(new Event("rocket-allScriptsLoaded")),this.everythingLoaded=!0,this.lastTouchEnd&&await new Promise(t=>setTimeout(t,500-Date.now()+this.lastTouchEnd)),this.I(),this.H(),this.U(),this.W()}i(){this.CSPIssue=sessionStorage.getItem("rocketCSPIssue"),document.addEventListener("securitypolicyviolation",t=>{this.CSPIssue||"script-src-elem"!==t.violatedDirective||"data"!==t.blockedURI||(this.CSPIssue=!0,sessionStorage.setItem("rocketCSPIssue",!0))},{isRocket:!0})}o(){window.addEventListener("pageshow",t=>{this.persisted=t.persisted,this.realWindowLoadedFired=!0},{isRocket:!0}),window.addEventListener("pagehide",()=>{this.onFirstUserAction=null},{isRocket:!0})}h(){let t;function e(e){t=e}window.addEventListener("touchstart",e,{isRocket:!0}),window.addEventListener("touchend",function i(o){o.changedTouches[0]&&t.changedTouches[0]&&Math.abs(o.changedTouches[0].pageX-t.changedTouches[0].pageX)<10&&Math.abs(o.changedTouches[0].pageY-t.changedTouches[0].pageY)<10&&o.timeStamp-t.timeStamp<200&&(window.removeEventListener("touchstart",e,{isRocket:!0}),window.removeEventListener("touchend",i,{isRocket:!0}),"INPUT"===o.target.tagName&&"text"===o.target.type||(o.target.dispatchEvent(new TouchEvent("touchend",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new MouseEvent("mouseover",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new PointerEvent("click",{target:o.target,bubbles:!0,cancelable:!0,detail:1,clientX:o.changedTouches[0].clientX,clientY:o.changedTouches[0].clientY})),event.preventDefault()))},{isRocket:!0})}q(t){this.userActionTriggered||("mousemove"!==t.type||this.firstMousemoveIgnored?"keyup"===t.type||"mouseover"===t.type||"mouseout"===t.type||(this.userActionTriggered=!0,this.onFirstUserAction&&this.onFirstUserAction()):this.firstMousemoveIgnored=!0),"click"===t.type&&t.preventDefault(),t.stopPropagation(),t.stopImmediatePropagation(),"touchstart"===this.lastEvent&&"touchend"===t.type&&(this.lastTouchEnd=Date.now()),"click"===t.type&&(this.lastTouchEnd=0),this.lastEvent=t.type,t.composedPath&&t.composedPath()[0].getRootNode()instanceof ShadowRoot&&(t.rocketTarget=t.composedPath()[0]),this.savedUserEvents.push(t)}u(){this.savedUserEvents=[],this.userEventHandler=this.q.bind(this),this.userEvents.forEach(t=>window.addEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.addEventListener("visibilitychange",this.userEventHandler,{isRocket:!0})}U(){this.userEvents.forEach(t=>window.removeEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.removeEventListener("visibilitychange",this.userEventHandler,{isRocket:!0}),this.savedUserEvents.forEach(t=>{(t.rocketTarget||t.target).dispatchEvent(new window[t.constructor.name](t.type,t))})}m(){const t="return false",e=Array.from(this.attributeEvents,t=>"data-rocket-"+t),i="["+this.attributeEvents.join("],[")+"]",o="[data-rocket-"+this.attributeEvents.join("],[data-rocket-")+"]",s=(e,i,o)=>{o&&o!==t&&(e.setAttribute("data-rocket-"+i,o),e["rocket"+i]=new Function("event",o),e.setAttribute(i,t))};new MutationObserver(t=>{for(const n of t)"attributes"===n.type&&(n.attributeName.startsWith("data-rocket-")||this.everythingLoaded?n.attributeName.startsWith("data-rocket-")&&this.everythingLoaded&&this.N(n.target,n.attributeName.substring(12)):s(n.target,n.attributeName,n.target.getAttribute(n.attributeName))),"childList"===n.type&&n.addedNodes.forEach(t=>{if(t.nodeType===Node.ELEMENT_NODE)if(this.everythingLoaded)for(const i of[t,...t.querySelectorAll(o)])for(const t of i.getAttributeNames())e.includes(t)&&this.N(i,t.substring(12));else for(const e of[t,...t.querySelectorAll(i)])for(const t of e.getAttributeNames())this.attributeEvents.includes(t)&&s(e,t,e.getAttribute(t))})}).observe(document,{subtree:!0,childList:!0,attributeFilter:[...this.attributeEvents,...e]})}I(){this.attributeEvents.forEach(t=>{document.querySelectorAll("[data-rocket-"+t+"]").forEach(e=>{this.N(e,t)})})}N(t,e){const i=t.getAttribute("data-rocket-"+e);i&&(t.setAttribute(e,i),t.removeAttribute("data-rocket-"+e))}k(t){Object.defineProperty(HTMLElement.prototype,"onclick",{get(){return this.rocketonclick||null},set(e){this.rocketonclick=e,this.setAttribute(t.everythingLoaded?"onclick":"data-rocket-onclick","this.rocketonclick(event)")}})}S(t){function e(e,i){let o=e[i];e[i]=null,Object.defineProperty(e,i,{get:()=>o,set(s){t.everythingLoaded?o=s:e["rocket"+i]=o=s}})}e(document,"onreadystatechange"),e(window,"onload"),e(window,"onpageshow");try{Object.defineProperty(document,"readyState",{get:()=>t.rocketReadyState,set(e){t.rocketReadyState=e},configurable:!0}),document.readyState="loading"}catch(t){console.log("WPRocket DJE readyState conflict, bypassing")}}l(t){this.originalAddEventListener=EventTarget.prototype.addEventListener,this.originalRemoveEventListener=EventTarget.prototype.removeEventListener,this.savedEventListeners=[],EventTarget.prototype.addEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalAddEventListener.call(this,e,i,o):(t.savedEventListeners.push({target:this,remove:!1,type:e,func:i,options:o}),"mouseenter"!==e&&"mouseleave"!==e||t.originalAddEventListener.call(this,e,t.savedUserEvents.push,o))},EventTarget.prototype.removeEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalRemoveEventListener.call(this,e,i,o):t.savedEventListeners.push({target:this,remove:!0,type:e,func:i,options:o})}}J(t,e){this.savedEventListeners=this.savedEventListeners.filter(i=>{let o=i.type,s=i.target||window;return e!==o||t!==s||(this.B(o,s)&&(i.type="rocket-"+o),this.$(i),!1)})}H(){EventTarget.prototype.addEventListener=this.originalAddEventListener,EventTarget.prototype.removeEventListener=this.originalRemoveEventListener,this.savedEventListeners.forEach(t=>this.$(t))}$(t){t.remove?this.originalRemoveEventListener.call(t.target,t.type,t.func,t.options):this.originalAddEventListener.call(t.target,t.type,t.func,t.options)}p(t){let e;function i(e){return t.everythingLoaded?e:e.split(" ").map(t=>"load"===t||t.startsWith("load.")?"rocket-jquery-load":t).join(" ")}function o(o){function s(e){const s=o.fn[e];o.fn[e]=o.fn.init.prototype[e]=function(){return this[0]===window&&t.userActionTriggered&&("string"==typeof arguments[0]||arguments[0]instanceof String?arguments[0]=i(arguments[0]):"object"==typeof arguments[0]&&Object.keys(arguments[0]).forEach(t=>{const e=arguments[0][t];delete arguments[0][t],arguments[0][i(t)]=e})),s.apply(this,arguments),this}}if(o&&o.fn&&!t.allJQueries.includes(o)){const e={DOMContentLoaded:[],"rocket-DOMContentLoaded":[]};for(const t in e)document.addEventListener(t,()=>{e[t].forEach(t=>t())},{isRocket:!0});o.fn.ready=o.fn.init.prototype.ready=function(i){function s(){parseInt(o.fn.jquery)>2?setTimeout(()=>i.bind(document)(o)):i.bind(document)(o)}return"function"==typeof i&&(t.realDomReadyFired?!t.userActionTriggered||t.fauxDomReadyFired?s():e["rocket-DOMContentLoaded"].push(s):e.DOMContentLoaded.push(s)),this},s("on"),s("one"),s("off"),t.allJQueries.push(o)}e=o}t.allJQueries=[],o(window.jQuery),Object.defineProperty(window,"jQuery",{get:()=>e,set(t){o(t)}})}P(){const t=new Map;document.write=document.writeln=function(e){const i=document.currentScript,o=document.createRange(),s=i.parentElement;let n=t.get(i);void 0===n&&(n=i.nextSibling,t.set(i,n));const c=document.createDocumentFragment();o.setStart(c,0),c.appendChild(o.createContextualFragment(e)),s.insertBefore(c,n)}}async R(){return new Promise(t=>{this.userActionTriggered?t():this.onFirstUserAction=t})}async L(){return new Promise(t=>{document.addEventListener("DOMContentLoaded",()=>{this.realDomReadyFired=!0,t()},{isRocket:!0})})}async j(){return this.realWindowLoadedFired?Promise.resolve():new Promise(t=>{window.addEventListener("load",t,{isRocket:!0})})}M(){this.pendingScripts=[];this.scriptsMutationObserver=new MutationObserver(t=>{for(const e of t)e.addedNodes.forEach(t=>{"SCRIPT"!==t.tagName||!t.src||t.noModule||t.isWPRocket||this.pendingScripts.push({script:t,promise:new Promise(e=>{const i=()=>{const i=this.pendingScripts.findIndex(e=>e.script===t);i>=0&&this.pendingScripts.splice(i,1),e()};t.addEventListener("load",i,{isRocket:!0}),t.addEventListener("error",i,{isRocket:!0}),setTimeout(i,1e3)})})})}),this.scriptsMutationObserver.observe(document,{childList:!0,subtree:!0})}async F(){await this.X(),this.pendingScripts.length?(await this.pendingScripts[0].promise,await this.F()):this.scriptsMutationObserver.disconnect()}D(){this.delayedScripts={normal:[],async:[],defer:[]},document.querySelectorAll("script[type$=rocketlazyloadscript]").forEach(t=>{t.hasAttribute("data-rocket-src")?t.hasAttribute("async")&&!1!==t.async?this.delayedScripts.async.push(t):t.hasAttribute("defer")&&!1!==t.defer||"module"===t.getAttribute("data-rocket-type")?this.delayedScripts.defer.push(t):this.delayedScripts.normal.push(t):this.delayedScripts.normal.push(t)})}async _(){await this.L();let t=[];document.querySelectorAll("script[type$=rocketlazyloadscript][data-rocket-src]").forEach(e=>{let i=e.getAttribute("data-rocket-src");if(i&&!i.startsWith("data:")){i.startsWith("//")&&(i=location.protocol+i);try{const o=new URL(i).origin;o!==location.origin&&t.push({src:o,crossOrigin:e.crossOrigin||"module"===e.getAttribute("data-rocket-type")})}catch(t){}}}),t=[...new Map(t.map(t=>[JSON.stringify(t),t])).values()],this.Y(t,"preconnect")}async G(t){if(await this.K(),!0!==t.noModule||!("noModule"in HTMLScriptElement.prototype))return new Promise(e=>{let i;function o(){(i||t).setAttribute("data-rocket-status","executed"),e()}try{if(navigator.userAgent.includes("Firefox/")||""===navigator.vendor||this.CSPIssue)i=document.createElement("script"),[...t.attributes].forEach(t=>{let e=t.nodeName;"type"!==e&&("data-rocket-type"===e&&(e="type"),"data-rocket-src"===e&&(e="src"),i.setAttribute(e,t.nodeValue))}),t.text&&(i.text=t.text),t.nonce&&(i.nonce=t.nonce),i.hasAttribute("src")?(i.addEventListener("load",o,{isRocket:!0}),i.addEventListener("error",()=>{i.setAttribute("data-rocket-status","failed-network"),e()},{isRocket:!0}),setTimeout(()=>{i.isConnected||e()},1)):(i.text=t.text,o()),i.isWPRocket=!0,t.parentNode.replaceChild(i,t);else{const i=t.getAttribute("data-rocket-type"),s=t.getAttribute("data-rocket-src");i?(t.type=i,t.removeAttribute("data-rocket-type")):t.removeAttribute("type"),t.addEventListener("load",o,{isRocket:!0}),t.addEventListener("error",i=>{this.CSPIssue&&i.target.src.startsWith("data:")?(console.log("WPRocket: CSP fallback activated"),t.removeAttribute("src"),this.G(t).then(e)):(t.setAttribute("data-rocket-status","failed-network"),e())},{isRocket:!0}),s?(t.fetchPriority="high",t.removeAttribute("data-rocket-src"),t.src=s):t.src="data:text/javascript;base64,"+window.btoa(unescape(encodeURIComponent(t.text)))}}catch(i){t.setAttribute("data-rocket-status","failed-transform"),e()}});t.setAttribute("data-rocket-status","skipped")}async C(t){const e=t.shift();return e?(e.isConnected&&await this.G(e),this.C(t)):Promise.resolve()}O(){this.Y([...this.delayedScripts.normal,...this.delayedScripts.defer,...this.delayedScripts.async],"preload")}Y(t,e){this.trash=this.trash||[];let i=!0;var o=document.createDocumentFragment();t.forEach(t=>{const s=t.getAttribute&&t.getAttribute("data-rocket-src")||t.src;if(s&&!s.startsWith("data:")){const n=document.createElement("link");n.href=s,n.rel=e,"preconnect"!==e&&(n.as="script",n.fetchPriority=i?"high":"low"),t.getAttribute&&"module"===t.getAttribute("data-rocket-type")&&(n.crossOrigin=!0),t.crossOrigin&&(n.crossOrigin=t.crossOrigin),t.integrity&&(n.integrity=t.integrity),t.nonce&&(n.nonce=t.nonce),o.appendChild(n),this.trash.push(n),i=!1}}),document.head.appendChild(o)}W(){this.trash.forEach(t=>t.remove())}async T(){try{document.readyState="interactive"}catch(t){}this.fauxDomReadyFired=!0;try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(document,"DOMContentLoaded"),document.dispatchEvent(new Event("rocket-DOMContentLoaded")),await this.K(),this.J(window,"DOMContentLoaded"),window.dispatchEvent(new Event("rocket-DOMContentLoaded"))}catch(t){console.error(t)}}async A(){try{document.readyState="complete"}catch(t){}try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(window,"load"),window.dispatchEvent(new Event("rocket-load")),await this.K(),window.rocketonload&&window.rocketonload(),await this.K(),this.allJQueries.forEach(t=>t(window).trigger("rocket-jquery-load")),await this.K(),this.J(window,"pageshow");const t=new Event("rocket-pageshow");t.persisted=this.persisted,window.dispatchEvent(t),await this.K(),window.rocketonpageshow&&window.rocketonpageshow({persisted:this.persisted})}catch(t){console.error(t)}}async K(){Date.now()-this.lastBreath>45&&(await this.X(),this.lastBreath=Date.now())}async X(){return document.hidden?new Promise(t=>setTimeout(t)):new Promise(t=>requestAnimationFrame(t))}B(t,e=window){return e===document&&"readystatechange"===t||(e===document&&"DOMContentLoaded"===t||(e===window&&"DOMContentLoaded"===t||(e===window&&"load"===t||e===window&&"pageshow"===t)))}static run(){(new RocketLazyLoadScripts).t()}}RocketLazyLoadScripts.run()})();
+</script>
+
+<!--
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-++-+
+	|v|e|l|o|c|i|d|a|d| |c|u|c|h|a|r|a|
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-+ +- -->
+
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="copyright" content="Velocidad Cuchara"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta property="fb:pages" content="117162944985048" />
+  <link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &#8211; El primer blog de recetas para Thermomix RSS Feed" href="https://www.velocidadcuchara.com/feed/" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000">
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="sitemap" href="https://www.velocidadcuchara.com/sitemap.xml" />
+  <link href="https://fonts.googleapis.com/css?family=Kaushan+Script" rel="stylesheet">
+
+  <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+	
+	<!-- This site is optimized with the Yoast SEO plugin v27.0 - https://yoast.com/product/yoast-seo-wordpress/ -->
+	<title>Bizcocho de naranja | Velocidad Cuchara</title>
+<link data-rocket-prefetch href="https://sdk.mrf.io" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://www.googletagmanager.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://estadisticas.mediasector.es" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://fonts.googleapis.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://static.addtoany.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://pagead2.googlesyndication.com" rel="dns-prefetch"><link rel="preload" data-rocket-preload as="image" imagesrcset="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-1024x684.jpg.webp 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-300x200.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-768x513.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-272x182.jpg.webp 272w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17.jpg.webp 1200w" imagesizes="(max-width: 1024px) 100vw, 1024px" fetchpriority="high">
+	<meta name="description" content="Receta de Bizcocho de naranja, una receta tan básica como deliciosa que se prepara de forma fácil y rápida con Thermomix®." />
+	<link rel="canonical" href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/" />
+	<meta property="og:locale" content="es_ES" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Bizcocho de naranja | Velocidad Cuchara" />
+	<meta property="og:description" content="Receta de Bizcocho de naranja, una receta tan básica como deliciosa que se prepara de forma fácil y rápida con Thermomix®." />
+	<meta property="og:url" content="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/" />
+	<meta property="og:site_name" content="Velocidad Cuchara" />
+	<meta property="article:publisher" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:author" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:published_time" content="2017-06-07T04:00:00+00:00" />
+	<meta property="article:modified_time" content="2023-04-23T07:33:40+00:00" />
+	<meta property="og:image" content="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-768x513.jpg" />
+	<meta property="og:image:width" content="768" />
+	<meta property="og:image:height" content="513" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="author" content="Rosa Ardá" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:creator" content="@rosaarda" />
+	<meta name="twitter:site" content="@rosaarda" />
+	<meta name="twitter:label1" content="Escrito por" />
+	<meta name="twitter:data1" content="Rosa Ardá" />
+	<meta name="twitter:label2" content="Tiempo de lectura" />
+	<meta name="twitter:data2" content="3 minutos" />
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//static.addtoany.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed" href="https://www.velocidadcuchara.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed de los comentarios" href="https://www.velocidadcuchara.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Comentario Bizcocho de naranja del feed" href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/feed/" />
+<link rel="shortcut icon" type="image/x-icon" href="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/favicon.png" /><!-- www.velocidadcuchara.com is managing ads with Advanced Ads 2.0.17 – https://wpadvancedads.com/ --><!--noptimize--><script type="rocketlazyloadscript" id="local-ready">
+			window.advanced_ads_ready=function(e,a){a=a||"complete";var d=function(e){return"interactive"===a?"loading"!==e:"complete"===e};d(document.readyState)?e():document.addEventListener("readystatechange",(function(a){d(a.target.readyState)&&e()}),{once:"interactive"===a})},window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[];		</script>
+		<!--/noptimize--><style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.velocidadcuchara.com/wp-includes/css/dist/block-library/style.min.css?ver=6.8.2' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+:root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
+</style>
+<link data-minify="1" rel='stylesheet' id='mostrar-comentarios-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='post_grid_style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-new.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='owl.carousel-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/owl.carousel.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='font-awesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/font-awesome.min.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style-woocommerce-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-woocommerce.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.skins-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.skins.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.layout-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.layout.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-17bc2272b535-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-17bc2272b535.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-654ee1169f99-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-654ee1169f99.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-b136017e055b-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-b136017e055b.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-7877d6771435-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-7877d6771435.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-d6014b76747a-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-d6014b76747a.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-base-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/widgets/button/css/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-a0517016730c-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-a0517016730c.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-b763d6af42b8-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-b763d6af42b8.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wpos-slick-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/slick.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wtpsw-public-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/wtpsw-public.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='cmplz-general-css' href='https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/assets/css/cookieblocker.min.css?ver=1768420286' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='megamenu-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/maxmegamenu/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='dashicons-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-includes/css/dashicons.min.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='easyrecipestyle-reset-css' href='https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/css/easyrecipe-style-reset-min.css?ver=3.5.3251' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipebuttonUI-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/ui/easyrecipe-buttonUI.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipestyle-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/styles/style002a/style.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='addtoany-css' href='https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.css?ver=1.16' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='kadence_theme-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/virtue.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='virtue_skin-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/skins/default.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='virtue_child-css' href='https://www.velocidadcuchara.com/wp-content/themes/velocidad/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='redux-google-fonts-virtue-css' href='https://fonts.googleapis.com/css?family=Lato%3A400%2C700%7CJosefin+Sans%3A400%2C600%2C300%7COpen+Sans%3A300%2C400%2C600%2C700%2C800%2C300italic%2C400italic%2C600italic%2C700italic%2C800italic&#038;subset=latin-ext&#038;ver=1774857236' type='text/css' media='all' />
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf-stub/build/index.js?ver=1773428753" id="cmplz-tcf-stub-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/vendor/DOMPurify/DOMPurify.min.js?ver=2.5.8" id="bodhi-dompurify-library-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="addtoany-core-js-before">
+/* <![CDATA[ */
+window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_localize = {
+	Share: "Compartir",
+	Save: "Guardar",
+	Subscribe: "Suscribir",
+	Email: "Correo electrónico",
+	Bookmark: "Marcador",
+	ShowAll: "Mostrar todo",
+	ShowLess: "Mostrar menos",
+	FindServices: "Encontrar servicio(s)",
+	FindAnyServiceToAddTo: "Encuentra al instante cualquier servicio para añadir a",
+	PoweredBy: "Funciona con",
+	ShareViaEmail: "Compartir por correo electrónico",
+	SubscribeViaEmail: "Suscribirse a través de correo electrónico",
+	BookmarkInYourBrowser: "Añadir a marcadores de tu navegador",
+	BookmarkInstructions: "Presiona «Ctrl+D» o «\u2318+D» para añadir esta página a marcadores",
+	AddToYourFavorites: "Añadir a tus favoritos",
+	SendFromWebOrProgram: "Enviar desde cualquier dirección o programa de correo electrónico ",
+	EmailProgram: "Programa de correo electrónico",
+	More: "Más&#8230;",
+	ThanksForSharing: "¡Gracias por compartir!",
+	ThanksForFollowing: "¡Gracias por seguirnos!"
+};
+
+a2a_config.icon_color = "#bdbeb2";
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://static.addtoany.com/menu/page.js" id="addtoany-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.js?ver=1.1" id="addtoany-jquery-js"></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.js?ver=1773428753" id="mostrar-comentarios-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="post_grid_scripts-js-extra">
+/* <![CDATA[ */
+var post_grid_ajax = {"post_grid_ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/scripts.js?ver=1773428753" id="post_grid_scripts-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/masonry.pkgd.min.js?ver=6.8.2" id="masonry.pkgd.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/owl.carousel.min.js?ver=6.8.2" id="owl.carousel.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/imagesloaded.pkgd.js?ver=1773428753" id="imagesloaded.pkgd.js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="bodhi_svg_inline-js-extra">
+/* <![CDATA[ */
+var svgSettings = {"skipNested":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/js/min/svgs-inline-min.js" id="bodhi_svg_inline-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="bodhi_svg_inline-js-after">
+/* <![CDATA[ */
+cssTarget={"Bodhi":"img.style-svg","ForceInlineSVG":"style-svg"};ForceInlineSVGActive="false";frontSanitizationEnabled="on";
+/* ]]> */
+</script>
+<script type="text/javascript" id="cmplz-tcf-js-extra">
+/* <![CDATA[ */
+var cmplz_tcf = {"cmp_url":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/","retention_string":"Retenci\u00f3n en d\u00edas","undeclared_string":"No declarado","isServiceSpecific":"1","excludedVendors":{"15":15,"66":66,"119":119,"139":139,"141":141,"174":174,"192":192,"262":262,"375":375,"377":377,"387":387,"427":427,"435":435,"512":512,"527":527,"569":569,"581":581,"587":587,"626":626,"644":644,"667":667,"713":713,"733":733,"736":736,"748":748,"776":776,"806":806,"822":822,"830":830,"836":836,"856":856,"879":879,"882":882,"888":888,"909":909,"970":970,"986":986,"1015":1015,"1018":1018,"1022":1022,"1039":1039,"1078":1078,"1079":1079,"1094":1094,"1149":1149,"1156":1156,"1167":1167,"1173":1173,"1199":1199,"1211":1211,"1216":1216,"1252":1252,"1263":1263,"1298":1298,"1305":1305,"1342":1342,"1343":1343,"1355":1355,"1365":1365,"1366":1366,"1368":1368,"1371":1371,"1373":1373,"1391":1391,"1405":1405,"1418":1418,"1423":1423,"1425":1425,"1440":1440,"1442":1442,"1482":1482,"1492":1492,"1496":1496,"1503":1503,"1508":1508,"1509":1509,"1510":1510,"1519":1519,"1529":1529,"1537":1537,"1541":1541,"1549":1549,"1550":1550,"1558":1558,"1564":1564,"1579":1579,"1580":1580},"purposes":[1,2,3,4,5,6,7,8,9,10],"specialPurposes":[1,2,3],"features":[1,2],"specialFeatures":[],"publisherCountryCode":"ES","lspact":"N","ccpa_applies":"","ac_mode":"1","debug":"","prefix":"cmplz_"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf/build/index.js?ver=1773428753" id="cmplz-tcf-js"></script>
+<script type="text/javascript" id="advanced-ads-advanced-js-js-extra">
+/* <![CDATA[ */
+var advads_options = {"blog_id":"1","privacy":{"enabled":true,"custom-cookie-name":"euconsent-v2","custom-cookie-value":"CO49HGNO49HGNAKALAESA1CsAP_AAH_AAAiQGatd_X9fb2vj-_5999t0eY1f9_63v-wzjgeNs-8NyZ_X_L4Xr2MyvB36pq4KmR4Eu3LBAQFlHOHcTQmQwIkVqTLsbk2Mq7NKJ7LEilMbM2dYGG9Pn8XTuZCY70_sf__z_3-_-___67bgYIQSYKl4BAkJYQEk2aUQogAhHEBUA4AKCEICBSw0ABATsCgI9QAAAEBgABAAAACCCAgEAAAAASEQAAACAgEABEAgABACNAQgAIkAAWAEgQBAAKAaEgBFEEIAhBgYBRygBAUAAAAA.fmAAAAAAAAAA","consent-method":"iab_tcf_20","state":"unknown"}};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/advanced-ads/public/assets/js/advanced.min.js?ver=2.0.17" id="advanced-ads-advanced-js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="utils-js-extra">
+/* <![CDATA[ */
+var userSettings = {"url":"\/","uid":"0","time":"1776938829","secure":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/utils.min.js?ver=6.8.2" id="utils-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/controlgroup.min.js?ver=1.13.3" id="jquery-ui-controlgroup-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/checkboxradio.min.js?ver=1.13.3" id="jquery-ui-checkboxradio-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/button.min.js?ver=1.13.3" id="jquery-ui-button-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/js/easyrecipe-min.js?ver=3.5.3251" id="EasyRecipePlus-js" data-rocket-defer defer></script>
+<link rel="https://api.w.org/" href="https://www.velocidadcuchara.com/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://www.velocidadcuchara.com/wp-json/wp/v2/posts/385" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.velocidadcuchara.com/xmlrpc.php?rsd" />
+<meta name="generator" content="WordPress 6.8.2" />
+<link rel='shortlink' href='https://www.velocidadcuchara.com/?p=385' />
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Fbizcocho-de-naranja-thermomix%2F" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Fbizcocho-de-naranja-thermomix%2F&#038;format=xml" />
+			<style>.cmplz-hidden {
+					display: none !important;
+				}</style><style type="text/css">#logo {padding-top:20px;}#logo {padding-bottom:20px;}#logo {margin-left:0px;}#logo {margin-right:0px;}#nav-main {margin-top:25px;}#nav-main {margin-bottom:10px;}.headerfont, .tp-caption {font-family:Josefin Sans;} 
+  .topbarmenu ul li {font-family:Josefin Sans;}
+  #kadbreadcrumbs {font-family:Open Sans;}.home-message:hover {background-color:#8faa8f; background-color: rgba(143, 170, 143, 0.6);}
+  nav.woocommerce-pagination ul li a:hover, .wp-pagenavi a:hover, .panel-heading .accordion-toggle, .variations .kad_radio_variations label:hover, .variations .kad_radio_variations label.selectedValue {border-color: #8faa8f;}
+  a, #nav-main ul.sf-menu ul li a:hover, .product_price ins .amount, .price ins .amount, .color_primary, .primary-color, #logo a.brand, #nav-main ul.sf-menu a:hover,
+  .woocommerce-message:before, .woocommerce-info:before, #nav-second ul.sf-menu a:hover, .footerclass a:hover, .posttags a:hover, .subhead a:hover, .nav-trigger-case:hover .kad-menu-name, 
+  .nav-trigger-case:hover .kad-navbtn, #kadbreadcrumbs a:hover, #wp-calendar a, .star-rating {color: #8faa8f;}
+.widget_price_filter .ui-slider .ui-slider-handle, .product_item .kad_add_to_cart:hover, .product_item:hover a.button:hover, .product_item:hover .kad_add_to_cart:hover, .kad-btn-primary, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li a:hover, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li.chosen a,
+.product-category.grid_item a:hover h5, .woocommerce-message .button, .widget_layered_nav_filters ul li a, .widget_layered_nav ul li.chosen a, .wpcf7 input.wpcf7-submit, .yith-wcan .yith-wcan-reset-navigation,
+#containerfooter .menu li a:hover, .bg_primary, .portfolionav a:hover, .home-iconmenu a:hover, p.demo_store, .topclass, #commentform .form-submit #submit, .kad-hover-bg-primary:hover, .widget_shopping_cart_content .checkout,
+.login .form-row .button, .variations .kad_radio_variations label.selectedValue, #payment #place_order, .wpcf7 input.wpcf7-back, .shop_table .actions input[type=submit].checkout-button, .cart_totals .checkout-button, input[type="submit"].button, .order-actions .button  {background: #8faa8f;}a:hover {color: #b7bfaf;} .kad-btn-primary:hover, .login .form-row .button:hover, #payment #place_order:hover, .yith-wcan .yith-wcan-reset-navigation:hover, .widget_shopping_cart_content .checkout:hover,
+.woocommerce-message .button:hover, #commentform .form-submit #submit:hover, .wpcf7 input.wpcf7-submit:hover, .widget_layered_nav_filters ul li a:hover, .cart_totals .checkout-button:hover,
+.widget_layered_nav ul li.chosen a:hover, .shop_table .actions input[type=submit].checkout-button:hover, .wpcf7 input.wpcf7-back:hover, .order-actions .button:hover, input[type="submit"].button:hover, .product_item:hover .kad_add_to_cart, .product_item:hover a.button {background: #b7bfaf;}input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; } input[type=number] {-moz-appearance: textfield;}.quantity input::-webkit-outer-spin-button,.quantity input::-webkit-inner-spin-button {display: none;}#containerfooter h3, #containerfooter, .footercredits p, .footerclass a, .footernav ul li a {color:#c6c6c6;}.topclass {background:transparent    ;}.navclass {background:#23282d    ;}.mobileclass {background:#23282d    ;}.footerclass {background:#23282d    ;}.product_item .product_details h5 {text-transform: none;} @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {#logo .kad-standard-logo {display: none;} #logo .kad-retina-logo {display: block;}}.product_item .product_details h5 {min-height:40px;}[class*="wp-image"] {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}[class*="wp-image"]:hover {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}.light-dropshaddow {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;}/*::::::::::::::::::::::::::::::::::::::::: PÁGINA LIBRO VC ::::::::::::::::::::::::::::::::::*/
+
+#textolibrovc {
+    font-family: "Open Sans";
+    line-height: 28px;
+    font-weight: 400;
+    font-style: normal;
+    font-size: 20px;
+}
+
+#titulibrovc {
+    font-family: "Josefin Sans";
+    line-height: 40px;
+    font-weight: 600;
+    font-style: normal;
+    font-size: 30px;
+}
+
+.page-id-56361 .titleclass { background-color: #c08993; } 
+.page-id-58566 .titleclass { background-color: #757575; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO PODCAST ::::::::::::::::::::::::::::::::::*/
+
+.page-id-59933 .titleclass { 
+background-image: url("https://velocidadcuchara.com/recursos/fondo_cabecera_pvc.png");
+margin-top: -15px; 
+background-color: #ad6b77; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO RADIO  ::::::::::::::::::::::::::::::::::*/
+    
+.page-id-57235 .titleclass { 
+background-color: #2d2f39; 
+;} 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESTILOS RELACIONADOS ::::::::::::::::::::::::::::::::::*/
+
+.bcarousellink>header>h5 {
+    padding: 0;
+    margin: 0;
+font-size:18px;
+font-weight: bold;
+}
+
+.bcarousellink>header .subhead {
+    text-align: right;
+display:none;
+}
+
+.post-grid .item .layer-media img {
+    border-radius: 50;
+    box-shadow: none;
+    width: 100%;
+    border-radius: 15px;
+}
+
+
+/*::::::::::::::::::::::::::::::::::::::::: CASILLA RGPD COMENTARIOS ::::::::::::::::::::::::::::::::::*/
+
+#commentform input {
+    display: inline-grid;
+}
+
+/*:::::::::::::::::::::::::::::::::::::::::  ELIMINAR ADMIN BAR WP ::::::::::::::::::::::::::::::::::*/
+
+#wpadminbar { display:none; }
+
+/*::::::::::::::::::::::::::::::::::::::::: CABECERA 10 ANIVERSARIO ::::::::::::::::::::::::::::::::::*/
+
+#thelogo .kad-standard-logo  {max-height: 100%}
+#thelogo .kad-retina-logo  {max-height: 100%}
+
+@media (min-width: 1024px) {NAV
+    #thelogo { width: 120%}
+}
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL HALLOWEEN ::::::::::::::::::::::::::::::::::*/
+
+.page-id-7832 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/10/fondo_cabecera_halloween_trans.png");
+    margin-top: -15px; background-color: #363636; background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-7832 .page-header .entry-title {  color: #ffa200; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CABECERA ::::::::::::::::::::::::::::::::::*/
+
+.page-id-8160 .titleclass { 
+background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; 
+background-color: #F3F3F3; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-8160 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700;} 
+
+.page-id-8160 .page-header > p {
+    color: #aa0000 } 
+
+.page-id-8160 .sidebar a {
+    color: #aa0000 } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-781 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+
+.category-781 .page-header .entry-title { 
+font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+
+.category-781 .page-header > p {
+    color: #aa0000 } 
+.category-781 .sidebar a {
+    color: #aa0000 } 
+
+.category-778 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-778 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-778 .page-header > p {
+    color: #aa0000 } 
+.category-778 .sidebar a {
+    color: #aa0000 } 
+
+.category-779 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-779 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-779 .page-header > p {
+    color: #aa0000 } 
+.category-779 .sidebar a {
+    color: #aa0000 } 
+
+.category-780 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-780 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-780 .page-header > p {
+    color: #aa0000 }
+.category-780 .sidebar a {
+    color: #aa0000 }  
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL SSANTA CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-121 .titleclass { background-color: #444560; } 
+
+/*:::::::::::::::::::::::::::::::::::::::::GENERAL ::::::::::::::::::::::::::::::::::*/
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+/*TOPBAR */
+
+/*iconos redes */
+.so-widget-sow-social-media-buttons .sow-social-media-button {
+padding:0.2em !important;}
+
+/* color del buscador textos y labels*/
+#topbar .form-search {border: 1px solid #000;}
+#topbar .form-search .search-icon {color: #000;}
+#topbar .form-search input[type="text"] {color: #000;}
+#topbar .topbar-widget {color: #000;}
+#topbar .form-search input[type="text"]::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]::-moz-placeholder { /* Firefox 19+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-ms-input-placeholder { /* IE 10+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-moz-placeholder { /* Firefox 18- */
+  color: #bdbeb2;
+}
+
+/*MENU FIJO PRINCIPAL*/
+.navclass.stickytop {
+   z-index: 9999; 
+   position: fixed; 
+   left: 0; 
+   top: 0; 
+   width: 100%
+}
+
+/*BREADCRUMBS*/
+#breadcrumbs {
+    color: #f2f2f2;
+    font-size: 0.8em;
+}
+#breadcrumbs a {
+    color: #f1f1f1;
+    text-decoration: underline;
+}
+
+/* margen superior de la página de resultado de búsquedas*/
+.search-results .wrap.contentclass .main.col-lg-9.col-md-8.postlist {
+ 	margin-top: 50px;
+}
+/* margen superior de página "estilo" blog*/
+.page-template-page-blog .main.col-lg-9.col-md-8.postlist {
+    margin-top: 50px;
+}
+
+/* etiqueta "publicidad" bloques de publicidad*/
+.local-adlabel {
+    color: #bdbeb2;
+    font-size: 14px;
+    font-style: italic;
+   text-align:center;
+}
+
+/* :::::::::::::::::::::::::::: HEADER ::::::::::::::::::::::::::::::: */
+/*tag line*/
+.kad_tagline {
+ margin-top: 20px;
+    padding-left: 0.1em;
+}
+
+/*títulos páginas*/
+.page-header{
+border-top: 0 solid rgba(0, 0, 0, 0);
+border-bottom: 0 solid rgba(0, 0, 0, 0);
+margin-bottom:0;
+}
+.titleclass {
+    background-color: #bdbeb2;
+margin-top:-15px;
+}
+.page-header .entry-title {
+padding:0.5em;
+text-transform: uppercase;
+color:#fff;
+}
+
+/*titulos páginas - visión móvil*/
+@media (max-width: 768px){
+.page-header {text-align:center;
+}
+}
+
+/* textos descripción categorias*/
+
+/* Menú principal*/
+#nav-second ul.sf-menu .menu-inicio.current-menu-item > a{
+   background-color: #fff;
+    color: #d36a5f ;
+}
+
+/* :::::: COLUMNA ::::: SIDEBAR :::::: */
+.sidebar .menu{
+font-family: "Josefin Sans";
+font-weight:600;
+margin-top: 30px;
+text-transform:uppercase;
+}
+.sidebar .widget-inner li {
+    border-bottom: 1px solid rgba(189, 190, 178, 0.5);
+    line-height: 40px;
+   }
+
+.sidebar .widget-title {
+    text-align: center;
+}
+
+/* títulos enlaces de videos en sidebar columna*/
+
+.titulovideo h3 { font-family:"Open Sans";
+font-size: 1em; 
+font-weight:600;
+text-align: center;
+
+}
+
+.sidebar .widget-inner .so-widget-sow-image > h3 {
+    text-align: center;
+}
+
+.so-widget-image {
+    border-radius: 15px;
+}
+
+/* botón suscripción*/
+#submitbox input[type="submit"] {
+    background-color: #bdbeb2;
+    color: #fff;
+    font-size: 0.9em;
+    font-style: italic;
+}
+
+/* Tïtulos de "Los más leídos"*/
+.wtpsw-post-thumb-right {
+    display: table-cell;
+    vertical-align: middle;
+}
+.wtpsw-post-thumb-right h6 a.wtpsw-post-title {
+    color: #555;
+    font-family: "Josefin Sans";
+    font-size: 1.3em;
+    line-height: 1.4em;
+    text-transform: uppercase;
+}
+
+/* fondo y bordes "Los más leídos"*/
+.wtpsw-post-items {
+    background-color: #e7e8e1;
+    border-radius: 12px;
+    padding-right: 0.5em;
+}
+
+/* botones categorías blog Te Cuento*/
+.sidebar .widget_sow-button {
+margin-bottom:-20px;
+}
+
+
+
+/*::::::::::::::::::::::::: POST GRID en páginas internas :::::::::::::::::::::::::::*/
+.post-grid .item {
+border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+/* navegadores entre páginas <<    >>*/
+.pagination.dark br {
+    display: none;
+}
+
+/* botones números  paginación */
+
+.post-grid .pagination.dark .page-numbers {
+color:#8faa8f;
+font-weight:700;
+margin:5px;
+background:#fff none repeat scroll 0 0;
+border: 2px solid rgba(0, 0, 0, 0.05);
+padding: 4px 10px;
+line-height: 37px;
+transition: border 0.2s ease-in-out 0s;
+
+}
+
+.post-grid .pagination.dark .page-numbers:hover{
+background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+border-color:#b7bfaf;
+}
+.post-grid .pagination.dark .current {
+    color:#222222;
+    background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+   border: 2px solid rgba(0, 0, 0, 0.05) !important;
+
+}
+
+
+/* mensaje de ERROR 404*/
+.alert {text-align:center; margin-top:50px;}
+.onomatopeya { font-size:2.5em; font-family:"Josefin Sans"; font-weight:600;}
+.error{font-size:1.6em; font-weight:300; line-height:1.3em;}
+
+.alert .form-search {
+margin-bottom:10px;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 303px;
+}
+
+
+/*:::::::::::::::::::::::::::::::::::::::::HOME:::::::::::::::::::::::::::::::::::::::*/
+
+.home-padding {
+padding-top:0;
+}
+.hometitle{
+padding-bottom:15px;
+}
+
+/*slide textos*/
+
+.kt-full-slider .flex-caption-case .captiontitle {
+    background: #c08993b0;
+    padding-top: 15px;
+    color: #ffffff;
+    font-size: 40px;
+    text-transform: uppercase;
+    text-shadow: 1px 1px 4px rgba(0, 0, 0, 0);
+    font-weight: 700;
+    letter-spacing: -1.5px;
+}
+
+.kt-full-slider .flex-caption-case .captiontext {
+    background: #ffffffc2;
+    color: #444;
+    text-shadow: 1px 1px 4px #eee;
+    font-size: 35px;
+    font-weight: 300;
+    letter-spacing: -2px;
+
+}
+
+/* receta principal destacada ocultar foto destacada */
+#post-grid-44850 .item .layer-media img {
+display:none;}
+
+/* receta principal destacada quitar borde recuadro*/
+#post-grid-44850 .item {
+border:none;}
+
+/* publicidad en el cuerpo de la home*/
+.publicidad{
+	margin-top:-40px;
+}
+
+/* imagenes de enlaces e iconos */
+.sow-masonry-grid-item:hover{
+opacity:0.7;
+}
+
+/*carrusel*/
+.sow-carousel-title a.sow-carousel-next {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+.sow-carousel-title a.sow-carousel-previous {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-wrapper ul.sow-carousel-items li.sow-carousel-item .sow-carousel-thumbnail a span.overlay {
+    background: #bebdbd none repeat scroll 0 0;}
+
+/* :::::::::::::::::::::::::::::::::::::::: RECETAS :::::::::::::::::::::::::::::::::::::::::::*/
+
+/* índice de recetas*/
+
+.azindex .head {
+    color: #000;
+}
+
+.azindex h4 {
+    border-bottom: 1px solid #ccc;
+    width: 90%;
+}
+.azindex h2 >a {
+color: #000;
+}
+.azlinks .azlink{
+display:inline-flex
+}
+.azlinks .azlink >a {
+      color: #000;
+    font-family: "josefin sans";
+    font-size: 1.2em;
+    font-weight: 700;
+    margin: 0.15em;
+    text-align: center;
+}
+
+
+/*visión movil*/
+@media (max-width: 600px){
+.azindex{width:100% !important;}
+}
+
+/* ::::::::::::::::::::  PÁGINAS INTERIORES DE RECETAS ::::::::::::::::::::::::*/
+.pagrecetcab {
+    margin-bottom: -30px;
+    margin-top: -30px;
+}
+
+/* :::::::::::::::::::::::::: CATEGORIAS RECETAS ::::::::::::::::::::::::::::::::::::::::::*/
+/* div del menu de tipos de recetas*/
+.recetnav {
+    margin-bottom: 40px;
+    margin-top: 40px;
+}
+
+/* texto descripción de la categoría*/
+.page-header > p {
+    color: #fff;
+    font-family:Open Sans;  /*"Josefin Sans";*/
+    font-size: 1.3em;
+    font-weight: 300;
+    padding-left: 1em;
+    margin-top: -20px;
+  padding-bottom:0.5em;
+line-height: 1.3em;
+
+}
+
+@media (max-width: 768px){
+.page-header > p {font-size:1em;
+}
+}
+
+/* ::::::::::::::::::::::::::::::::: POST RECETA :::::::::::::::::::::::::::*/
+.single-article article h1 { font-family:"Open Sans";
+/*border-bottom:1px solid #24292e;
+width:85%;*/
+text-decoration:none;
+padding-bottom:5px;}
+.postedintop{display:none}
+.single-footer .posttags a {
+font-size:16px;
+}
+
+/* Línea autora y comentarios*/
+.subhead {
+    margin-top: -12px;
+}
+/* ocultar divisor de más  entre "autora" "comentarios" post */
+.kad-hidepostedin {
+    display: none;
+}
+.postcommentscount {
+    margin-left: -2px;
+}
+
+/* Línea iconos redes*/
+.addtoany_share_save_container.addtoany_content_top {
+    margin-left: -5px;
+    margin-top: -5px;
+}
+
+/* etiquetas de ingredientes ocultas*/
+.single-footer .posttags {
+    display: none;
+}
+
+/* recetas plugin recipe en movil*/
+@media (max-width: 560px){
+.easyrecipe .ERSTimes .ERSTime {
+    float: left;
+    font-weight: bold;
+    min-width: 120px;
+    text-align: center;
+    width: 100%;
+    border:1px dotted #bdbeb2;}
+}
+
+easyrecipe-styl…ver=3.2.2708.1
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+
+/* ::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD :::::::::::::::::::::::::::: */
+.desnavidad {
+    border: 3px solid #bdbeb2;
+    border-radius: 20px;
+    padding: 1.5em  0.5em  0.2em 0.5em;
+  }
+
+.desnavidad h3 {
+   text-align:center;
+  font-family: 'Josefin Sans';
+  text-transform: uppercase; 
+ margin-bottom: 40px;
+ font-size:2.0em;
+color:#aa0000;
+}
+
+/* ::::::::::::::::::::::::::::::::::: VISIÓN TABLET :::::::::::::::::::::::::::::::::::::*/
+.iconhover{ width:80%;}
+/* Tablet APAISADA*/
+@media (min-width: 1020px) and (max-width: 1025px){
+.container{width:1010px;}
+}
+/* ajuste de padding izquierdo de receta en resultdos de búqueda 
+o visión tipo categorias para tablet apaisada*/
+@media (min-width: 768px) and (max-width: 1025px){
+.col-md-7.post-text-container.postcontent {
+padding-left:32px;
+}
+}
+/* whatsapp*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_whatsapp {
+display:none;}
+}
+
+/* telegram*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_telegram {
+display:none;}
+}
+
+
+/* ::::::::::::::::::::::::::: ELIMINAR BORDE AVATAR COMENT :::::::::::::::::::::::::: */
+
+.comment .avatar { border: 0px solid #f0eef0;
+}
+
+/* :::::::::::::::::::::::::::::::::: BOTONES CARRUSEL PORTADA ::::::::::::::::::::::::::::::::::::::::::::::: */
+
+.sow-carousel-title a.sow-carousel-next {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-title a.sow-carousel-previous {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-right: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+
+/* :::::::::::::::::::::::::::::::::: FOOTER ::::::::::::::::::::::::::::::::::::::::::::::: */
+/*Créditos*/
+.footercredits.clearfix {
+float:right;
+}
+.footercredits.clearfix > p {
+    font-size: 0.85em;
+    line-height: 1.5em;
+}
+
+.freehare {
+    font-size: 0.86em;
+}
+
+/* :::::::::::::::::::::::::::::::::: CHECKBOX ::::::::::::::::::::::::::::::::::::::::::::::: */
+.form-check {
+  width: 1em;
+  height: 1em;
+  vertical-align: top;
+}
+</style>
+<!-- Matomo -->
+<script type="rocketlazyloadscript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://estadisticas.mediasector.es/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '34']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
+		<script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+			var advadsCfpQueue = [];
+			var advadsCfpAd = function( adID ) {
+				if ( 'undefined' === typeof advadsProCfp ) {
+					advadsCfpQueue.push( adID )
+				} else {
+					advadsProCfp.addElement( adID )
+				}
+			}
+		</script>
+		<!--[if lt IE 9]>
+<script src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/vendor/respond.min.js"></script>
+<![endif]-->
+<style type="text/css">
+html body div.easyrecipe .ERSNotesDiv .ERSNotesHeader { font-size: 18px!important;font-style: italic!important;margin-top: 21px!important;margin-bottom: 1px!important;margin-left: 41px!important; }
+html body div.easyrecipe .ERSNotesDiv .ERSNotes { font-style: italic!important;font-size: 15px!important;padding-left: 39px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe .ERSName { font-family: inherit!important;color: rgb(5, 5, 5)!important;font-weight: bold!important;font-size: 27px!important;margin-top: 31px!important;margin-bottom: 16px!important;margin-left: 1px!important;padding-top: 1px!important;padding-left: 2px!important; }
+html body div.easyrecipe .ERSTimes { color: rgb(5, 5, 5)!important;margin-top: 10px!important;margin-bottom: 9px!important;padding-top: 8px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSTimes .ERSTimeItem { color: rgb(5, 5, 5)!important;font-size: 14px!important;margin-bottom: 9px!important;margin-left: -4px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSSummary { font-family: inherit!important;font-weight: bold!important;font-size: 18px!important;margin-top: 10px!important;margin-bottom: 8px!important;margin-left: 1px!important;padding-top: 6px!important;padding-right: 2px!important; }
+html body div.easyrecipe .ERSAuthor { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important;margin-left: 0px!important; }
+html body div.easyrecipe .ERSCategory { padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSCuisine { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSServes { font-size: 15px!important;padding-left: 0px!important; }
+html body div.easyrecipe .ERSPrintBtnSpan .ERSPrintBtn { font-family: inherit!important;background-color: rgb(189, 190, 178)!important;font-weight: bold!important;font-size: 14px!important;margin-top: -10px!important;margin-bottom: -11px!important;margin-right: 2px!important;padding: 8px!important; }
+html body div.easyrecipe .ERSIngredientsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;margin: 24px -3px 20px 0px!important;padding-left: 21px!important;font-weight: normal!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSIngredients li.ingredient { font-size: 15px!important;list-style-type: circle!important;margin: -4px -10px 8px 13px!important;padding-left: 3px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructionsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;font-weight: normal!important;margin-top: 24px!important;margin-bottom: 9px!important;margin-right: -2px!important;padding-left: 21px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructions .instruction { font-size: 15px!important;margin: 12px -6px 12px 32px!important;padding: 0px 20px 6px 9px!important;font-family: inherit!important; }
+div.easyrecipe { border-radius:18px; font-family: 'Open Sans' !important;}
+.ERSRatingOuter .review {
+margin-top:0.5em;
+}
+
+div.easyrecipe div.ERSSavePrint span.ERSPrintBtnSpan a.ERSPrintBtn span.ERSPrintIcon {
+background-image: url(images/printicon.png);
+width: 16px;
+height: 16px;
+display: none;
+/* padding-top: 20px; */
+}</style>
+<style type="text/css" class="options-output">header #logo a.brand,.logofont{font-family:Lato;line-height:40px;font-weight:400;font-style:normal;font-size:32px;}.kad_tagline{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;color:#444444;font-size:20px;}.product_item .product_details h5{font-family:Lato;line-height:20px;font-weight:700;font-style:normal;font-size:16px;}h1{font-family:"Josefin Sans";line-height:40px;font-weight:600;font-style:normal;font-size:32px;}h2{font-family:"Josefin Sans";line-height:32px;font-weight:400;font-style:normal;font-size:28px;}h3{font-family:"Josefin Sans";line-height:28px;font-weight:400;font-style:normal;font-size:24px;}h4{font-family:"Open Sans";line-height:24px;font-weight:400;font-style:normal;font-size:20px;}h5{font-family:"Josefin Sans";line-height:22px;font-weight:300;font-style:normal;font-size:18px;}body{font-family:"Open Sans";line-height:25px;font-weight:400;font-style:normal;font-size:16px;}#nav-main ul.sf-menu a{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;font-size:22px;}#nav-second ul.sf-menu a{font-family:"Josefin Sans";line-height:20px;font-weight:600;font-style:normal;font-size:16px;}.kad-nav-inner .kad-mnav, .kad-mobile-nav .kad-nav-inner li a,.nav-trigger-case{font-family:"Josefin Sans";line-height:22px;font-weight:600;font-style:normal;font-size:16px;}</style><style type="text/css">/** Mega Menu CSS Disabled **/</style>
+
+    <!-- Custom scripts -->
+
+
+<!-- Menú fijo-->
+
+<script type="rocketlazyloadscript">jQuery("document").ready(function($){
+
+	var nav = $('.navclass');
+
+	$(window).scroll(function () {
+		if ($(this).scrollTop() > 173) {
+			nav.addClass("stickytop");
+		} else {
+			nav.removeClass("stickytop");
+		}
+	});
+
+});
+
+</script>
+
+<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style><meta name="generator" content="WP Rocket 3.20.4" data-wpr-features="wpr_delay_js wpr_defer_js wpr_minify_js wpr_preconnect_external_domains wpr_automatic_lazy_rendering wpr_oci wpr_minify_css wpr_preload_links wpr_desktop" /></head>
+  	
+  	<body data-cmplz=1 class="wp-singular post-template-default single single-post postid-385 single-format-standard wp-theme-virtue wp-child-theme-velocidad mega-menu-secondary-navigation mega-menu-max-mega-menu-1 mega-menu-max-mega-menu-2 mega-menu-max-mega-menu-3 mega-menu-max-mega-menu-4 mega-menu-max-mega-menu-6 mega-menu-max-mega-menu-7 mega-menu-max-mega-menu-8 mega-menu-max-mega-menu-9 mega-menu-max-mega-menu-10 mega-menu-max-mega-menu-11 mega-menu-max-mega-menu-12 wide bizcocho-de-naranja-thermomix aa-prefix-local- er-recipe">
+  	<div  id="kt-skip-link"><a href="#content">Skip to Main Content</a></div>
+    <div  id="wrapper" class="container">
+    <header  class="banner headerclass" itemscope itemtype="http://schema.org/WPHeader">
+  <div  id="topbar" class="topclass">
+    <div  class="container">
+      <div class="row">
+        <div class="col-md-6 col-sm-6 kad-topbar-left">
+          <div class="topbarmenu clearfix">
+                                </div>
+        </div><!-- close col-md-6 --> 
+        <div class="col-md-6 col-sm-6 kad-topbar-right">
+          <div id="topbar-search" class="topbar-widget">
+            <form role="search" method="get" class="form-search" action="https://www.velocidadcuchara.com/">
+  <label>
+  	<span class="screen-reader-text">Búsqueda para:</span>
+  	<input type="text" value="" name="s" class="search-query" placeholder="Busca tu receta">
+  </label>
+  <button type="submit" class="search-icon"><i class="icon-search"></i></button>
+</form>        </div>
+        </div> <!-- close col-md-6-->
+      </div> <!-- Close Row -->
+    </div> <!-- Close Container -->
+  </div><div  class="container">
+  <div class="row">
+      <div class="col-md-4 clearfix kad-header-left">
+            <div id="logo" class="logocase">
+              <a class="brand logofont" href="https://www.velocidadcuchara.com/">
+                                  <div id="thelogo">
+                    <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-standard-logo" />
+                                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-retina-logo" style="max-height:121px" />                   </div>
+                              </a>
+                         </div> <!-- Close #logo -->
+       </div><!-- close logo span -->
+              
+    </div> <!-- Close Row -->
+     
+</div> <!-- Close Container -->
+    <section id="cat_nav" class="navclass">
+    <div class="container">
+      <nav id="nav-second" class="clearfix" itemscope itemtype="http://schema.org/SiteNavigationElement">
+        <div id="mega-menu-wrap-secondary_navigation" class="mega-menu-wrap"><div class="mega-menu-toggle" tabindex="0"><div class='mega-toggle-block mega-menu-toggle-block mega-toggle-block-right mega-toggle-block-1' id='mega-toggle-block-1'></div></div><ul id="mega-menu-secondary_navigation" class="mega-menu mega-menu-horizontal mega-no-js" data-event="hover_intent" data-effect="fade_up" data-effect-speed="200" data-second-click="close" data-document-click="collapse" data-vertical-behaviour="accordion" data-breakpoint="768" data-unbind="true"><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-58762' id='mega-menu-item-58762'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/indice-recetas-thermomix/" tabindex="0">Índice</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58774' id='mega-menu-item-58774'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/todas-las-recetas/" aria-haspopup="true" tabindex="0">Recetas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-custom mega-menu-item-object-custom mega-menu-item-58775' id='mega-menu-item-58775'><a class="mega-menu-link" href="https://velocidadcuchara.com/todas-las-recetas/">Todas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58778' id='mega-menu-item-58778'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/carnes/">Carnes</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58779' id='mega-menu-item-58779'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/pescados-y-marisco/">Pescados y mariscos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58780' id='mega-menu-item-58780'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/ensaladas/">Ensaladas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58781' id='mega-menu-item-58781'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/legumbres-y-verduras/">Legumbres y verduras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58782' id='mega-menu-item-58782'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/arroces-y-pastas/">Arroces y pastas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58783' id='mega-menu-item-58783'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sopas-y-cremas/">Sopas y cremas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58784' id='mega-menu-item-58784'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/masas-y-pan/">Masas y pan</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58785' id='mega-menu-item-58785'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/reposteria/">Repostería</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58786' id='mega-menu-item-58786'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/postres-y-dulces/">Postres y dulces</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58787' id='mega-menu-item-58787'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/conservas-y-confituras/">Conservas y confituras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-59720' id='mega-menu-item-59720'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/desayuno/">Desayunos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58788' id='mega-menu-item-58788'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/bebidas/">Bebidas y cócteles</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58789' id='mega-menu-item-58789'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetarios/">Recetarios</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58803' id='mega-menu-item-58803'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dos-en-uno/">Dos en uno</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58776' id='mega-menu-item-58776'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/dietas/" aria-haspopup="true" tabindex="0">Dietas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58790' id='mega-menu-item-58790'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-gluten/">Sin gluten</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58791' id='mega-menu-item-58791'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-lactosa/">Sin lactosa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58792' id='mega-menu-item-58792'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-huevo/">Sin huevo</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58793' id='mega-menu-item-58793'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-azucar/">Sin azúcar</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58794' id='mega-menu-item-58794'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/vegetariana/">Vegetariana</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58795' id='mega-menu-item-58795'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/hipocalorica/">Hipocalórica</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58777' id='mega-menu-item-58777'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas-sin-thermomix/" aria-haspopup="true" tabindex="0">Sin TMX</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58798' id='mega-menu-item-58798'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/olla-rapida/">Olla rápida</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58797' id='mega-menu-item-58797'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/cocotte/">Cocotte</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-60222' id='mega-menu-item-60222'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/freidora-de-aire/">Freidora de aire</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58799' id='mega-menu-item-58799'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/crock-pot/">Crock Pot</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58796' id='mega-menu-item-58796'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/kitchenaid/">Kitchenaid</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58801' id='mega-menu-item-58801'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/al-vacio/">Al vacío</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58800' id='mega-menu-item-58800'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/barbacoa/">Barbacoa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58802' id='mega-menu-item-58802'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/otros/">Otros</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58763' id='mega-menu-item-58763'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" aria-haspopup="true" tabindex="0">Libros</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58765' id='mega-menu-item-58765'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-cocina-rico-todos-los-dias-thermomix/">Cocina rico todos los días</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58764' id='mega-menu-item-58764'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-mis-recetas-imprescindibles-thermomix/">Mis recetas imprescindibles</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-60105' id='mega-menu-item-60105'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/podcast-velocidad-cuchara/" tabindex="0">🎧 Pódcast</a></li></ul></div>      </nav>
+    </div><!--close container-->
+  </section>
+  </header>
+      <div  class="wrap contentclass" role="document">
+
+        <div  id="content" class="container">
+    <div class="row single-article" itemscope itemtype="http://schema.org/BlogPosting">
+        <div class="main col-lg-9 col-md-8" role="main">
+                    <article class="post-385 post type-post status-publish format-standard has-post-thumbnail hentry category-30-minutos category-bizcochos category-desayuno category-recetas category-reposteria tag-harina tag-huevos tag-levadura-quimica tag-naranjas tag-yogurt-natural">
+            <div class="meta_post_image" itemprop="image" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17.jpg"><meta itemprop="width" content="1200"><meta itemprop="height" content="801"></div>
+                <div class="postmeta updated color_gray">
+      <div class="postdate bg-lightgray headerfont" itemprop="datePublished">
+      <span class="postday">7</span>
+      Jun 2017    </div>
+</div>                <header>
+                    <h1 class="entry-title" itemprop="name headline">Bizcocho de naranja</h1><div class="subhead">
+    <span class="postauthortop author vcard">
+    <i class="icon-user"></i> por  <span itemprop="author"><a href="https://www.velocidadcuchara.com/author/admin/" class="fn" rel="author">Rosa Ardá</a></span> |</span>
+      
+    <span class="postedintop"><i class="icon-folder-open"></i> publicado en: <a href="https://www.velocidadcuchara.com/tiempo/30-minutos/" rel="category tag">30 minutos</a>, <a href="https://www.velocidadcuchara.com/recetas/reposteria/bizcochos/" rel="category tag">Bizcochos</a>, <a href="https://www.velocidadcuchara.com/recetas/desayuno/" rel="category tag">Desayunos</a>, <a href="https://www.velocidadcuchara.com/recetas/" rel="category tag">Recetas</a>, <a href="https://www.velocidadcuchara.com/recetas/reposteria/" rel="category tag">Repostería</a></span>     <span class="kad-hidepostedin">|</span>
+    <span class="postcommentscount">
+    <i class="icon-comments-alt"></i> 141    </span>
+</div>                </header>
+
+                <div class="entry-content" itemprop="articleBody">
+                    <p><a href="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17.jpg"><picture fetchpriority="high" decoding="async" class="aligncenter wp-image-45830 size-large" title="Bizcocho naranja con chocolate">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-1024x684.jpg.webp 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-300x200.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-768x513.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-272x182.jpg.webp 272w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17.jpg.webp 1200w" sizes="(max-width: 1024px) 100vw, 1024px"/>
+<img fetchpriority="high" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-1024x684.jpg" alt="Bizcocho naranja con Thermomix®" width="1024" height="684" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-1024x684.jpg 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-300x200.jpg 300w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-768x513.jpg 768w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17-272x182.jpg 272w, https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-naranja-corte-VC17.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px"/>
+</picture>
+</a></p>
+<div class="space_20 clearfix"></div>
+<p><strong>Siempre hay que tener en el repertorio de bizcochos esas recetas fáciles que nunca fallan y que generalmente a todos les agrada.</strong> Es el caso de este bizcocho de naranja, una receta de las más fáciles que vas a preparar en Thermomix®. Fácil y rápido. Mezclar y al horno. Es sin duda uno de los que preparo en casa cuando de repente llegan invitados.</p><script type="text/plain" data-tcf="waiting-for-consent" data-id="45718" data-bid="1" data-placement="61266">PGRpdiBpZD0ibG9jYWwtMTU5NDUwODY1MyIgY2xhc3M9Imdhc19mYWxsYmFjay1hZF80NTcxOC0tcGxhY2VtZW50XzYxMjY2IiBzdHlsZT0ibWFyZ2luLXRvcDogMjBweDttYXJnaW4tYm90dG9tOiAyMHB4OyI+PHNjcmlwdCBhc3luYyBzcmM9Ii8vcGFnZWFkMi5nb29nbGVzeW5kaWNhdGlvbi5jb20vcGFnZWFkL2pzL2Fkc2J5Z29vZ2xlLmpzP2NsaWVudD1jYS1wdWItMDQzMjcyNjA0MDAwOTY3NiIgY3Jvc3NvcmlnaW49ImFub255bW91cyI+PC9zY3JpcHQ+PGlucyBjbGFzcz0iYWRzYnlnb29nbGUiIHN0eWxlPSJkaXNwbGF5OmJsb2NrOyIgZGF0YS1hZC1jbGllbnQ9ImNhLXB1Yi0wNDMyNzI2MDQwMDA5Njc2IiAKZGF0YS1hZC1zbG90PSI5ODk1NDgwOTQ4IiAKZGF0YS1hZC1mb3JtYXQ9ImF1dG8iPjwvaW5zPgo8c2NyaXB0PiAKKGFkc2J5Z29vZ2xlID0gd2luZG93LmFkc2J5Z29vZ2xlIHx8IFtdKS5wdXNoKHt9KTsgCjwvc2NyaXB0Pgo8L2Rpdj4=</script>
+<p>Para darle un acabado precioso, a mi me gusta usar los moldes <strong><a title="Babaria de Nordic Ware®" href="https://www.claudiaandjulia.com/products/molde-aluminio-bavaria-nordic-ware" target="_blank" rel="noopener noreferrer">Nordic Ware®, este en concreto es un &#8220;Babaria&#8221;</a></strong> pero hay montones de formas que harán que cada vez que lo cocines sea diferente y apetecible y si no tienes estos moldes usa un molde redondo de 22 cm de diámetro. Estoy deseando que lo prepares. :D</p>
+<address><strong>✔ Recuerda:</strong> Prepara tus moldes para esos desayunos de vacaciones, aprovecha los descuentos que tenemos en <strong><a title="https://www.claudiaandjulia.com/" href="https://www.claudiaandjulia.com/" target="_blank" rel="noopener noreferrer">Claudia&amp;Julia</a> y disfruta de los <a title="Productos Nordic Ware®" href="https://www.claudiaandjulia.com/collections/vendors?q=Nordic%20Ware" target="_blank" rel="noopener noreferrer">moldes Nordic Ware</a> y<a title="Moldes, repostería en Claudia&amp;Julia" href="https://www.claudiaandjulia.com/collections/dulces-y-reposteria#repostera-9876" target="_blank" rel="noopener noreferrer"> otros moldes para horno</a>.</strong> Compra tus botes de cristal en<a style="font-weight: bold;" title="Recipientes de cristal de JUVASA.COM" href="http://www.juvasa.com/es/50/envases-alimentarios-vidrio/460/tarro-de-vidrio-hermetico-le-parfait-super-500-ml-500ml-bocalps-085mm/--/cat:27" target="_blank" rel="noopener noreferrer"> Juvasa.com</a> y llena la despensa de harinas y útiles para pan con los productos de <strong><a title="El Amasadero, tu tienda para el pan" href="http://www.elamasadero.com/?utm_source=velocidadcuchara&amp;utm_medium=banner&amp;utm_campaign=en_blogs" target="_blank" rel="noopener noreferrer">El Amasadero</a>.</strong> Este verano no te puede faltar de nada. <strong>Nuestro</strong> <strong>código es &#8220;VelocidadCuchara&#8221;</strong>. Síguenos en <strong><a title="https://www.instagram.com/rosaarda/" href="https://www.instagram.com/rosaarda/" target="_blank" rel="noopener noreferrer">INSTAGRAM</a>, <a title="Twitter @Rosaarda" href="https://twitter.com/rosaarda" target="_blank" rel="noopener noreferrer">TWITTER</a> </strong> y en nuestro<strong><a title="Nuestro canal en Youtube" href="https://www.youtube.com/user/velocidadcuchara" target="_blank" rel="noopener noreferrer"> canal de YOUTUBE</a>.</strong></address>
+<p><span id="more-385"></span><br />
+<div id="easyrecipe-385-0" class="easyrecipe" itemscope itemtype="http://schema.org/Recipe"> <link itemprop="image" href="https://www.velocidadcuchara.com/wp-content/uploads/2010/03/Bizcocho-de-naranja-VC17-140x93.jpg"/> <div class="ERSRatings" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"> <div class="ERSRatingOuter"> <div class="ERSRatingInner" style="width: 92%"></div> <div class="review"><span class="rating"><span class="average" itemprop="ratingValue">4.6</span> de <span class="count" itemprop="ratingCount">13</span> opiniones</span></div> </div> </div> <div itemprop="name" class="ERSName">Bizcocho de naranja</div> <div class="ERSClear">&nbsp;</div> <div class="ERSTopRight"> <div class="ERSSavePrint"> <span class="ERSPrintBtnSpan"><a class="ERSPrintBtn" href="https://www.velocidadcuchara.com/easyrecipe-print/385-0/" rel="nofollow" target="_blank">Imprimir</a></span> </div> </div> <div class="ERSTimes"> <div class="ERSTime"> <div class="ERSTimeHeading">Preparación</div> <div class="ERSTimeItem"> <time itemprop="prepTime" datetime="PT10M">10 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Cocción</div> <div class="ERSTimeItem"> <time itemprop="cookTime" datetime="PT30M">30 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Tiempo total</div> <div class="ERSTimeItem"> <time itemprop="totalTime" datetime="PT40M">40 min</time> </div> </div> <div class="ERSClearLeft">&nbsp;</div> </div> <div class="divERSHeadItems"> <div class="ERSAuthor">Autor: <span itemprop="author">Rosa Ardá</span></div> <div class="ERSServes">Raciones: <span itemprop="recipeYield">8</span></div> </div> <div class="ERSIngredients"> <div class="ERSIngredientsHeader ERSHeading">Ingredientes</div> <ul> <li class="ingredient" itemprop="ingredients">1 naranja de zumo entera con o sin piel - a veces la piel puede amargar, así que ralla la piel de la naranja para el bizcocho y luego quita toda la parte blanca-</li> <li class="ingredient" itemprop="ingredients">200 gr de azúcar o al gusto o su equivalente en edulcorante acalórico</li> <li class="ingredient" itemprop="ingredients">3 huevos medianos</li> <li class="ingredient" itemprop="ingredients">100 gr de aceite de girasol o aceite de oliva tipo arberquina</li> <li class="ingredient" itemprop="ingredients">1 yogur natural de 125 gr</li> <li class="ingredient" itemprop="ingredients">250 gr de harina de repostería</li> <li class="ingredient" itemprop="ingredients">1 sobre o 16 gr de levadura Royal®</li> <li class="ingredient" itemprop="ingredients">Una pizca de sal</li> </ul> <div class="ERSClear"></div> </div> <div class="ERSInstructions"> <div class="ERSInstructionsHeader ERSHeading">Pasos a seguir</div> <ol> <li class="instruction" itemprop="recipeInstructions">Pon en el vaso el<strong> azúcar, la naranja troceada en cuartos y los huevos </strong>y programa<strong> 3 minutos, 37º, velocidad 5.</strong></li> <li class="instruction" itemprop="recipeInstructions">Añade el <strong>aceite y el yogur</strong> y mezcla<strong> 15 segundos en velocidad 2 y medio</strong>.</li> <li class="instruction" itemprop="recipeInstructions">Incorpora la<strong> harina, la levadura y la sal</strong> y mezcla <strong>15 segundos en velocidad 3</strong>. Termina de envolver con la espátula.</li> <li class="instruction" itemprop="recipeInstructions"><strong>Engrasa el molde</strong> que prefieras y vierte la mezcla.<strong> Hornea a 180º durante 30 minutos calor arriba y abajo.</strong> Deja enfriar sobre una rejilla y decora al gusto.</li> </ol> <div class="ERSClear"></div> </div> <div class="endeasyrecipe" title="style002a" style="display: none">3.2.2708</div> </div>
+Fuente: <em>Libro básico de Thermomix</em></p>
+<div class="addtoany_share_save_container addtoany_content addtoany_content_bottom"><div class="a2a_kit a2a_kit_size_32 addtoany_list" data-a2a-url="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/" data-a2a-title="Bizcocho de naranja"><a class="a2a_button_facebook" href="https://www.addtoany.com/add_to/facebook?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fbizcocho-de-naranja-thermomix%2F&amp;linkname=Bizcocho%20de%20naranja" title="Facebook" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_x" href="https://www.addtoany.com/add_to/x?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fbizcocho-de-naranja-thermomix%2F&amp;linkname=Bizcocho%20de%20naranja" title="X" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_pinterest" href="https://www.addtoany.com/add_to/pinterest?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fbizcocho-de-naranja-thermomix%2F&amp;linkname=Bizcocho%20de%20naranja" title="Pinterest" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_whatsapp" href="https://www.addtoany.com/add_to/whatsapp?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fbizcocho-de-naranja-thermomix%2F&amp;linkname=Bizcocho%20de%20naranja" title="WhatsApp" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_telegram" href="https://www.addtoany.com/add_to/telegram?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fbizcocho-de-naranja-thermomix%2F&amp;linkname=Bizcocho%20de%20naranja" title="Telegram" rel="nofollow noopener" target="_blank"></a></div></div>                </div>
+
+                <footer class="single-footer">
+                <span class="posttags"><i class="icon-tag"></i><a href="https://www.velocidadcuchara.com/tag/harina/" rel="tag">Harina</a>, <a href="https://www.velocidadcuchara.com/tag/huevos/" rel="tag">Huevos</a>, <a href="https://www.velocidadcuchara.com/tag/levadura-quimica/" rel="tag">Levadura química</a>, <a href="https://www.velocidadcuchara.com/tag/naranjas/" rel="tag">Naranjas</a>, <a href="https://www.velocidadcuchara.com/tag/yogurt-natural/" rel="tag">Yogurt natural</a></span><meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/"><meta itemprop="dateModified" content="2023-04-23T09:33:40+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div>                </footer>
+            </article>
+            <div id="blog_carousel_container" class="carousel_outerrim">
+    <h3 class="title">Publicaciones Recientes</h3>    <div class="blog-carouselcase fredcarousel">
+    		<div id="carouselcontainer-blog" class="rowtight">
+		<div id="blog_carousel" class="blog_carousel caroufedselclass initcaroufedsel clearfix" data-carousel-container="#carouselcontainer-blog" data-carousel-transition="300" data-carousel-scroll="1" data-carousel-auto="true" data-carousel-speed="9000" data-carousel-id="blog" data-carousel-md="3" data-carousel-sm="3" data-carousel-xs="2" data-carousel-ss="1">
+            				<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61247 post type-post status-publish format-standard has-post-thumbnail hentry category-cocina-para-ninos category-dietas category-dulces-para-ninos category-postres-de-cuchara category-postres-y-dulces category-recetas category-sin-gluten category-sin-lactosa tag-azucar-blanquilla tag-esencia-de-vainilla tag-galletas-tipo-maria tag-huevos tag-leche-sin-lactosa course-postres-reposteria cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" title="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg" alt="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">23 octubre, 2025</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Cocina para todos una receta sin gluten y sin lactosa. Este Pudin te va a...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/"><meta itemprop="dateModified" content="2025-10-24T18:03:21+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-274 post type-post status-publish format-standard has-post-thumbnail hentry category-30-minutos category-dietas category-ensaladas category-estaciones category-frias category-hipocalorica category-pescado-azul category-pescados-y-marisco category-primeros-dieta category-recetas category-sin-azucar category-sin-gluten category-sin-lactosa category-verano category-verduras-y-hortalizas tag-aceitunas-negras tag-aceitunas-rellenas-de-anchoa tag-atun tag-cebollas-tomates tag-huevos tag-patatas tag-pimiento-rojo tag-pimiento-verde course-ensaladas cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/ensalada-campera/" title="Ensalada campera">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg" alt="Ensalada campera" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/ensalada-campera/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Ensalada campera</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">7 junio, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>En días de calor no hay nada más apetecible que una ensalada. Te propongo que...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/ensalada-campera/"><meta itemprop="dateModified" content="2025-11-30T17:58:48+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61149 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-estaciones category-invierno category-otono category-otros category-pescado-blanco category-pescados-y-marisco category-primavera category-recetas category-sin-thermomix category-tiempo category-tupper tag-ajos tag-bacalao tag-cebollas tag-guindillas tag-harina tag-perejil tag-pimienta-negra tag-sal tag-tomate-natural-triturado course-segundos-pescados cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" title="Bacalao en salsa de tomate">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg" alt="Bacalao en salsa de tomate" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Bacalao en salsa de tomate</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 abril, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Hoy quiero compartir con vosotros esta receta. ¿Sabéis lo buenísima que está? Es deliciosaaaaaaa. En...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/"><meta itemprop="dateModified" content="2025-11-30T18:03:39+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-10498 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-dulces category-fiestas category-masas-y-pan category-pan category-postres-de-cuchara category-postres-y-dulces category-recetas category-semana-santa tag-canela tag-cointreau tag-huevos tag-leche-entera tag-naranjas tag-pan course-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" title="Torrijas fritas de Semana Santa con Thermomix">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg" alt="Torrijas fritas de Semana Santa con Thermomix" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-730x730.jpg 730w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-365x365.jpg 365w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Torrijas fritas de Semana Santa con Thermomix</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">27 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¿Estáis listos para la segunda parte del &#8220;Pan para torrijas&#8221;? Pues agarraros a la silla...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/"><meta itemprop="dateModified" content="2024-03-27T11:23:07+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-60562 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-desayuno category-dulces category-estaciones category-fiestas category-freidora-de-aire category-masas-dulces category-postres-de-cuchara category-postres-y-dulces category-primavera category-recetas category-reposteria category-semana-santa category-sin-thermomix category-tiempo tag-azucar tag-azucar-blanquilla tag-canela tag-huevos tag-leche-entera tag-limones tag-pan course-reposteria-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" title="Mis primeras Torrijas en Freidora de aire o Airfryer">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg" alt="Mis primeras Torrijas en Freidora de aire o Airfryer" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-150x150.jpeg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-532x532.jpeg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Mis primeras Torrijas en Freidora de aire o Airfryer</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">5 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Receta de Torrijas de Semana Santa en freidora de aire o Airfryer. Prepáralas en pocos...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/"><meta itemprop="dateModified" content="2024-04-06T10:23:15+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61100 post type-post status-publish format-standard has-post-thumbnail hentry category-carne-de-pollo category-carnes category-cocina-del-mundo category-estaciones category-india category-invierno category-otono category-otros category-primavera category-recetas category-sin-thermomix category-tupper tag-aguacates tag-ajos tag-carne-de-pollo tag-fideos-de-arroz tag-jengibre tag-lima tag-miel tag-pimienta-negra tag-sal tag-salsa-de-soja tag-semillas-de-sesamo course-carnes-segundos" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" title="Pollo con soja y jengibre">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg" alt="Pollo con soja y jengibre" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pollo con soja y jengibre</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 enero, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¡Que se nota dicen!! Que si, que estoy feliz. Sobre todo estoy tranquila y este...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/"><meta itemprop="dateModified" content="2024-12-23T09:15:20+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+					</div>
+     <div class="clearfix"></div>
+            <a id="prevport-blog" class="prev_carousel icon-chevron-left" href="#"></a>
+			<a id="nextport-blog" class="next_carousel icon-chevron-right" href="#"></a>
+            </div>
+            </div>
+</div><!-- Carousel Container-->  <section id="comments">
+    <h3>141 Comentarios</h3>
+
+      <button class="mostrar-comentarios antes button" style="cursor:pointer">Mostrar comentarios</button>
+
+    <ol class="media-list">
+      
+  <li id="comment-232470" class="comment even thread-even depth-1 media comment-232470">
+    <img alt='' src='https://secure.gravatar.com/avatar/484439af9019aab6d180550da2f8344aef0e91e439a180beb553e25ae65aca06?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/484439af9019aab6d180550da2f8344aef0e91e439a180beb553e25ae65aca06?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rafael González</h5>
+        <div class="comment-meta">
+        <time datetime="2021-10-09T17:25:39+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-232470">
+          9 octubre, 2021</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-232470" data-commentid="232470" data-postid="385" data-belowelement="comment-232470" data-respondelement="respond" data-replyto="Responder a Rafael González" aria-label="Responder a Rafael González">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Esta mañana recibí la receta por email y me animé a hacerla. ¡¡Espectacular!! No sale un bizcocho grande, medianito, que para mi que vivo solo está genial para no tirar nada. ¡¡Buenísimo!! Muchísimas gracias Rosa.      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-232470">
+    
+  <li id="comment-232542" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-232542">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2021-10-30T12:12:14+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-232542">
+          30 octubre, 2021</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>De nada Rafa!!! Es un bizcocho muyyy rico</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-228463" class="comment odd alt thread-even depth-1 media comment-228463">
+    <img alt='' src='https://secure.gravatar.com/avatar/6e91a57ef58ba05abc9da999663852958d86188e747d7ad5d7819b889f2c9166?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/6e91a57ef58ba05abc9da999663852958d86188e747d7ad5d7819b889f2c9166?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carmen</h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-27T16:14:25+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-228463">
+          27 abril, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-228463" data-commentid="228463" data-postid="385" data-belowelement="comment-228463" data-respondelement="respond" data-replyto="Responder a Carmen" aria-label="Responder a Carmen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenas tardes, me gustaría hacer este bizcocho pero sólo lo como yo en casa y acabó tirando la mitad, si pongo la mitad de los ingredientes la receta la hago igual? Entiendo que el tiempo de horno será algo menos, por lógica. Gracias      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-228463">
+    
+  <li id="comment-228746" class="comment odd alt depth-2 media comment-228746">
+    <img alt='' src='https://secure.gravatar.com/avatar/384ea46635db9d1b03281bf30cde0de761ccd3fd68b84a0836795003ce911d4d?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/384ea46635db9d1b03281bf30cde0de761ccd3fd68b84a0836795003ce911d4d?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">María</h5>
+        <div class="comment-meta">
+        <time datetime="2020-05-30T13:39:24+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-228746">
+          30 mayo, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Nosotros solo somos dos, lo que hago es congelarlo en 4 partes y así tenemos para los desayunos de los fines de semana. Descongela perfecta, sacandola la noche anterior y dejandola en la encimera. Vale la pena. Espero haber sido de ayuda.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-227288" class="comment even thread-even depth-1 media comment-227288">
+    <img alt='' src='https://secure.gravatar.com/avatar/d19a5431a9bb770a339b6670477d342907a9846e0868b54a4efb68371afe7476?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/d19a5431a9bb770a339b6670477d342907a9846e0868b54a4efb68371afe7476?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Marina</h5>
+        <div class="comment-meta">
+        <time datetime="2020-01-12T11:17:22+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-227288">
+          12 enero, 2020</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-227288" data-commentid="227288" data-postid="385" data-belowelement="comment-227288" data-respondelement="respond" data-replyto="Responder a Marina" aria-label="Responder a Marina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>¿Algún sustituto del yogurt? Gracias</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-227288">
+    
+  <li id="comment-233959" class="comment even depth-2 media comment-233959">
+    <img alt='' src='https://secure.gravatar.com/avatar/e7f59b5933a010e2ea7ef5e8b2038529cb9f45a895443ad87e04ef2c0419bfe7?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e7f59b5933a010e2ea7ef5e8b2038529cb9f45a895443ad87e04ef2c0419bfe7?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rocío</h5>
+        <div class="comment-meta">
+        <time datetime="2022-11-10T18:38:06+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-233959">
+          10 noviembre, 2022</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Yo voy a probar a hacerlo con &#8220;yogurt&#8221; de soja. Ya te contaré qué tal sale.      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-225136" class="comment odd alt thread-even depth-1 media comment-225136">
+    <img alt='' src='https://secure.gravatar.com/avatar/f83bded4335701fd13241966be7a19b4dcf6ac8d3ed56c3805405a58df01390f?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f83bded4335701fd13241966be7a19b4dcf6ac8d3ed56c3805405a58df01390f?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Laura</h5>
+        <div class="comment-meta">
+        <time datetime="2019-04-13T21:46:01+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-225136">
+          13 abril, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-225136" data-commentid="225136" data-postid="385" data-belowelement="comment-225136" data-respondelement="respond" data-replyto="Responder a Laura" aria-label="Responder a Laura">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola,<br />
+Pinta muy buena, pero el bizcocho no ha subido.      </p>
+<div class="ERRatingComment">
+<div style="width:20%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-225079" class="comment even thread-odd thread-alt depth-1 media comment-225079">
+    <img alt='' src='https://secure.gravatar.com/avatar/b9bc7d3feefddfa0c4462dfe2cf036f8899c25515871ef7c46c65d03c402e560?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b9bc7d3feefddfa0c4462dfe2cf036f8899c25515871ef7c46c65d03c402e560?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rocio</h5>
+        <div class="comment-meta">
+        <time datetime="2019-03-31T21:02:00+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-225079">
+          31 marzo, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-225079" data-commentid="225079" data-postid="385" data-belowelement="comment-225079" data-respondelement="respond" data-replyto="Responder a Rocio" aria-label="Responder a Rocio">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola! Lo he preparado esta mañana, pero no ha subido!! ???? cuál podría ser la razón?<br />
+De sabor muy bueno, pero apenas ha subido 2 cm.<br />
+Q pena!<br />
+Gracias</p>
+      
+  </div></li>
+
+  <li id="comment-224838" class="comment odd alt thread-even depth-1 media comment-224838">
+    <img alt='' src='https://secure.gravatar.com/avatar/4e6c6cbe042b9cced2e964b10c64694ed8d0a0edfea6607818177405a616cd9b?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/4e6c6cbe042b9cced2e964b10c64694ed8d0a0edfea6607818177405a616cd9b?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Agustin</h5>
+        <div class="comment-meta">
+        <time datetime="2019-03-12T18:33:48+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-224838">
+          12 marzo, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-224838" data-commentid="224838" data-postid="385" data-belowelement="comment-224838" data-respondelement="respond" data-replyto="Responder a Agustin" aria-label="Responder a Agustin">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>A mí me sale muy seco, poco esponjoso</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-224838">
+    
+  <li id="comment-224926" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-224926">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2019-03-24T18:46:30+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-224926">
+          24 marzo, 2019</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hornea menos tiempo!!! A ver si tu horno lo cocina antes. No es un bizcocho secooo</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-224716" class="comment even thread-even depth-1 media comment-224716">
+    <img alt='' src='https://secure.gravatar.com/avatar/21012aae5c3eda302a584f861088d6530fb30a9ba7abcd1ee0389dea5c698ac8?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/21012aae5c3eda302a584f861088d6530fb30a9ba7abcd1ee0389dea5c698ac8?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carolina</h5>
+        <div class="comment-meta">
+        <time datetime="2019-02-11T16:38:17+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-224716">
+          11 febrero, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-224716" data-commentid="224716" data-postid="385" data-belowelement="comment-224716" data-respondelement="respond" data-replyto="Responder a Carolina" aria-label="Responder a Carolina">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rico, esponjoso y fácil de hacer&#8230;alguien ha probado con limón? quedará muy ácido?      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-224716">
+    
+  <li id="comment-228943" class="comment even depth-2 media comment-228943">
+    <img alt='' src='https://secure.gravatar.com/avatar/436cc36a22e64ecc5859372288998a14821313dc09f90da2148fa2c279ce7f12?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/436cc36a22e64ecc5859372288998a14821313dc09f90da2148fa2c279ce7f12?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Lucía</h5>
+        <div class="comment-meta">
+        <time datetime="2020-07-05T17:53:15+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-228943">
+          5 julio, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Yo siempre lo hago con limón y un poco de vainilla, queda genial!!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-224662" class="comment odd alt thread-even depth-1 media comment-224662">
+    <img alt='' src='https://secure.gravatar.com/avatar/deb5603837e4bc1c9aee9e68d45ef87a7fc042a82ef22861879bc6014c846e7e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/deb5603837e4bc1c9aee9e68d45ef87a7fc042a82ef22861879bc6014c846e7e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Marta</h5>
+        <div class="comment-meta">
+        <time datetime="2019-02-03T14:56:47+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-224662">
+          3 febrero, 2019</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-224662" data-commentid="224662" data-postid="385" data-belowelement="comment-224662" data-respondelement="respond" data-replyto="Responder a Marta" aria-label="Responder a Marta">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Se puede sustituir el aceite por mantequilla? Muchas gracias<br />
+P. D. Me encanta tu web ;-)<br />
+Marta      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-223978" class="comment even thread-odd thread-alt depth-1 media comment-223978">
+    <img alt='' src='https://secure.gravatar.com/avatar/0695770973e057cef94e71b20631da4a476a84c8da3e7d6e6a5454cc6dd0f2a2?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/0695770973e057cef94e71b20631da4a476a84c8da3e7d6e6a5454cc6dd0f2a2?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">judithponsezquerra</h5>
+        <div class="comment-meta">
+        <time datetime="2018-11-06T16:11:01+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-223978">
+          6 noviembre, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223978" data-commentid="223978" data-postid="385" data-belowelement="comment-223978" data-respondelement="respond" data-replyto="Responder a judithponsezquerra" aria-label="Responder a judithponsezquerra">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>perfecto!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-223703" class="comment odd alt thread-even depth-1 media comment-223703">
+    <img alt='' src='https://secure.gravatar.com/avatar/01c799b483cbcf7a31ce0446aca9cdffaac229e34d27aedd1662cb62a5e9a198?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/01c799b483cbcf7a31ce0446aca9cdffaac229e34d27aedd1662cb62a5e9a198?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mrpl</h5>
+        <div class="comment-meta">
+        <time datetime="2018-10-05T20:59:52+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-223703">
+          5 octubre, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-223703" data-commentid="223703" data-postid="385" data-belowelement="comment-223703" data-respondelement="respond" data-replyto="Responder a Mrpl" aria-label="Responder a Mrpl">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola , quiero hacer este bizcocho pero me acabo de dar cuenta que solo tengo harina de fuerza . Como lo hago? Pongo los 250grms y no le añado levadura???. Gracias!!!      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-223703">
+    
+  <li id="comment-223709" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-223709">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2018-10-06T11:52:05+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-223709">
+          6 octubre, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Nooo&#8230; la harina de fuerza tiene más proteínas, no tiene nada que ver con la levadura&#8230; No te vale para un bizcocho.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-219706" class="comment even thread-even depth-1 media comment-219706">
+    <img alt='' src='https://secure.gravatar.com/avatar/10e430f2f7b42c5b0daaa79c00c3e7b3b56c85d5a000b6f6d8e26fdda282116e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/10e430f2f7b42c5b0daaa79c00c3e7b3b56c85d5a000b6f6d8e26fdda282116e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Marta</h5>
+        <div class="comment-meta">
+        <time datetime="2018-02-25T09:37:53+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-219706">
+          25 febrero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-219706" data-commentid="219706" data-postid="385" data-belowelement="comment-219706" data-respondelement="respond" data-replyto="Responder a Marta" aria-label="Responder a Marta">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa,</p>
+<p>Lo hice ayer para desayunarlo hoy. Muy rico de sabor pero al partirlo se destroza en trocitos pequeños (como granulos grandes). Usé un Nordicware. A qué se debe?. La receta la seguí tal cua. Gracias por la ayuda para que no se repita de nuevo.</p>
+      
+  </div></li>
+
+  <li id="comment-219705" class="comment odd alt thread-odd thread-alt depth-1 media comment-219705">
+    <img alt='' src='https://secure.gravatar.com/avatar/e4a3c0545c52ba96cd6735d574620476e5764e908e0799b7f7fb970694019578?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e4a3c0545c52ba96cd6735d574620476e5764e908e0799b7f7fb970694019578?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Marta</h5>
+        <div class="comment-meta">
+        <time datetime="2018-02-25T09:16:59+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-219705">
+          25 febrero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-219705" data-commentid="219705" data-postid="385" data-belowelement="comment-219705" data-respondelement="respond" data-replyto="Responder a Marta" aria-label="Responder a Marta">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa,</p>
+<p>Lo hice ayer para desayunarlo hoy. Muy rico de sabor pero al partirlo se destroza en trocitos pequeños (como granulos grandes). Usé un Nordicware. A qué se debe?. La receta la seguí tal cua. Gracias por la ayuda para que no se repita de nuevo.</p>
+      
+  </div></li>
+
+  <li id="comment-217601" class="comment even thread-even depth-1 media comment-217601">
+    <img alt='' src='https://secure.gravatar.com/avatar/20cc90c690a7b7b39e3ddc278a5b29cb1bd646ec89986c354eb63643d5454700?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/20cc90c690a7b7b39e3ddc278a5b29cb1bd646ec89986c354eb63643d5454700?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mjesus</h5>
+        <div class="comment-meta">
+        <time datetime="2018-01-30T14:33:25+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-217601">
+          30 enero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-217601" data-commentid="217601" data-postid="385" data-belowelement="comment-217601" data-respondelement="respond" data-replyto="Responder a Mjesus" aria-label="Responder a Mjesus">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Riquisimo todo      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-216823" class="comment odd alt thread-odd thread-alt depth-1 media comment-216823">
+    <img alt='' src='https://secure.gravatar.com/avatar/af7082ad4830a73b26332c3bdf782a65f0091d7a0daf65dcdf757f8fd165c368?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/af7082ad4830a73b26332c3bdf782a65f0091d7a0daf65dcdf757f8fd165c368?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Susana</h5>
+        <div class="comment-meta">
+        <time datetime="2018-01-20T16:18:12+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-216823">
+          20 enero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-216823" data-commentid="216823" data-postid="385" data-belowelement="comment-216823" data-respondelement="respond" data-replyto="Responder a Susana" aria-label="Responder a Susana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola, quería hacer el bizcocho hoy pero no tengo yogur natural.<br />
+Porque lo podría sustituir?<br />
+Gracias.  Un abrazo      </p>
+<div class="ERRatingComment">
+<div style="width:80%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-216823">
+    
+  <li id="comment-217324" class="comment odd alt depth-2 media comment-217324">
+    <img alt='' src='https://secure.gravatar.com/avatar/3c2a7f3920ba73ea0da67a45a403f05242e9d7479ea795df0f937b8e2a7389c9?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/3c2a7f3920ba73ea0da67a45a403f05242e9d7479ea795df0f937b8e2a7389c9?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mari Carmen Mompeán</h5>
+        <div class="comment-meta">
+        <time datetime="2018-01-26T18:21:37+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-217324">
+          26 enero, 2018</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola! Lo puedes sustituir por un brick de nata o también por un vaso de leche.????      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-216324" class="comment even thread-odd thread-alt depth-1 media comment-216324">
+    <img alt='' src='https://secure.gravatar.com/avatar/a6c5d6b9f9e5b855b24c4c8eba9b5de13c740096342904402b3d25890106f270?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/a6c5d6b9f9e5b855b24c4c8eba9b5de13c740096342904402b3d25890106f270?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Olga</h5>
+        <div class="comment-meta">
+        <time datetime="2018-01-14T19:32:59+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-216324">
+          14 enero, 2018</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-216324" data-commentid="216324" data-postid="385" data-belowelement="comment-216324" data-respondelement="respond" data-replyto="Responder a Olga" aria-label="Responder a Olga">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Acabo de hacerlo, estupendo de aspecto y muy esponjoso, pero un poco insulso, solo le he echado la naranja en cuatro trozos sin la piel, porque creí que quedaría amargo, para la próxima le rayaré la piel a ver si sabe un poco más. Gracias por todas tus recetas.</p>
+      
+  </div></li>
+
+  <li id="comment-212938" class="comment odd alt thread-even depth-1 media comment-212938">
+    <img alt='' src='https://secure.gravatar.com/avatar/3b65495093b93e6ae74e530479a9eae6f788bd42d295a606b9b0592c77805ea0?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/3b65495093b93e6ae74e530479a9eae6f788bd42d295a606b9b0592c77805ea0?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carlos Basart</h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-19T16:02:49+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-212938">
+          19 octubre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-212938" data-commentid="212938" data-postid="385" data-belowelement="comment-212938" data-respondelement="respond" data-replyto="Responder a Carlos Basart" aria-label="Responder a Carlos Basart">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Muy bueno, vistoso y fácil de hacer.</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-212938">
+    
+  <li id="comment-213143" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-213143">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-24T20:51:04+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-213143">
+          24 octubre, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Y ricoooooo :D</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-212565" class="comment even thread-even depth-1 media comment-212565">
+    <img alt='' src='https://secure.gravatar.com/avatar/a22011f7e5129ede9f1df28d56af4522343fe860e186eb069f4e6f58af355791?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/a22011f7e5129ede9f1df28d56af4522343fe860e186eb069f4e6f58af355791?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carme</h5>
+        <div class="comment-meta">
+        <time datetime="2017-10-09T20:14:26+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-212565">
+          9 octubre, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-212565" data-commentid="212565" data-postid="385" data-belowelement="comment-212565" data-respondelement="respond" data-replyto="Responder a Carme" aria-label="Responder a Carme">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hace tiempo que no consigo que los bizcochos queden esponjosos y suba la masa. Sube cuando están dentro del horno, pero después quedan bajos y nada esponjosos. Lo he probado de mil maneres y no lo consigo. Puede ser el horno?. Como saberlo?.<br />
+Gracias. Carme</p>
+      
+  </div></li>
+
+  <li id="comment-208074" class="comment odd alt thread-odd thread-alt depth-1 media comment-208074">
+    <img alt='' src='https://secure.gravatar.com/avatar/011eb5401ca814443e0f020130f5a90bf8101c0064b1baa095e31e21bca1fb73?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/011eb5401ca814443e0f020130f5a90bf8101c0064b1baa095e31e21bca1fb73?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Manuela</h5>
+        <div class="comment-meta">
+        <time datetime="2017-08-29T01:33:49+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-208074">
+          29 agosto, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-208074" data-commentid="208074" data-postid="385" data-belowelement="comment-208074" data-respondelement="respond" data-replyto="Responder a Manuela" aria-label="Responder a Manuela">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Encuentro que queda mejor con 200gr de harina, es muy fácil y rico el queque, gracias      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-176980" class="comment even thread-even depth-1 media comment-176980">
+    <img alt='' src='https://secure.gravatar.com/avatar/674088564b68337fe3b5f4d086fe75861e3926f7a2e89a8fd09115728407987e?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/674088564b68337fe3b5f4d086fe75861e3926f7a2e89a8fd09115728407987e?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">mireia</h5>
+        <div class="comment-meta">
+        <time datetime="2017-02-06T10:34:08+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-176980">
+          6 febrero, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-176980" data-commentid="176980" data-postid="385" data-belowelement="comment-176980" data-respondelement="respond" data-replyto="Responder a mireia" aria-label="Responder a mireia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>buenos dias, he hecho el bizcocho y realmentes esta espectacular, pero deja un resabor al final amargo, puede ser de la piel naranja??como puedo solucionarlo para la proxima vez, al igual bastantes tropezones de piel que no ha convencido a mi hijo jajaja</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-176980">
+    
+  <li id="comment-181769" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-181769">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2017-02-16T22:35:29+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-181769">
+          16 febrero, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Pélala si no te gusta con la piel :D</p>
+      
+  </div></li>
+
+  <li id="comment-200553" class="comment odd alt depth-2 media comment-200553">
+    <img alt='' src='https://secure.gravatar.com/avatar/b1b5dad9f20522cb76b7e9438baa18832f1d11b49496237591ab867a7512e647?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b1b5dad9f20522cb76b7e9438baa18832f1d11b49496237591ab867a7512e647?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mari Carmen</h5>
+        <div class="comment-meta">
+        <time datetime="2017-03-26T12:59:48+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-200553">
+          26 marzo, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Yo solamente echo la parte naranja, la parte blanca la desecho y te quitas ese sabor amargo q comentas pero no le quitas color</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-170458" class="comment even thread-even depth-1 media comment-170458">
+    <img alt='' src='https://secure.gravatar.com/avatar/60d19b780d450ed8b09691823bf813c79bd8e818ad4626038a175a3a64be78d2?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/60d19b780d450ed8b09691823bf813c79bd8e818ad4626038a175a3a64be78d2?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ana Vazquez</h5>
+        <div class="comment-meta">
+        <time datetime="2017-01-23T01:19:11+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-170458">
+          23 enero, 2017</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-170458" data-commentid="170458" data-postid="385" data-belowelement="comment-170458" data-respondelement="respond" data-replyto="Responder a Ana Vazquez" aria-label="Responder a Ana Vazquez">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Ufff&#8230;.como huele la casa. Dormir con este olorcito a bizcocho, mañana lo probaremos en el desayuno.</p>
+      
+  </div></li>
+
+  <li id="comment-121061" class="comment odd alt thread-odd thread-alt depth-1 media comment-121061">
+    <img alt='' src='https://secure.gravatar.com/avatar/f91bfeddf7863abf15458e7c08ebbb5657666d08e75e382fe9bb852567e68a53?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f91bfeddf7863abf15458e7c08ebbb5657666d08e75e382fe9bb852567e68a53?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Natalia</h5>
+        <div class="comment-meta">
+        <time datetime="2016-03-08T18:55:23+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-121061">
+          8 marzo, 2016</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-121061" data-commentid="121061" data-postid="385" data-belowelement="comment-121061" data-respondelement="respond" data-replyto="Responder a Natalia" aria-label="Responder a Natalia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!<br />
+Me encanta este bizcocho, pero necesito hacerlo en su versión &#8220;XL&#8221;.<br />
+¿¿Bastaría con doblar todos los ingredientes, o habría que retocar un poco?? Me parece demasiada harina y demasiado azúcar&#8230;</p>
+<p>Gracias!!</p>
+      
+  </div></li>
+
+  <li id="comment-120999" class="comment even thread-even depth-1 media comment-120999">
+    <img alt='' src='https://secure.gravatar.com/avatar/924a7970b561ab937612daaafe65ee6858f3e23f4711ae1b4b447b10acc730da?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/924a7970b561ab937612daaafe65ee6858f3e23f4711ae1b4b447b10acc730da?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Noemí</h5>
+        <div class="comment-meta">
+        <time datetime="2016-03-04T14:07:30+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-120999">
+          4 marzo, 2016</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-120999" data-commentid="120999" data-postid="385" data-belowelement="comment-120999" data-respondelement="respond" data-replyto="Responder a Noemí" aria-label="Responder a Noemí">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenos días,<br />
+El otro día hice el bizcocho y lo bañé con chocolate&#8230;Espectacular&#8230;el bizcocho esponjoso<br />
+&#8230;..ummmm<br />
+Ayer lo hice de nuevo y al ver el primer paso me dio la sensación que la primera vez no puse los huevos. Casi segura al 100%..trituré el azúcar con la naranja.  Ayer lo hice tal cual la receta, con los huevos y no salió igual&#8230;el bizcocho un poco pastosillo, como mojado&#8230;.<br />
+El mismo molde, todo igual. ¿Es posible que la causa fueran los huevos?<br />
+Gracias!!!1</p>
+      
+  </div></li>
+
+  <li id="comment-120835" class="pingback odd alt thread-odd thread-alt depth-1 media comment-120835">
+        <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://entre3fogones.com/2016/02/24/bundt-cake-de-naranja-con-nueces-garrapinadas/" class="url" rel="ugc external nofollow">Bundt Cake de Naranja con Nueces Garrapiñadas | Entre 3 Fogones</a></h5>
+        <div class="comment-meta">
+        <time datetime="2016-02-24T08:06:58+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-120835">
+          24 febrero, 2016</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-120835" data-commentid="120835" data-postid="385" data-belowelement="comment-120835" data-respondelement="respond" data-replyto="Responder a Bundt Cake de Naranja con Nueces Garrapiñadas | Entre 3 Fogones" aria-label="Responder a Bundt Cake de Naranja con Nueces Garrapiñadas | Entre 3 Fogones">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>[&#8230;] A continuación os facilito el enlace al Bizcocho de Yolanda: Velocidad Cuchara [&#8230;]</p>
+      
+  </div></li>
+
+  <li id="comment-119252" class="comment even thread-even depth-1 media comment-119252">
+    <img alt='' src='https://secure.gravatar.com/avatar/bcabd77a45afb3297b307bccf141694ca68d1b4d488d29f1a5a8b529cfe01e39?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/bcabd77a45afb3297b307bccf141694ca68d1b4d488d29f1a5a8b529cfe01e39?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Nani</h5>
+        <div class="comment-meta">
+        <time datetime="2015-12-21T09:14:09+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-119252">
+          21 diciembre, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-119252" data-commentid="119252" data-postid="385" data-belowelement="comment-119252" data-respondelement="respond" data-replyto="Responder a Nani" aria-label="Responder a Nani">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa,<br />
+El otro día hice este bizcocho y los trozos de cáscara de naranja se notaban al comer, es normal o quizás debía haberlo triturado más?<br />
+De sabor espectacular, un bizcocho muy suave y fresco con ese aroma a naranja.<br />
+Gracias</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-119252">
+    
+  <li id="comment-175582" class="comment even depth-2 media comment-175582">
+    <img alt='' src='https://secure.gravatar.com/avatar/bf11985cf435f4c681a10861ab8a3e314c4fe9b267c6581bb3cab36455b6a37f?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/bf11985cf435f4c681a10861ab8a3e314c4fe9b267c6581bb3cab36455b6a37f?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carmen</h5>
+        <div class="comment-meta">
+        <time datetime="2017-02-03T13:31:40+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-175582">
+          3 febrero, 2017</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Yo rallo la naranja o limón con un rallador fino antes de agregarlo a la preparación y se consigue un sabor mucho mas intenso y sin tropezones</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-118199" class="comment odd alt thread-even depth-1 media comment-118199">
+    <img alt='' src='https://secure.gravatar.com/avatar/ea602ec57ad0b09a1670493176f51ce77efc2949dde885a575624e571c9f2250?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ea602ec57ad0b09a1670493176f51ce77efc2949dde885a575624e571c9f2250?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Beatriz</h5>
+        <div class="comment-meta">
+        <time datetime="2015-11-16T17:19:51+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-118199">
+          16 noviembre, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-118199" data-commentid="118199" data-postid="385" data-belowelement="comment-118199" data-respondelement="respond" data-replyto="Responder a Beatriz" aria-label="Responder a Beatriz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!<br />
+He intentado varias veces hacer el bizcocho y no me sube. Se tuesta por fuera pero por dentro no está hecho aunque lo tenga mucho tiempo. Lo poquito que sube en seguida se hunde. El caso es que los bizcochos sin fruta me quedan bien pero cuando le hecho fruta fatal. El de manzana sube pero cuando lo saco se hunde. Y el de naranja se queda como una torta, no se hace el bizcocho ¿sabes por qué puede ser que unos me queden bien y otros no??</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-118199">
+    
+  <li id="comment-121355" class="comment odd alt depth-2 media comment-121355">
+    <img alt='' src='https://secure.gravatar.com/avatar/a81c42dc54b14507d9e7322e5f5a00d64c7c770883c32e95a45cfe1ed11ffadd?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/a81c42dc54b14507d9e7322e5f5a00d64c7c770883c32e95a45cfe1ed11ffadd?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Lola Perez</h5>
+        <div class="comment-meta">
+        <time datetime="2016-03-18T15:18:50+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-121355">
+          18 marzo, 2016</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>A mi me ocurrió lo mismo y creo que es por falta de temperatura! Lo volví a repetir a 220° y me salió esponjoso,alto y dorado! Riquisimo!</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-118197" class="comment even thread-even depth-1 media comment-118197">
+    <img alt='' src='https://secure.gravatar.com/avatar/ac0698df683f3386d9d3f44789ed5f6ea1ad260e071b75b39affae060b329241?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ac0698df683f3386d9d3f44789ed5f6ea1ad260e071b75b39affae060b329241?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Encarna</h5>
+        <div class="comment-meta">
+        <time datetime="2015-11-16T14:48:58+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-118197">
+          16 noviembre, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-118197" data-commentid="118197" data-postid="385" data-belowelement="comment-118197" data-respondelement="respond" data-replyto="Responder a Encarna" aria-label="Responder a Encarna">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rico, rico , </p>
+      
+  </div></li>
+
+  <li id="comment-113122" class="comment odd alt thread-odd thread-alt depth-1 media comment-113122">
+    <img alt='' src='https://secure.gravatar.com/avatar/5da799404fd952407e6794f18d29418abcff57956bf7880bbe09da7865026b13?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/5da799404fd952407e6794f18d29418abcff57956bf7880bbe09da7865026b13?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Eva Maria</h5>
+        <div class="comment-meta">
+        <time datetime="2015-04-05T05:56:37+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-113122">
+          5 abril, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-113122" data-commentid="113122" data-postid="385" data-belowelement="comment-113122" data-respondelement="respond" data-replyto="Responder a Eva Maria" aria-label="Responder a Eva Maria">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola! Soy novata en el uso del thermomix.<br />
+Mi duda es: ¿Hace falta utilizar el accesorio de la mariposa para mezclar?<br />
+Gracias</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-113122">
+    
+  <li id="comment-113238" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-113238">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2015-04-08T11:04:22+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-113238">
+          8 abril, 2015</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola Eva. Cuando una receta necesite poner la mariposa os lo ponemos, normalmente incluso lo subrayo para que lo veáis, así que no te preocupes, puedes seguir la receta tal cual.<br />
+Besotes y bienvenida :D</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-112733" class="comment even thread-odd thread-alt depth-1 media comment-112733">
+    <img alt='' src='https://secure.gravatar.com/avatar/6927971754eb4f9b6c3b25a320de9cad4c8e4f5e0dafdca780d8339725673845?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/6927971754eb4f9b6c3b25a320de9cad4c8e4f5e0dafdca780d8339725673845?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">SANDRA</h5>
+        <div class="comment-meta">
+        <time datetime="2015-03-20T17:14:57+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-112733">
+          20 marzo, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-112733" data-commentid="112733" data-postid="385" data-belowelement="comment-112733" data-respondelement="respond" data-replyto="Responder a SANDRA" aria-label="Responder a SANDRA">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!, mañana viene bastante gente a mi casa y quería hacer un bizcocho grande. Esta receta quedará bien en un molde redonde de 26?<br />
+y si le añado pepitas de chocolate?<br />
+muchas gracias</p>
+      
+  </div></li>
+
+  <li id="comment-112673" class="comment odd alt thread-even depth-1 media comment-112673">
+    <img alt='' src='https://secure.gravatar.com/avatar/21b603a2ead7c1904d1c5116bd74d694b98df40d76def2745e75b939c47c9bcd?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/21b603a2ead7c1904d1c5116bd74d694b98df40d76def2745e75b939c47c9bcd?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Laura</h5>
+        <div class="comment-meta">
+        <time datetime="2015-03-19T11:23:55+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-112673">
+          19 marzo, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-112673" data-commentid="112673" data-postid="385" data-belowelement="comment-112673" data-respondelement="respond" data-replyto="Responder a Laura" aria-label="Responder a Laura">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa,<br />
+muchisimas gracias por tus recetas, me estan ayudando mucho a sacarle todo el partido a mi Thermomix! Casi no la dejo parar<br />
+con respecto a esta receta; me gustaria ponerle unacobertura de chocolate, pero la combinacion naranja-chocolate no me sienta bien&#8230; podria sustituirla por otra fruta? O no añadir fruta y echar un chorrito de vainilLa? Gracias</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-112673">
+    
+  <li id="comment-112698" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-112698">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2015-03-20T09:39:35+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-112698">
+          20 marzo, 2015</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Eso siempre al gusto&#8230; puedes hacerla solo de chocolate o de nata y queso&#8230; en el blog tienes más tartas y bizcochos y puedes usar otras coberturas</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-111248" class="comment even thread-even depth-1 media comment-111248">
+    <img alt='' src='https://secure.gravatar.com/avatar/ebcf2c74ec8de1d2e092ddeae2af5af981b0d032be207c4893cc841dbe91c605?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ebcf2c74ec8de1d2e092ddeae2af5af981b0d032be207c4893cc841dbe91c605?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Marimar</h5>
+        <div class="comment-meta">
+        <time datetime="2015-02-15T16:46:34+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-111248">
+          15 febrero, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-111248" data-commentid="111248" data-postid="385" data-belowelement="comment-111248" data-respondelement="respond" data-replyto="Responder a Marimar" aria-label="Responder a Marimar">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>hola Rosa mi pregunta es si el yogur natural se puede utilizar azucarado</p>
+      
+  </div></li>
+
+  <li id="comment-111209" class="comment odd alt thread-odd thread-alt depth-1 media comment-111209">
+    <img alt='' src='https://secure.gravatar.com/avatar/4eabbf122a8c8a64af6de3721a2243d4bb0b058e90e9cd6ec92eebd378dcbbfb?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/4eabbf122a8c8a64af6de3721a2243d4bb0b058e90e9cd6ec92eebd378dcbbfb?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">maytes</h5>
+        <div class="comment-meta">
+        <time datetime="2015-02-13T13:38:50+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-111209">
+          13 febrero, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-111209" data-commentid="111209" data-postid="385" data-belowelement="comment-111209" data-respondelement="respond" data-replyto="Responder a maytes" aria-label="Responder a maytes">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>&#8230;en el horno está..subiendo poquito a poco..y que olorcito que desprende&#8230;</p>
+      
+  </div></li>
+
+  <li id="comment-109577" class="comment even thread-even depth-1 media comment-109577">
+    <img alt='' src='https://secure.gravatar.com/avatar/4cdf92a62af2efb3cdef2480a5fc1db4c549127940c7f2509e632e2c912c4205?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/4cdf92a62af2efb3cdef2480a5fc1db4c549127940c7f2509e632e2c912c4205?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Manolito</h5>
+        <div class="comment-meta">
+        <time datetime="2015-01-08T19:15:33+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-109577">
+          8 enero, 2015</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-109577" data-commentid="109577" data-postid="385" data-belowelement="comment-109577" data-respondelement="respond" data-replyto="Responder a Manolito" aria-label="Responder a Manolito">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>El bizcocho es el alma de todas las celebraciones. Muchas gracias y muchas felicidades por la página.</p>
+      
+  </div></li>
+
+  <li id="comment-106189" class="comment odd alt thread-odd thread-alt depth-1 media comment-106189">
+    <img alt='' src='https://secure.gravatar.com/avatar/296f59d2fe6c9966e26d33f648bce982cf48c8810ca05da7cbaca91c6c8af8cb?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/296f59d2fe6c9966e26d33f648bce982cf48c8810ca05da7cbaca91c6c8af8cb?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">JUDITH</h5>
+        <div class="comment-meta">
+        <time datetime="2014-11-30T21:51:22+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-106189">
+          30 noviembre, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-106189" data-commentid="106189" data-postid="385" data-belowelement="comment-106189" data-respondelement="respond" data-replyto="Responder a JUDITH" aria-label="Responder a JUDITH">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Muchas gracias Rosa!!! Lo acabo de cocinar, es rapidísimo! que ilusión! Gracias por inspirarnos tanto y con tanta dulzura!</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-106189">
+    
+  <li id="comment-106195" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-106195">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2014-11-30T23:07:07+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-106195">
+          30 noviembre, 2014</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Graciasssssss</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-105851" class="comment even thread-odd thread-alt depth-1 media comment-105851">
+    <img alt='' src='https://secure.gravatar.com/avatar/8d7ce337d1d4ace12313d6bda657d61372bc955068e570a6896f9b97b0040255?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/8d7ce337d1d4ace12313d6bda657d61372bc955068e570a6896f9b97b0040255?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Yoly</h5>
+        <div class="comment-meta">
+        <time datetime="2014-11-25T11:20:56+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-105851">
+          25 noviembre, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-105851" data-commentid="105851" data-postid="385" data-belowelement="comment-105851" data-respondelement="respond" data-replyto="Responder a Yoly" aria-label="Responder a Yoly">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa!<br />
+Que rico este bizcocho. Esa textura un pelín húmeda, es fantástica.<br />
+Una pregunta, podria cambiar la naranja por otra fruta, por ejemplo pera o plátano, evidentemente sin piel&#8230;..:-)</p>
+      
+  </div></li>
+
+  <li id="comment-100347" class="comment odd alt thread-even depth-1 media comment-100347">
+    <img alt='' src='https://secure.gravatar.com/avatar/992a6469197fcce78a2d808b1b11a322ca75e39cd32f36df4b817df0c78a2ad0?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/992a6469197fcce78a2d808b1b11a322ca75e39cd32f36df4b817df0c78a2ad0?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">dori</h5>
+        <div class="comment-meta">
+        <time datetime="2014-10-14T21:45:11+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-100347">
+          14 octubre, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-100347" data-commentid="100347" data-postid="385" data-belowelement="comment-100347" data-respondelement="respond" data-replyto="Responder a dori" aria-label="Responder a dori">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Estupendo y sencillo, lo unico  que he variado el tiempo con 30 min me quedaba crudo, le puse 45 min a 150 de temperatura para que no se quemase. Un saludo.</p>
+<p>Gracias por tu blog</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-100347">
+    
+  <li id="comment-100811" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-100811">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2014-10-17T10:05:12+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-100811">
+          17 octubre, 2014</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Gracias a ti&#8230; los tiempos de la repostería siempre puede variar porque depende del horno, del tamaño de tu molde, etc&#8230;</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-83263" class="comment even thread-even depth-1 media comment-83263">
+    <img alt='' src='https://secure.gravatar.com/avatar/58d35b15acd33535853af14f7371357b7c341f932120998b50bba5e69e1baa41?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/58d35b15acd33535853af14f7371357b7c341f932120998b50bba5e69e1baa41?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">angela</h5>
+        <div class="comment-meta">
+        <time datetime="2014-06-17T20:51:04+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-83263">
+          17 junio, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-83263" data-commentid="83263" data-postid="385" data-belowelement="comment-83263" data-respondelement="respond" data-replyto="Responder a angela" aria-label="Responder a angela">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Se m queda como cruda y no se q es mejor si poner un molde estrecho para q quede alta o un poco mas ancho para q se hornee mejor</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-83263">
+    
+  <li id="comment-83595" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-83595">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2014-06-18T09:47:33+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-83595">
+          18 junio, 2014</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Los moldes y los hornos hacen que los tiempos de horneado varíen. En un molde estrecho vas a tardar más en cocinar que un uno redondo grande&#8230; tienes que ir viendo si es´ta cocinado:<br />
+Lee esto que te va a ayudar: <a href="https://www.velocidadcuchara.com/trucos-para-conseguir-unos-bizcochos-perfectos-thermomix/" rel="ugc">https://www.velocidadcuchara.com/trucos-para-conseguir-unos-bizcochos-perfectos-thermomix/</a></p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-79102" class="comment odd alt thread-even depth-1 media comment-79102">
+    <img alt='' src='https://secure.gravatar.com/avatar/aad786258cd2e3d93381dd791abf53ea9fa5f24f7225dfd517a3730ff2ffa6b6?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/aad786258cd2e3d93381dd791abf53ea9fa5f24f7225dfd517a3730ff2ffa6b6?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Paula</h5>
+        <div class="comment-meta">
+        <time datetime="2014-06-07T21:40:02+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-79102">
+          7 junio, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-79102" data-commentid="79102" data-postid="385" data-belowelement="comment-79102" data-respondelement="respond" data-replyto="Responder a Paula" aria-label="Responder a Paula">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Gracias por la receta, una duda si quisiera adornarlo como podría hacerlo?, si quisiera hacerlo con chocolate tipo al que trae la foto? Que quede así duro</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-79102">
+    
+  <li id="comment-79632" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-79632">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2014-06-09T02:29:54+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-79632">
+          9 junio, 2014</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Ese es un sirope de chocolate comprado&#8230; te vale.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-72762" class="comment even thread-even depth-1 media comment-72762">
+    <img alt='' src='https://secure.gravatar.com/avatar/5cec504ad0a71cadbe331d583d7309df5cdae7502c9dffc53ed30e316be373c3?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/5cec504ad0a71cadbe331d583d7309df5cdae7502c9dffc53ed30e316be373c3?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">caro</h5>
+        <div class="comment-meta">
+        <time datetime="2014-05-23T19:02:13+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-72762">
+          23 mayo, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-72762" data-commentid="72762" data-postid="385" data-belowelement="comment-72762" data-respondelement="respond" data-replyto="Responder a caro" aria-label="Responder a caro">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenas tardes,<br />
+alguien me podría decir como puedo hacer este bizcocho pero SIN HUEVO,<br />
+Muchas gracias<br />
+Caro</p>
+      
+  </div></li>
+
+  <li id="comment-53159" class="comment odd alt thread-odd thread-alt depth-1 media comment-53159">
+    <img alt='' src='https://secure.gravatar.com/avatar/b184a2ad398fb9026356aec99f3a68c7366b46b3f4236afe79ca1a9c6f081492?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b184a2ad398fb9026356aec99f3a68c7366b46b3f4236afe79ca1a9c6f081492?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Eva</h5>
+        <div class="comment-meta">
+        <time datetime="2014-02-26T20:34:09+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-53159">
+          26 febrero, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-53159" data-commentid="53159" data-postid="385" data-belowelement="comment-53159" data-respondelement="respond" data-replyto="Responder a Eva" aria-label="Responder a Eva">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenísimo!! Rosa pon bien el enlace que lleva a las fotos del Reto porque no se ven :-)</p>
+      
+  </div></li>
+
+  <li id="comment-50649" class="comment even thread-even depth-1 media comment-50649">
+    <img alt='' src='https://secure.gravatar.com/avatar/70af91b7e0fc1efd0c5d4e0cb57e129569ca03a0d3e15553e6c96b542738c244?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/70af91b7e0fc1efd0c5d4e0cb57e129569ca03a0d3e15553e6c96b542738c244?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Paloma</h5>
+        <div class="comment-meta">
+        <time datetime="2014-01-29T21:21:57+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-50649">
+          29 enero, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-50649" data-commentid="50649" data-postid="385" data-belowelement="comment-50649" data-respondelement="respond" data-replyto="Responder a Paloma" aria-label="Responder a Paloma">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa, el bizcocho buenisimo !!! que esponjoso!! y que saborcito a naranja&#8230;nada mejor que vitamina C para afrontar el frío de estos días&#8230;Un achuchón a Willy&#8230;:)</p>
+      
+  </div></li>
+
+  <li id="comment-50387" class="comment odd alt thread-odd thread-alt depth-1 media comment-50387">
+    <img alt='' src='https://secure.gravatar.com/avatar/62bb0f2887632c33623caf74d69dc8fe67660baedd462e1c19356d90a3e85147?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/62bb0f2887632c33623caf74d69dc8fe67660baedd462e1c19356d90a3e85147?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mamen</h5>
+        <div class="comment-meta">
+        <time datetime="2014-01-25T23:08:53+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-50387">
+          25 enero, 2014</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-50387" data-commentid="50387" data-postid="385" data-belowelement="comment-50387" data-respondelement="respond" data-replyto="Responder a Mamen" aria-label="Responder a Mamen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>hOLA rOSA,,.QUE RICO HA SALIDO ,DESEANDO QUE LLEGUE MAÑANA PARA DESAYUNARLO CON UN BUEN CAFE.mE ENCANTA TU BLOG .uN SALUDO</p>
+      
+  </div></li>
+
+  <li id="comment-46389" class="comment even thread-even depth-1 media comment-46389">
+    <img alt='' src='https://secure.gravatar.com/avatar/ebde18269ea63ff3cdf3dc686cbe211844a3e56ba217c0334f25ebbf81ffafcc?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ebde18269ea63ff3cdf3dc686cbe211844a3e56ba217c0334f25ebbf81ffafcc?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">maria luisa</h5>
+        <div class="comment-meta">
+        <time datetime="2013-11-19T15:45:32+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-46389">
+          19 noviembre, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-46389" data-commentid="46389" data-postid="385" data-belowelement="comment-46389" data-respondelement="respond" data-replyto="Responder a maria luisa" aria-label="Responder a maria luisa">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Lo primero decir que para mies el bizcocho mas rico,no se hace nada pesado,en  mi casa no duran nada.Despues queria compartiir un truco,mi horno es de los que tiene mucha temperatura y a la que te descuidas te ha churruscado todo,tengo que variar siempre los tiempos y estar muy pendiente de lo que meta;pues al principio de comprarlo peor todavia los bizcochos o se me quemaban o salían mal en el centro,entonces compre unos moldes de esos con agujero en el centro,de aluminio y desde entonces salen siempre genial.</p>
+      
+  </div></li>
+
+  <li id="comment-43622" class="comment odd alt thread-odd thread-alt depth-1 media comment-43622">
+    <img alt='' src='https://secure.gravatar.com/avatar/288f887c392bf60d3dc8833dbfaba7bcd915cc1be02ab4e81f444bbef98debf2?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/288f887c392bf60d3dc8833dbfaba7bcd915cc1be02ab4e81f444bbef98debf2?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://www.gloriaceballos.com" class="url" rel="ugc external nofollow">Gloria</a></h5>
+        <div class="comment-meta">
+        <time datetime="2013-10-05T21:30:07+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-43622">
+          5 octubre, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-43622" data-commentid="43622" data-postid="385" data-belowelement="comment-43622" data-respondelement="respond" data-replyto="Responder a Gloria" aria-label="Responder a Gloria">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>¡¡¡¡¡¡¡¡¡ESPECTACULAR!!!!!!!!!!!!<br />
+Receta sencilla y buenísima.<br />
+Gracias a ti me ha salido bien un bizcocho por primera vez en mi vida, estoy encantada. GRACIAS.</p>
+      
+  </div></li>
+
+  <li id="comment-43535" class="pingback even thread-even depth-1 media comment-43535">
+        <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://derosasybaobabs.es/bizcocho-de-naranja-y-chocolateregalo-2-en-1/" class="url" rel="ugc external nofollow">bizcocho de naranja y chocolate+regalo, 2 en 1 | De rosas y baobabs</a></h5>
+        <div class="comment-meta">
+        <time datetime="2013-10-03T08:50:50+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-43535">
+          3 octubre, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-43535" data-commentid="43535" data-postid="385" data-belowelement="comment-43535" data-respondelement="respond" data-replyto="Responder a bizcocho de naranja y chocolate+regalo, 2 en 1 | De rosas y baobabs" aria-label="Responder a bizcocho de naranja y chocolate+regalo, 2 en 1 | De rosas y baobabs">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>[&#8230;] naranja que encontré en uno de mis blogs preferidos para las que usamos tanto la thermomix como es Velocidad Cuchara. Podéis ver la receta pinchando aquí. La única diferencia es que en el último paso, a la hora [&#8230;]</p>
+      
+  </div></li>
+
+  <li id="comment-43367" class="comment odd alt thread-odd thread-alt depth-1 media comment-43367">
+    <img alt='' src='https://secure.gravatar.com/avatar/cfc4c4aa913b419740682e515232cb525d4a85ad5481f8004940739f37f8dede?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/cfc4c4aa913b419740682e515232cb525d4a85ad5481f8004940739f37f8dede?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Begoña</h5>
+        <div class="comment-meta">
+        <time datetime="2013-09-28T12:00:26+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-43367">
+          28 septiembre, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-43367" data-commentid="43367" data-postid="385" data-belowelement="comment-43367" data-respondelement="respond" data-replyto="Responder a Begoña" aria-label="Responder a Begoña">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa, ayer hice este bizcocho y lo probamos hoy para desayunar. Está muy rico, lo hice en un molde Nordic Ware, pero yo lo puse a hornear a 170º, 60 minutos. Con otros bizcochos he probado otras temperaturas y tiempos en mi horno y no bajo de 50 minutos. He probado a más temperatura y no se pasan bien por el medio. No sé si para este bizcocho admitiría más temperatura porque tiene un textura como más húmedo.</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-43367">
+    
+  <li id="comment-43395" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-43395">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2013-09-29T15:56:25+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-43395">
+          29 septiembre, 2013</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>No sé como va tu horno&#8230; el acabado tienes que dárselo tu e ir valorando como está, de todos modos este no es un bizcocho seco</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-40356" class="comment even thread-odd thread-alt depth-1 media comment-40356">
+    <img alt='' src='https://secure.gravatar.com/avatar/b8c144c4fc91bf97639e4eb26e396c3732a59c00185c84f74a06e4cb83610412?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/b8c144c4fc91bf97639e4eb26e396c3732a59c00185c84f74a06e4cb83610412?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mariló</h5>
+        <div class="comment-meta">
+        <time datetime="2013-04-30T19:49:59+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-40356">
+          30 abril, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-40356" data-commentid="40356" data-postid="385" data-belowelement="comment-40356" data-respondelement="respond" data-replyto="Responder a Mariló" aria-label="Responder a Mariló">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Este bizcocho lo he hecho varias veces, no me salía bien del todo, creo que por el tipo de molde, me he comprado uno de este estilo y ha salido de 10!!!!<br />
+Estoy super contenta, porque mira que está rico, eh!!!! :D</p>
+<p>Un besiño y muchas gracias.</p>
+      
+      <ul class="comment odd alt thread-even depth-1 media unstyled comment-40356">
+    
+  <li id="comment-40391" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-40391">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2013-05-01T14:05:25+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-40391">
+          1 mayo, 2013</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Ya he visto la foto.IMPRESIONANTE!! a mi me encanta el sabor que tiene :))</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-39070" class="comment odd alt thread-odd thread-alt depth-1 media comment-39070">
+    <img alt='' src='https://secure.gravatar.com/avatar/bf6374d324b6385fde69b2ffd54de967e80cf2b9333bc7be60460fbe7e4d8b39?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/bf6374d324b6385fde69b2ffd54de967e80cf2b9333bc7be60460fbe7e4d8b39?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Peque</h5>
+        <div class="comment-meta">
+        <time datetime="2013-03-22T00:13:09+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-39070">
+          22 marzo, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-39070" data-commentid="39070" data-postid="385" data-belowelement="comment-39070" data-respondelement="respond" data-replyto="Responder a Peque" aria-label="Responder a Peque">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!!<br />
+El bizcocho tiene una pintaza de jugoso de morirse, pero&#8230; Podría hacerlo con batidora normal? No tengo thermomix y con la naranja entera lo veo complicadillo, igual si la paso por la picadura primero&#8230;<br />
+Gracias!!!</p>
+      
+  </div></li>
+
+  <li id="comment-38060" class="comment even thread-even depth-1 media comment-38060">
+    <img alt='' src='https://secure.gravatar.com/avatar/0962dab71110050ce141a7fa1351ed8fa119316b5ff4bebb7add247485e76e2a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/0962dab71110050ce141a7fa1351ed8fa119316b5ff4bebb7add247485e76e2a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anabel</h5>
+        <div class="comment-meta">
+        <time datetime="2013-02-23T12:01:35+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-38060">
+          23 febrero, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-38060" data-commentid="38060" data-postid="385" data-belowelement="comment-38060" data-respondelement="respond" data-replyto="Responder a Anabel" aria-label="Responder a Anabel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Este mismo bizcocho lo puedo utilizar para el molde del gingerman?</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-38060">
+    
+  <li id="comment-38162" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-38162">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2013-02-26T23:45:57+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-38162">
+          26 febrero, 2013</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Si, yo creo que cabe.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-37876" class="comment odd alt thread-even depth-1 media comment-37876">
+    <img alt='' src='https://secure.gravatar.com/avatar/c823894be28c4951cffd1d751c0c85de000e4dc6e0a01fd7551e8d76f948dd42?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/c823894be28c4951cffd1d751c0c85de000e4dc6e0a01fd7551e8d76f948dd42?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">belen</h5>
+        <div class="comment-meta">
+        <time datetime="2013-02-18T13:04:16+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-37876">
+          18 febrero, 2013</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-37876" data-commentid="37876" data-postid="385" data-belowelement="comment-37876" data-respondelement="respond" data-replyto="Responder a belen" aria-label="Responder a belen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa el bizcocho es estupendo pero se puede sustituir el yogur por nata si es así dime que cantidad poner&#8230;&#8230;&#8230;gracias</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-37876">
+    
+  <li id="comment-37973" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-37973">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2013-02-20T23:07:34+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-37973">
+          20 febrero, 2013</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>La misma cantidad</p>
+      
+  </div></li>
+
+  <li id="comment-38039" class="comment even depth-2 media comment-38039">
+    <img alt='' src='https://secure.gravatar.com/avatar/c823894be28c4951cffd1d751c0c85de000e4dc6e0a01fd7551e8d76f948dd42?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/c823894be28c4951cffd1d751c0c85de000e4dc6e0a01fd7551e8d76f948dd42?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">belen</h5>
+        <div class="comment-meta">
+        <time datetime="2013-02-22T15:36:47+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-38039">
+          22 febrero, 2013</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Gracias rosa !?????=</p>
+      
+  </div></li>
+
+  <li id="comment-38173" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-38173">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2013-02-26T23:56:44+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-38173">
+          26 febrero, 2013</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>A ti</p>
+      
+  </div></li>
+
+  <li id="comment-130436" class="comment even depth-2 media comment-130436">
+    <img alt='' src='https://secure.gravatar.com/avatar/c40d98016828e7f6429976712f447bc31b881213bdaab8aeaeaf0cb516eac5f3?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/c40d98016828e7f6429976712f447bc31b881213bdaab8aeaeaf0cb516eac5f3?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://tiernitos.com" class="url" rel="ugc external nofollow">Mar</a></h5>
+        <div class="comment-meta">
+        <time datetime="2016-10-30T16:02:58+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-130436">
+          30 octubre, 2016</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Me pasa igual, tengo todo menos el yogur, pero sí tengo nata de montar. Qué cantidad pusiste de nata?<br />
+Gracias!</p>
+      
+  </div></li>
+
+  <li id="comment-228292" class="comment odd alt depth-2 media comment-228292">
+    <img alt='' src='https://secure.gravatar.com/avatar/ee7cb01707630504ccc196deb43d15379e4f0e9283be67e97a333ebec858baf6?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/ee7cb01707630504ccc196deb43d15379e4f0e9283be67e97a333ebec858baf6?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Nuria</h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-16T19:06:47+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-228292">
+          16 abril, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Nata líquida o de montar?</p>
+      
+  </div></li>
+
+  <li id="comment-228306" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-228306">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2020-04-16T19:15:39+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-228306">
+          16 abril, 2020</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>La que tengas&#8230; una es más grasa que otra.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-34009" class="comment odd alt thread-even depth-1 media comment-34009">
+    <img alt='' src='https://secure.gravatar.com/avatar/7a32bf18646260b70b0c4f61bd7c4fcd423de569a5256f4097e6bb8728ec3395?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/7a32bf18646260b70b0c4f61bd7c4fcd423de569a5256f4097e6bb8728ec3395?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://www.narinan.com" class="url" rel="ugc external nofollow">Ana</a></h5>
+        <div class="comment-meta">
+        <time datetime="2012-11-27T12:58:15+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-34009">
+          27 noviembre, 2012</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-34009" data-commentid="34009" data-postid="385" data-belowelement="comment-34009" data-respondelement="respond" data-replyto="Responder a Ana" aria-label="Responder a Ana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Pues a mi me ha quedado estupendo, hice a la misma vez madalenas y unos muffins poniendo unas poquitas perlas de chocolate dentro y que no necesitaron tanto tiempo de horno. El bizcocho lo he adornado con cobertura de chocolate y tiene pinta de estar ñam!</p>
+      
+  </div></li>
+
+  <li id="comment-31852" class="comment even thread-odd thread-alt depth-1 media comment-31852">
+    <img alt='' src='https://secure.gravatar.com/avatar/e8df619c0613c6c89edf08dea8c2555895056c2a7ac41a13cd0d284c936d445c?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/e8df619c0613c6c89edf08dea8c2555895056c2a7ac41a13cd0d284c936d445c?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://marymarysweetdesigns.com/" class="url" rel="ugc external nofollow">Mary Mary</a></h5>
+        <div class="comment-meta">
+        <time datetime="2012-11-02T17:22:28+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-31852">
+          2 noviembre, 2012</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-31852" data-commentid="31852" data-postid="385" data-belowelement="comment-31852" data-respondelement="respond" data-replyto="Responder a Mary Mary" aria-label="Responder a Mary Mary">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Que pasada! pintaza! me estan entrando ganas de hacer uno ya! ;))))))</p>
+      
+  </div></li>
+
+  <li id="comment-30390" class="comment odd alt thread-even depth-1 media comment-30390">
+    <img alt='' src='https://secure.gravatar.com/avatar/93750ee689bd7983aeaa947450c64db06052833ecd2896fd162424061b1f2308?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/93750ee689bd7983aeaa947450c64db06052833ecd2896fd162424061b1f2308?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">pilar</h5>
+        <div class="comment-meta">
+        <time datetime="2012-09-19T18:56:43+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-30390">
+          19 septiembre, 2012</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-30390" data-commentid="30390" data-postid="385" data-belowelement="comment-30390" data-respondelement="respond" data-replyto="Responder a pilar" aria-label="Responder a pilar">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola!, tiene una pinta estupenda, sería posible hacerlo en el robot de cocina?, es la supercheff, normalmente hago bizcochos en el, pero tengo dudas sobre este. Muchas gracias.</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-30390">
+    
+  <li id="comment-30392" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-30392">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="https://www.velocidadcuchara.com" class="url" rel="ugc">Rosa Ardá</a></h5>
+        <div class="comment-meta">
+        <time datetime="2012-09-19T20:13:00+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-30392">
+          19 septiembre, 2012</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Hola Pilar. Nunca he usado el superchef, vamos no sé ni como funciona, así que siento no poder ayudarte. :(</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-20355" class="comment even thread-even depth-1 media comment-20355">
+    <img alt='' src='https://secure.gravatar.com/avatar/f74b5168646361a01d6b7816eab6103fab9be0c95a38146d3ee8d7757d934c6a?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/f74b5168646361a01d6b7816eab6103fab9be0c95a38146d3ee8d7757d934c6a?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">maricarmen</h5>
+        <div class="comment-meta">
+        <time datetime="2012-03-19T22:13:15+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-20355">
+          19 marzo, 2012</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-20355" data-commentid="20355" data-postid="385" data-belowelement="comment-20355" data-respondelement="respond" data-replyto="Responder a maricarmen" aria-label="Responder a maricarmen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola me gustaria que me dijerais el por que el bizcocho de naranja sale buenisimo pero apelmasado, no sale esponjoso donde esta mi fallo lo e hecho como pone en esta receta con la termomix gracias</p>
+      
+      <ul class="comment odd alt thread-odd thread-alt depth-1 media unstyled comment-20355">
+    
+  <li id="comment-20406" class="comment byuser comment-author-admin bypostauthor even depth-2 media comment-20406">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2012-03-20T20:09:49+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-20406">
+          20 marzo, 2012</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Le habrás puesto poca levadura??? Mira esto <a href="https://www.velocidadcuchara.com/2012/02/trucos-para-conseguir-unos-bizcochos-perfectos-thermomix/id=9856" rel="ugc">https://www.velocidadcuchara.com/2012/02/trucos-para-conseguir-unos-bizcochos-perfectos-thermomix/id=9856</a></p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-17530" class="comment odd alt thread-even depth-1 media comment-17530">
+    <img alt='' src='https://secure.gravatar.com/avatar/2fcf6244c13a1a86f6f619b8c0d3c6c69396200ac516264d809260c5989397ee?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2fcf6244c13a1a86f6f619b8c0d3c6c69396200ac516264d809260c5989397ee?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">marian</h5>
+        <div class="comment-meta">
+        <time datetime="2012-01-15T19:59:49+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-17530">
+          15 enero, 2012</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-17530" data-commentid="17530" data-postid="385" data-belowelement="comment-17530" data-respondelement="respond" data-replyto="Responder a marian" aria-label="Responder a marian">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>lo acabo de hacer para mi oficina&#8230;pero no llega mi marido se lo está comiendo y he tenido que hacer otro para que se lo lleve esta noche a tus compañeros&#8230;Gracias Rosa, no sabes como me &#8220;adoran sus compis&#8221; muaccc</p>
+      
+      <ul class="comment even thread-odd thread-alt depth-1 media unstyled comment-17530">
+    
+  <li id="comment-17531" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-17531">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2012-01-15T20:11:18+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-17531">
+          15 enero, 2012</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Jajajaja, que bueno! Por lo menos que se pasen un día a decir algo por aquí, para ver si les gusta lo que les preparas que por lo que parece es un SI rotundo.</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-14470" class="comment even thread-even depth-1 media comment-14470">
+    <img alt='' src='https://secure.gravatar.com/avatar/af250890bfaf5d408863bf9e8114508f864c9a383b6e207420704794659f5ffb?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/af250890bfaf5d408863bf9e8114508f864c9a383b6e207420704794659f5ffb?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mon</h5>
+        <div class="comment-meta">
+        <time datetime="2011-10-10T14:25:16+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-14470">
+          10 octubre, 2011</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-14470" data-commentid="14470" data-postid="385" data-belowelement="comment-14470" data-respondelement="respond" data-replyto="Responder a Mon" aria-label="Responder a Mon">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Gracias!!! haré el segundo intento a ver que tal :)</p>
+      
+  </div></li>
+
+  <li id="comment-14266" class="comment odd alt thread-odd thread-alt depth-1 media comment-14266">
+    <img alt='' src='https://secure.gravatar.com/avatar/af250890bfaf5d408863bf9e8114508f864c9a383b6e207420704794659f5ffb?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/af250890bfaf5d408863bf9e8114508f864c9a383b6e207420704794659f5ffb?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mon</h5>
+        <div class="comment-meta">
+        <time datetime="2011-10-04T13:45:31+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-14266">
+          4 octubre, 2011</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-14266" data-commentid="14266" data-postid="385" data-belowelement="comment-14266" data-respondelement="respond" data-replyto="Responder a Mon" aria-label="Responder a Mon">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa!!! descubrí tu blog de purita casualidad buscando la receta del azucar invertido y desde entonces&#8230;. blog de cabecera!!!! Mis felicitaciones.<br />
+He hecho varias de tus publicaciones y bien, pero con este bizcocho me ha sucedido lo mismo que a Antharess, se me queda crudo por dentro. La verdad es que tengo horno nuevo y creo que todavía no le tengo pillado el puntillo. Tendrías algún consejo para evitar eso?<br />
+Un saludiño</p>
+<p>Mon</p>
+      
+      <ul class="comment even thread-even depth-1 media unstyled comment-14266">
+    
+  <li id="comment-14276" class="comment byuser comment-author-admin bypostauthor odd alt depth-2 media comment-14276">
+    <img alt='' src='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/2f2404ab33179a8970a13abbb4d66b90a2372321fe4e7a16e79b4bac677274d5?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2011-10-04T21:09:02+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-14276">
+          4 octubre, 2011</a>
+        </time>
+        |
+                
+                </div>
+      </div>
+
+      
+      <p>Pínchalo para saber si está hecho, metes una brocheta y si sale húmeda es que aún no esta. Los moldes varian de tamaños y pueden hacer que si el bizcocho es más alto, necesite unos minutos más de cocción, además de que cada horno es un mundo!</p>
+      
+  </div></li>
+</ul></div></li>
+
+  <li id="comment-10085" class="comment even thread-odd thread-alt depth-1 media comment-10085">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2011-01-17T16:41:49+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-10085">
+          17 enero, 2011</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-10085" data-commentid="10085" data-postid="385" data-belowelement="comment-10085" data-respondelement="respond" data-replyto="Responder a Rosa Ardá" aria-label="Responder a Rosa Ardá">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Pues algo ha pasado ahí para que te pasara eso, porque yo lo hice una vez en bizcocho y salió genial, y ya ves las fotos!!! Tienes que repetirlo, pero un día que no haya que llevarlo a ninguna parte, no vaya a ser&#8230;<br />Besos y lo siento mucho!!<br />Ro</p>
+      
+  </div></li>
+
+  <li id="comment-10082" class="comment odd alt thread-even depth-1 media comment-10082">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Antharess</h5>
+        <div class="comment-meta">
+        <time datetime="2011-01-17T12:28:26+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-10082">
+          17 enero, 2011</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-10082" data-commentid="10082" data-postid="385" data-belowelement="comment-10082" data-respondelement="respond" data-replyto="Responder a Antharess" aria-label="Responder a Antharess">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>dios que fracaso&#8230; esta receta la he hecho varias veces con moldes de magdalenas y quedan estupendas. pues este domingo fui a una comida familiar y pense llevar mis magdalenas, pues cuando me puse manos a la obra no tenia los papelitos, asi que pense&#8230; bueno pues al molde de los bizcochos y listo&#8230; pues fue un verdadero desastre. puse 45 minutos al horno, lo saque, pero estaba crudo por dentro, lo puse otros 30 minutos, pues casi peor&#8230;. se bajo, con lo que la masa quedo compacta, quedadillo por arriba&#8230; la textura era similar a la de una tarta de queso&#8230; asi que yo creo que mi familia me quiere mucho, porque de sabor estaba pichin y de aspecto patetico&#8230;</p>
+      
+  </div></li>
+
+  <li id="comment-8494" class="comment even thread-odd thread-alt depth-1 media comment-8494">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Amara</h5>
+        <div class="comment-meta">
+        <time datetime="2010-10-20T18:36:50+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-8494">
+          20 octubre, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-8494" data-commentid="8494" data-postid="385" data-belowelement="comment-8494" data-respondelement="respond" data-replyto="Responder a Amara" aria-label="Responder a Amara">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Listooo!! Que ganas tenia de hacerlo!!! Y que facil me resulto!! Yo lo decore con sirope de chocolate y una flor con la cascara de una naranja.</p>
+      
+  </div></li>
+
+  <li id="comment-7621" class="comment odd alt thread-even depth-1 media comment-7621">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2010-08-26T12:41:56+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-7621">
+          26 agosto, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-7621" data-commentid="7621" data-postid="385" data-belowelement="comment-7621" data-respondelement="respond" data-replyto="Responder a Rosa Ardá" aria-label="Responder a Rosa Ardá">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>LA verdad es que sale riquísimo y es muy facilito!!!. Si es que hay mil posibilidades de decoración. <br />Besos</p>
+      
+  </div></li>
+
+  <li id="comment-7611" class="comment even thread-odd thread-alt depth-1 media comment-7611">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-08-25T19:45:19+02:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-7611">
+          25 agosto, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-7611" data-commentid="7611" data-postid="385" data-belowelement="comment-7611" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Este bizcocho lo he hecho un par deveces o incluso mas y me gusta mucho a parte una amiga mia  de el blogs dos lobitoslo ha hecho 2 veces para su cumpleaÑOS Y LO CUBRE DE chocolate fundido y frutas rojas por encima y estaba riquisimo.Xauuuuu</p>
+      
+  </div></li>
+
+  <li id="comment-5314" class="comment odd alt thread-even depth-1 media comment-5314">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-24T11:38:11+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5314">
+          24 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5314" data-commentid="5314" data-postid="385" data-belowelement="comment-5314" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Qué pena no haber visto antes este reto, pues precisamente he hecho yo este mes un bizcocho de naranja que tiene una presentación estupenda y original. En fin la próxima vez será!!!</p>
+      
+  </div></li>
+
+  <li id="comment-5293" class="comment even thread-odd thread-alt depth-1 media comment-5293">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-23T09:44:07+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5293">
+          23 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5293" data-commentid="5293" data-postid="385" data-belowelement="comment-5293" data-respondelement="respond" data-replyto="Responder a Rosa Ardá" aria-label="Responder a Rosa Ardá">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Pues Belén eso de &quot;infrautilizada&quot; tenemos que arreglarlo. Ya sabes que si te puedo ayudar en algo, no tienen más que preguntar.<br />Besos</p>
+      
+  </div></li>
+
+  <li id="comment-5291" class="comment odd alt thread-even depth-1 media comment-5291">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Belen</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-23T09:26:17+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5291">
+          23 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5291" data-commentid="5291" data-postid="385" data-belowelement="comment-5291" data-respondelement="respond" data-replyto="Responder a Belen" aria-label="Responder a Belen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Me encanta vuestra web y aunque soy mala mala cocinera, trato de hacer recetillas de las que publicais. Parece mentira que 12 años de Thermo en casa&#8230;.y tan infrautilizada!!!! Muchas gracias de verdad,<br />Belén</p>
+      
+  </div></li>
+
+  <li id="comment-5244" class="comment even thread-odd thread-alt depth-1 media comment-5244">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-20T11:16:56+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5244">
+          20 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5244" data-commentid="5244" data-postid="385" data-belowelement="comment-5244" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>hola, sí la naranja se pone enterita y tal cual, animate que el resultado es superior.</p>
+      
+  </div></li>
+
+  <li id="comment-5238" class="comment odd alt thread-even depth-1 media comment-5238">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Lamboadas</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-18T23:02:25+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5238">
+          18 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5238" data-commentid="5238" data-postid="385" data-belowelement="comment-5238" data-respondelement="respond" data-replyto="Responder a Lamboadas" aria-label="Responder a Lamboadas">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>¡¡¡ PLAS, PLAS, PLAS !!! (aplausos)<br />Enhorabuena por este reportaje tan fantástico, y en general a todas<br />y todos los que han participado en este reto.<br />A la vista de estos resultados, ya estoy esperando el próximo evento.<br />Un abrazo,</p>
+      
+  </div></li>
+
+  <li id="comment-5237" class="comment even thread-odd thread-alt depth-1 media comment-5237">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Marita</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-18T19:59:18+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5237">
+          18 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5237" data-commentid="5237" data-postid="385" data-belowelement="comment-5237" data-respondelement="respond" data-replyto="Responder a Marita" aria-label="Responder a Marita">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Que maravilla, yo he llegado tarde y el bizcocho lo hice ayer pero me han encantado todas las presentaciones, sois unos artistas, ya me paso con el solomillo con cebolla caramelizada pero a pesar de no llegar a tiempo no me pierdo un reto, mas vale tarde &#8230; Besos!!</p>
+      
+  </div></li>
+
+  <li id="comment-5236" class="comment odd alt thread-even depth-1 media comment-5236">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-18T16:01:56+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5236">
+          18 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5236" data-commentid="5236" data-postid="385" data-belowelement="comment-5236" data-respondelement="respond" data-replyto="Responder a Rosa Ardá" aria-label="Responder a Rosa Ardá">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Si es así, lo ha explicado en un comentario anterior,<br />Besos</p>
+      
+  </div></li>
+
+  <li id="comment-5235" class="comment even thread-odd thread-alt depth-1 media comment-5235">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mabel</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-18T15:24:09+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5235">
+          18 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5235" data-commentid="5235" data-postid="385" data-belowelement="comment-5235" data-respondelement="respond" data-replyto="Responder a Mabel" aria-label="Responder a Mabel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Que bonitos todos los bizcochos y que apetecibles!!! Rosa te ha quedado muy bonito, como siempre.<br />Oye, en la foto que ha hecho Vicky me parece ver que ha usado las capsulas de nespresso como molde para hacer el bizcocho, es eso asi??<br />Besitos</p>
+      
+  </div></li>
+
+  <li id="comment-5233" class="comment odd alt thread-even depth-1 media comment-5233">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Pamen</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-18T09:41:20+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5233">
+          18 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5233" data-commentid="5233" data-postid="385" data-belowelement="comment-5233" data-respondelement="respond" data-replyto="Responder a Pamen" aria-label="Responder a Pamen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa, que maravilla de fotos y cuantos estilos para un mismo bizcocho, yo también lo tengo hecho y no se parece a ninguno de estos, si esque con una misma receta, puede parecer diferente en las manos de cada una, vamos que salen infinidad de modelos, jeje<br />Me encanta como te ha quedado el post, se nota que te lo has currado<br />Besos</p>
+      
+  </div></li>
+
+  <li id="comment-5232" class="comment even thread-odd thread-alt depth-1 media comment-5232">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-18T08:57:56+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5232">
+          18 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5232" data-commentid="5232" data-postid="385" data-belowelement="comment-5232" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenos dias ,confieso que soy una novata y quería probar a hacer el bizcocho de naranja que tan buena pinta tiene,pero me choca lo de la naranja entera con piel y todo? Es asi como hay que hacerlo o solo con el zumo de la narana.Gracias.Sois unas artistas.</p>
+      
+  </div></li>
+
+  <li id="comment-5231" class="comment odd alt thread-even depth-1 media comment-5231">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Vicky Ortiz</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-18T06:13:27+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5231">
+          18 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5231" data-commentid="5231" data-postid="385" data-belowelement="comment-5231" data-respondelement="respond" data-replyto="Responder a Vicky Ortiz" aria-label="Responder a Vicky Ortiz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Madre mía, qué nivel. Nivelazo total.<br />Enhorabuena a tod@s.</p>
+<p>Lo de las cápsulas de la Nespreso, fue un experimento y como todos hay que mejorarlo. Quedó muy bien, pero aunque engrasé muy bien la cápsula, se queó muy pegado y por tanto solo se podía comer ahí dentro con cucharilla. Pero poniedo papel de aluminio, en vez de engrasar, pienso que saldrá sin problemas. Se quedan de pié muy bien, si alguno se tuerce, se presiona un poco la base y ya se queda fijo. Hay que llenarlo un poquito más de la mitad. Y las cápsulas aguantan muy bien el calor del horno.</p>
+<p>Besos<br />Vicky</p>
+      
+  </div></li>
+
+  <li id="comment-5230" class="comment even thread-odd thread-alt depth-1 media comment-5230">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">sugus</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T23:39:13+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5230">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5230" data-commentid="5230" data-postid="385" data-belowelement="comment-5230" data-respondelement="respond" data-replyto="Responder a sugus" aria-label="Responder a sugus">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Es impresionante, la cantidad de presentaciones para una única receta.<br />Esta receta ya la había hecho anteriormente y es cierto que el bizcocho queda muy rico, pero es que con estas fotos tan espectaculares y con esa presentación no deja lugar a dudas.</p>
+<p>Enhorabuena por esta idea tan maravillosa. En la siguiente intentaré participar.</p>
+      
+  </div></li>
+
+  <li id="comment-5224" class="comment odd alt thread-even depth-1 media comment-5224">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Pili Diaz</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T21:24:02+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5224">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5224" data-commentid="5224" data-postid="385" data-belowelement="comment-5224" data-respondelement="respond" data-replyto="Responder a Pili Diaz" aria-label="Responder a Pili Diaz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Me ha encantado este reto.Las fotos están preciosas y dan muchas ideas Como hace poco que tengo la thermomix yo lo hice y estoy contenta de que me salió, pero todavía no me veo preparada para sacarle fotos. Igual con el siguiente me animo. Un beso Rosa. estoy enganchada a facebook y al blog. Es una maravilla!!!</p>
+      
+  </div></li>
+
+  <li id="comment-5223" class="comment even thread-odd thread-alt depth-1 media comment-5223">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">txinnih</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T20:51:55+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5223">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5223" data-commentid="5223" data-postid="385" data-belowelement="comment-5223" data-respondelement="respond" data-replyto="Responder a txinnih" aria-label="Responder a txinnih">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Verdaderamente esto se esta poniendo emocionante. Lastima no haber podido participar y eso q hago ese bizcocho a menudo. Queria preguntarte Rosa sobre lo de cambiar el azucar por sacarina, dado q esta endulza mas. Es la misma cantidad? Gracias y enhorabuena. Visito el blog a diario.</p>
+      
+  </div></li>
+
+  <li id="comment-5222" class="comment odd alt thread-even depth-1 media comment-5222">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Tatiana</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T20:41:34+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5222">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5222" data-commentid="5222" data-postid="385" data-belowelement="comment-5222" data-respondelement="respond" data-replyto="Responder a Tatiana" aria-label="Responder a Tatiana">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola chicas!!!</p>
+<p>Muchas gracias por estos retos, al final no mandé mis fotos, pero madre mia que cantidad de ellas hay, que guay.</p>
+<p>Por cierto Vicky, yo también tengo curiosidad de como usas las cápsulas de nespreso como molde, cuenta, cuenta.</p>
+<p>Gracias por todo.</p>
+<p>Saluditos.</p>
+      
+  </div></li>
+
+  <li id="comment-5221" class="comment even thread-odd thread-alt depth-1 media comment-5221">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T20:35:45+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5221">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5221" data-commentid="5221" data-postid="385" data-belowelement="comment-5221" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>hola a tod@s, soy una recién llegada (acabo de comprar la thmx) y ya estoy deseando probar todas vuestras recetas. gracias por compartirlas. y que bonito que de una misma receta se puedan obtener resultados tan diferentes y apetecibles. me encantaría sumarme al tercer reto. si alguien me pudiera decir cómo hacer para usar las cápsulas de café y que no se vuelquen me gustaría probarlo ya que yo uso ese café. gracias por todo.</p>
+      
+  </div></li>
+
+  <li id="comment-5220" class="comment odd alt thread-even depth-1 media comment-5220">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Amor</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T19:55:47+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5220">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5220" data-commentid="5220" data-postid="385" data-belowelement="comment-5220" data-respondelement="respond" data-replyto="Responder a Amor" aria-label="Responder a Amor">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>GRACIAS por dejarnos participar con este grano de arena en vuestro foro, me encanta poder ver mi foto, para cuando el tercero?<br />Enhorabuena a todos los participantes.</p>
+      
+  </div></li>
+
+  <li id="comment-5219" class="comment even thread-odd thread-alt depth-1 media comment-5219">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Conxi</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T19:14:48+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5219">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5219" data-commentid="5219" data-postid="385" data-belowelement="comment-5219" data-respondelement="respond" data-replyto="Responder a Conxi" aria-label="Responder a Conxi">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Que ganas tenia de ver el resultado del reto! una cosa tan simple y que ademas no cuesta dinero nos hace pasar un rato super chulo. El montaje impresionante se puede apreciar el interés,la ilusión y el amor que le hemos puesto todas al cocinar.<br />Muchas gracias y muchas felicidades para todas, me quedo con un pedacito de todos para mi!<br />Cual será el 3º? Esto pica chicas&#8230;.</p>
+      
+  </div></li>
+
+  <li id="comment-5218" class="comment odd alt thread-even depth-1 media comment-5218">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">José Enrique</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T17:53:23+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5218">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5218" data-commentid="5218" data-postid="385" data-belowelement="comment-5218" data-respondelement="respond" data-replyto="Responder a José Enrique" aria-label="Responder a José Enrique">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Hola Rosa y Vicky, ¿a qué altura del horno ponéis el bizcocho? Es que lo solía hacer así pero se me quema o no me sube lo suficiente.</p>
+<p>Saludos Kike</p>
+      
+  </div></li>
+
+  <li id="comment-5215" class="comment even thread-odd thread-alt depth-1 media comment-5215">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Angel</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T16:02:40+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5215">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5215" data-commentid="5215" data-postid="385" data-belowelement="comment-5215" data-respondelement="respond" data-replyto="Responder a Angel" aria-label="Responder a Angel">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>que envidia me da no haber participado &#8230;. el próximo prometo que no me lo pierdo!!!!</p>
+<p>Felicidades a las dos por la convocatoria y a todas y todo las /el participantes en este concurso, les han quedado unas fotos de lo más nutritivas &#8230; ya siento mis jugos gástricos alterados!!!!</p>
+<p>Un fuerte beso</p>
+<p>Angel</p>
+      
+  </div></li>
+
+  <li id="comment-5214" class="comment odd alt thread-even depth-1 media comment-5214">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Monica</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T15:00:22+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5214">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5214" data-commentid="5214" data-postid="385" data-belowelement="comment-5214" data-respondelement="respond" data-replyto="Responder a Monica" aria-label="Responder a Monica">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>¡Que bonitas! Es increíble lo que se puede hacer con ganas eh, felicidades!</p>
+      
+  </div></li>
+
+  <li id="comment-5213" class="comment even thread-odd thread-alt depth-1 media comment-5213">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Carmen</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T14:45:36+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5213">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5213" data-commentid="5213" data-postid="385" data-belowelement="comment-5213" data-respondelement="respond" data-replyto="Responder a Carmen" aria-label="Responder a Carmen">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Que buena idea, me he unido al grupo así que espero participar,y los bizcochos tiene todos una pinta increible.</p>
+      
+  </div></li>
+
+  <li id="comment-5212" class="comment odd alt thread-even depth-1 media comment-5212">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Xiueta</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T14:43:20+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5212">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5212" data-commentid="5212" data-postid="385" data-belowelement="comment-5212" data-respondelement="respond" data-replyto="Responder a Xiueta" aria-label="Responder a Xiueta">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Perdón, perdón, perdón, que no había dejado mensaje!!<br />Felicidades a tod@s!<br />Puedo hacer también aquí una ola&#8230;? UOOOOOooooooOOOOOOOO!<br />Besazos!<br />Laia</p>
+      
+  </div></li>
+
+  <li id="comment-5211" class="comment even thread-odd thread-alt depth-1 media comment-5211">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T14:30:07+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5211">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5211" data-commentid="5211" data-postid="385" data-belowelement="comment-5211" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Gracias a ti tambien Rosa, por la idea del reto y por todo el curro para hacer esas composiciones con todos las fotos, están chulísimas.<br />Ana López.</p>
+      
+  </div></li>
+
+  <li id="comment-5209" class="comment odd alt thread-even depth-1 media comment-5209">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">lorena estrada</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T14:16:12+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5209">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5209" data-commentid="5209" data-postid="385" data-belowelement="comment-5209" data-respondelement="respond" data-replyto="Responder a lorena estrada" aria-label="Responder a lorena estrada">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>FELICIDADES!!!!!!!! Haceis un trabajo increible y que nos enganchemos mas a la TH.Ya estamos impacientes por el 3 reto . Un beso para tod@s!</p>
+      
+  </div></li>
+
+  <li id="comment-5203" class="comment even thread-odd thread-alt depth-1 media comment-5203">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">S.B.Galocha</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T13:29:24+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5203">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5203" data-commentid="5203" data-postid="385" data-belowelement="comment-5203" data-respondelement="respond" data-replyto="Responder a S.B.Galocha" aria-label="Responder a S.B.Galocha">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa muchísimas felicidades, ha quedado increible.<br />Esta precioso y las presentaciones han sido espectaculares, no se con cual quedarme. Y aunque suene mal, me ha encantado ver mi foto, y aportar ese garnito de arena a tu post.<br />Enhorabuena!!</p>
+      
+  </div></li>
+
+  <li id="comment-5202" class="comment odd alt thread-even depth-1 media comment-5202">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">nati2525</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T12:45:49+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5202">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5202" data-commentid="5202" data-postid="385" data-belowelement="comment-5202" data-respondelement="respond" data-replyto="Responder a nati2525" aria-label="Responder a nati2525">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Que chulo que ha quedado, yo he llegado tarde, porque ademas este bizcocho es uno de los que mas preparo!! Tienen todos una pinta estupenda, podria estar incluydo en el reto, el poder probarlos!! jajajaj.. Pues ya estoy esperando el tercer reto!! a este si que me apunto!! Besitooos!!</p>
+      
+  </div></li>
+
+  <li id="comment-5198" class="comment even thread-odd thread-alt depth-1 media comment-5198">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">María (Úbeda)</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T11:47:44+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5198">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5198" data-commentid="5198" data-postid="385" data-belowelement="comment-5198" data-respondelement="respond" data-replyto="Responder a María (Úbeda)" aria-label="Responder a María (Úbeda)">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Cómo te lo curras Rosa. Los montajes han quedado genial! Además, seguro que la próxima vez que haga un bizcocho todas vuestras diferentes ideas me servirán de inspiración. Yo no pude participar en el primer reto, pero sí en este segundo y espero que en todos los que vengan a continuación. Felicidades a todas, vaya pinta que tienen todos los bizcochos!</p>
+      
+  </div></li>
+
+  <li id="comment-5197" class="comment odd alt thread-even depth-1 media comment-5197">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T11:43:40+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5197">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5197" data-commentid="5197" data-postid="385" data-belowelement="comment-5197" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>felicidades por todo lo que mandáis,tiene todo una pinta estupenda.</p>
+      
+  </div></li>
+
+  <li id="comment-5194" class="comment even thread-odd thread-alt depth-1 media comment-5194">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Patricia</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T11:08:35+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5194">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5194" data-commentid="5194" data-postid="385" data-belowelement="comment-5194" data-respondelement="respond" data-replyto="Responder a Patricia" aria-label="Responder a Patricia">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>q maravilla!!!!!enhorabuena a todos los participantes de este segundo reto,y ya estamos impacientes por saber cual es el tercero,a este me animo fijo.</p>
+      
+  </div></li>
+
+  <li id="comment-5193" class="comment odd alt thread-even depth-1 media comment-5193">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">queca</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T10:51:52+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5193">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5193" data-commentid="5193" data-postid="385" data-belowelement="comment-5193" data-respondelement="respond" data-replyto="Responder a queca" aria-label="Responder a queca">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>sois unas verdaderas artistas de la decoración!!!!!!!!! qué bonitos!!!buff lo que me queda por aprenderrrrrr</p>
+      
+  </div></li>
+
+  <li id="comment-5192" class="comment even thread-odd thread-alt depth-1 media comment-5192">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">queca</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T10:36:10+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5192">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5192" data-commentid="5192" data-postid="385" data-belowelement="comment-5192" data-respondelement="respond" data-replyto="Responder a queca" aria-label="Responder a queca">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>qué pena! la semana pasada hice este bizcocho decorao para mis sobris, y no me acordé de fotografíarlo ¡a ver si ando más espabilada para el 3º reto!</p>
+      
+  </div></li>
+
+  <li id="comment-5191" class="comment odd alt thread-even depth-1 media comment-5191">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Nuria</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T10:11:25+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5191">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5191" data-commentid="5191" data-postid="385" data-belowelement="comment-5191" data-respondelement="respond" data-replyto="Responder a Nuria" aria-label="Responder a Nuria">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>¡¡Buenos días y lindas fotos !!! Rosa y Vicky gracias por el reto y con ansias espero el siguiente&#8230;. gracias totales<br />Nuría</p>
+      
+  </div></li>
+
+  <li id="comment-5190" class="comment even thread-odd thread-alt depth-1 media comment-5190">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Beatriz</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T09:46:13+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5190">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5190" data-commentid="5190" data-postid="385" data-belowelement="comment-5190" data-respondelement="respond" data-replyto="Responder a Beatriz" aria-label="Responder a Beatriz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Emocionada me hallo!!!!!</p>
+<p>Es un placer para mí haber participado también en éste reto y que sepais que estoy deseando saber cuál es el siguiente.</p>
+<p>Enhorabuena por vuestro trabajo ;) <br />Aquí os dejo mi agradecimiento en mi blog. <a href="http://2mandarinasenmicocina.blogspot.com/2010/03/reto-del-grupo-de-facebook-cocinar-con.html" rel="nofollow ugc">http://2mandarinasenmicocina.blogspot.com/2010/03/reto-del-grupo-de-facebook-cocinar-con.html</a></p>
+      
+  </div></li>
+
+  <li id="comment-5188" class="comment odd alt thread-even depth-1 media comment-5188">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">M.CAMACHO</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T09:17:14+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5188">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5188" data-commentid="5188" data-postid="385" data-belowelement="comment-5188" data-respondelement="respond" data-replyto="Responder a M.CAMACHO" aria-label="Responder a M.CAMACHO">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Han quedado como un catalogo!!!, os felicito Rosa y Vicki. Ya estamos esperando el 3 reto?? <br />Gracias.<br />M.Camacho</p>
+      
+  </div></li>
+
+  <li id="comment-5186" class="comment even thread-odd thread-alt depth-1 media comment-5186">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Ignacio</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T08:38:10+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5186">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5186" data-commentid="5186" data-postid="385" data-belowelement="comment-5186" data-respondelement="respond" data-replyto="Responder a Ignacio" aria-label="Responder a Ignacio">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>¡¡¡qué barbaridad de presentaciones!!!</p>
+<p>Variante: yo le pongo 60 gr de brandy, junto con el yogurt y el aceite, y le da &quot;un toque&quot; estupendo.</p>
+<p>Saludos,<br />Ignacio</p>
+      
+  </div></li>
+
+  <li id="comment-5185" class="comment odd alt thread-even depth-1 media comment-5185">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Paqui</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T08:13:14+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5185">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5185" data-commentid="5185" data-postid="385" data-belowelement="comment-5185" data-respondelement="respond" data-replyto="Responder a Paqui" aria-label="Responder a Paqui">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Paqui.17/03/10.<br />Felicidades Rosa y Vicki,ha quedado estupendo,con estas presentaciones y estos bizcochos es muy dificil meterse en la operacion bikini.Ehorabuena a las dos y gracias por hacernos formar parte este grupo tan estenso y maravilloso.<br />Un besoy apor el tercero!!!!!</p>
+      
+  </div></li>
+
+  <li id="comment-5184" class="comment even thread-odd thread-alt depth-1 media comment-5184">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">María José</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T08:00:08+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5184">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5184" data-commentid="5184" data-postid="385" data-belowelement="comment-5184" data-respondelement="respond" data-replyto="Responder a María José" aria-label="Responder a María José">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>El bizcocho es delicioso y la entrada con tantas fotos bonitas&#8230;.preciosa.<br />Un abrazo,<br />María José.</p>
+      
+  </div></li>
+
+  <li id="comment-5183" class="comment odd alt thread-even depth-1 media comment-5183">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rebeca.</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:59:38+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5183">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5183" data-commentid="5183" data-postid="385" data-belowelement="comment-5183" data-respondelement="respond" data-replyto="Responder a Rebeca." aria-label="Responder a Rebeca.">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Que chulo! me gustan tooodas! no sabria cual elegir, aunque los de chocolate me pierden. En el próximo reto si mis retoños me dejan me uno.</p>
+<p>Muchas felicidades a todos! </p>
+<p>Gracias a Rosa y Vicky por haber abierto las puertas a éste maravilloso grupo y por gestinarlo tan bien, sólo puedo decir que me encanta!!</p>
+<p>un saludo!</p>
+      
+  </div></li>
+
+  <li id="comment-5182" class="comment even thread-odd thread-alt depth-1 media comment-5182">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Su</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:41:33+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5182">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5182" data-commentid="5182" data-postid="385" data-belowelement="comment-5182" data-respondelement="respond" data-replyto="Responder a Su" aria-label="Responder a Su">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Me encanta estas iniciativas chicas!!<br />Enhorabuena por todo, es un gusto pasar a veros!!</p>
+<p>Besos</p>
+      
+  </div></li>
+
+  <li id="comment-5181" class="comment odd alt thread-even depth-1 media comment-5181">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Anonymous</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:37:57+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5181">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5181" data-commentid="5181" data-postid="385" data-belowelement="comment-5181" data-respondelement="respond" data-replyto="Responder a Anonymous" aria-label="Responder a Anonymous">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Pero que nivel. Parece mentira que una receta tan sencilla se pueda preparar de tantas formas&#8230; Al final se me ha pasado y no he participado, en el siguiente prometo participar!!!!!!!!<br />Enhorabuena por esta entrada tan espectacular y currada!!!<br />Besos<br />Pilar</p>
+      
+  </div></li>
+
+  <li id="comment-5180" class="comment even thread-odd thread-alt depth-1 media comment-5180">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Goizalde</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:30:48+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5180">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5180" data-commentid="5180" data-postid="385" data-belowelement="comment-5180" data-respondelement="respond" data-replyto="Responder a Goizalde" aria-label="Responder a Goizalde">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Como puede una cosa ser tan diferente según cada persona? Me parece una pasada, es que no hay dos que digas: Estos se parecen un poco&#8230;<br />Genial, está genial!!!</p>
+      
+  </div></li>
+
+  <li id="comment-5179" class="comment odd alt thread-even depth-1 media comment-5179">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">piquices</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:30:43+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5179">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5179" data-commentid="5179" data-postid="385" data-belowelement="comment-5179" data-respondelement="respond" data-replyto="Responder a piquices" aria-label="Responder a piquices">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Yupiiiiiiiiii gracias Rosa ya me veo y ahora mismo me tomaría un trocito de cada uno con la alegría.</p>
+<p>¿Vamos a por el tercero? <br />Gracias</p>
+      
+  </div></li>
+
+  <li id="comment-5178" class="comment even thread-odd thread-alt depth-1 media comment-5178">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">maria elena</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:12:15+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5178">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5178" data-commentid="5178" data-postid="385" data-belowelement="comment-5178" data-respondelement="respond" data-replyto="Responder a maria elena" aria-label="Responder a maria elena">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>pues el bizcocho tiene que estar buenisimo y las presentaciones &#8230;no sabria con cual quedarme.<br />un besin.</p>
+      
+  </div></li>
+
+  <li id="comment-5177" class="comment odd alt thread-even depth-1 media comment-5177">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Juanfri</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:12:14+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5177">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5177" data-commentid="5177" data-postid="385" data-belowelement="comment-5177" data-respondelement="respond" data-replyto="Responder a Juanfri" aria-label="Responder a Juanfri">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Bueno, bueno, bueno, me has dejado sin palabras!!! Vaya post más guay, qué fotos más preciosas y qué bien explicado todo. Qué ilusión levantarme esta mañana y mientras me tomo el café poder disfrutar de todas estas fotos y de esta entrada del blog. La verdad es que han quedado las fotos chulísimas, y qué originalidad. La gente se lo curra mucho, cada vez se presentan las cosas mejor y se cuidan más los detalles; tengo que ponerme al día, esto está subiendo de nivel. <br />Enhorabuena Rosa, te ha quedado espectacular este montaje y el reto en general. Espero otro pronto.<br />Vicky, qué originalidad, sí señor, hasta con las cápsulas de Nespresso.<br />SUPER BUENOS DÍAS!!!</p>
+      
+  </div></li>
+
+  <li id="comment-5176" class="comment even thread-odd thread-alt depth-1 media comment-5176">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Mar</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:11:07+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5176">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5176" data-commentid="5176" data-postid="385" data-belowelement="comment-5176" data-respondelement="respond" data-replyto="Responder a Mar" aria-label="Responder a Mar">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa, te lo has &quot;currado&quot; para meter tantas fotos&#8230; Y de verdad, daros &quot;palmaditas en la espalda&quot; (es que a mi no me llega la mano) porque menudo poder de convocatoria que teneis.</p>
+<p>Un beso grande<br />Mar Martinez</p>
+      
+  </div></li>
+
+  <li id="comment-5175" class="comment odd alt thread-even depth-1 media comment-5175">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Rosa Ardá</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T07:08:17+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5175">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5175" data-commentid="5175" data-postid="385" data-belowelement="comment-5175" data-respondelement="respond" data-replyto="Responder a Rosa Ardá" aria-label="Responder a Rosa Ardá">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Arreglado!!!! Como se me pudo pasar!!!!. Espero que no falte nadie más. Perdona Piqui.</p>
+      
+  </div></li>
+
+  <li id="comment-5174" class="comment even thread-odd thread-alt depth-1 media comment-5174">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">piquices</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T06:16:27+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5174">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5174" data-commentid="5174" data-postid="385" data-belowelement="comment-5174" data-respondelement="respond" data-replyto="Responder a piquices" aria-label="Responder a piquices">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>BUAAAAA!!!! Rosa ¿se ha perdido mi foto o es que me tienes castigada?&#8230;.. con lo buena que yo soy&#8230;. casi siempre buaaaaaa!!!!!<br />¿no te doy penita? buaaaaaa mira como llorooooo</p>
+      
+  </div></li>
+
+  <li id="comment-5173" class="comment odd alt thread-even depth-1 media comment-5173">
+    <img alt='' src='https://secure.gravatar.com/avatar/?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo avatar-default' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">Vicky Ortiz</h5>
+        <div class="comment-meta">
+        <time datetime="2010-03-17T06:08:40+01:00"><a href="https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/#comment-5173">
+          17 marzo, 2010</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-5173" data-commentid="5173" data-postid="385" data-belowelement="comment-5173" data-respondelement="respond" data-replyto="Responder a Vicky Ortiz" aria-label="Responder a Vicky Ortiz">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Rosa, estás hecha una artista. Menudo post más bien preparado.<br />Y a tod@s los participantes, enhorabuena.</p>
+<p>Besos<br />Vicky</p>
+      
+  </div></li>
+    </ol>
+
+    
+      </section><!-- /#comments -->
+  
+
+<button class="mostrar-comentarios despues button" style="cursor:pointer">Mostrar comentarios</button>
+
+  <section id="respond">
+  	<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Dejar una opinión <small><a rel="nofollow" id="cancel-comment-reply-link" href="/bizcocho-de-naranja-thermomix/#respond" style="display:none;">Cancelar la respuesta</a></small></h3><form action="https://www.velocidadcuchara.com/wp-comments-post.php" method="post" id="commentform" class="comment-form"><p class="comment-form-comment"><label for="comment">Comentarios</label> <textarea id="comment" name="comment" cols="45" rows="8" class="input-xlarge" aria-required="true" required="required"></textarea></p><p class="pprivacy"><input type="checkbox" class="form-check" name="privacy" value="privacy-key" class="privacyBox" aria-req="true">&nbsp;&nbsp;Acepto la <a target="blank" href="https://velocidadcuchara.com/politica-de-privacidad">política de privacidad</a><p><div class="row"><div class="col-md-4"><label for="author">Nombre <span class="comment-required">*</span></label> <input id="author" name="author" type="text" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="email">Email (no será publicado) <span class="comment-required">*</span></label> <input type="email" class="text" name="email" id="email" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="url">Sitio Web</label> <input id="url" name="url" type="url" value="" /></div>
+</div><p class="form-submit"><input name="submit" type="submit" id="submit" class="kad-btn kad-btn-primary" value="Enviar" /> <input type='hidden' name='comment_post_ID' value='385' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><span class="ERComment">
+<span style="float:left">Valora esta receta: </span>
+<span class="ERRateBG">
+<span class="ERRateStars"></span>
+</span>
+<input type="hidden" class="inpERRating" name="ERRating" value="0" />
+&nbsp;
+</span><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="7152745145" /></p><p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="205"/><script type="rocketlazyloadscript">document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );</script></p></form>	</div><!-- #respond -->
+	
+  </section><!-- /#respond -->
+        </div>
+                    
+          	            <aside class="col-lg-3 col-md-4 kad-sidebar" role="complementary" itemscope itemtype="http://schema.org/WPSideBar">
+	              <div class="sidebar">
+	                <section class="widget-2 widget local-widget"><div class="widget-inner"><div id="local-3891450358" style="margin-bottom: 25px;margin-left: auto;margin-right: auto;text-align: center;"><picture style="display: inline-block; max-width: 100%; height: auto;">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg.webp"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg" alt="Claudia &amp; Julia: Utensilios para una cocina tradicional y saludable" width="300" height="100"/>
+</picture>
+</div></div></section><section id="siteorigin-panels-builder-28" class="widget-4 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w64208d0f963d5"  class="panel-layout" ><div id="pg-w64208d0f963d5-0"  class="panel-grid panel-no-style" ><div id="pgc-w64208d0f963d5-0-0"  class="panel-grid-cell" ><div id="panel-w64208d0f963d5-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://newsletter.velocidadcuchara.com/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Suscribete.svg" width="300" height="45" sizes="(max-width: 300px) 100vw, 300px" title="Suscríbete Newsletter" alt="Suscríbete a Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div><div id="panel-w64208d0f963d5-0-0-1" class="so-panel widget widget_sow-editor panel-last-child" data-index="1" ><div class="panel-widget-style panel-widget-style-for-w64208d0f963d5-0-0-1" ><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p style="text-align: center;"><a href="https://newsletter.velocidadcuchara.com/" target="_blank" rel="noopener"><em>Recibe nuestra Newsletter<br />
+en tu correo electrónico</em></a></p>
+</div>
+</div></div></div></div></div></div></div></section><section id="sow-image-26" class="widget-5 widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/todas-las-recetas/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2018/07/descubre_todas_nuestras_recetas-1.svg" width="1" height="1" sizes="(max-width: 1px) 100vw, 1px" title="Todas las recetas Thermomix" alt="Todas las recetas Thermomix" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section><section id="custom_html-5" class="widget_text widget-6 widget widget_custom_html"><div class="widget_text widget-inner"><div class="textwidget custom-html-widget"><script type="rocketlazyloadscript" async data-rocket-src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0432726040009676"
+     crossorigin="anonymous"></script>
+<!-- PRUEBA 23 -->
+<ins class="adsbygoogle"
+     style="display:block"
+     data-ad-client="ca-pub-0432726040009676"
+     data-ad-slot="7485608005"
+     data-ad-format="auto"
+     data-full-width-responsive="true"></ins>
+<script type="rocketlazyloadscript">
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script></div></div></section><section id="siteorigin-panels-builder-29" class="widget-7 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w5f89a361017dd"  class="panel-layout" ><div id="pg-w5f89a361017dd-0"  class="panel-grid panel-has-style" ><div class="panel-row-style panel-row-style-for-w5f89a361017dd-0" ><div id="pgc-w5f89a361017dd-0-0"  class="panel-grid-cell" ><div id="panel-w5f89a361017dd-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.youtube.com/user/velocidadcuchara" target="_blank" rel="noopener noreferrer" >	<picture class="so-widget-image">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png.webp 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png.webp 600w" sizes="(max-width: 300px) 100vw, 300px"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png 600w" sizes="(max-width: 300px) 100vw, 300px" alt=""/>
+</picture>
+
+</a></div>
+
+</div></div></div><div id="panel-w5f89a361017dd-0-0-1" class="so-panel widget widget_sow-image" data-index="1" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-1" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/tarta-sacher-paso-a-paso-con-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Tarta Sacher" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Tarta Sacher</h3></div></div></div><div id="panel-w5f89a361017dd-0-0-2" class="so-panel widget widget_sow-image panel-last-child" data-index="2" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-2" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/como-preparar-yogur-en-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Yogurt casero" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Yogurt casero</h3></div></div></div></div></div></div></div></div></section><section id="sow-image-18" class="widget-8 widget-last widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Podcast-Caratula-cuadrados-1080-×-1920-px-1000-×-1000-px.svg" width="300" height="300" sizes="(max-width: 300px) 100vw, 300px" title="Promo libros Velocidad Cuchara" alt="Promo libros Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section>	              </div><!-- /.sidebar -->
+	            </aside><!-- /aside -->
+                    </div><!-- /.row-->
+        </div><!-- /.content -->
+      </div><!-- /.wrap -->
+      <footer data-wpr-lazyrender="1" id="containerfooter" class="footerclass" itemscope itemtype="http://schema.org/WPFooter">
+  <div class="container">
+  	<div class="row">
+  							<div class="col-md-4 footercol1">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-5" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="https://www.velocidadcuchara.com"><img loading="lazy" decoding="async" class="alignnone wp-image-45320" src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/footer_vc.svg" alt="" width="171" height="53" /></a></p>
+<p>Desde 2008 cocinamos con (y sin) el robot de cocina más famoso del mundo</p>
+<div class="space_20 clearfix"></div>
+<figure id="attachment_43492" class="thumbnail wp-caption alignnone" style="width: 176px"><picture loading="lazy" decoding="async" class="size-full wp-image-43492">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png.webp 176w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+<img loading="lazy" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png" alt="" width="176" height="46" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png 176w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-140x36.png 140w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-24x6.png 24w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-36x9.png 36w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-48x12.png 48w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+</picture>
+<figcaption class="caption wp-caption-text">Ganadores en la XII edición</figcaption></figure>
+<figure id="attachment_45318" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45318" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/gastroblogs.png" alt="" width="176" height="52" /><figcaption class="caption wp-caption-text">Ganador Gastroblogs</figcaption></figure>
+<figure id="attachment_45319" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45319" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/bitacoras.png" alt="" width="176" height="46" /><figcaption class="caption wp-caption-text">Finalista en Gastronomía</figcaption></figure>
+</div>
+</div></aside></div>					</div>
+            										<div class="col-md-4 footercol2">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-social-media-buttons-4" class="widget widget_sow-social-media-buttons"><div class="so-widget-sow-social-media-buttons so-widget-sow-social-media-buttons-flat-3af2f923c85f"><h3>EN LAS REDES</h3>
+<div class="social-media-button-container">
+	
+		<a class="ow-button-hover sow-social-media-button-facebook sow-social-media-button" title="Velocidad Cuchara en Facebook" aria-label="Velocidad Cuchara en Facebook" target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf39e;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-instagram sow-social-media-button" title="Velocidad Cuchara en Instagram" aria-label="Velocidad Cuchara en Instagram" target="_blank" rel="noopener noreferrer" href="https://www.instagram.com/velocidadcuchara/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf16d;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-youtube sow-social-media-button" title="Velocidad Cuchara en Youtube" aria-label="Velocidad Cuchara en Youtube" target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/user/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf167;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-twitter sow-social-media-button" title="Velocidad Cuchara en Twitter" aria-label="Velocidad Cuchara en Twitter" target="_blank" rel="noopener noreferrer" href="https://twitter.com/rosaarda" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf099;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-pinterest sow-social-media-button" title="Velocidad Cuchara en Pinterest" aria-label="Velocidad Cuchara en Pinterest" target="_blank" rel="noopener noreferrer" href="https://es.pinterest.com/rosaarda/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf0d2;" ></span>							</span>
+		</a>
+	</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-6" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>ROSA ARDÁ</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>Enganchada a la Thermomix, uno de los grandes inventos de la historia :D</p>
+</div>
+</div></aside></div><div class="widget-3 widget-last footer-widget"><aside id="media_image-2" class="widget widget_media_image"><h3>NUESTROS LIBROS</h3><a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/"><picture class="image wp-image-58705  attachment-full size-full" style="max-width: 100%; height: auto;" title="NUESTRO LIBRO" decoding="async" loading="lazy">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png.webp 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png.webp 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+<img width="241" height="148" src="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png" alt="" decoding="async" loading="lazy" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+</picture>
+</a></aside></div>					</div>
+		        		        					<div class="col-md-4 footercol3">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-7" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>AVISO LEGAL</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>VelocidadCuchara.com y Velocidad Cuchara <a href="https://www.velocidadcuchara.com/aviso-legal/">son marcas registradas</a>. Consulta la <a href="https://www.velocidadcuchara.com/declaracion-de-privacidad-ue/" target="_blank" rel="noopener">Política de privacidad</a> y la <a href="https://www.velocidadcuchara.com/politica-de-cookies-ue/" target="_blank" rel="noopener">Política de Cookies</a></p>
+</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-8" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>NOS ENCANTA LEER</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="http://www.averquecocinamoshoy.com/" target="_blank" rel="noopener noreferrer">A ver qué cocinamos hoy</a><br />
+<a href="http://www.crockpotting.es/" target="_blank" rel="noopener">Crockpotting</a><br />
+<a href="https://elcomidista.elpais.com/" target="_blank" rel="noopener noreferrer">El Comidista</a><br />
+<a href="http://www.misthermorecetas.com/" target="_blank" rel="noopener noreferrer">Mis thermorecetas</a><br />
+<a href="http://pepacooks.com/" target="_blank" rel="noopener noreferrer">Pepa Cooks </a><br />
+<a href="http://www.recetasderechupete.com/" target="_blank" rel="noopener noreferrer">Recetas de Rechupete </a><br />
+<a href="https://webosfritos.es/" target="_blank" rel="noopener noreferrer">Webos Fritos</a></p>
+</div>
+</div></aside></div><div class="widget_text widget-3 widget-last footer-widget"><aside id="custom_html-3" class="widget_text widget widget_custom_html"><div class="textwidget custom-html-widget"></div></aside></div>					</div>
+	            			        </div>
+        <div class="footercredits clearfix">
+
+    		        	<p>&copy; 2008 - 2026 Velocidad Cuchara</p>
+    	</div>
+
+  </div>
+
+</footer>
+</div><!--Wrapper-->
+
+<script type="rocketlazyloadscript" data-rocket-type='text/javascript'>
+/* <![CDATA[ */
+var advancedAds = {"adHealthNotice":{"enabled":true,"pattern":"AdSense fallback was loaded for empty AdSense ad \"[ad_title]\""},"frontendPrefix":"local-"};
+
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript">(function(){var advanced_ads_ga_UID="rosaarda",advanced_ads_ga_anonymIP=!!1;window.advanced_ads_check_adblocker=function(){var t=[],n=null;function e(t){var n=window.requestAnimationFrame||window.mozRequestAnimationFrame||window.webkitRequestAnimationFrame||function(t){return setTimeout(t,16)};n.call(window,t)}return e((function(){var a=document.createElement("div");a.innerHTML="&nbsp;",a.setAttribute("class","ad_unit ad-unit text-ad text_ad pub_300x250"),a.setAttribute("style","width: 1px !important; height: 1px !important; position: absolute !important; left: 0px !important; top: 0px !important; overflow: hidden !important;"),document.body.appendChild(a),e((function(){var e,o,i=null===(e=(o=window).getComputedStyle)||void 0===e?void 0:e.call(o,a),d=null==i?void 0:i.getPropertyValue("-moz-binding");n=i&&"none"===i.getPropertyValue("display")||"string"==typeof d&&-1!==d.indexOf("about:");for(var c=0,r=t.length;c<r;c++)t[c](n);t=[]}))})),function(e){"undefined"==typeof advanced_ads_adblocker_test&&(n=!0),null!==n?e(n):t.push(e)}}(),(()=>{function t(t){this.UID=t,this.analyticsObject="function"==typeof gtag;var n=this;return this.count=function(){gtag("event","AdBlock",{event_category:"Advanced Ads",event_label:"Yes",non_interaction:!0,send_to:n.UID})},function(){if(!n.analyticsObject){var e=document.createElement("script");e.src="https://www.googletagmanager.com/gtag/js?id="+t,e.async=!0,document.body.appendChild(e),window.dataLayer=window.dataLayer||[],window.gtag=function(){dataLayer.push(arguments)},n.analyticsObject=!0,gtag("js",new Date)}var a={send_page_view:!1,transport_type:"beacon"};window.advanced_ads_ga_anonymIP&&(a.anonymize_ip=!0),gtag("config",t,a)}(),this}advanced_ads_check_adblocker((function(n){n&&new t(advanced_ads_ga_UID).count()}))})();})();</script><script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"\/*"},{"not":{"href_matches":["\/wp-*.php","\/wp-admin\/*","\/wp-content\/uploads\/*","\/wp-content\/*","\/wp-content\/plugins\/*","\/wp-content\/themes\/velocidad\/*","\/wp-content\/themes\/virtue\/*","\/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+
+<!-- Consent Management powered by Complianz | GDPR/CCPA Cookie Consent https://wordpress.org/plugins/complianz-gdpr -->
+<div id="cmplz-cookiebanner-container"><div class="cmplz-cookiebanner cmplz-hidden banner-1 velocidad-cuchara optin cmplz-bottom cmplz-categories-type-view-preferences" aria-modal="true" data-nosnippet="true" role="dialog" aria-live="polite" aria-labelledby="cmplz-header-1-optin" aria-describedby="cmplz-message-1-optin">
+	<div class="cmplz-header">
+		<div class="cmplz-logo"><img width="350" height="100" src="https://www.velocidadcuchara.com/wp-content/uploads/2024/03/cookies-350x100.png" class="attachment-cmplz_banner_image size-cmplz_banner_image" alt="Velocidad Cuchara" decoding="async" loading="lazy" /></div>
+		<div class="cmplz-title" id="cmplz-header-1-optin">Gestiona tu privacidad</div>
+		<div class="cmplz-close" tabindex="0" role="button" aria-label="Cerrar diálogo">
+			<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>
+		</div>
+	</div>
+
+	<div class="cmplz-divider cmplz-divider-header"></div>
+	<div class="cmplz-body">
+		<div class="cmplz-message" id="cmplz-message-1-optin"><p>Para ofrecer las mejores experiencias, nosotros y nuestros socios utilizamos tecnologías como cookies para almacenar y/o acceder a la información del dispositivo. La aceptación de estas tecnologías nos permitirá a nosotros y a nuestros socios procesar datos personales como el comportamiento de navegación o identificaciones únicas (IDs) en este sitio y mostrar anuncios (no-) personalizados. No consentir o retirar el consentimiento, puede afectar negativamente a ciertas características y funciones.</p><p>Haz clic a continuación para aceptar lo anterior o realizar elecciones más detalladas.&nbsp;Tus elecciones se aplicarán solo en este sitio.&nbsp;Puedes cambiar tus ajustes en cualquier momento, incluso retirar tu consentimiento, utilizando los botones de la Política de cookies o haciendo clic en el icono de Privacidad situado en la parte inferior de la pantalla.</p></div>
+		<!-- categories start -->
+		<div class="cmplz-categories">
+			<details class="cmplz-category cmplz-functional" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Funcional</span>
+							<span class='cmplz-always-active'>
+								<span class="cmplz-banner-checkbox">
+									<input type="checkbox"
+										   id="cmplz-functional-optin"
+										   data-category="cmplz_functional"
+										   class="cmplz-consent-checkbox cmplz-functional"
+										   size="40"
+										   value="1"/>
+									<label class="cmplz-label" for="cmplz-functional-optin"><span class="screen-reader-text">Funcional</span></label>
+								</span>
+								Siempre activo							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-functional">El almacenamiento o acceso técnico es estrictamente necesario para el propósito legítimo de permitir el uso de un servicio específico explícitamente solicitado por el abonado o usuario, o con el único propósito de llevar a cabo la transmisión de una comunicación a través de una red de comunicaciones electrónicas.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-preferences" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Preferencias</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-preferences-optin"
+									   data-category="cmplz_preferences"
+									   class="cmplz-consent-checkbox cmplz-preferences"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-preferences-optin"><span class="screen-reader-text">Preferencias</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-preferences">El almacenamiento o acceso técnico es necesario para la finalidad legítima de almacenar preferencias no solicitadas por el abonado o usuario.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-statistics" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Estadísticas</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-statistics-optin"
+									   data-category="cmplz_statistics"
+									   class="cmplz-consent-checkbox cmplz-statistics"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-statistics-optin"><span class="screen-reader-text">Estadísticas</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-statistics">El almacenamiento o acceso técnico que es utilizado exclusivamente con fines estadísticos.</span>
+					<span class="cmplz-description-statistics-anonymous">El almacenamiento o acceso técnico que se utiliza exclusivamente con fines estadísticos anónimos. Sin un requerimiento, el cumplimiento voluntario por parte de tu Proveedor de servicios de Internet, o los registros adicionales de un tercero, la información almacenada o recuperada sólo para este propósito no se puede utilizar para identificarte.</span>
+				</div>
+			</details>
+			<details class="cmplz-category cmplz-marketing" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Marketing</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-marketing-optin"
+									   data-category="cmplz_marketing"
+									   class="cmplz-consent-checkbox cmplz-marketing"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-marketing-optin"><span class="screen-reader-text">Marketing</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-marketing">El almacenamiento o acceso técnico es necesario para crear perfiles de usuario para enviar publicidad, o para rastrear al usuario en una web o en varias web con fines de marketing similares.</span>
+				</div>
+			</details>
+		</div><!-- categories end -->
+		
+<div class="cmplz-categories cmplz-tcf">
+
+	<div class="cmplz-category cmplz-statistics">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Estadísticas</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-marketing">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Marketing</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-features">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Características</div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialfeatures">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'></div>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialpurposes">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+		</div>
+	</div>
+
+</div>
+	</div>
+
+	<div class="cmplz-links cmplz-information">
+		<ul>
+			<li><a class="cmplz-link cmplz-manage-options cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a></li>
+			<li><a class="cmplz-link cmplz-manage-third-parties cookie-statement" href="#" data-relative_url="#cmplz-cookies-overview">Gestionar los servicios</a></li>
+			<li><a class="cmplz-link cmplz-manage-vendors tcf cookie-statement" href="#" data-relative_url="#cmplz-tcf-wrapper">Gestionar {vendor_count} proveedores</a></li>
+			<li><a class="cmplz-link cmplz-external cmplz-read-more-purposes tcf" target="_blank" rel="noopener noreferrer nofollow" href="https://cookiedatabase.org/tcf/purposes/" aria-label="Read more about TCF purposes on Cookie Database">Leer más sobre estos propósitos</a></li>
+		</ul>
+			</div>
+
+	<div class="cmplz-divider cmplz-footer"></div>
+
+	<div class="cmplz-buttons">
+		<button class="cmplz-btn cmplz-accept">Aceptar</button>
+		<button class="cmplz-btn cmplz-deny">Rechazar</button>
+		<button class="cmplz-btn cmplz-view-preferences">Administrar opciones</button>
+		<button class="cmplz-btn cmplz-save-preferences">Guardar preferencias</button>
+		<a class="cmplz-btn cmplz-manage-options tcf cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a>
+			</div>
+
+	
+	<div class="cmplz-documents cmplz-links">
+		<ul>
+			<li><a class="cmplz-link cookie-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link privacy-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link impressum" href="#" data-relative_url="">{title}</a></li>
+		</ul>
+			</div>
+</div>
+</div>
+					<div id="cmplz-manage-consent" data-nosnippet="true"><button class="cmplz-btn cmplz-hidden cmplz-manage-consent manage-consent-1">Privacidad</button>
+
+</div>        <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        jQuery(document).ready(function($){
+            $("#submit").click(function(e)){
+                if (!$('.privacyBox').prop('checked')){
+                    e.preventDefault();
+                    alert('Debes aceptar nuestra política de privacidad <p><a href="javascript:history.back()">' . __('&laquo; Volver') . '</a></p>');
+                    return false;
+                }
+            }
+        });
+        </script>
+                        <style type="text/css" media="all"
+                       id="siteorigin-panels-layouts-footer">/* Layout w64208d0f963d5 */ #pgc-w64208d0f963d5-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-0 , #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-1 {  } #pl-w64208d0f963d5 .so-panel { margin-bottom:30px } #pl-w64208d0f963d5 .so-panel:last-child { margin-bottom:0px } #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w64208d0f963d5-0-0-1> .panel-widget-style { color:#bdbeb2;margin-top:-18px;font-size:1.2em;font-weight:400;line-height:1.2em } @media (max-width:780px){ #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w64208d0f963d5-0 > .panel-grid-cell , #pg-w64208d0f963d5-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w64208d0f963d5 .panel-grid-cell { padding:0 } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-empty { display:none } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } /* Layout w5f89a361017dd */ #pgc-w5f89a361017dd-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-0 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-1 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-2 {  } #pl-w5f89a361017dd .so-panel { margin-bottom:30px } #pl-w5f89a361017dd .so-panel:last-child { margin-bottom:0px } #pg-w5f89a361017dd-0> .panel-row-style { background-color:#e7e8e1;padding:0.5em } #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w5f89a361017dd-0-0-0> .panel-widget-style { margin-bottom:20px } @media (max-width:780px){ #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w5f89a361017dd-0 > .panel-grid-cell , #pg-w5f89a361017dd-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w5f89a361017dd .panel-grid-cell { padding:0 } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-empty { display:none } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } </style><link rel='stylesheet' id='siteorigin-panels-front-css' href='https://www.velocidadcuchara.com/wp-content/plugins/siteorigin-panels/css/front-flex.min.css?ver=2.10.9' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-3af2f923c85f-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-3af2f923c85f.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='siteorigin-widget-icon-font-fontawesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/icons/fontawesome/style.css?ver=1773428753' type='text/css' media='all' />
+<script type="text/javascript" id="wtpsw-public-script-js-extra">
+/* <![CDATA[ */
+var Wtpsw = {"elementor_preview":"0","ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","is_mobile":"0","is_avada":"0","is_rtl":"0","post_view_count":"385","data_nonce":"aca6b40d34"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/js/wtpsw-public.js?ver=1773428753" id="wtpsw-public-script-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-browser-checker-js-after">
+/* <![CDATA[ */
+"use strict";var _createClass=function(){function defineProperties(target,props){for(var i=0;i<props.length;i++){var descriptor=props[i];descriptor.enumerable=descriptor.enumerable||!1,descriptor.configurable=!0,"value"in descriptor&&(descriptor.writable=!0),Object.defineProperty(target,descriptor.key,descriptor)}}return function(Constructor,protoProps,staticProps){return protoProps&&defineProperties(Constructor.prototype,protoProps),staticProps&&defineProperties(Constructor,staticProps),Constructor}}();function _classCallCheck(instance,Constructor){if(!(instance instanceof Constructor))throw new TypeError("Cannot call a class as a function")}var RocketBrowserCompatibilityChecker=function(){function RocketBrowserCompatibilityChecker(options){_classCallCheck(this,RocketBrowserCompatibilityChecker),this.passiveSupported=!1,this._checkPassiveOption(this),this.options=!!this.passiveSupported&&options}return _createClass(RocketBrowserCompatibilityChecker,[{key:"_checkPassiveOption",value:function(self){try{var options={get passive(){return!(self.passiveSupported=!0)}};window.addEventListener("test",null,options),window.removeEventListener("test",null,options)}catch(err){self.passiveSupported=!1}}},{key:"initRequestIdleCallback",value:function(){!1 in window&&(window.requestIdleCallback=function(cb){var start=Date.now();return setTimeout(function(){cb({didTimeout:!1,timeRemaining:function(){return Math.max(0,50-(Date.now()-start))}})},1)}),!1 in window&&(window.cancelIdleCallback=function(id){return clearTimeout(id)})}},{key:"isDataSaverModeOn",value:function(){return"connection"in navigator&&!0===navigator.connection.saveData}},{key:"supportsLinkPrefetch",value:function(){var elem=document.createElement("link");return elem.relList&&elem.relList.supports&&elem.relList.supports("prefetch")&&window.IntersectionObserver&&"isIntersecting"in IntersectionObserverEntry.prototype}},{key:"isSlowConnection",value:function(){return"connection"in navigator&&"effectiveType"in navigator.connection&&("2g"===navigator.connection.effectiveType||"slow-2g"===navigator.connection.effectiveType)}}]),RocketBrowserCompatibilityChecker}();
+/* ]]> */
+</script>
+<script type="text/javascript" id="rocket-preload-links-js-extra">
+/* <![CDATA[ */
+var RocketPreloadLinksConfig = {"excludeUris":"\/(?:.+\/)?feed(?:\/(?:.+\/?)?)?$|\/(?:.+\/)?embed\/|\/(index.php\/)?(.*)wp-json(\/.*|$)|\/refer\/|\/go\/|\/recommend\/|\/recommends\/","usesTrailingSlash":"1","imageExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php","fileExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php|html|htm","siteUrl":"https:\/\/www.velocidadcuchara.com","onHoverDelay":"100","rateThrottle":"3"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-preload-links-js-after">
+/* <![CDATA[ */
+(function() {
+"use strict";var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},e=function(){function i(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}return function(e,t,n){return t&&i(e.prototype,t),n&&i(e,n),e}}();function i(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var t=function(){function n(e,t){i(this,n),this.browser=e,this.config=t,this.options=this.browser.options,this.prefetched=new Set,this.eventTime=null,this.threshold=1111,this.numOnHover=0}return e(n,[{key:"init",value:function(){!this.browser.supportsLinkPrefetch()||this.browser.isDataSaverModeOn()||this.browser.isSlowConnection()||(this.regex={excludeUris:RegExp(this.config.excludeUris,"i"),images:RegExp(".("+this.config.imageExt+")$","i"),fileExt:RegExp(".("+this.config.fileExt+")$","i")},this._initListeners(this))}},{key:"_initListeners",value:function(e){-1<this.config.onHoverDelay&&document.addEventListener("mouseover",e.listener.bind(e),e.listenerOptions),document.addEventListener("mousedown",e.listener.bind(e),e.listenerOptions),document.addEventListener("touchstart",e.listener.bind(e),e.listenerOptions)}},{key:"listener",value:function(e){var t=e.target.closest("a"),n=this._prepareUrl(t);if(null!==n)switch(e.type){case"mousedown":case"touchstart":this._addPrefetchLink(n);break;case"mouseover":this._earlyPrefetch(t,n,"mouseout")}}},{key:"_earlyPrefetch",value:function(t,e,n){var i=this,r=setTimeout(function(){if(r=null,0===i.numOnHover)setTimeout(function(){return i.numOnHover=0},1e3);else if(i.numOnHover>i.config.rateThrottle)return;i.numOnHover++,i._addPrefetchLink(e)},this.config.onHoverDelay);t.addEventListener(n,function e(){t.removeEventListener(n,e,{passive:!0}),null!==r&&(clearTimeout(r),r=null)},{passive:!0})}},{key:"_addPrefetchLink",value:function(i){return this.prefetched.add(i.href),new Promise(function(e,t){var n=document.createElement("link");n.rel="prefetch",n.href=i.href,n.onload=e,n.onerror=t,document.head.appendChild(n)}).catch(function(){})}},{key:"_prepareUrl",value:function(e){if(null===e||"object"!==(void 0===e?"undefined":r(e))||!1 in e||-1===["http:","https:"].indexOf(e.protocol))return null;var t=e.href.substring(0,this.config.siteUrl.length),n=this._getPathname(e.href,t),i={original:e.href,protocol:e.protocol,origin:t,pathname:n,href:t+n};return this._isLinkOk(i)?i:null}},{key:"_getPathname",value:function(e,t){var n=t?e.substring(this.config.siteUrl.length):e;return n.startsWith("/")||(n="/"+n),this._shouldAddTrailingSlash(n)?n+"/":n}},{key:"_shouldAddTrailingSlash",value:function(e){return this.config.usesTrailingSlash&&!e.endsWith("/")&&!this.regex.fileExt.test(e)}},{key:"_isLinkOk",value:function(e){return null!==e&&"object"===(void 0===e?"undefined":r(e))&&(!this.prefetched.has(e.href)&&e.origin===this.config.siteUrl&&-1===e.href.indexOf("?")&&-1===e.href.indexOf("#")&&!this.regex.excludeUris.test(e.href)&&!this.regex.images.test(e.href))}}],[{key:"run",value:function(){"undefined"!=typeof RocketPreloadLinksConfig&&new n(new RocketBrowserCompatibilityChecker({capture:!0,passive:!0}),RocketPreloadLinksConfig).init()}}]),n}();t.run();
+}());
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads/admin/assets/js/advertisement.js?ver=1773428753" id="advanced-ads-find-adblocker-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro-main-js-extra">
+/* <![CDATA[ */
+var advanced_ads_cookies = {"cookie_path":"\/","cookie_domain":""};
+var advadsCfpInfo = {"cfpExpHours":"3","cfpClickLimit":"3","cfpBan":"7","cfpPath":"","cfpDomain":"www.velocidadcuchara.com","cfpEnabled":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/advanced-ads-pro.js?ver=1773428753" id="advanced-ads-pro-main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/js/postscribe.js?ver=1773428753" id="advanced-ads-pro/postscribe-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro/cache_busting-js-extra">
+/* <![CDATA[ */
+var advanced_ads_pro_ajax_object = {"ajax_url":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","lazy_load_module_enabled":"1","lazy_load":{"default_offset":0,"offsets":[]},"moveintohidden":"","wp_timezone_offset":"7200","the_id":"385","is_singular":"1"};
+var advanced_ads_responsive = {"reload_on_resize":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/front.js?ver=1773428753" id="advanced-ads-pro/cache_busting-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/comment-reply.min.js?ver=6.8.2" id="comment-reply-js" async="async" data-wp-strategy="async"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/imagesloaded.min.js?ver=5.0.0" id="imagesloaded-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/masonry.min.js?ver=4.2.2" id="masonry-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/min/plugins-min.js?ver=303" id="kadence_plugins-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/js/main.js?ver=1773428753" id="kadence_main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/hoverIntent.min.js?ver=1.10.2" id="hoverIntent-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="megamenu-js-extra">
+/* <![CDATA[ */
+var megamenu = {"timeout":"300","interval":"100"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/megamenu/js/maxmegamenu.js?ver=1773428753" id="megamenu-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="cmplz-cookiebanner-js-extra">
+/* <![CDATA[ */
+var complianz = {"prefix":"cmplz_","user_banner_id":"1","set_cookies":[],"block_ajax_content":"0","banner_version":"48","version":"7.5.6.1","store_consent":"1","do_not_track_enabled":"","consenttype":"optin","region":"eu","geoip":"1","dismiss_timeout":"","disable_cookiebanner":"","soft_cookiewall":"","dismiss_on_scroll":"","cookie_expiry":"365","url":"https:\/\/www.velocidadcuchara.com\/wp-json\/complianz\/v1\/","locale":"lang=es&locale=es_ES","set_cookies_on_root":"0","cookie_domain":"","current_policy_id":"44","cookie_path":"\/","categories":{"statistics":"estad\u00edsticas","marketing":"m\u00e1rketing"},"tcf_active":"1","placeholdertext":"Haz clic para aceptar {category} cookies y habilitar este contenido","css_file":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/css\/banner-{banner_id}-{type}.css?v=48","page_links":{"eu":{"cookie-statement":{"title":"Pol\u00edtica de cookies ","url":"https:\/\/www.velocidadcuchara.com\/politica-de-cookies-ue\/"},"privacy-statement":{"title":"Declaraci\u00f3n de privacidad ","url":"https:\/\/www.velocidadcuchara.com\/declaracion-de-privacidad-ue\/"}}},"tm_categories":"1","forceEnableStats":"","preview":"","clean_cookies":"","aria_label":"Haz clic para aceptar {category} cookies y habilitar este contenido","tcf_regions":["us","ca","eu","uk","au","za","br"]};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/cookiebanner/js/complianz.min.js?ver=1768420286" id="cmplz-cookiebanner-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="cmplz-cookiebanner-js-after">
+/* <![CDATA[ */
+	let cmplzBlockedContent = document.querySelector('.cmplz-blocked-content-notice');
+	if ( cmplzBlockedContent) {
+	        cmplzBlockedContent.addEventListener('click', function(event) {
+            event.stopPropagation();
+        });
+	}
+    
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1773428753" id="akismet-frontend-js"></script>
+<!-- Statistics script Complianz GDPR/CCPA -->
+						<script type="rocketlazyloadscript" data-category="functional">
+							(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MBHRNJL');
+
+const revokeListeners = [];
+window.addRevokeListener = (callback) => {
+	revokeListeners.push(callback);
+};
+document.addEventListener("cmplz_revoke", function (e) {
+	cmplz_set_cookie('cmplz_consent_mode', 'revoked', false );
+	revokeListeners.forEach((callback) => {
+		callback();
+	});
+});
+
+const consentListeners = [];
+/**
+ * Called from GTM template to set callback to be executed when user consent is provided.
+ * @param callback
+ */
+window.addConsentUpdateListener = (callback) => {
+	consentListeners.push(callback);
+};
+document.addEventListener("cmplz_fire_categories", function (e) {
+	var consentedCategories = e.detail.categories;
+	const consent = {
+		'security_storage': "granted",
+		'functionality_storage': "granted",
+		'personalization_storage':  cmplz_in_array( 'preferences', consentedCategories ) ? 'granted' : 'denied',
+		'analytics_storage':  cmplz_in_array( 'statistics', consentedCategories ) ? 'granted' : 'denied',
+		'ad_storage': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_user_data': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_personalization': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+	};
+
+	//don't use automatic prefixing, as the TM template needs to be sure it's cmplz_.
+	let consented = [];
+	for (const [key, value] of Object.entries(consent)) {
+		if (value === 'granted') {
+			consented.push(key);
+		}
+	}
+	cmplz_set_cookie('cmplz_consent_mode', consented.join(','), false );
+	consentListeners.forEach((callback) => {
+		callback(consent);
+	});
+});
+						</script><!--noptimize--><script type="rocketlazyloadscript">window.advads_admin_bar_items = [{"title":"ADS RECETA P\u00c1RRAFO 1","type":"ad","count":1},{"title":"Contenido","type":"placement","count":1},{"title":"PRP C&amp;J ESCRITORIO","type":"ad","count":1}];</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">window.advads_has_ads = [["45718","ad","ADS RECETA P\u00c1RRAFO 1","off"],["49235","ad","PRP C&J ESCRITORIO","off"]];
+( window.advanced_ads_ready || jQuery( document ).ready ).call( null, function() {if ( !window.advanced_ads_pro ) {console.log("Advanced Ads Pro: cache-busting can not be initialized");} });</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">!function(){window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[],advanced_ads_ready_queue.push=window.advanced_ads_ready;for(var d=0,a=advanced_ads_ready_queue.length;d<a;d++)advanced_ads_ready(advanced_ads_ready_queue[d])}();</script><!--/noptimize-->
+      <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        window._taboola = window._taboola || [];
+        _taboola.push({flush: true});
+      </script>
+
+  </body>
+</html>
+
+<!-- This website is like a Rocket, isn't it? Performance optimized by WP Rocket. Learn more: https://wp-rocket.me - Debug: cached@1776938829 -->

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_4.json
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_4.json
@@ -1,0 +1,33 @@
+{
+  "author": "Rosa Ardá",
+  "canonical_url": "https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/",
+  "site_name": "Velocidad Cuchara",
+  "host": "velocidadcuchara.com",
+  "language": "es",
+  "title": "Salsa cremosa de calabaza y curry",
+  "ingredients": [
+    "40 ml de aceite de oliva virgen extra",
+    "250 g de cebolla",
+    "400 g de calabaza troceada",
+    "Sal y pimienta al gusto",
+    "220 ml de leche de coco",
+    "2 cucharaditas de curry",
+    "Un puñado de anacardos"
+  ],
+  "instructions_list": [
+    "Pon el aceite y la cebolla en cuartos en el vaso y trocea 4 segundos velocidad 4. Sofríe 8-10 minutos, Varoma, velocidad cuchara -sin cubilete-.",
+    "Incorpora la calabaza, la sal y la pimienta y cocina 15 minutos, Varoma, velocidad cuchara -sin cubilete-.",
+    "Añade la leche de coco y el curry y cuece 5 minutos, Varoma, velocidad 2.",
+    "Cuando acabe el tiempo tritura 1 minuto en velocidad 5-10. Rectifica el punto de sal y usa sobre tu pasta junto con los anacardos."
+  ],
+  "category": "Pastas, Salsas",
+  "yields": "6 servings",
+  "description": "4 ingredientes para una salsa deliciosa. Apunta: cebolla, calabaza, leche de coco y curry. Añade la pasta que más te guste y a comer.",
+  "total_time": 35,
+  "cook_time": 30,
+  "prep_time": 5,
+  "cuisine": "Española",
+  "ratings": 5.0,
+  "ratings_count": 2,
+  "image": "https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-768x513.jpg"
+}

--- a/tests/test_data/velocidadcuchara.com/velocidadcuchara_4.testhtml
+++ b/tests/test_data/velocidadcuchara.com/velocidadcuchara_4.testhtml
@@ -1,0 +1,1811 @@
+<!DOCTYPE html>
+<html class="no-js" lang="es" itemscope="itemscope" itemtype="http://schema.org/WebPage">
+<head><meta charset="UTF-8"><script>if(navigator.userAgent.match(/MSIE|Internet Explorer/i)||navigator.userAgent.match(/Trident\/7\..*?rv:11/i)){var href=document.location.href;if(!href.match(/[?&]nowprocket/)){if(href.indexOf("?")==-1){if(href.indexOf("#")==-1){document.location.href=href+"?nowprocket=1"}else{document.location.href=href.replace("#","?nowprocket=1#")}}else{if(href.indexOf("#")==-1){document.location.href=href+"&nowprocket=1"}else{document.location.href=href.replace("#","&nowprocket=1#")}}}}</script><script>(()=>{class RocketLazyLoadScripts{constructor(){this.v="2.0.5",this.userEvents=["keydown","keyup","mousedown","mouseup","mousemove","mouseover","mouseout","touchmove","touchstart","touchend","touchcancel","wheel","click","dblclick","input"],this.attributeEvents=["onblur","onclick","oncontextmenu","ondblclick","onfocus","onmousedown","onmouseenter","onmouseleave","onmousemove","onmouseout","onmouseover","onmouseup","onmousewheel","onscroll","onsubmit"]}async t(){this.i(),this.o(),/iP(ad|hone)/.test(navigator.userAgent)&&this.h(),this.u(),this.l(this),this.m(),this.k(this),this.p(this),this._(),await Promise.all([this.R(),this.L()]),this.lastBreath=Date.now(),this.S(this),this.P(),this.D(),this.O(),this.M(),await this.C(this.delayedScripts.normal),await this.C(this.delayedScripts.defer),await this.C(this.delayedScripts.async),await this.T(),await this.F(),await this.j(),await this.A(),window.dispatchEvent(new Event("rocket-allScriptsLoaded")),this.everythingLoaded=!0,this.lastTouchEnd&&await new Promise(t=>setTimeout(t,500-Date.now()+this.lastTouchEnd)),this.I(),this.H(),this.U(),this.W()}i(){this.CSPIssue=sessionStorage.getItem("rocketCSPIssue"),document.addEventListener("securitypolicyviolation",t=>{this.CSPIssue||"script-src-elem"!==t.violatedDirective||"data"!==t.blockedURI||(this.CSPIssue=!0,sessionStorage.setItem("rocketCSPIssue",!0))},{isRocket:!0})}o(){window.addEventListener("pageshow",t=>{this.persisted=t.persisted,this.realWindowLoadedFired=!0},{isRocket:!0}),window.addEventListener("pagehide",()=>{this.onFirstUserAction=null},{isRocket:!0})}h(){let t;function e(e){t=e}window.addEventListener("touchstart",e,{isRocket:!0}),window.addEventListener("touchend",function i(o){o.changedTouches[0]&&t.changedTouches[0]&&Math.abs(o.changedTouches[0].pageX-t.changedTouches[0].pageX)<10&&Math.abs(o.changedTouches[0].pageY-t.changedTouches[0].pageY)<10&&o.timeStamp-t.timeStamp<200&&(window.removeEventListener("touchstart",e,{isRocket:!0}),window.removeEventListener("touchend",i,{isRocket:!0}),"INPUT"===o.target.tagName&&"text"===o.target.type||(o.target.dispatchEvent(new TouchEvent("touchend",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new MouseEvent("mouseover",{target:o.target,bubbles:!0})),o.target.dispatchEvent(new PointerEvent("click",{target:o.target,bubbles:!0,cancelable:!0,detail:1,clientX:o.changedTouches[0].clientX,clientY:o.changedTouches[0].clientY})),event.preventDefault()))},{isRocket:!0})}q(t){this.userActionTriggered||("mousemove"!==t.type||this.firstMousemoveIgnored?"keyup"===t.type||"mouseover"===t.type||"mouseout"===t.type||(this.userActionTriggered=!0,this.onFirstUserAction&&this.onFirstUserAction()):this.firstMousemoveIgnored=!0),"click"===t.type&&t.preventDefault(),t.stopPropagation(),t.stopImmediatePropagation(),"touchstart"===this.lastEvent&&"touchend"===t.type&&(this.lastTouchEnd=Date.now()),"click"===t.type&&(this.lastTouchEnd=0),this.lastEvent=t.type,t.composedPath&&t.composedPath()[0].getRootNode()instanceof ShadowRoot&&(t.rocketTarget=t.composedPath()[0]),this.savedUserEvents.push(t)}u(){this.savedUserEvents=[],this.userEventHandler=this.q.bind(this),this.userEvents.forEach(t=>window.addEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.addEventListener("visibilitychange",this.userEventHandler,{isRocket:!0})}U(){this.userEvents.forEach(t=>window.removeEventListener(t,this.userEventHandler,{passive:!1,isRocket:!0})),document.removeEventListener("visibilitychange",this.userEventHandler,{isRocket:!0}),this.savedUserEvents.forEach(t=>{(t.rocketTarget||t.target).dispatchEvent(new window[t.constructor.name](t.type,t))})}m(){const t="return false",e=Array.from(this.attributeEvents,t=>"data-rocket-"+t),i="["+this.attributeEvents.join("],[")+"]",o="[data-rocket-"+this.attributeEvents.join("],[data-rocket-")+"]",s=(e,i,o)=>{o&&o!==t&&(e.setAttribute("data-rocket-"+i,o),e["rocket"+i]=new Function("event",o),e.setAttribute(i,t))};new MutationObserver(t=>{for(const n of t)"attributes"===n.type&&(n.attributeName.startsWith("data-rocket-")||this.everythingLoaded?n.attributeName.startsWith("data-rocket-")&&this.everythingLoaded&&this.N(n.target,n.attributeName.substring(12)):s(n.target,n.attributeName,n.target.getAttribute(n.attributeName))),"childList"===n.type&&n.addedNodes.forEach(t=>{if(t.nodeType===Node.ELEMENT_NODE)if(this.everythingLoaded)for(const i of[t,...t.querySelectorAll(o)])for(const t of i.getAttributeNames())e.includes(t)&&this.N(i,t.substring(12));else for(const e of[t,...t.querySelectorAll(i)])for(const t of e.getAttributeNames())this.attributeEvents.includes(t)&&s(e,t,e.getAttribute(t))})}).observe(document,{subtree:!0,childList:!0,attributeFilter:[...this.attributeEvents,...e]})}I(){this.attributeEvents.forEach(t=>{document.querySelectorAll("[data-rocket-"+t+"]").forEach(e=>{this.N(e,t)})})}N(t,e){const i=t.getAttribute("data-rocket-"+e);i&&(t.setAttribute(e,i),t.removeAttribute("data-rocket-"+e))}k(t){Object.defineProperty(HTMLElement.prototype,"onclick",{get(){return this.rocketonclick||null},set(e){this.rocketonclick=e,this.setAttribute(t.everythingLoaded?"onclick":"data-rocket-onclick","this.rocketonclick(event)")}})}S(t){function e(e,i){let o=e[i];e[i]=null,Object.defineProperty(e,i,{get:()=>o,set(s){t.everythingLoaded?o=s:e["rocket"+i]=o=s}})}e(document,"onreadystatechange"),e(window,"onload"),e(window,"onpageshow");try{Object.defineProperty(document,"readyState",{get:()=>t.rocketReadyState,set(e){t.rocketReadyState=e},configurable:!0}),document.readyState="loading"}catch(t){console.log("WPRocket DJE readyState conflict, bypassing")}}l(t){this.originalAddEventListener=EventTarget.prototype.addEventListener,this.originalRemoveEventListener=EventTarget.prototype.removeEventListener,this.savedEventListeners=[],EventTarget.prototype.addEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalAddEventListener.call(this,e,i,o):(t.savedEventListeners.push({target:this,remove:!1,type:e,func:i,options:o}),"mouseenter"!==e&&"mouseleave"!==e||t.originalAddEventListener.call(this,e,t.savedUserEvents.push,o))},EventTarget.prototype.removeEventListener=function(e,i,o){o&&o.isRocket||!t.B(e,this)&&!t.userEvents.includes(e)||t.B(e,this)&&!t.userActionTriggered||e.startsWith("rocket-")||t.everythingLoaded?t.originalRemoveEventListener.call(this,e,i,o):t.savedEventListeners.push({target:this,remove:!0,type:e,func:i,options:o})}}J(t,e){this.savedEventListeners=this.savedEventListeners.filter(i=>{let o=i.type,s=i.target||window;return e!==o||t!==s||(this.B(o,s)&&(i.type="rocket-"+o),this.$(i),!1)})}H(){EventTarget.prototype.addEventListener=this.originalAddEventListener,EventTarget.prototype.removeEventListener=this.originalRemoveEventListener,this.savedEventListeners.forEach(t=>this.$(t))}$(t){t.remove?this.originalRemoveEventListener.call(t.target,t.type,t.func,t.options):this.originalAddEventListener.call(t.target,t.type,t.func,t.options)}p(t){let e;function i(e){return t.everythingLoaded?e:e.split(" ").map(t=>"load"===t||t.startsWith("load.")?"rocket-jquery-load":t).join(" ")}function o(o){function s(e){const s=o.fn[e];o.fn[e]=o.fn.init.prototype[e]=function(){return this[0]===window&&t.userActionTriggered&&("string"==typeof arguments[0]||arguments[0]instanceof String?arguments[0]=i(arguments[0]):"object"==typeof arguments[0]&&Object.keys(arguments[0]).forEach(t=>{const e=arguments[0][t];delete arguments[0][t],arguments[0][i(t)]=e})),s.apply(this,arguments),this}}if(o&&o.fn&&!t.allJQueries.includes(o)){const e={DOMContentLoaded:[],"rocket-DOMContentLoaded":[]};for(const t in e)document.addEventListener(t,()=>{e[t].forEach(t=>t())},{isRocket:!0});o.fn.ready=o.fn.init.prototype.ready=function(i){function s(){parseInt(o.fn.jquery)>2?setTimeout(()=>i.bind(document)(o)):i.bind(document)(o)}return"function"==typeof i&&(t.realDomReadyFired?!t.userActionTriggered||t.fauxDomReadyFired?s():e["rocket-DOMContentLoaded"].push(s):e.DOMContentLoaded.push(s)),this},s("on"),s("one"),s("off"),t.allJQueries.push(o)}e=o}t.allJQueries=[],o(window.jQuery),Object.defineProperty(window,"jQuery",{get:()=>e,set(t){o(t)}})}P(){const t=new Map;document.write=document.writeln=function(e){const i=document.currentScript,o=document.createRange(),s=i.parentElement;let n=t.get(i);void 0===n&&(n=i.nextSibling,t.set(i,n));const c=document.createDocumentFragment();o.setStart(c,0),c.appendChild(o.createContextualFragment(e)),s.insertBefore(c,n)}}async R(){return new Promise(t=>{this.userActionTriggered?t():this.onFirstUserAction=t})}async L(){return new Promise(t=>{document.addEventListener("DOMContentLoaded",()=>{this.realDomReadyFired=!0,t()},{isRocket:!0})})}async j(){return this.realWindowLoadedFired?Promise.resolve():new Promise(t=>{window.addEventListener("load",t,{isRocket:!0})})}M(){this.pendingScripts=[];this.scriptsMutationObserver=new MutationObserver(t=>{for(const e of t)e.addedNodes.forEach(t=>{"SCRIPT"!==t.tagName||!t.src||t.noModule||t.isWPRocket||this.pendingScripts.push({script:t,promise:new Promise(e=>{const i=()=>{const i=this.pendingScripts.findIndex(e=>e.script===t);i>=0&&this.pendingScripts.splice(i,1),e()};t.addEventListener("load",i,{isRocket:!0}),t.addEventListener("error",i,{isRocket:!0}),setTimeout(i,1e3)})})})}),this.scriptsMutationObserver.observe(document,{childList:!0,subtree:!0})}async F(){await this.X(),this.pendingScripts.length?(await this.pendingScripts[0].promise,await this.F()):this.scriptsMutationObserver.disconnect()}D(){this.delayedScripts={normal:[],async:[],defer:[]},document.querySelectorAll("script[type$=rocketlazyloadscript]").forEach(t=>{t.hasAttribute("data-rocket-src")?t.hasAttribute("async")&&!1!==t.async?this.delayedScripts.async.push(t):t.hasAttribute("defer")&&!1!==t.defer||"module"===t.getAttribute("data-rocket-type")?this.delayedScripts.defer.push(t):this.delayedScripts.normal.push(t):this.delayedScripts.normal.push(t)})}async _(){await this.L();let t=[];document.querySelectorAll("script[type$=rocketlazyloadscript][data-rocket-src]").forEach(e=>{let i=e.getAttribute("data-rocket-src");if(i&&!i.startsWith("data:")){i.startsWith("//")&&(i=location.protocol+i);try{const o=new URL(i).origin;o!==location.origin&&t.push({src:o,crossOrigin:e.crossOrigin||"module"===e.getAttribute("data-rocket-type")})}catch(t){}}}),t=[...new Map(t.map(t=>[JSON.stringify(t),t])).values()],this.Y(t,"preconnect")}async G(t){if(await this.K(),!0!==t.noModule||!("noModule"in HTMLScriptElement.prototype))return new Promise(e=>{let i;function o(){(i||t).setAttribute("data-rocket-status","executed"),e()}try{if(navigator.userAgent.includes("Firefox/")||""===navigator.vendor||this.CSPIssue)i=document.createElement("script"),[...t.attributes].forEach(t=>{let e=t.nodeName;"type"!==e&&("data-rocket-type"===e&&(e="type"),"data-rocket-src"===e&&(e="src"),i.setAttribute(e,t.nodeValue))}),t.text&&(i.text=t.text),t.nonce&&(i.nonce=t.nonce),i.hasAttribute("src")?(i.addEventListener("load",o,{isRocket:!0}),i.addEventListener("error",()=>{i.setAttribute("data-rocket-status","failed-network"),e()},{isRocket:!0}),setTimeout(()=>{i.isConnected||e()},1)):(i.text=t.text,o()),i.isWPRocket=!0,t.parentNode.replaceChild(i,t);else{const i=t.getAttribute("data-rocket-type"),s=t.getAttribute("data-rocket-src");i?(t.type=i,t.removeAttribute("data-rocket-type")):t.removeAttribute("type"),t.addEventListener("load",o,{isRocket:!0}),t.addEventListener("error",i=>{this.CSPIssue&&i.target.src.startsWith("data:")?(console.log("WPRocket: CSP fallback activated"),t.removeAttribute("src"),this.G(t).then(e)):(t.setAttribute("data-rocket-status","failed-network"),e())},{isRocket:!0}),s?(t.fetchPriority="high",t.removeAttribute("data-rocket-src"),t.src=s):t.src="data:text/javascript;base64,"+window.btoa(unescape(encodeURIComponent(t.text)))}}catch(i){t.setAttribute("data-rocket-status","failed-transform"),e()}});t.setAttribute("data-rocket-status","skipped")}async C(t){const e=t.shift();return e?(e.isConnected&&await this.G(e),this.C(t)):Promise.resolve()}O(){this.Y([...this.delayedScripts.normal,...this.delayedScripts.defer,...this.delayedScripts.async],"preload")}Y(t,e){this.trash=this.trash||[];let i=!0;var o=document.createDocumentFragment();t.forEach(t=>{const s=t.getAttribute&&t.getAttribute("data-rocket-src")||t.src;if(s&&!s.startsWith("data:")){const n=document.createElement("link");n.href=s,n.rel=e,"preconnect"!==e&&(n.as="script",n.fetchPriority=i?"high":"low"),t.getAttribute&&"module"===t.getAttribute("data-rocket-type")&&(n.crossOrigin=!0),t.crossOrigin&&(n.crossOrigin=t.crossOrigin),t.integrity&&(n.integrity=t.integrity),t.nonce&&(n.nonce=t.nonce),o.appendChild(n),this.trash.push(n),i=!1}}),document.head.appendChild(o)}W(){this.trash.forEach(t=>t.remove())}async T(){try{document.readyState="interactive"}catch(t){}this.fauxDomReadyFired=!0;try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(document,"DOMContentLoaded"),document.dispatchEvent(new Event("rocket-DOMContentLoaded")),await this.K(),this.J(window,"DOMContentLoaded"),window.dispatchEvent(new Event("rocket-DOMContentLoaded"))}catch(t){console.error(t)}}async A(){try{document.readyState="complete"}catch(t){}try{await this.K(),this.J(document,"readystatechange"),document.dispatchEvent(new Event("rocket-readystatechange")),await this.K(),document.rocketonreadystatechange&&document.rocketonreadystatechange(),await this.K(),this.J(window,"load"),window.dispatchEvent(new Event("rocket-load")),await this.K(),window.rocketonload&&window.rocketonload(),await this.K(),this.allJQueries.forEach(t=>t(window).trigger("rocket-jquery-load")),await this.K(),this.J(window,"pageshow");const t=new Event("rocket-pageshow");t.persisted=this.persisted,window.dispatchEvent(t),await this.K(),window.rocketonpageshow&&window.rocketonpageshow({persisted:this.persisted})}catch(t){console.error(t)}}async K(){Date.now()-this.lastBreath>45&&(await this.X(),this.lastBreath=Date.now())}async X(){return document.hidden?new Promise(t=>setTimeout(t)):new Promise(t=>requestAnimationFrame(t))}B(t,e=window){return e===document&&"readystatechange"===t||(e===document&&"DOMContentLoaded"===t||(e===window&&"DOMContentLoaded"===t||(e===window&&"load"===t||e===window&&"pageshow"===t)))}static run(){(new RocketLazyLoadScripts).t()}}RocketLazyLoadScripts.run()})();
+</script>
+
+<!--
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-++-+
+	|v|e|l|o|c|i|d|a|d| |c|u|c|h|a|r|a|
+	+-+-+-+-+-+-+-+-+-+ +-+-++-+-+-+ +- -->
+
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="copyright" content="Velocidad Cuchara"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta property="fb:pages" content="117162944985048" />
+  <link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &#8211; El primer blog de recetas para Thermomix RSS Feed" href="https://www.velocidadcuchara.com/feed/" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+  <link rel="manifest" href="/site.webmanifest">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000">
+  <meta name="msapplication-TileColor" content="#da532c">
+  <meta name="theme-color" content="#ffffff">
+  <link rel="sitemap" href="https://www.velocidadcuchara.com/sitemap.xml" />
+  <link href="https://fonts.googleapis.com/css?family=Kaushan+Script" rel="stylesheet">
+
+  <meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+	
+	<!-- This site is optimized with the Yoast SEO plugin v27.0 - https://yoast.com/product/yoast-seo-wordpress/ -->
+	<title>Salsa cremosa de calabaza y curry | Velocidad Cuchara</title>
+<link data-rocket-prefetch href="https://pagead2.googlesyndication.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://sdk.mrf.io" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://www.googletagmanager.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://estadisticas.mediasector.es" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://fonts.googleapis.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://static.addtoany.com" rel="dns-prefetch">
+<link data-rocket-prefetch href="https://ep2.adtrafficquality.google" rel="dns-prefetch"><link rel="preload" data-rocket-preload as="image" imagesrcset="https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22.jpg.webp 1200w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-300x200.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-1024x684.jpg.webp 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-768x513.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-560x374.jpg.webp 560w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-272x182.jpg.webp 272w" imagesizes="(max-width: 1200px) 100vw, 1200px" fetchpriority="high">
+	<meta name="description" content="4 ingredientes para una salsa deliciosa. Apunta: cebolla, calabaza, leche de coco y curry. Añade la pasta que más te guste y a comer." />
+	<link rel="canonical" href="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/" />
+	<meta property="og:locale" content="es_ES" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Salsa cremosa de calabaza y curry | Velocidad Cuchara" />
+	<meta property="og:description" content="4 ingredientes para una salsa deliciosa. Apunta: cebolla, calabaza, leche de coco y curry. Añade la pasta que más te guste y a comer." />
+	<meta property="og:url" content="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/" />
+	<meta property="og:site_name" content="Velocidad Cuchara" />
+	<meta property="article:publisher" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:author" content="http://www.facebook.com/velocidadcuchara" />
+	<meta property="article:published_time" content="2022-11-24T10:31:56+00:00" />
+	<meta property="article:modified_time" content="2022-12-09T20:40:21+00:00" />
+	<meta property="og:image" content="https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-768x513.jpg" />
+	<meta property="og:image:width" content="768" />
+	<meta property="og:image:height" content="513" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="author" content="Rosa Ardá" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:creator" content="@rosaarda" />
+	<meta name="twitter:site" content="@rosaarda" />
+	<meta name="twitter:label1" content="Escrito por" />
+	<meta name="twitter:data1" content="Rosa Ardá" />
+	<meta name="twitter:label2" content="Tiempo de lectura" />
+	<meta name="twitter:data2" content="4 minutos" />
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//static.addtoany.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed" href="https://www.velocidadcuchara.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Feed de los comentarios" href="https://www.velocidadcuchara.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Velocidad Cuchara &raquo; Comentario Salsa cremosa de calabaza y curry del feed" href="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/feed/" />
+<link rel="shortcut icon" type="image/x-icon" href="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/favicon.png" /><!-- www.velocidadcuchara.com is managing ads with Advanced Ads 2.0.17 – https://wpadvancedads.com/ --><!--noptimize--><script type="rocketlazyloadscript" id="local-ready">
+			window.advanced_ads_ready=function(e,a){a=a||"complete";var d=function(e){return"interactive"===a?"loading"!==e:"complete"===e};d(document.readyState)?e():document.addEventListener("readystatechange",(function(a){d(a.target.readyState)&&e()}),{once:"interactive"===a})},window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[];		</script>
+		<!--/noptimize--><style id='wp-emoji-styles-inline-css' type='text/css'>
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.velocidadcuchara.com/wp-includes/css/dist/block-library/style.min.css?ver=6.8.2' type='text/css' media='all' />
+<style id='classic-theme-styles-inline-css' type='text/css'>
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+</style>
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);}:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+:where(.wp-block-post-template.is-layout-flex){gap: 1.25em;}:where(.wp-block-post-template.is-layout-grid){gap: 1.25em;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
+:root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
+</style>
+<link data-minify="1" rel='stylesheet' id='mostrar-comentarios-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='post_grid_style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-new.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='owl.carousel-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/owl.carousel.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='font-awesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/font-awesome.min.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style-woocommerce-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/css/style-woocommerce.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.skins-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.skins.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='style.layout-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/global/css/style.layout.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-17bc2272b535-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-17bc2272b535.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-654ee1169f99-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-654ee1169f99.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-b136017e055b-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-b136017e055b.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-7877d6771435-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-7877d6771435.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-image-default-d6014b76747a-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-image-default-d6014b76747a.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-base-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/widgets/button/css/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-a0517016730c-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-a0517016730c.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-button-flat-b763d6af42b8-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-button-flat-b763d6af42b8.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wpos-slick-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/slick.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='wtpsw-public-style-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/css/wtpsw-public.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='cmplz-general-css' href='https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/assets/css/cookieblocker.min.css?ver=1768420286' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='megamenu-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/maxmegamenu/style.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='dashicons-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-includes/css/dashicons.min.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='easyrecipestyle-reset-css' href='https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/css/easyrecipe-style-reset-min.css?ver=3.5.3251' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipebuttonUI-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/ui/easyrecipe-buttonUI.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='easyrecipestyle-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/easyrecipeplus/styles/style002a/style.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='addtoany-css' href='https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.css?ver=1.16' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='kadence_theme-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/virtue.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='virtue_skin-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/css/skins/default.css?ver=1773428753' type='text/css' media='all' />
+<link rel='stylesheet' id='virtue_child-css' href='https://www.velocidadcuchara.com/wp-content/themes/velocidad/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='redux-google-fonts-virtue-css' href='https://fonts.googleapis.com/css?family=Lato%3A400%2C700%7CJosefin+Sans%3A400%2C600%2C300%7COpen+Sans%3A300%2C400%2C600%2C700%2C800%2C300italic%2C400italic%2C600italic%2C700italic%2C800italic&#038;subset=latin-ext&#038;ver=1774857236' type='text/css' media='all' />
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf-stub/build/index.js?ver=1773428753" id="cmplz-tcf-stub-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/vendor/DOMPurify/DOMPurify.min.js?ver=2.5.8" id="bodhi-dompurify-library-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="addtoany-core-js-before">
+/* <![CDATA[ */
+window.a2a_config=window.a2a_config||{};a2a_config.callbacks=[];a2a_config.overlays=[];a2a_config.templates={};a2a_localize = {
+	Share: "Compartir",
+	Save: "Guardar",
+	Subscribe: "Suscribir",
+	Email: "Correo electrónico",
+	Bookmark: "Marcador",
+	ShowAll: "Mostrar todo",
+	ShowLess: "Mostrar menos",
+	FindServices: "Encontrar servicio(s)",
+	FindAnyServiceToAddTo: "Encuentra al instante cualquier servicio para añadir a",
+	PoweredBy: "Funciona con",
+	ShareViaEmail: "Compartir por correo electrónico",
+	SubscribeViaEmail: "Suscribirse a través de correo electrónico",
+	BookmarkInYourBrowser: "Añadir a marcadores de tu navegador",
+	BookmarkInstructions: "Presiona «Ctrl+D» o «\u2318+D» para añadir esta página a marcadores",
+	AddToYourFavorites: "Añadir a tus favoritos",
+	SendFromWebOrProgram: "Enviar desde cualquier dirección o programa de correo electrónico ",
+	EmailProgram: "Programa de correo electrónico",
+	More: "Más&#8230;",
+	ThanksForSharing: "¡Gracias por compartir!",
+	ThanksForFollowing: "¡Gracias por seguirnos!"
+};
+
+a2a_config.icon_color = "#bdbeb2";
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://static.addtoany.com/menu/page.js" id="addtoany-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" defer data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/add-to-any/addtoany.min.js?ver=1.1" id="addtoany-jquery-js"></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/mostrar-comentarios/mostrar-comentarios.js?ver=1773428753" id="mostrar-comentarios-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="post_grid_scripts-js-extra">
+/* <![CDATA[ */
+var post_grid_ajax = {"post_grid_ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/scripts.js?ver=1773428753" id="post_grid_scripts-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/masonry.pkgd.min.js?ver=6.8.2" id="masonry.pkgd.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/post-grid/assets/frontend/js/owl.carousel.min.js?ver=6.8.2" id="owl.carousel.min-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/post-grid/assets/frontend/js/imagesloaded.pkgd.js?ver=1773428753" id="imagesloaded.pkgd.js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="bodhi_svg_inline-js-extra">
+/* <![CDATA[ */
+var svgSettings = {"skipNested":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/svg-support/js/min/svgs-inline-min.js" id="bodhi_svg_inline-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="bodhi_svg_inline-js-after">
+/* <![CDATA[ */
+cssTarget={"Bodhi":"img.style-svg","ForceInlineSVG":"style-svg"};ForceInlineSVGActive="false";frontSanitizationEnabled="on";
+/* ]]> */
+</script>
+<script type="text/javascript" id="cmplz-tcf-js-extra">
+/* <![CDATA[ */
+var cmplz_tcf = {"cmp_url":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/","retention_string":"Retenci\u00f3n en d\u00edas","undeclared_string":"No declarado","isServiceSpecific":"1","excludedVendors":{"15":15,"66":66,"119":119,"139":139,"141":141,"174":174,"192":192,"262":262,"375":375,"377":377,"387":387,"427":427,"435":435,"512":512,"527":527,"569":569,"581":581,"587":587,"626":626,"644":644,"667":667,"713":713,"733":733,"736":736,"748":748,"776":776,"806":806,"822":822,"830":830,"836":836,"856":856,"879":879,"882":882,"888":888,"909":909,"970":970,"986":986,"1015":1015,"1018":1018,"1022":1022,"1039":1039,"1078":1078,"1079":1079,"1094":1094,"1149":1149,"1156":1156,"1167":1167,"1173":1173,"1199":1199,"1211":1211,"1216":1216,"1252":1252,"1263":1263,"1298":1298,"1305":1305,"1342":1342,"1343":1343,"1355":1355,"1365":1365,"1366":1366,"1368":1368,"1371":1371,"1373":1373,"1391":1391,"1405":1405,"1418":1418,"1423":1423,"1425":1425,"1440":1440,"1442":1442,"1482":1482,"1492":1492,"1496":1496,"1503":1503,"1508":1508,"1509":1509,"1510":1510,"1519":1519,"1529":1529,"1537":1537,"1541":1541,"1549":1549,"1550":1550,"1558":1558,"1564":1564,"1579":1579,"1580":1580},"purposes":[1,2,3,4,5,6,7,8,9,10],"specialPurposes":[1,2,3],"features":[1,2],"specialFeatures":[],"publisherCountryCode":"ES","lspact":"N","ccpa_applies":"","ac_mode":"1","debug":"","prefix":"cmplz_"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/complianz-gdpr-premium/pro/tcf/build/index.js?ver=1773428753" id="cmplz-tcf-js"></script>
+<script type="text/javascript" id="advanced-ads-advanced-js-js-extra">
+/* <![CDATA[ */
+var advads_options = {"blog_id":"1","privacy":{"enabled":true,"custom-cookie-name":"euconsent-v2","custom-cookie-value":"CO49HGNO49HGNAKALAESA1CsAP_AAH_AAAiQGatd_X9fb2vj-_5999t0eY1f9_63v-wzjgeNs-8NyZ_X_L4Xr2MyvB36pq4KmR4Eu3LBAQFlHOHcTQmQwIkVqTLsbk2Mq7NKJ7LEilMbM2dYGG9Pn8XTuZCY70_sf__z_3-_-___67bgYIQSYKl4BAkJYQEk2aUQogAhHEBUA4AKCEICBSw0ABATsCgI9QAAAEBgABAAAACCCAgEAAAAASEQAAACAgEABEAgABACNAQgAIkAAWAEgQBAAKAaEgBFEEIAhBgYBRygBAUAAAAA.fmAAAAAAAAAA","consent-method":"iab_tcf_20","state":"unknown"}};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/advanced-ads/public/assets/js/advanced.min.js?ver=2.0.17" id="advanced-ads-advanced-js-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="utils-js-extra">
+/* <![CDATA[ */
+var userSettings = {"url":"\/","uid":"0","time":"1776938643","secure":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/utils.min.js?ver=6.8.2" id="utils-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/controlgroup.min.js?ver=1.13.3" id="jquery-ui-controlgroup-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/checkboxradio.min.js?ver=1.13.3" id="jquery-ui-checkboxradio-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/jquery/ui/button.min.js?ver=1.13.3" id="jquery-ui-button-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/easyrecipeplus/js/easyrecipe-min.js?ver=3.5.3251" id="EasyRecipePlus-js" data-rocket-defer defer></script>
+<link rel="https://api.w.org/" href="https://www.velocidadcuchara.com/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://www.velocidadcuchara.com/wp-json/wp/v2/posts/59817" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.velocidadcuchara.com/xmlrpc.php?rsd" />
+<meta name="generator" content="WordPress 6.8.2" />
+<link rel='shortlink' href='https://www.velocidadcuchara.com/?p=59817' />
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-cremosa-de-calabaza-y-curry%2F" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.velocidadcuchara.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-cremosa-de-calabaza-y-curry%2F&#038;format=xml" />
+			<style>.cmplz-hidden {
+					display: none !important;
+				}</style><style type="text/css">#logo {padding-top:20px;}#logo {padding-bottom:20px;}#logo {margin-left:0px;}#logo {margin-right:0px;}#nav-main {margin-top:25px;}#nav-main {margin-bottom:10px;}.headerfont, .tp-caption {font-family:Josefin Sans;} 
+  .topbarmenu ul li {font-family:Josefin Sans;}
+  #kadbreadcrumbs {font-family:Open Sans;}.home-message:hover {background-color:#8faa8f; background-color: rgba(143, 170, 143, 0.6);}
+  nav.woocommerce-pagination ul li a:hover, .wp-pagenavi a:hover, .panel-heading .accordion-toggle, .variations .kad_radio_variations label:hover, .variations .kad_radio_variations label.selectedValue {border-color: #8faa8f;}
+  a, #nav-main ul.sf-menu ul li a:hover, .product_price ins .amount, .price ins .amount, .color_primary, .primary-color, #logo a.brand, #nav-main ul.sf-menu a:hover,
+  .woocommerce-message:before, .woocommerce-info:before, #nav-second ul.sf-menu a:hover, .footerclass a:hover, .posttags a:hover, .subhead a:hover, .nav-trigger-case:hover .kad-menu-name, 
+  .nav-trigger-case:hover .kad-navbtn, #kadbreadcrumbs a:hover, #wp-calendar a, .star-rating {color: #8faa8f;}
+.widget_price_filter .ui-slider .ui-slider-handle, .product_item .kad_add_to_cart:hover, .product_item:hover a.button:hover, .product_item:hover .kad_add_to_cart:hover, .kad-btn-primary, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li a:hover, html .woocommerce-page .widget_layered_nav ul.yith-wcan-label li.chosen a,
+.product-category.grid_item a:hover h5, .woocommerce-message .button, .widget_layered_nav_filters ul li a, .widget_layered_nav ul li.chosen a, .wpcf7 input.wpcf7-submit, .yith-wcan .yith-wcan-reset-navigation,
+#containerfooter .menu li a:hover, .bg_primary, .portfolionav a:hover, .home-iconmenu a:hover, p.demo_store, .topclass, #commentform .form-submit #submit, .kad-hover-bg-primary:hover, .widget_shopping_cart_content .checkout,
+.login .form-row .button, .variations .kad_radio_variations label.selectedValue, #payment #place_order, .wpcf7 input.wpcf7-back, .shop_table .actions input[type=submit].checkout-button, .cart_totals .checkout-button, input[type="submit"].button, .order-actions .button  {background: #8faa8f;}a:hover {color: #b7bfaf;} .kad-btn-primary:hover, .login .form-row .button:hover, #payment #place_order:hover, .yith-wcan .yith-wcan-reset-navigation:hover, .widget_shopping_cart_content .checkout:hover,
+.woocommerce-message .button:hover, #commentform .form-submit #submit:hover, .wpcf7 input.wpcf7-submit:hover, .widget_layered_nav_filters ul li a:hover, .cart_totals .checkout-button:hover,
+.widget_layered_nav ul li.chosen a:hover, .shop_table .actions input[type=submit].checkout-button:hover, .wpcf7 input.wpcf7-back:hover, .order-actions .button:hover, input[type="submit"].button:hover, .product_item:hover .kad_add_to_cart, .product_item:hover a.button {background: #b7bfaf;}input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; } input[type=number] {-moz-appearance: textfield;}.quantity input::-webkit-outer-spin-button,.quantity input::-webkit-inner-spin-button {display: none;}#containerfooter h3, #containerfooter, .footercredits p, .footerclass a, .footernav ul li a {color:#c6c6c6;}.topclass {background:transparent    ;}.navclass {background:#23282d    ;}.mobileclass {background:#23282d    ;}.footerclass {background:#23282d    ;}.product_item .product_details h5 {text-transform: none;} @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {#logo .kad-standard-logo {display: none;} #logo .kad-retina-logo {display: block;}}.product_item .product_details h5 {min-height:40px;}[class*="wp-image"] {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}[class*="wp-image"]:hover {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;border:none;}.light-dropshaddow {-webkit-box-shadow: none;-moz-box-shadow: none;box-shadow: none;}/*::::::::::::::::::::::::::::::::::::::::: PÁGINA LIBRO VC ::::::::::::::::::::::::::::::::::*/
+
+#textolibrovc {
+    font-family: "Open Sans";
+    line-height: 28px;
+    font-weight: 400;
+    font-style: normal;
+    font-size: 20px;
+}
+
+#titulibrovc {
+    font-family: "Josefin Sans";
+    line-height: 40px;
+    font-weight: 600;
+    font-style: normal;
+    font-size: 30px;
+}
+
+.page-id-56361 .titleclass { background-color: #c08993; } 
+.page-id-58566 .titleclass { background-color: #757575; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO PODCAST ::::::::::::::::::::::::::::::::::*/
+
+.page-id-59933 .titleclass { 
+background-image: url("https://velocidadcuchara.com/recursos/fondo_cabecera_pvc.png");
+margin-top: -15px; 
+background-color: #ad6b77; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+
+/*::::::::::::::::::::::::::::::::::::::::: FONDO RADIO  ::::::::::::::::::::::::::::::::::*/
+    
+.page-id-57235 .titleclass { 
+background-color: #2d2f39; 
+;} 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESTILOS RELACIONADOS ::::::::::::::::::::::::::::::::::*/
+
+.bcarousellink>header>h5 {
+    padding: 0;
+    margin: 0;
+font-size:18px;
+font-weight: bold;
+}
+
+.bcarousellink>header .subhead {
+    text-align: right;
+display:none;
+}
+
+.post-grid .item .layer-media img {
+    border-radius: 50;
+    box-shadow: none;
+    width: 100%;
+    border-radius: 15px;
+}
+
+
+/*::::::::::::::::::::::::::::::::::::::::: CASILLA RGPD COMENTARIOS ::::::::::::::::::::::::::::::::::*/
+
+#commentform input {
+    display: inline-grid;
+}
+
+/*:::::::::::::::::::::::::::::::::::::::::  ELIMINAR ADMIN BAR WP ::::::::::::::::::::::::::::::::::*/
+
+#wpadminbar { display:none; }
+
+/*::::::::::::::::::::::::::::::::::::::::: CABECERA 10 ANIVERSARIO ::::::::::::::::::::::::::::::::::*/
+
+#thelogo .kad-standard-logo  {max-height: 100%}
+#thelogo .kad-retina-logo  {max-height: 100%}
+
+@media (min-width: 1024px) {NAV
+    #thelogo { width: 120%}
+}
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL HALLOWEEN ::::::::::::::::::::::::::::::::::*/
+
+.page-id-7832 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/10/fondo_cabecera_halloween_trans.png");
+    margin-top: -15px; background-color: #363636; background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-7832 .page-header .entry-title {  color: #ffa200; } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CABECERA ::::::::::::::::::::::::::::::::::*/
+
+.page-id-8160 .titleclass { 
+background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; 
+background-color: #F3F3F3; 
+background-repeat: no-repeat;
+}{display:none;} 
+
+.page-id-8160 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700;} 
+
+.page-id-8160 .page-header > p {
+    color: #aa0000 } 
+
+.page-id-8160 .sidebar a {
+    color: #aa0000 } 
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-781 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+
+.category-781 .page-header .entry-title { 
+font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+
+.category-781 .page-header > p {
+    color: #aa0000 } 
+.category-781 .sidebar a {
+    color: #aa0000 } 
+
+.category-778 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-778 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-778 .page-header > p {
+    color: #aa0000 } 
+.category-778 .sidebar a {
+    color: #aa0000 } 
+
+.category-779 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-779 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-779 .page-header > p {
+    color: #aa0000 } 
+.category-779 .sidebar a {
+    color: #aa0000 } 
+
+.category-780 .titleclass { background-image: url("https://www.velocidadcuchara.com/wp-content/uploads/2017/11/cabecera_Estrellas_ok.png");
+    margin-top: -15px; background-color: #F3F3F3; background-repeat: no-repeat;
+}{display:none;} 
+.category-780 .page-header .entry-title { font-family: 'Josefin Sans'; color: #aa0000; text-transform: uppercase; font-size: 250%; font-weight: 700; } 
+.category-780 .page-header > p {
+    color: #aa0000 }
+.category-780 .sidebar a {
+    color: #aa0000 }  
+
+/*::::::::::::::::::::::::::::::::::::::::: ESPECIAL SSANTA CAB CATEGORIAS ::::::::::::::::::::::::::::::::::*/
+
+.category-121 .titleclass { background-color: #444560; } 
+
+/*:::::::::::::::::::::::::::::::::::::::::GENERAL ::::::::::::::::::::::::::::::::::*/
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+/*TOPBAR */
+
+/*iconos redes */
+.so-widget-sow-social-media-buttons .sow-social-media-button {
+padding:0.2em !important;}
+
+/* color del buscador textos y labels*/
+#topbar .form-search {border: 1px solid #000;}
+#topbar .form-search .search-icon {color: #000;}
+#topbar .form-search input[type="text"] {color: #000;}
+#topbar .topbar-widget {color: #000;}
+#topbar .form-search input[type="text"]::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]::-moz-placeholder { /* Firefox 19+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-ms-input-placeholder { /* IE 10+ */
+  color: #bdbeb2;}
+#topbar .form-search input[type="text"]:-moz-placeholder { /* Firefox 18- */
+  color: #bdbeb2;
+}
+
+/*MENU FIJO PRINCIPAL*/
+.navclass.stickytop {
+   z-index: 9999; 
+   position: fixed; 
+   left: 0; 
+   top: 0; 
+   width: 100%
+}
+
+/*BREADCRUMBS*/
+#breadcrumbs {
+    color: #f2f2f2;
+    font-size: 0.8em;
+}
+#breadcrumbs a {
+    color: #f1f1f1;
+    text-decoration: underline;
+}
+
+/* margen superior de la página de resultado de búsquedas*/
+.search-results .wrap.contentclass .main.col-lg-9.col-md-8.postlist {
+ 	margin-top: 50px;
+}
+/* margen superior de página "estilo" blog*/
+.page-template-page-blog .main.col-lg-9.col-md-8.postlist {
+    margin-top: 50px;
+}
+
+/* etiqueta "publicidad" bloques de publicidad*/
+.local-adlabel {
+    color: #bdbeb2;
+    font-size: 14px;
+    font-style: italic;
+   text-align:center;
+}
+
+/* :::::::::::::::::::::::::::: HEADER ::::::::::::::::::::::::::::::: */
+/*tag line*/
+.kad_tagline {
+ margin-top: 20px;
+    padding-left: 0.1em;
+}
+
+/*títulos páginas*/
+.page-header{
+border-top: 0 solid rgba(0, 0, 0, 0);
+border-bottom: 0 solid rgba(0, 0, 0, 0);
+margin-bottom:0;
+}
+.titleclass {
+    background-color: #bdbeb2;
+margin-top:-15px;
+}
+.page-header .entry-title {
+padding:0.5em;
+text-transform: uppercase;
+color:#fff;
+}
+
+/*titulos páginas - visión móvil*/
+@media (max-width: 768px){
+.page-header {text-align:center;
+}
+}
+
+/* textos descripción categorias*/
+
+/* Menú principal*/
+#nav-second ul.sf-menu .menu-inicio.current-menu-item > a{
+   background-color: #fff;
+    color: #d36a5f ;
+}
+
+/* :::::: COLUMNA ::::: SIDEBAR :::::: */
+.sidebar .menu{
+font-family: "Josefin Sans";
+font-weight:600;
+margin-top: 30px;
+text-transform:uppercase;
+}
+.sidebar .widget-inner li {
+    border-bottom: 1px solid rgba(189, 190, 178, 0.5);
+    line-height: 40px;
+   }
+
+.sidebar .widget-title {
+    text-align: center;
+}
+
+/* títulos enlaces de videos en sidebar columna*/
+
+.titulovideo h3 { font-family:"Open Sans";
+font-size: 1em; 
+font-weight:600;
+text-align: center;
+
+}
+
+.sidebar .widget-inner .so-widget-sow-image > h3 {
+    text-align: center;
+}
+
+.so-widget-image {
+    border-radius: 15px;
+}
+
+/* botón suscripción*/
+#submitbox input[type="submit"] {
+    background-color: #bdbeb2;
+    color: #fff;
+    font-size: 0.9em;
+    font-style: italic;
+}
+
+/* Tïtulos de "Los más leídos"*/
+.wtpsw-post-thumb-right {
+    display: table-cell;
+    vertical-align: middle;
+}
+.wtpsw-post-thumb-right h6 a.wtpsw-post-title {
+    color: #555;
+    font-family: "Josefin Sans";
+    font-size: 1.3em;
+    line-height: 1.4em;
+    text-transform: uppercase;
+}
+
+/* fondo y bordes "Los más leídos"*/
+.wtpsw-post-items {
+    background-color: #e7e8e1;
+    border-radius: 12px;
+    padding-right: 0.5em;
+}
+
+/* botones categorías blog Te Cuento*/
+.sidebar .widget_sow-button {
+margin-bottom:-20px;
+}
+
+
+
+/*::::::::::::::::::::::::: POST GRID en páginas internas :::::::::::::::::::::::::::*/
+.post-grid .item {
+border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+/* navegadores entre páginas <<    >>*/
+.pagination.dark br {
+    display: none;
+}
+
+/* botones números  paginación */
+
+.post-grid .pagination.dark .page-numbers {
+color:#8faa8f;
+font-weight:700;
+margin:5px;
+background:#fff none repeat scroll 0 0;
+border: 2px solid rgba(0, 0, 0, 0.05);
+padding: 4px 10px;
+line-height: 37px;
+transition: border 0.2s ease-in-out 0s;
+
+}
+
+.post-grid .pagination.dark .page-numbers:hover{
+background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+border-color:#b7bfaf;
+}
+.post-grid .pagination.dark .current {
+    color:#222222;
+    background: rgba(0, 0, 0, 0.05) none repeat scroll 0 0;
+   border: 2px solid rgba(0, 0, 0, 0.05) !important;
+
+}
+
+
+/* mensaje de ERROR 404*/
+.alert {text-align:center; margin-top:50px;}
+.onomatopeya { font-size:2.5em; font-family:"Josefin Sans"; font-weight:600;}
+.error{font-size:1.6em; font-weight:300; line-height:1.3em;}
+
+.alert .form-search {
+margin-bottom:10px;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 303px;
+}
+
+
+/*:::::::::::::::::::::::::::::::::::::::::HOME:::::::::::::::::::::::::::::::::::::::*/
+
+.home-padding {
+padding-top:0;
+}
+.hometitle{
+padding-bottom:15px;
+}
+
+/*slide textos*/
+
+.kt-full-slider .flex-caption-case .captiontitle {
+    background: #c08993b0;
+    padding-top: 15px;
+    color: #ffffff;
+    font-size: 40px;
+    text-transform: uppercase;
+    text-shadow: 1px 1px 4px rgba(0, 0, 0, 0);
+    font-weight: 700;
+    letter-spacing: -1.5px;
+}
+
+.kt-full-slider .flex-caption-case .captiontext {
+    background: #ffffffc2;
+    color: #444;
+    text-shadow: 1px 1px 4px #eee;
+    font-size: 35px;
+    font-weight: 300;
+    letter-spacing: -2px;
+
+}
+
+/* receta principal destacada ocultar foto destacada */
+#post-grid-44850 .item .layer-media img {
+display:none;}
+
+/* receta principal destacada quitar borde recuadro*/
+#post-grid-44850 .item {
+border:none;}
+
+/* publicidad en el cuerpo de la home*/
+.publicidad{
+	margin-top:-40px;
+}
+
+/* imagenes de enlaces e iconos */
+.sow-masonry-grid-item:hover{
+opacity:0.7;
+}
+
+/*carrusel*/
+.sow-carousel-title a.sow-carousel-next {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+.sow-carousel-title a.sow-carousel-previous {
+  -moz-osx-font-smoothing: grayscale;
+    background: #23282d none repeat scroll 0 0;
+    border-radius: 15px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-wrapper ul.sow-carousel-items li.sow-carousel-item .sow-carousel-thumbnail a span.overlay {
+    background: #bebdbd none repeat scroll 0 0;}
+
+/* :::::::::::::::::::::::::::::::::::::::: RECETAS :::::::::::::::::::::::::::::::::::::::::::*/
+
+/* índice de recetas*/
+
+.azindex .head {
+    color: #000;
+}
+
+.azindex h4 {
+    border-bottom: 1px solid #ccc;
+    width: 90%;
+}
+.azindex h2 >a {
+color: #000;
+}
+.azlinks .azlink{
+display:inline-flex
+}
+.azlinks .azlink >a {
+      color: #000;
+    font-family: "josefin sans";
+    font-size: 1.2em;
+    font-weight: 700;
+    margin: 0.15em;
+    text-align: center;
+}
+
+
+/*visión movil*/
+@media (max-width: 600px){
+.azindex{width:100% !important;}
+}
+
+/* ::::::::::::::::::::  PÁGINAS INTERIORES DE RECETAS ::::::::::::::::::::::::*/
+.pagrecetcab {
+    margin-bottom: -30px;
+    margin-top: -30px;
+}
+
+/* :::::::::::::::::::::::::: CATEGORIAS RECETAS ::::::::::::::::::::::::::::::::::::::::::*/
+/* div del menu de tipos de recetas*/
+.recetnav {
+    margin-bottom: 40px;
+    margin-top: 40px;
+}
+
+/* texto descripción de la categoría*/
+.page-header > p {
+    color: #fff;
+    font-family:Open Sans;  /*"Josefin Sans";*/
+    font-size: 1.3em;
+    font-weight: 300;
+    padding-left: 1em;
+    margin-top: -20px;
+  padding-bottom:0.5em;
+line-height: 1.3em;
+
+}
+
+@media (max-width: 768px){
+.page-header > p {font-size:1em;
+}
+}
+
+/* ::::::::::::::::::::::::::::::::: POST RECETA :::::::::::::::::::::::::::*/
+.single-article article h1 { font-family:"Open Sans";
+/*border-bottom:1px solid #24292e;
+width:85%;*/
+text-decoration:none;
+padding-bottom:5px;}
+.postedintop{display:none}
+.single-footer .posttags a {
+font-size:16px;
+}
+
+/* Línea autora y comentarios*/
+.subhead {
+    margin-top: -12px;
+}
+/* ocultar divisor de más  entre "autora" "comentarios" post */
+.kad-hidepostedin {
+    display: none;
+}
+.postcommentscount {
+    margin-left: -2px;
+}
+
+/* Línea iconos redes*/
+.addtoany_share_save_container.addtoany_content_top {
+    margin-left: -5px;
+    margin-top: -5px;
+}
+
+/* etiquetas de ingredientes ocultas*/
+.single-footer .posttags {
+    display: none;
+}
+
+/* recetas plugin recipe en movil*/
+@media (max-width: 560px){
+.easyrecipe .ERSTimes .ERSTime {
+    float: left;
+    font-weight: bold;
+    min-width: 120px;
+    text-align: center;
+    width: 100%;
+    border:1px dotted #bdbeb2;}
+}
+
+easyrecipe-styl…ver=3.2.2708.1
+
+/*CAMBIO TIPOGRAFIA SOLUCION ESPACIO LETRAS PARA JOSEFIN SANS*/
+
+H1, H2, H3, H5 {
+letter-spacing: -0.9px; 
+}
+
+
+/* ::::::::::::::::::::::::::::::::::::::: ESPECIAL NAVIDAD :::::::::::::::::::::::::::: */
+.desnavidad {
+    border: 3px solid #bdbeb2;
+    border-radius: 20px;
+    padding: 1.5em  0.5em  0.2em 0.5em;
+  }
+
+.desnavidad h3 {
+   text-align:center;
+  font-family: 'Josefin Sans';
+  text-transform: uppercase; 
+ margin-bottom: 40px;
+ font-size:2.0em;
+color:#aa0000;
+}
+
+/* ::::::::::::::::::::::::::::::::::: VISIÓN TABLET :::::::::::::::::::::::::::::::::::::*/
+.iconhover{ width:80%;}
+/* Tablet APAISADA*/
+@media (min-width: 1020px) and (max-width: 1025px){
+.container{width:1010px;}
+}
+/* ajuste de padding izquierdo de receta en resultdos de búqueda 
+o visión tipo categorias para tablet apaisada*/
+@media (min-width: 768px) and (max-width: 1025px){
+.col-md-7.post-text-container.postcontent {
+padding-left:32px;
+}
+}
+/* whatsapp*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_whatsapp {
+display:none;}
+}
+
+/* telegram*/
+@media (min-width: 641px){
+.a2a_svg.a2a_s__default.a2a_s_telegram {
+display:none;}
+}
+
+
+/* ::::::::::::::::::::::::::: ELIMINAR BORDE AVATAR COMENT :::::::::::::::::::::::::: */
+
+.comment .avatar { border: 0px solid #f0eef0;
+}
+
+/* :::::::::::::::::::::::::::::::::: BOTONES CARRUSEL PORTADA ::::::::::::::::::::::::::::::::::::::::::::::: */
+
+.sow-carousel-title a.sow-carousel-next {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: right;
+    line-height: 28px;
+    margin-left: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+.sow-carousel-title a.sow-carousel-previous {
+    -moz-osx-font-smoothing: grayscale;
+    background: #bdbeb2 none repeat scroll 0 0;
+    border-radius: 7px;
+    display: inline-block;
+    float: left;
+    line-height: 28px;
+    margin-left: 2px;
+    margin-right: 3px;
+    margin-top: 60px;
+    width: 28px;
+}
+
+
+/* :::::::::::::::::::::::::::::::::: FOOTER ::::::::::::::::::::::::::::::::::::::::::::::: */
+/*Créditos*/
+.footercredits.clearfix {
+float:right;
+}
+.footercredits.clearfix > p {
+    font-size: 0.85em;
+    line-height: 1.5em;
+}
+
+.freehare {
+    font-size: 0.86em;
+}
+
+/* :::::::::::::::::::::::::::::::::: CHECKBOX ::::::::::::::::::::::::::::::::::::::::::::::: */
+.form-check {
+  width: 1em;
+  height: 1em;
+  vertical-align: top;
+}
+</style>
+<!-- Matomo -->
+<script type="rocketlazyloadscript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://estadisticas.mediasector.es/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '34']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
+		<script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+			var advadsCfpQueue = [];
+			var advadsCfpAd = function( adID ) {
+				if ( 'undefined' === typeof advadsProCfp ) {
+					advadsCfpQueue.push( adID )
+				} else {
+					advadsProCfp.addElement( adID )
+				}
+			}
+		</script>
+		<!--[if lt IE 9]>
+<script src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/vendor/respond.min.js"></script>
+<![endif]-->
+<style type="text/css">
+html body div.easyrecipe .ERSNotesDiv .ERSNotesHeader { font-size: 18px!important;font-style: italic!important;margin-top: 21px!important;margin-bottom: 1px!important;margin-left: 41px!important; }
+html body div.easyrecipe .ERSNotesDiv .ERSNotes { font-style: italic!important;font-size: 15px!important;padding-left: 39px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe { border-width: 2px!important;border-style: solid!important;font-family: inherit!important;font-size: 16px!important;color: rgb(5, 5, 5)!important;margin-top: 30px!important;padding: 12px 23px 31px 24px!important;margin-bottom: 12px!important; }
+html body div.easyrecipe .ERSName { font-family: inherit!important;color: rgb(5, 5, 5)!important;font-weight: bold!important;font-size: 27px!important;margin-top: 31px!important;margin-bottom: 16px!important;margin-left: 1px!important;padding-top: 1px!important;padding-left: 2px!important; }
+html body div.easyrecipe .ERSTimes { color: rgb(5, 5, 5)!important;margin-top: 10px!important;margin-bottom: 9px!important;padding-top: 8px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSTimes .ERSTimeItem { color: rgb(5, 5, 5)!important;font-size: 14px!important;margin-bottom: 9px!important;margin-left: -4px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSSummary { font-family: inherit!important;font-weight: bold!important;font-size: 18px!important;margin-top: 10px!important;margin-bottom: 8px!important;margin-left: 1px!important;padding-top: 6px!important;padding-right: 2px!important; }
+html body div.easyrecipe .ERSAuthor { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important;margin-left: 0px!important; }
+html body div.easyrecipe .ERSCategory { padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSCuisine { font-size: 15px!important;padding-left: 0px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSServes { font-size: 15px!important;padding-left: 0px!important; }
+html body div.easyrecipe .ERSPrintBtnSpan .ERSPrintBtn { font-family: inherit!important;background-color: rgb(189, 190, 178)!important;font-weight: bold!important;font-size: 14px!important;margin-top: -10px!important;margin-bottom: -11px!important;margin-right: 2px!important;padding: 8px!important; }
+html body div.easyrecipe .ERSIngredientsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;margin: 24px -3px 20px 0px!important;padding-left: 21px!important;font-weight: normal!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSIngredients li.ingredient { font-size: 15px!important;list-style-type: circle!important;margin: -4px -10px 8px 13px!important;padding-left: 3px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructionsHeader { color: rgb(255, 255, 255)!important;background-color: rgb(189, 190, 178)!important;font-size: 24px!important;font-weight: normal!important;margin-top: 24px!important;margin-bottom: 9px!important;margin-right: -2px!important;padding-left: 21px!important;font-family: inherit!important; }
+html body div.easyrecipe .ERSInstructions .instruction { font-size: 15px!important;margin: 12px -6px 12px 32px!important;padding: 0px 20px 6px 9px!important;font-family: inherit!important; }
+div.easyrecipe { border-radius:18px; font-family: 'Open Sans' !important;}
+.ERSRatingOuter .review {
+margin-top:0.5em;
+}
+
+div.easyrecipe div.ERSSavePrint span.ERSPrintBtnSpan a.ERSPrintBtn span.ERSPrintIcon {
+background-image: url(images/printicon.png);
+width: 16px;
+height: 16px;
+display: none;
+/* padding-top: 20px; */
+}</style>
+<style type="text/css" class="options-output">header #logo a.brand,.logofont{font-family:Lato;line-height:40px;font-weight:400;font-style:normal;font-size:32px;}.kad_tagline{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;color:#444444;font-size:20px;}.product_item .product_details h5{font-family:Lato;line-height:20px;font-weight:700;font-style:normal;font-size:16px;}h1{font-family:"Josefin Sans";line-height:40px;font-weight:600;font-style:normal;font-size:32px;}h2{font-family:"Josefin Sans";line-height:32px;font-weight:400;font-style:normal;font-size:28px;}h3{font-family:"Josefin Sans";line-height:28px;font-weight:400;font-style:normal;font-size:24px;}h4{font-family:"Open Sans";line-height:24px;font-weight:400;font-style:normal;font-size:20px;}h5{font-family:"Josefin Sans";line-height:22px;font-weight:300;font-style:normal;font-size:18px;}body{font-family:"Open Sans";line-height:25px;font-weight:400;font-style:normal;font-size:16px;}#nav-main ul.sf-menu a{font-family:"Josefin Sans";line-height:24px;font-weight:400;font-style:normal;font-size:22px;}#nav-second ul.sf-menu a{font-family:"Josefin Sans";line-height:20px;font-weight:600;font-style:normal;font-size:16px;}.kad-nav-inner .kad-mnav, .kad-mobile-nav .kad-nav-inner li a,.nav-trigger-case{font-family:"Josefin Sans";line-height:22px;font-weight:600;font-style:normal;font-size:16px;}</style><style type="text/css">/** Mega Menu CSS Disabled **/</style>
+
+    <!-- Custom scripts -->
+
+
+<!-- Menú fijo-->
+
+<script type="rocketlazyloadscript">jQuery("document").ready(function($){
+
+	var nav = $('.navclass');
+
+	$(window).scroll(function () {
+		if ($(this).scrollTop() > 173) {
+			nav.addClass("stickytop");
+		} else {
+			nav.removeClass("stickytop");
+		}
+	});
+
+});
+
+</script>
+
+<style id="rocket-lazyrender-inline-css">[data-wpr-lazyrender] {content-visibility: auto;}</style><meta name="generator" content="WP Rocket 3.20.4" data-wpr-features="wpr_delay_js wpr_defer_js wpr_minify_js wpr_preconnect_external_domains wpr_automatic_lazy_rendering wpr_oci wpr_minify_css wpr_preload_links wpr_desktop" /></head>
+  	
+  	<body data-cmplz=1 class="wp-singular post-template-default single single-post postid-59817 single-format-standard wp-theme-virtue wp-child-theme-velocidad mega-menu-secondary-navigation mega-menu-max-mega-menu-1 mega-menu-max-mega-menu-2 mega-menu-max-mega-menu-3 mega-menu-max-mega-menu-4 mega-menu-max-mega-menu-6 mega-menu-max-mega-menu-7 mega-menu-max-mega-menu-8 mega-menu-max-mega-menu-9 mega-menu-max-mega-menu-10 mega-menu-max-mega-menu-11 mega-menu-max-mega-menu-12 wide salsa-cremosa-de-calabaza-y-curry aa-prefix-local- er-recipe">
+  	<div  id="kt-skip-link"><a href="#content">Skip to Main Content</a></div>
+    <div  id="wrapper" class="container">
+    <header  class="banner headerclass" itemscope itemtype="http://schema.org/WPHeader">
+  <div  id="topbar" class="topclass">
+    <div  class="container">
+      <div class="row">
+        <div class="col-md-6 col-sm-6 kad-topbar-left">
+          <div class="topbarmenu clearfix">
+                                </div>
+        </div><!-- close col-md-6 --> 
+        <div class="col-md-6 col-sm-6 kad-topbar-right">
+          <div id="topbar-search" class="topbar-widget">
+            <form role="search" method="get" class="form-search" action="https://www.velocidadcuchara.com/">
+  <label>
+  	<span class="screen-reader-text">Búsqueda para:</span>
+  	<input type="text" value="" name="s" class="search-query" placeholder="Busca tu receta">
+  </label>
+  <button type="submit" class="search-icon"><i class="icon-search"></i></button>
+</form>        </div>
+        </div> <!-- close col-md-6-->
+      </div> <!-- Close Row -->
+    </div> <!-- Close Container -->
+  </div><div  class="container">
+  <div class="row">
+      <div class="col-md-4 clearfix kad-header-left">
+            <div id="logo" class="logocase">
+              <a class="brand logofont" href="https://www.velocidadcuchara.com/">
+                                  <div id="thelogo">
+                    <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-standard-logo" />
+                                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg" alt="Velocidad Cuchara" class="kad-retina-logo" style="max-height:121px" />                   </div>
+                              </a>
+                         </div> <!-- Close #logo -->
+       </div><!-- close logo span -->
+              
+    </div> <!-- Close Row -->
+     
+</div> <!-- Close Container -->
+    <section id="cat_nav" class="navclass">
+    <div class="container">
+      <nav id="nav-second" class="clearfix" itemscope itemtype="http://schema.org/SiteNavigationElement">
+        <div id="mega-menu-wrap-secondary_navigation" class="mega-menu-wrap"><div class="mega-menu-toggle" tabindex="0"><div class='mega-toggle-block mega-menu-toggle-block mega-toggle-block-right mega-toggle-block-1' id='mega-toggle-block-1'></div></div><ul id="mega-menu-secondary_navigation" class="mega-menu mega-menu-horizontal mega-no-js" data-event="hover_intent" data-effect="fade_up" data-effect-speed="200" data-second-click="close" data-document-click="collapse" data-vertical-behaviour="accordion" data-breakpoint="768" data-unbind="true"><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-58762' id='mega-menu-item-58762'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/indice-recetas-thermomix/" tabindex="0">Índice</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58774' id='mega-menu-item-58774'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/todas-las-recetas/" aria-haspopup="true" tabindex="0">Recetas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-custom mega-menu-item-object-custom mega-menu-item-58775' id='mega-menu-item-58775'><a class="mega-menu-link" href="https://velocidadcuchara.com/todas-las-recetas/">Todas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58778' id='mega-menu-item-58778'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/carnes/">Carnes</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58779' id='mega-menu-item-58779'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/pescados-y-marisco/">Pescados y mariscos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58780' id='mega-menu-item-58780'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/ensaladas/">Ensaladas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58781' id='mega-menu-item-58781'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/legumbres-y-verduras/">Legumbres y verduras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58782' id='mega-menu-item-58782'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/arroces-y-pastas/">Arroces y pastas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58783' id='mega-menu-item-58783'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sopas-y-cremas/">Sopas y cremas</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58784' id='mega-menu-item-58784'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/masas-y-pan/">Masas y pan</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58785' id='mega-menu-item-58785'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/reposteria/">Repostería</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58786' id='mega-menu-item-58786'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/postres-y-dulces/">Postres y dulces</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58787' id='mega-menu-item-58787'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/conservas-y-confituras/">Conservas y confituras</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-59720' id='mega-menu-item-59720'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/desayuno/">Desayunos</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58788' id='mega-menu-item-58788'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/bebidas/">Bebidas y cócteles</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58789' id='mega-menu-item-58789'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetarios/">Recetarios</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58803' id='mega-menu-item-58803'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dos-en-uno/">Dos en uno</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58776' id='mega-menu-item-58776'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/dietas/" aria-haspopup="true" tabindex="0">Dietas</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58790' id='mega-menu-item-58790'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-gluten/">Sin gluten</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58791' id='mega-menu-item-58791'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-lactosa/">Sin lactosa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58792' id='mega-menu-item-58792'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-huevo/">Sin huevo</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58793' id='mega-menu-item-58793'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/sin-azucar/">Sin azúcar</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-current-post-ancestor mega-current-menu-parent mega-current-post-parent mega-menu-item-58794' id='mega-menu-item-58794'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/vegetariana/">Vegetariana</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58795' id='mega-menu-item-58795'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/dietas/hipocalorica/">Hipocalórica</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58777' id='mega-menu-item-58777'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas-sin-thermomix/" aria-haspopup="true" tabindex="0">Sin TMX</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58798' id='mega-menu-item-58798'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/olla-rapida/">Olla rápida</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58797' id='mega-menu-item-58797'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/cocotte/">Cocotte</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-60222' id='mega-menu-item-60222'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/freidora-de-aire/">Freidora de aire</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58799' id='mega-menu-item-58799'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/crock-pot/">Crock Pot</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58796' id='mega-menu-item-58796'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/kitchenaid/">Kitchenaid</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58801' id='mega-menu-item-58801'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/al-vacio/">Al vacío</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58800' id='mega-menu-item-58800'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/barbacoa/">Barbacoa</a></li><li class='mega-menu-item mega-menu-item-type-taxonomy mega-menu-item-object-category mega-menu-item-58802' id='mega-menu-item-58802'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/recetas/sin-thermomix/otros/">Otros</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-has-children mega-align-bottom-left mega-menu-flyout mega-menu-item-58763' id='mega-menu-item-58763'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" aria-haspopup="true" tabindex="0">Libros</a>
+<ul class="mega-sub-menu">
+<li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58765' id='mega-menu-item-58765'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-cocina-rico-todos-los-dias-thermomix/">Cocina rico todos los días</a></li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-menu-item-58764' id='mega-menu-item-58764'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/libro-mis-recetas-imprescindibles-thermomix/">Mis recetas imprescindibles</a></li></ul>
+</li><li class='mega-menu-item mega-menu-item-type-post_type mega-menu-item-object-page mega-align-bottom-left mega-menu-flyout mega-menu-item-60105' id='mega-menu-item-60105'><a class="mega-menu-link" href="https://www.velocidadcuchara.com/podcast-velocidad-cuchara/" tabindex="0">🎧 Pódcast</a></li></ul></div>      </nav>
+    </div><!--close container-->
+  </section>
+  </header>
+      <div  class="wrap contentclass" role="document">
+
+        <div  id="content" class="container">
+    <div class="row single-article" itemscope itemtype="http://schema.org/BlogPosting">
+        <div class="main col-lg-9 col-md-8" role="main">
+                    <article class="post-59817 post type-post status-publish format-standard has-post-thumbnail hentry category-arroces-y-pastas category-pastas category-recetas category-sin-azucar category-sin-gluten category-sin-huevo category-sin-lactosa category-vegetariana tag-aceite-de-oliva-virgen-extra tag-anacardos tag-calabaza tag-cebollas tag-curry tag-curry-en-polvo tag-leche-de-coco tag-pasta tag-pimienta-negra tag-sal course-pastas-salsas cuisine-espanola">
+            <div class="meta_post_image" itemprop="image" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22.jpg"><meta itemprop="width" content="1200"><meta itemprop="height" content="801"></div>
+                <div class="postmeta updated color_gray">
+      <div class="postdate bg-lightgray headerfont" itemprop="datePublished">
+      <span class="postday">24</span>
+      Nov 2022    </div>
+</div>                <header>
+                    <h1 class="entry-title" itemprop="name headline">Salsa cremosa de calabaza y curry</h1><div class="subhead">
+    <span class="postauthortop author vcard">
+    <i class="icon-user"></i> por  <span itemprop="author"><a href="https://www.velocidadcuchara.com/author/admin/" class="fn" rel="author">Rosa Ardá</a></span> |</span>
+      
+    <span class="postedintop"><i class="icon-folder-open"></i> publicado en: <a href="https://www.velocidadcuchara.com/recetas/arroces-y-pastas/" rel="category tag">Arroces y pastas</a>, <a href="https://www.velocidadcuchara.com/recetas/arroces-y-pastas/pastas/" rel="category tag">Pastas</a>, <a href="https://www.velocidadcuchara.com/recetas/" rel="category tag">Recetas</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/sin-azucar/" rel="category tag">Sin azúcar</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/sin-gluten/" rel="category tag">Sin gluten</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/sin-huevo/" rel="category tag">Sin huevo</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/sin-lactosa/" rel="category tag">Sin lactosa</a>, <a href="https://www.velocidadcuchara.com/recetas/dietas/vegetariana/" rel="category tag">Vegetariana</a></span>     <span class="kad-hidepostedin">|</span>
+    <span class="postcommentscount">
+    <i class="icon-comments-alt"></i> 3    </span>
+</div>                </header>
+
+                <div class="entry-content" itemprop="articleBody">
+                    <p><picture fetchpriority="high" decoding="async" class="aligncenter wp-image-59818 size-full">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22.jpg.webp 1200w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-300x200.jpg.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-1024x684.jpg.webp 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-768x513.jpg.webp 768w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-560x374.jpg.webp 560w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-272x182.jpg.webp 272w" sizes="(max-width: 1200px) 100vw, 1200px"/>
+<img fetchpriority="high" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22.jpg" alt="" width="1200" height="801" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22.jpg 1200w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-300x200.jpg 300w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-1024x684.jpg 1024w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-768x513.jpg 768w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-560x374.jpg 560w, https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22-272x182.jpg 272w" sizes="(max-width: 1200px) 100vw, 1200px"/>
+</picture>
+</p>
+<p class="p1">Creo que no os lo he contado… Hace unos cuantos meses que Javi ha decidido que no come cierta carne: no cerdo, no cordero, no ternera,… solo pollo y poquito… Es un tema personal, así que en estamos adaptando el día a día y cocinando más verduras, pescados, legumbres, arroces y pastas. Sobre todo intentamos aumentar las verduras y hoy me he puesto con una salsa cremosa con calabaza. Es super fácil&#8230; ya veréis</p><script type="text/plain" data-tcf="waiting-for-consent" data-id="45718" data-bid="1" data-placement="61266">PGRpdiBpZD0ibG9jYWwtMjc3NTI5MjE1NiIgY2xhc3M9Imdhc19mYWxsYmFjay1hZF80NTcxOC0tcGxhY2VtZW50XzYxMjY2IiBzdHlsZT0ibWFyZ2luLXRvcDogMjBweDttYXJnaW4tYm90dG9tOiAyMHB4OyI+PHNjcmlwdCBhc3luYyBzcmM9Ii8vcGFnZWFkMi5nb29nbGVzeW5kaWNhdGlvbi5jb20vcGFnZWFkL2pzL2Fkc2J5Z29vZ2xlLmpzP2NsaWVudD1jYS1wdWItMDQzMjcyNjA0MDAwOTY3NiIgY3Jvc3NvcmlnaW49ImFub255bW91cyI+PC9zY3JpcHQ+PGlucyBjbGFzcz0iYWRzYnlnb29nbGUiIHN0eWxlPSJkaXNwbGF5OmJsb2NrOyIgZGF0YS1hZC1jbGllbnQ9ImNhLXB1Yi0wNDMyNzI2MDQwMDA5Njc2IiAKZGF0YS1hZC1zbG90PSI5ODk1NDgwOTQ4IiAKZGF0YS1hZC1mb3JtYXQ9ImF1dG8iPjwvaW5zPgo8c2NyaXB0PiAKKGFkc2J5Z29vZ2xlID0gd2luZG93LmFkc2J5Z29vZ2xlIHx8IFtdKS5wdXNoKHt9KTsgCjwvc2NyaXB0Pgo8L2Rpdj4=</script>
+<p class="p1">En el blog ya tenéis<a href="https://www.velocidadcuchara.com/bolonesa-de-lentejas-thermomix/"> <strong>boloñesas de lentejas</strong></a>, salsa como las de hoy o <strong><a href="https://www.velocidadcuchara.com/salsa-pesto/">pesto verde</a> </strong>y <strong><a href="https://www.velocidadcuchara.com/pesto-rojo-rosso/">pesto rojo</a></strong>,<strong><a href="https://www.velocidadcuchara.com/pasta-con-pesto-de-brocoli/"> pesto de brócoli</a> </strong>-que me encantan-&#8230; iré haciendo más salsitas, tengo en mente hacer alguna con aguacete&#8230; a ver que me sale :D.</p>
+<p>No os váis a creer lo mal que tengo la cabeza&#8230; los que me conocen saben de mis despistes. Resulta que me pongo a hacer el<a href="https://www.instagram.com/p/ClS1Iy4Kq5b/"> VIDEO de esta receta</a> y cómo voy contrareloj, se me olvida la foto final para el blog..<em>. ¡¡¡mecachis en todo!!!!</em> Eso se arregla fácil pero que rabia, porque con el trabajo de centro de salud tengo los minutos contados.</p><div  class="local-ed112ad6febd1813d9639d93e3eec1b1 local-contenido-2" id="local-ed112ad6febd1813d9639d93e3eec1b1"></div>
+<p>Ahora estamos con la campaña de vacunación y no nos da tiempo a nada entre preparar todo: cargar las vacunas, repasar las ya puestas de los listados, comprobar que el que se vacuna lo hace correctamente y no acaba de pasar el Covid -deben pasar 3 meses para los mayores de 80 años y 5 meses para el resto-, que las gripes se corresponden con las edades -hay 2 vacunas, una para menores de 65 años y otras para mayores-, preparar el centro para habilitar una zona de vacunación porque no tenemos sitio ni para nosotros. ¡Que sería de nosotros sin nuestros biombos! -yo comparto consulta con otra enfermera en mi jornada habitual, mi centro es que es muy<em> cutre</em> y se queda enano. Ni ventanas tenemos en <em>&#8220;ninguna&#8221;</em> consulta- y ya sabéis cómo se transmite el COVID. Hacemos lo que podemos y vamos con la lengua fuera sobre todo en horas punta&#8230; pero nos llevamos genial :D. Menos mal!!! No os asustéis, en Madrid hay centros de salud<em> así,</em> de esos que no te esperas en una capital, este no es el único. Hace muchos años que prometieron un nuevo centro, pero los que llevan ahí toda la vida ya han perdido la esperanza.</p>
+<p class="p1"><strong>La receta:</strong> para darle un toquecito, he añadido unos anacardos fritos… que podéis incorporar al triturado o simplemente ponerlos por encima en el momento de servir. No guardéis los anacardos con la pasta porque se quedan blanditos -blandos no me gustan-. Y apuntaros la salsa porque cunde mucho -para 500 g de pasta- y así come toda la familia.</p><script type="text/plain" data-tcf="waiting-for-consent" data-id="55554" data-bid="1" data-placement="61269">PGRpdiBpZD0ibG9jYWwtNzAwNjc3MDY5IiBjbGFzcz0iZ2FzX2ZhbGxiYWNrLWFkXzU1NTU0LS1wbGFjZW1lbnRfNjEyNjkiIHN0eWxlPSJtYXJnaW4tdG9wOiAyMHB4O21hcmdpbi1ib3R0b206IDIwcHg7Ij48c2NyaXB0IGFzeW5jIHNyYz0iLy9wYWdlYWQyLmdvb2dsZXN5bmRpY2F0aW9uLmNvbS9wYWdlYWQvanMvYWRzYnlnb29nbGUuanM/Y2xpZW50PWNhLXB1Yi0wNDMyNzI2MDQwMDA5Njc2IiBjcm9zc29yaWdpbj0iYW5vbnltb3VzIj48L3NjcmlwdD48aW5zIGNsYXNzPSJhZHNieWdvb2dsZSIgc3R5bGU9ImRpc3BsYXk6YmxvY2s7IiBkYXRhLWFkLWNsaWVudD0iY2EtcHViLTA0MzI3MjYwNDAwMDk2NzYiIApkYXRhLWFkLXNsb3Q9IjIwMjk2MTA5NzgiIApkYXRhLWFkLWZvcm1hdD0iYXV0byI+PC9pbnM+CjxzY3JpcHQ+IAooYWRzYnlnb29nbGUgPSB3aW5kb3cuYWRzYnlnb29nbGUgfHwgW10pLnB1c2goe30pOyAKPC9zY3JpcHQ+CjwvZGl2Pg==</script>
+<blockquote><p>Otras recetas: <a href="https://www.velocidadcuchara.com/lazos-con-pesto-y-langostinos/">Pasta con pesto y langostinos</a>, <a href="https://www.velocidadcuchara.com/ensalada-de-patata-con-pesto-rojo/">Ensalada de patata con pesto rojo</a>, <a href="https://www.velocidadcuchara.com/pasta-con-verduras-asadas/">Pasta con verduras asadas</a>,<a href="https://www.velocidadcuchara.com/ensalada-de-pasta-caprese/"> Ensalada de pasta Capresse</a>, <a href="https://www.velocidadcuchara.com/pasta-al-pesto-al-estilo-de-lucca/">Pasta al pesto al estilo de Lucca</a>, <a href="https://www.velocidadcuchara.com/pasta-con-salsa-amatriciana/">Pasta con salsa Amatriciana</a>, <a href="https://www.velocidadcuchara.com/pasta-fresca-con-la-thermomix/">Pasta fresca casera</a>, <a href="https://www.velocidadcuchara.com/espaguetis-a-la-vongole/">Espaguetis a la Vongole</a>, <a href="https://www.velocidadcuchara.com/espaguetis-a-la-carbonara-tradicional-thermomix/">Espaguetis carbonara &#8220;tradicional&#8221;</a>, <a href="https://www.velocidadcuchara.com/espaguetis-carbonara-thermomix/">Espaguetis carbonara de &#8220;nata&#8221;</a>. Más recetas de pasta: <a href="https://www.velocidadcuchara.com/recetas/arroces-y-pastas/pastas/"><strong>AQUÍ.</strong></a></p></blockquote>
+<p><span id="more-59817"></span><br />
+<div id="easyrecipe-59817-0" class="easyrecipe" itemscope itemtype="http://schema.org/Recipe"> <link itemprop="image" href="https://www.velocidadcuchara.com/wp-content/uploads/2022/11/Salsa-cremosa-de-calabaza-y-curry-VC22.jpg"/> <div class="ERSRatings" itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating"> <div class="ERSRatingOuter"> <div class="ERSRatingInner" style="width: 100%"></div> <div class="review"><span class="rating"><span class="average" itemprop="ratingValue">5.0</span> de <span class="count" itemprop="ratingCount">2</span> opiniones</span></div> </div> </div> <div itemprop="name" class="ERSName">Salsa cremosa de calabaza y curry</div> <div class="ERSClear">&nbsp;</div> <div class="ERSTopRight"> <div class="ERSSavePrint"> <span class="ERSPrintBtnSpan"><a class="ERSPrintBtn" href="https://www.velocidadcuchara.com/easyrecipe-print/59817-0/" rel="nofollow" target="_blank">Imprimir</a></span> </div> </div> <div class="ERSTimes"> <div class="ERSTime"> <div class="ERSTimeHeading">Preparación</div> <div class="ERSTimeItem"> <time itemprop="prepTime" datetime="PT5M">5 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Cocción</div> <div class="ERSTimeItem"> <time itemprop="cookTime" datetime="PT30M">30 min</time> </div> </div> <div class="ERSTime ERSTimeRight"> <div class="ERSTimeHeading">Tiempo total</div> <div class="ERSTimeItem"> <time itemprop="totalTime" datetime="PT35M">35 min</time> </div> </div> <div class="ERSClearLeft">&nbsp;</div> </div> <div itemprop="description" class="ERSSummary">4 ingredientes para una salsa deliciosa. Apunta: cebolla, calabaza, leche de coco y curry. Añade la pasta que más te guste y a comer.</div> <div class="divERSHeadItems"> <div class="ERSAuthor">Autor: <span itemprop="author">Rosa Ardá</span></div> <div class="ERSCategory">Tipo de receta: <span itemprop="recipeCategory">Pastas, Salsas</span></div> <div class="ERSCuisine">Cocina: <span itemprop="recipeCuisine">Española</span></div> <div class="ERSServes">Raciones: <span itemprop="recipeYield">4-6</span></div> </div> <div class="ERSIngredients"> <div class="ERSIngredientsHeader ERSHeading">Ingredientes</div> <ul> <li class="ingredient" itemprop="ingredients">40 ml de aceite de oliva virgen extra</li> <li class="ingredient" itemprop="ingredients">250 g de cebolla</li> <li class="ingredient" itemprop="ingredients">400 g de calabaza troceada</li> <li class="ingredient" itemprop="ingredients">Sal y pimienta al gusto</li> <li class="ingredient" itemprop="ingredients">220 ml de leche de coco</li> <li class="ingredient" itemprop="ingredients">2 cucharaditas de curry</li> <li class="ingredient" itemprop="ingredients">Un puñado de anacardos</li> </ul> <div class="ERSClear"></div> </div> <div class="ERSInstructions"> <div class="ERSInstructionsHeader ERSHeading">Pasos a seguir</div> <ol> <li class="instruction" itemprop="recipeInstructions">Pon el aceite y la cebolla en cuartos en el vaso y <strong>trocea 4 segundos velocidad 4</strong>. Sofríe <strong>8-10 minutos, Varoma, velocidad cuchara</strong> -sin cubilete-.</li> <li class="instruction" itemprop="recipeInstructions">Incorpora la calabaza, la sal y la pimienta y<strong> cocina 15 minutos, Varoma, velocidad cuchara</strong> -sin cubilete-.</li> <li class="instruction" itemprop="recipeInstructions">Añade la leche de coco y el curry y <strong>cuece 5 minutos, Varoma, velocidad 2</strong>.</li> <li class="instruction" itemprop="recipeInstructions">Cuando acabe el tiempo<strong> tritura 1 minuto en velocidad 5-10</strong>. Rectifica el punto de sal y usa sobre tu pasta junto con los anacardos.</li> </ol> <div class="ERSClear"></div> </div> <div class="endeasyrecipe" title="style002a" style="display: none">3.5.3251</div> </div>
+ </p>
+<div class="addtoany_share_save_container addtoany_content addtoany_content_bottom"><div class="a2a_kit a2a_kit_size_32 addtoany_list" data-a2a-url="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/" data-a2a-title="Salsa cremosa de calabaza y curry"><a class="a2a_button_facebook" href="https://www.addtoany.com/add_to/facebook?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-cremosa-de-calabaza-y-curry%2F&amp;linkname=Salsa%20cremosa%20de%20calabaza%20y%20curry" title="Facebook" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_x" href="https://www.addtoany.com/add_to/x?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-cremosa-de-calabaza-y-curry%2F&amp;linkname=Salsa%20cremosa%20de%20calabaza%20y%20curry" title="X" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_pinterest" href="https://www.addtoany.com/add_to/pinterest?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-cremosa-de-calabaza-y-curry%2F&amp;linkname=Salsa%20cremosa%20de%20calabaza%20y%20curry" title="Pinterest" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_whatsapp" href="https://www.addtoany.com/add_to/whatsapp?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-cremosa-de-calabaza-y-curry%2F&amp;linkname=Salsa%20cremosa%20de%20calabaza%20y%20curry" title="WhatsApp" rel="nofollow noopener" target="_blank"></a><a class="a2a_button_telegram" href="https://www.addtoany.com/add_to/telegram?linkurl=https%3A%2F%2Fwww.velocidadcuchara.com%2Fsalsa-cremosa-de-calabaza-y-curry%2F&amp;linkname=Salsa%20cremosa%20de%20calabaza%20y%20curry" title="Telegram" rel="nofollow noopener" target="_blank"></a></div></div>                </div>
+
+                <footer class="single-footer">
+                <span class="posttags"><i class="icon-tag"></i><a href="https://www.velocidadcuchara.com/tag/aceite-de-oliva-virgen-extra/" rel="tag">Aceite de oliva virgen extra</a>, <a href="https://www.velocidadcuchara.com/tag/anacardos/" rel="tag">Anacardos</a>, <a href="https://www.velocidadcuchara.com/tag/calabaza/" rel="tag">Calabaza</a>, <a href="https://www.velocidadcuchara.com/tag/cebollas/" rel="tag">Cebollas</a>, <a href="https://www.velocidadcuchara.com/tag/curry/" rel="tag">Curry</a>, <a href="https://www.velocidadcuchara.com/tag/curry-en-polvo/" rel="tag">Curry en polvo</a>, <a href="https://www.velocidadcuchara.com/tag/leche-de-coco/" rel="tag">Leche de coco</a>, <a href="https://www.velocidadcuchara.com/tag/pasta/" rel="tag">Pasta</a>, <a href="https://www.velocidadcuchara.com/tag/pimienta-negra/" rel="tag">Pimienta negra</a>, <a href="https://www.velocidadcuchara.com/tag/sal/" rel="tag">Sal</a></span><meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/"><meta itemprop="dateModified" content="2022-12-09T21:40:21+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div>                </footer>
+            </article>
+            <div id="blog_carousel_container" class="carousel_outerrim">
+    <h3 class="title">Publicaciones Recientes</h3>    <div class="blog-carouselcase fredcarousel">
+    		<div id="carouselcontainer-blog" class="rowtight">
+		<div id="blog_carousel" class="blog_carousel caroufedselclass initcaroufedsel clearfix" data-carousel-container="#carouselcontainer-blog" data-carousel-transition="300" data-carousel-scroll="1" data-carousel-auto="true" data-carousel-speed="9000" data-carousel-id="blog" data-carousel-md="3" data-carousel-sm="3" data-carousel-xs="2" data-carousel-ss="1">
+            				<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61247 post type-post status-publish format-standard has-post-thumbnail hentry category-cocina-para-ninos category-dietas category-dulces-para-ninos category-postres-de-cuchara category-postres-y-dulces category-recetas category-sin-gluten category-sin-lactosa tag-azucar-blanquilla tag-esencia-de-vainilla tag-galletas-tipo-maria tag-huevos tag-leche-sin-lactosa course-postres-reposteria cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" title="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg" alt="Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/Gullon-VC25-rec-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pudin de galletas Gullón, &#8220;sin gluten&#8221; y &#8220;sin lactosa&#8221;</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">23 octubre, 2025</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Cocina para todos una receta sin gluten y sin lactosa. Este Pudin te va a...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pudin-de-galletas-gullon-sin-gluten-y-sin-lactosa/"><meta itemprop="dateModified" content="2025-10-24T18:03:21+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-274 post type-post status-publish format-standard has-post-thumbnail hentry category-30-minutos category-dietas category-ensaladas category-estaciones category-frias category-hipocalorica category-pescado-azul category-pescados-y-marisco category-primeros-dieta category-recetas category-sin-azucar category-sin-gluten category-sin-lactosa category-verano category-verduras-y-hortalizas tag-aceitunas-negras tag-aceitunas-rellenas-de-anchoa tag-atun tag-cebollas-tomates tag-huevos tag-patatas tag-pimiento-rojo tag-pimiento-verde course-ensaladas cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/ensalada-campera/" title="Ensalada campera">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg" alt="Ensalada campera" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/Ensalada-Campera-VC22-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/ensalada-campera/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Ensalada campera</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">7 junio, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>En días de calor no hay nada más apetecible que una ensalada. Te propongo que...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/ensalada-campera/"><meta itemprop="dateModified" content="2025-11-30T17:58:48+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61149 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-estaciones category-invierno category-otono category-otros category-pescado-blanco category-pescados-y-marisco category-primavera category-recetas category-sin-thermomix category-tiempo category-tupper tag-ajos tag-bacalao tag-cebollas tag-guindillas tag-harina tag-perejil tag-pimienta-negra tag-sal tag-tomate-natural-triturado course-segundos-pescados cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" title="Bacalao en salsa de tomate">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg" alt="Bacalao en salsa de tomate" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/04/Bacalao-en-salsa-de-tomate-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Bacalao en salsa de tomate</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 abril, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Hoy quiero compartir con vosotros esta receta. ¿Sabéis lo buenísima que está? Es deliciosaaaaaaa. En...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/bacalao-en-salsa-de-tomate/"><meta itemprop="dateModified" content="2025-11-30T18:03:39+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-10498 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-dulces category-fiestas category-masas-y-pan category-pan category-postres-de-cuchara category-postres-y-dulces category-recetas category-semana-santa tag-canela tag-cointreau tag-huevos tag-leche-entera tag-naranjas tag-pan course-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" title="Torrijas fritas de Semana Santa con Thermomix">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg" alt="Torrijas fritas de Semana Santa con Thermomix" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-730x730.jpg 730w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-365x365.jpg 365w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2012/03/Torrijas-fritas-VC17-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Torrijas fritas de Semana Santa con Thermomix</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">27 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¿Estáis listos para la segunda parte del &#8220;Pan para torrijas&#8221;? Pues agarraros a la silla...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-fritas-de-semana-santa-paso-a-paso/"><meta itemprop="dateModified" content="2024-03-27T11:23:07+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-60562 post type-post status-publish format-standard has-post-thumbnail hentry category-45-minutos category-desayuno category-dulces category-estaciones category-fiestas category-freidora-de-aire category-masas-dulces category-postres-de-cuchara category-postres-y-dulces category-primavera category-recetas category-reposteria category-semana-santa category-sin-thermomix category-tiempo tag-azucar tag-azucar-blanquilla tag-canela tag-huevos tag-leche-entera tag-limones tag-pan course-reposteria-postres cuisine-espanola" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" title="Mis primeras Torrijas en Freidora de aire o Airfryer">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg" alt="Mis primeras Torrijas en Freidora de aire o Airfryer" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-150x150.jpeg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-532x532.jpeg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2023/04/CC6048A4-7050-4AF6-AF8E-858103CFB449-266x266.jpeg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Mis primeras Torrijas en Freidora de aire o Airfryer</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">5 marzo, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>Receta de Torrijas de Semana Santa en freidora de aire o Airfryer. Prepáralas en pocos...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/torrijas-en-freidora-de-aire-o-airfryer/"><meta itemprop="dateModified" content="2024-04-06T10:23:15+02:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+						<div class="tcol-md-4 tcol-sm-4 tcol-xs-6 tcol-ss-12">
+                	<div class="blog_item grid_item post-61100 post type-post status-publish format-standard has-post-thumbnail hentry category-carne-de-pollo category-carnes category-cocina-del-mundo category-estaciones category-india category-invierno category-otono category-otros category-primavera category-recetas category-sin-thermomix category-tupper tag-aguacates tag-ajos tag-carne-de-pollo tag-fideos-de-arroz tag-jengibre tag-lima tag-miel tag-pimienta-negra tag-sal tag-salsa-de-soja tag-semillas-de-sesamo course-carnes-segundos" itemscope="" itemtype="http://schema.org/BlogPosting">
+	                    								<div class="imghoverclass" itemprop="image" itemscope itemtype="https://schema.org/ImageObject">
+		                    <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" title="Pollo con soja y jengibre">
+		                        <img src="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg" alt="Pollo con soja y jengibre" width="266" height="266" class="iconhover" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-150x150.jpg 150w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg 266w, https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-532x532.jpg 532w" sizes="(max-width: 266px) 100vw, 266px">
+		                        <meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2024/01/Pollo-con-salda-de-soja-y-jengibre-VC24-266x266.jpg">
+                                <meta itemprop="width" content="266">
+                                <meta itemprop="height" content="266">
+		                    </a> 
+		                </div>
+                    	
+              <a href="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/" class="bcarousellink">
+				<header>
+			        <h5 class="entry-title" itemprop="name headline">Pollo con soja y jengibre</h5>
+			        <div class="subhead" itemprop="datePublished">
+			        <span class="postday">29 enero, 2024</span>
+			        </div>
+				</header>
+		       	<div class="entry-content" itemprop="articleBody">
+		        <p>¡Que se nota dicen!! Que si, que estoy feliz. Sobre todo estoy tranquila y este...</p>
+		        </div>
+				 </a>
+				 <meta itemscope itemprop="mainEntityOfPage"  itemType="https://schema.org/WebPage" itemid="https://www.velocidadcuchara.com/pollo-con-soja-y-jengibre/"><meta itemprop="dateModified" content="2024-12-23T09:15:20+01:00"><div itemprop="publisher" itemscope itemtype="https://schema.org/Organization"><div itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"><meta itemprop="url" content="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/cabecera_velocidad_cuchara_20.svg"><meta itemprop="width" content="425"><meta itemprop="height" content="121"></div><meta itemprop="name" content="Velocidad Cuchara"></div><meta class="author vcard fn" itemprop="author" content="Rosa Ardá"/>                </div>
+			</div>
+					</div>
+     <div class="clearfix"></div>
+            <a id="prevport-blog" class="prev_carousel icon-chevron-left" href="#"></a>
+			<a id="nextport-blog" class="next_carousel icon-chevron-right" href="#"></a>
+            </div>
+            </div>
+</div><!-- Carousel Container-->  <section id="comments">
+    <h3>3 Comentarios</h3>
+
+      <button class="mostrar-comentarios antes button" style="cursor:pointer">Mostrar comentarios</button>
+
+    <ol class="media-list">
+      
+  <li id="comment-234920" class="comment even thread-even depth-1 media comment-234920">
+    <img alt='' src='https://secure.gravatar.com/avatar/5094dcdfc174c2654e1a6c099788cf8a7fae8fad70b1a38e99ec31f350331a42?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/5094dcdfc174c2654e1a6c099788cf8a7fae8fad70b1a38e99ec31f350331a42?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">MARIA ANGELES</h5>
+        <div class="comment-meta">
+        <time datetime="2023-09-05T09:24:28+02:00"><a href="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/#comment-234920">
+          5 septiembre, 2023</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-234920" data-commentid="234920" data-postid="59817" data-belowelement="comment-234920" data-respondelement="respond" data-replyto="Responder a MARIA ANGELES" aria-label="Responder a MARIA ANGELES">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>ohhh muchas gracias de acordarte de nosotros, yo adapto muchas recetas tuyas, para que sean sin gluten, pero es fantástico que tengas este apartado, </p>
+<p>gracias </p>
+<p>besos Maria Ángeles      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+
+  <li id="comment-234214" class="comment odd alt thread-odd thread-alt depth-1 media comment-234214">
+    <img alt='' src='https://secure.gravatar.com/avatar/052f357996579c9c914f284a5067007b834af881072be87ab2e0c281aa1da748?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/052f357996579c9c914f284a5067007b834af881072be87ab2e0c281aa1da748?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading">David</h5>
+        <div class="comment-meta">
+        <time datetime="2023-01-13T15:14:31+01:00"><a href="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/#comment-234214">
+          13 enero, 2023</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-234214" data-commentid="234214" data-postid="59817" data-belowelement="comment-234214" data-respondelement="respond" data-replyto="Responder a David" aria-label="Responder a David">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Por qué esta receta se encuentra en el apartado de recetas sin gluten?.Acaso la pasta no lleva gluten?</p>
+      
+  </div></li>
+
+  <li id="comment-234017" class="comment even thread-even depth-1 media comment-234017">
+    <img alt='' src='https://secure.gravatar.com/avatar/533b503d3fc1781cdd76eacd2aa8f68348cdb3201605fe5b4616e6032a228068?s=56&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g' srcset='https://secure.gravatar.com/avatar/533b503d3fc1781cdd76eacd2aa8f68348cdb3201605fe5b4616e6032a228068?s=112&#038;d=https%3A%2F%2Fwww.velocidadcuchara.com%2Fimages%2Favatarnew_vc_2019.gif&#038;r=g 2x' class='avatar pull-left media-object avatar-56 photo' height='56' width='56' loading='lazy' decoding='async'/>    <div class="media-body">
+      <div class="comment-header clearfix">
+        <h5 class="media-heading"><a href="http://lacestitadelbebe.es/es" class="url" rel="ugc external nofollow">LaCestitadelBebe</a></h5>
+        <div class="comment-meta">
+        <time datetime="2022-11-30T06:27:46+01:00"><a href="https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/#comment-234017">
+          30 noviembre, 2022</a>
+        </time>
+        |
+        <a rel="nofollow" class="comment-reply-link" href="#comment-234017" data-commentid="234017" data-postid="59817" data-belowelement="comment-234017" data-respondelement="respond" data-replyto="Responder a LaCestitadelBebe" aria-label="Responder a LaCestitadelBebe">Responder</a>        
+                </div>
+      </div>
+
+      
+      <p>Buenas,</p>
+<p>no somos mucho de calabaza, pero la verdad es que sale genial. Nosotros estuvimos comiendo pastel de calabaza con las que nos sobraron de Halloween y estaban muy buenos!</p>
+<p>Gracias,</p>
+<p>Besos!</p>
+<p>A. Moreno      </p>
+<div class="ERRatingComment">
+<div style="width:100%" class="ERRatingCommentInner"></div>
+</p></div>
+      
+  </div></li>
+    </ol>
+
+    
+      </section><!-- /#comments -->
+  
+
+<button class="mostrar-comentarios despues button" style="cursor:pointer">Mostrar comentarios</button>
+
+  <section id="respond">
+  	<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Dejar una opinión <small><a rel="nofollow" id="cancel-comment-reply-link" href="/salsa-cremosa-de-calabaza-y-curry/#respond" style="display:none;">Cancelar la respuesta</a></small></h3><form action="https://www.velocidadcuchara.com/wp-comments-post.php" method="post" id="commentform" class="comment-form"><p class="comment-form-comment"><label for="comment">Comentarios</label> <textarea id="comment" name="comment" cols="45" rows="8" class="input-xlarge" aria-required="true" required="required"></textarea></p><p class="pprivacy"><input type="checkbox" class="form-check" name="privacy" value="privacy-key" class="privacyBox" aria-req="true">&nbsp;&nbsp;Acepto la <a target="blank" href="https://velocidadcuchara.com/politica-de-privacidad">política de privacidad</a><p><div class="row"><div class="col-md-4"><label for="author">Nombre <span class="comment-required">*</span></label> <input id="author" name="author" type="text" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="email">Email (no será publicado) <span class="comment-required">*</span></label> <input type="email" class="text" name="email" id="email" value="" aria-required="true" /></div>
+<div class="col-md-4"><label for="url">Sitio Web</label> <input id="url" name="url" type="url" value="" /></div>
+</div><p class="form-submit"><input name="submit" type="submit" id="submit" class="kad-btn kad-btn-primary" value="Enviar" /> <input type='hidden' name='comment_post_ID' value='59817' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><span class="ERComment">
+<span style="float:left">Valora esta receta: </span>
+<span class="ERRateBG">
+<span class="ERRateStars"></span>
+</span>
+<input type="hidden" class="inpERRating" name="ERRating" value="0" />
+&nbsp;
+</span><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="039a822123" /></p><p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="40"/><script type="rocketlazyloadscript">document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );</script></p></form>	</div><!-- #respond -->
+	
+  </section><!-- /#respond -->
+        </div>
+                    
+          	            <aside class="col-lg-3 col-md-4 kad-sidebar" role="complementary" itemscope itemtype="http://schema.org/WPSideBar">
+	              <div class="sidebar">
+	                <section class="widget-2 widget local-widget"><div class="widget-inner"><div id="local-2773051240" style="margin-bottom: 25px;margin-left: auto;margin-right: auto;text-align: center;"><picture style="display: inline-block; max-width: 100%; height: auto;">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg.webp"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/08/claudia_julia_300x100_codigo.jpg" alt="Claudia &amp; Julia: Utensilios para una cocina tradicional y saludable" width="300" height="100"/>
+</picture>
+</div></div></section><section id="siteorigin-panels-builder-28" class="widget-4 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w64208d0f963d5"  class="panel-layout" ><div id="pg-w64208d0f963d5-0"  class="panel-grid panel-no-style" ><div id="pgc-w64208d0f963d5-0-0"  class="panel-grid-cell" ><div id="panel-w64208d0f963d5-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://newsletter.velocidadcuchara.com/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Suscribete.svg" width="300" height="45" sizes="(max-width: 300px) 100vw, 300px" title="Suscríbete Newsletter" alt="Suscríbete a Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div><div id="panel-w64208d0f963d5-0-0-1" class="so-panel widget widget_sow-editor panel-last-child" data-index="1" ><div class="panel-widget-style panel-widget-style-for-w64208d0f963d5-0-0-1" ><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p style="text-align: center;"><a href="https://newsletter.velocidadcuchara.com/" target="_blank" rel="noopener"><em>Recibe nuestra Newsletter<br />
+en tu correo electrónico</em></a></p>
+</div>
+</div></div></div></div></div></div></div></section><section id="sow-image-26" class="widget-5 widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/todas-las-recetas/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2018/07/descubre_todas_nuestras_recetas-1.svg" width="1" height="1" sizes="(max-width: 1px) 100vw, 1px" title="Todas las recetas Thermomix" alt="Todas las recetas Thermomix" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section><section id="custom_html-5" class="widget_text widget-6 widget widget_custom_html"><div class="widget_text widget-inner"><div class="textwidget custom-html-widget"><script type="rocketlazyloadscript" async data-rocket-src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0432726040009676"
+     crossorigin="anonymous"></script>
+<!-- PRUEBA 23 -->
+<ins class="adsbygoogle"
+     style="display:block"
+     data-ad-client="ca-pub-0432726040009676"
+     data-ad-slot="7485608005"
+     data-ad-format="auto"
+     data-full-width-responsive="true"></ins>
+<script type="rocketlazyloadscript">
+     (adsbygoogle = window.adsbygoogle || []).push({});
+</script></div></div></section><section id="siteorigin-panels-builder-29" class="widget-7 widget widget_siteorigin-panels-builder"><div class="widget-inner"><div id="pl-w5f89a361017dd"  class="panel-layout" ><div id="pg-w5f89a361017dd-0"  class="panel-grid panel-has-style" ><div class="panel-row-style panel-row-style-for-w5f89a361017dd-0" ><div id="pgc-w5f89a361017dd-0-0"  class="panel-grid-cell" ><div id="panel-w5f89a361017dd-0-0-0" class="so-panel widget widget_sow-image panel-first-child" data-index="0" ><div class="panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-0" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.youtube.com/user/velocidadcuchara" target="_blank" rel="noopener noreferrer" >	<picture class="so-widget-image">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png.webp 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png.webp 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png.webp 600w" sizes="(max-width: 300px) 100vw, 300px"/>
+<img src="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020-560x280.png 560w, https://www.velocidadcuchara.com/wp-content/uploads/2020/10/video_vc_general_2020.png 600w" sizes="(max-width: 300px) 100vw, 300px" alt=""/>
+</picture>
+
+</a></div>
+
+</div></div></div><div id="panel-w5f89a361017dd-0-0-1" class="so-panel widget widget_sow-image" data-index="1" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-1" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/tarta-sacher-paso-a-paso-con-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_tarta_sacher.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Tarta Sacher" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Tarta Sacher</h3></div></div></div><div id="panel-w5f89a361017dd-0-0-2" class="so-panel widget widget_sow-image panel-last-child" data-index="2" ><div class="titulovideo panel-widget-style panel-widget-style-for-w5f89a361017dd-0-0-2" ><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/como-preparar-yogur-en-thermomix/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png" width="300" height="150" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2-300x150.png 300w, https://www.velocidadcuchara.com/wp-content/uploads/2017/05/video_yogurt_casero2.png 600w" sizes="(max-width: 300px) 100vw, 300px" title="Yogurt casero" alt="" 		class="so-widget-image"/>
+</a></div>
+
+	<h3 class="widget-title">Yogurt casero</h3></div></div></div></div></div></div></div></div></section><section id="sow-image-18" class="widget-8 widget-last widget widget_sow-image"><div class="widget-inner"><div class="so-widget-sow-image so-widget-sow-image-default-17bc2272b535">
+
+<div class="sow-image-container">
+<a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/" >	<img src="https://www.velocidadcuchara.com/wp-content/uploads/2023/03/Podcast-Caratula-cuadrados-1080-×-1920-px-1000-×-1000-px.svg" width="300" height="300" sizes="(max-width: 300px) 100vw, 300px" title="Promo libros Velocidad Cuchara" alt="Promo libros Velocidad Cuchara" 		class="so-widget-image"/>
+</a></div>
+
+</div></div></section>	              </div><!-- /.sidebar -->
+	            </aside><!-- /aside -->
+                    </div><!-- /.row-->
+        </div><!-- /.content -->
+      </div><!-- /.wrap -->
+      <footer data-wpr-lazyrender="1" id="containerfooter" class="footerclass" itemscope itemtype="http://schema.org/WPFooter">
+  <div class="container">
+  	<div class="row">
+  							<div class="col-md-4 footercol1">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-5" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base">
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="https://www.velocidadcuchara.com"><img loading="lazy" decoding="async" class="alignnone wp-image-45320" src="https://www.velocidadcuchara.com/wp-content/uploads/2025/10/footer_vc.svg" alt="" width="171" height="53" /></a></p>
+<p>Desde 2008 cocinamos con (y sin) el robot de cocina más famoso del mundo</p>
+<div class="space_20 clearfix"></div>
+<figure id="attachment_43492" class="thumbnail wp-caption alignnone" style="width: 176px"><picture loading="lazy" decoding="async" class="size-full wp-image-43492">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png.webp 176w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+<img loading="lazy" decoding="async" src="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png" alt="" width="176" height="46" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016.png 176w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-140x36.png 140w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-24x6.png 24w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-36x9.png 36w, https://www.velocidadcuchara.com/wp-content/uploads/2016/11/bitacoras_2016-48x12.png 48w" sizes="auto, (max-width: 176px) 100vw, 176px"/>
+</picture>
+<figcaption class="caption wp-caption-text">Ganadores en la XII edición</figcaption></figure>
+<figure id="attachment_45318" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45318" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/gastroblogs.png" alt="" width="176" height="52" /><figcaption class="caption wp-caption-text">Ganador Gastroblogs</figcaption></figure>
+<figure id="attachment_45319" class="thumbnail wp-caption alignnone" style="width: 176px"><img loading="lazy" decoding="async" class="size-full wp-image-45319" src="https://www.velocidadcuchara.com/wp-content/uploads/2017/06/bitacoras.png" alt="" width="176" height="46" /><figcaption class="caption wp-caption-text">Finalista en Gastronomía</figcaption></figure>
+</div>
+</div></aside></div>					</div>
+            										<div class="col-md-4 footercol2">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-social-media-buttons-4" class="widget widget_sow-social-media-buttons"><div class="so-widget-sow-social-media-buttons so-widget-sow-social-media-buttons-flat-3af2f923c85f"><h3>EN LAS REDES</h3>
+<div class="social-media-button-container">
+	
+		<a class="ow-button-hover sow-social-media-button-facebook sow-social-media-button" title="Velocidad Cuchara en Facebook" aria-label="Velocidad Cuchara en Facebook" target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf39e;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-instagram sow-social-media-button" title="Velocidad Cuchara en Instagram" aria-label="Velocidad Cuchara en Instagram" target="_blank" rel="noopener noreferrer" href="https://www.instagram.com/velocidadcuchara/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf16d;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-youtube sow-social-media-button" title="Velocidad Cuchara en Youtube" aria-label="Velocidad Cuchara en Youtube" target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/user/velocidadcuchara" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf167;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-twitter sow-social-media-button" title="Velocidad Cuchara en Twitter" aria-label="Velocidad Cuchara en Twitter" target="_blank" rel="noopener noreferrer" href="https://twitter.com/rosaarda" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf099;" ></span>							</span>
+		</a>
+	
+		<a class="ow-button-hover sow-social-media-button-pinterest sow-social-media-button" title="Velocidad Cuchara en Pinterest" aria-label="Velocidad Cuchara en Pinterest" target="_blank" rel="noopener noreferrer" href="https://es.pinterest.com/rosaarda/" >
+			<span>
+								<span class="sow-icon-fontawesome sow-fab" data-sow-icon="&#xf0d2;" ></span>							</span>
+		</a>
+	</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-6" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>ROSA ARDÁ</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>Enganchada a la Thermomix, uno de los grandes inventos de la historia :D</p>
+</div>
+</div></aside></div><div class="widget-3 widget-last footer-widget"><aside id="media_image-2" class="widget widget_media_image"><h3>NUESTROS LIBROS</h3><a href="https://www.velocidadcuchara.com/libros-velocidad-cuchara/"><picture class="image wp-image-58705  attachment-full size-full" style="max-width: 100%; height: auto;" title="NUESTRO LIBRO" decoding="async" loading="lazy">
+<source type="image/webp" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png.webp 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png.webp 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+<img width="241" height="148" src="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png" alt="" decoding="async" loading="lazy" srcset="https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter.png 241w, https://www.velocidadcuchara.com/wp-content/uploads/2021/11/librosfooter-80x50.png 80w" sizes="auto, (max-width: 241px) 100vw, 241px"/>
+</picture>
+</a></aside></div>					</div>
+		        		        					<div class="col-md-4 footercol3">
+					<div class="widget-1 widget-first footer-widget"><aside id="sow-editor-7" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>AVISO LEGAL</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p>VelocidadCuchara.com y Velocidad Cuchara <a href="https://www.velocidadcuchara.com/aviso-legal/">son marcas registradas</a>. Consulta la <a href="https://www.velocidadcuchara.com/declaracion-de-privacidad-ue/" target="_blank" rel="noopener">Política de privacidad</a> y la <a href="https://www.velocidadcuchara.com/politica-de-cookies-ue/" target="_blank" rel="noopener">Política de Cookies</a></p>
+</div>
+</div></aside></div><div class="widget-2 footer-widget"><aside id="sow-editor-8" class="widget widget_sow-editor"><div class="so-widget-sow-editor so-widget-sow-editor-base"><h3>NOS ENCANTA LEER</h3>
+<div class="siteorigin-widget-tinymce textwidget">
+	<p><a href="http://www.averquecocinamoshoy.com/" target="_blank" rel="noopener noreferrer">A ver qué cocinamos hoy</a><br />
+<a href="http://www.crockpotting.es/" target="_blank" rel="noopener">Crockpotting</a><br />
+<a href="https://elcomidista.elpais.com/" target="_blank" rel="noopener noreferrer">El Comidista</a><br />
+<a href="http://www.misthermorecetas.com/" target="_blank" rel="noopener noreferrer">Mis thermorecetas</a><br />
+<a href="http://pepacooks.com/" target="_blank" rel="noopener noreferrer">Pepa Cooks </a><br />
+<a href="http://www.recetasderechupete.com/" target="_blank" rel="noopener noreferrer">Recetas de Rechupete </a><br />
+<a href="https://webosfritos.es/" target="_blank" rel="noopener noreferrer">Webos Fritos</a></p>
+</div>
+</div></aside></div><div class="widget_text widget-3 widget-last footer-widget"><aside id="custom_html-3" class="widget_text widget widget_custom_html"><div class="textwidget custom-html-widget"></div></aside></div>					</div>
+	            			        </div>
+        <div class="footercredits clearfix">
+
+    		        	<p>&copy; 2008 - 2026 Velocidad Cuchara</p>
+    	</div>
+
+  </div>
+
+</footer>
+</div><!--Wrapper-->
+
+<script type="rocketlazyloadscript" data-rocket-type='text/javascript'>
+/* <![CDATA[ */
+var advancedAds = {"adHealthNotice":{"enabled":true,"pattern":"AdSense fallback was loaded for empty AdSense ad \"[ad_title]\""},"frontendPrefix":"local-"};
+
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript">(function(){var advanced_ads_ga_UID="rosaarda",advanced_ads_ga_anonymIP=!!1;window.advanced_ads_check_adblocker=function(){var t=[],n=null;function e(t){var n=window.requestAnimationFrame||window.mozRequestAnimationFrame||window.webkitRequestAnimationFrame||function(t){return setTimeout(t,16)};n.call(window,t)}return e((function(){var a=document.createElement("div");a.innerHTML="&nbsp;",a.setAttribute("class","ad_unit ad-unit text-ad text_ad pub_300x250"),a.setAttribute("style","width: 1px !important; height: 1px !important; position: absolute !important; left: 0px !important; top: 0px !important; overflow: hidden !important;"),document.body.appendChild(a),e((function(){var e,o,i=null===(e=(o=window).getComputedStyle)||void 0===e?void 0:e.call(o,a),d=null==i?void 0:i.getPropertyValue("-moz-binding");n=i&&"none"===i.getPropertyValue("display")||"string"==typeof d&&-1!==d.indexOf("about:");for(var c=0,r=t.length;c<r;c++)t[c](n);t=[]}))})),function(e){"undefined"==typeof advanced_ads_adblocker_test&&(n=!0),null!==n?e(n):t.push(e)}}(),(()=>{function t(t){this.UID=t,this.analyticsObject="function"==typeof gtag;var n=this;return this.count=function(){gtag("event","AdBlock",{event_category:"Advanced Ads",event_label:"Yes",non_interaction:!0,send_to:n.UID})},function(){if(!n.analyticsObject){var e=document.createElement("script");e.src="https://www.googletagmanager.com/gtag/js?id="+t,e.async=!0,document.body.appendChild(e),window.dataLayer=window.dataLayer||[],window.gtag=function(){dataLayer.push(arguments)},n.analyticsObject=!0,gtag("js",new Date)}var a={send_page_view:!1,transport_type:"beacon"};window.advanced_ads_ga_anonymIP&&(a.anonymize_ip=!0),gtag("config",t,a)}(),this}advanced_ads_check_adblocker((function(n){n&&new t(advanced_ads_ga_UID).count()}))})();})();</script><script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"\/*"},{"not":{"href_matches":["\/wp-*.php","\/wp-admin\/*","\/wp-content\/uploads\/*","\/wp-content\/*","\/wp-content\/plugins\/*","\/wp-content\/themes\/velocidad\/*","\/wp-content\/themes\/virtue\/*","\/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+
+<!-- Consent Management powered by Complianz | GDPR/CCPA Cookie Consent https://wordpress.org/plugins/complianz-gdpr -->
+<div id="cmplz-cookiebanner-container"><div class="cmplz-cookiebanner cmplz-hidden banner-1 velocidad-cuchara optin cmplz-bottom cmplz-categories-type-view-preferences" aria-modal="true" data-nosnippet="true" role="dialog" aria-live="polite" aria-labelledby="cmplz-header-1-optin" aria-describedby="cmplz-message-1-optin">
+	<div class="cmplz-header">
+		<div class="cmplz-logo"><img width="350" height="100" src="https://www.velocidadcuchara.com/wp-content/uploads/2024/03/cookies-350x100.png" class="attachment-cmplz_banner_image size-cmplz_banner_image" alt="Velocidad Cuchara" decoding="async" loading="lazy" /></div>
+		<div class="cmplz-title" id="cmplz-header-1-optin">Gestiona tu privacidad</div>
+		<div class="cmplz-close" tabindex="0" role="button" aria-label="Cerrar diálogo">
+			<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>
+		</div>
+	</div>
+
+	<div class="cmplz-divider cmplz-divider-header"></div>
+	<div class="cmplz-body">
+		<div class="cmplz-message" id="cmplz-message-1-optin"><p>Para ofrecer las mejores experiencias, nosotros y nuestros socios utilizamos tecnologías como cookies para almacenar y/o acceder a la información del dispositivo. La aceptación de estas tecnologías nos permitirá a nosotros y a nuestros socios procesar datos personales como el comportamiento de navegación o identificaciones únicas (IDs) en este sitio y mostrar anuncios (no-) personalizados. No consentir o retirar el consentimiento, puede afectar negativamente a ciertas características y funciones.</p><p>Haz clic a continuación para aceptar lo anterior o realizar elecciones más detalladas.&nbsp;Tus elecciones se aplicarán solo en este sitio.&nbsp;Puedes cambiar tus ajustes en cualquier momento, incluso retirar tu consentimiento, utilizando los botones de la Política de cookies o haciendo clic en el icono de Privacidad situado en la parte inferior de la pantalla.</p></div>
+		<!-- categories start -->
+		<div class="cmplz-categories">
+			<details class="cmplz-category cmplz-functional" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Funcional</span>
+							<span class='cmplz-always-active'>
+								<span class="cmplz-banner-checkbox">
+									<input type="checkbox"
+										   id="cmplz-functional-optin"
+										   data-category="cmplz_functional"
+										   class="cmplz-consent-checkbox cmplz-functional"
+										   size="40"
+										   value="1"/>
+									<label class="cmplz-label" for="cmplz-functional-optin"><span class="screen-reader-text">Funcional</span></label>
+								</span>
+								Siempre activo							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-functional">El almacenamiento o acceso técnico es estrictamente necesario para el propósito legítimo de permitir el uso de un servicio específico explícitamente solicitado por el abonado o usuario, o con el único propósito de llevar a cabo la transmisión de una comunicación a través de una red de comunicaciones electrónicas.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-preferences" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Preferencias</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-preferences-optin"
+									   data-category="cmplz_preferences"
+									   class="cmplz-consent-checkbox cmplz-preferences"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-preferences-optin"><span class="screen-reader-text">Preferencias</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-preferences">El almacenamiento o acceso técnico es necesario para la finalidad legítima de almacenar preferencias no solicitadas por el abonado o usuario.</span>
+				</div>
+			</details>
+
+			<details class="cmplz-category cmplz-statistics" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Estadísticas</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-statistics-optin"
+									   data-category="cmplz_statistics"
+									   class="cmplz-consent-checkbox cmplz-statistics"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-statistics-optin"><span class="screen-reader-text">Estadísticas</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-statistics">El almacenamiento o acceso técnico que es utilizado exclusivamente con fines estadísticos.</span>
+					<span class="cmplz-description-statistics-anonymous">El almacenamiento o acceso técnico que se utiliza exclusivamente con fines estadísticos anónimos. Sin un requerimiento, el cumplimiento voluntario por parte de tu Proveedor de servicios de Internet, o los registros adicionales de un tercero, la información almacenada o recuperada sólo para este propósito no se puede utilizar para identificarte.</span>
+				</div>
+			</details>
+			<details class="cmplz-category cmplz-marketing" >
+				<summary>
+						<span class="cmplz-category-header">
+							<span class="cmplz-category-title">Marketing</span>
+							<span class="cmplz-banner-checkbox">
+								<input type="checkbox"
+									   id="cmplz-marketing-optin"
+									   data-category="cmplz_marketing"
+									   class="cmplz-consent-checkbox cmplz-marketing"
+									   size="40"
+									   value="1"/>
+								<label class="cmplz-label" for="cmplz-marketing-optin"><span class="screen-reader-text">Marketing</span></label>
+							</span>
+							<span class="cmplz-icon cmplz-open">
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
+							</span>
+						</span>
+				</summary>
+				<div class="cmplz-description">
+					<span class="cmplz-description-marketing">El almacenamiento o acceso técnico es necesario para crear perfiles de usuario para enviar publicidad, o para rastrear al usuario en una web o en varias web con fines de marketing similares.</span>
+				</div>
+			</details>
+		</div><!-- categories end -->
+		
+<div class="cmplz-categories cmplz-tcf">
+
+	<div class="cmplz-category cmplz-statistics">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Estadísticas</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-marketing">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Marketing</div>
+			<div class='cmplz-always-active'></div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-features">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title">Características</div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+			<p class="cmplz-description"></p>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialfeatures">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'></div>
+		</div>
+	</div>
+
+	<div class="cmplz-category cmplz-specialpurposes">
+		<div class="cmplz-category-header">
+			<div class="cmplz-title"></div>
+			<div class='cmplz-always-active'>Siempre activo</div>
+		</div>
+	</div>
+
+</div>
+	</div>
+
+	<div class="cmplz-links cmplz-information">
+		<ul>
+			<li><a class="cmplz-link cmplz-manage-options cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a></li>
+			<li><a class="cmplz-link cmplz-manage-third-parties cookie-statement" href="#" data-relative_url="#cmplz-cookies-overview">Gestionar los servicios</a></li>
+			<li><a class="cmplz-link cmplz-manage-vendors tcf cookie-statement" href="#" data-relative_url="#cmplz-tcf-wrapper">Gestionar {vendor_count} proveedores</a></li>
+			<li><a class="cmplz-link cmplz-external cmplz-read-more-purposes tcf" target="_blank" rel="noopener noreferrer nofollow" href="https://cookiedatabase.org/tcf/purposes/" aria-label="Read more about TCF purposes on Cookie Database">Leer más sobre estos propósitos</a></li>
+		</ul>
+			</div>
+
+	<div class="cmplz-divider cmplz-footer"></div>
+
+	<div class="cmplz-buttons">
+		<button class="cmplz-btn cmplz-accept">Aceptar</button>
+		<button class="cmplz-btn cmplz-deny">Rechazar</button>
+		<button class="cmplz-btn cmplz-view-preferences">Administrar opciones</button>
+		<button class="cmplz-btn cmplz-save-preferences">Guardar preferencias</button>
+		<a class="cmplz-btn cmplz-manage-options tcf cookie-statement" href="#" data-relative_url="#cmplz-manage-consent-container">Administrar opciones</a>
+			</div>
+
+	
+	<div class="cmplz-documents cmplz-links">
+		<ul>
+			<li><a class="cmplz-link cookie-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link privacy-statement" href="#" data-relative_url="">{title}</a></li>
+			<li><a class="cmplz-link impressum" href="#" data-relative_url="">{title}</a></li>
+		</ul>
+			</div>
+</div>
+</div>
+					<div id="cmplz-manage-consent" data-nosnippet="true"><button class="cmplz-btn cmplz-hidden cmplz-manage-consent manage-consent-1">Privacidad</button>
+
+</div>        <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        jQuery(document).ready(function($){
+            $("#submit").click(function(e)){
+                if (!$('.privacyBox').prop('checked')){
+                    e.preventDefault();
+                    alert('Debes aceptar nuestra política de privacidad <p><a href="javascript:history.back()">' . __('&laquo; Volver') . '</a></p>');
+                    return false;
+                }
+            }
+        });
+        </script>
+                        <style type="text/css" media="all"
+                       id="siteorigin-panels-layouts-footer">/* Layout w64208d0f963d5 */ #pgc-w64208d0f963d5-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-0 , #pl-w64208d0f963d5 #panel-w64208d0f963d5-0-0-1 {  } #pl-w64208d0f963d5 .so-panel { margin-bottom:30px } #pl-w64208d0f963d5 .so-panel:last-child { margin-bottom:0px } #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w64208d0f963d5-0-0-1> .panel-widget-style { color:#bdbeb2;margin-top:-18px;font-size:1.2em;font-weight:400;line-height:1.2em } @media (max-width:780px){ #pg-w64208d0f963d5-0.panel-no-style, #pg-w64208d0f963d5-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w64208d0f963d5-0 > .panel-grid-cell , #pg-w64208d0f963d5-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w64208d0f963d5 .panel-grid-cell { padding:0 } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-empty { display:none } #pl-w64208d0f963d5 .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } /* Layout w5f89a361017dd */ #pgc-w5f89a361017dd-0-0 { width:100%;width:calc(100% - ( 0 * 30px ) ) } #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-0 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-1 , #pl-w5f89a361017dd #panel-w5f89a361017dd-0-0-2 {  } #pl-w5f89a361017dd .so-panel { margin-bottom:30px } #pl-w5f89a361017dd .so-panel:last-child { margin-bottom:0px } #pg-w5f89a361017dd-0> .panel-row-style { background-color:#e7e8e1;padding:0.5em } #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-align-items:flex-start;align-items:flex-start } #panel-w5f89a361017dd-0-0-0> .panel-widget-style { margin-bottom:20px } @media (max-width:780px){ #pg-w5f89a361017dd-0.panel-no-style, #pg-w5f89a361017dd-0.panel-has-style > .panel-row-style { -webkit-flex-direction:column;-ms-flex-direction:column;flex-direction:column } #pg-w5f89a361017dd-0 > .panel-grid-cell , #pg-w5f89a361017dd-0 > .panel-row-style > .panel-grid-cell { width:100%;margin-right:0 } #pl-w5f89a361017dd .panel-grid-cell { padding:0 } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-empty { display:none } #pl-w5f89a361017dd .panel-grid .panel-grid-cell-mobile-last { margin-bottom:0px }  } </style><link rel='stylesheet' id='siteorigin-panels-front-css' href='https://www.velocidadcuchara.com/wp-content/plugins/siteorigin-panels/css/front-flex.min.css?ver=2.10.9' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='sow-social-media-buttons-flat-3af2f923c85f-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/uploads/siteorigin-widgets/sow-social-media-buttons-flat-3af2f923c85f.css?ver=1773428753' type='text/css' media='all' />
+<link data-minify="1" rel='stylesheet' id='siteorigin-widget-icon-font-fontawesome-css' href='https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/so-widgets-bundle/icons/fontawesome/style.css?ver=1773428753' type='text/css' media='all' />
+<script type="text/javascript" id="wtpsw-public-script-js-extra">
+/* <![CDATA[ */
+var Wtpsw = {"elementor_preview":"0","ajaxurl":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","is_mobile":"0","is_avada":"0","is_rtl":"0","post_view_count":"59817","data_nonce":"aca6b40d34"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/wp-trending-post-slider-and-widget/assets/js/wtpsw-public.js?ver=1773428753" id="wtpsw-public-script-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-browser-checker-js-after">
+/* <![CDATA[ */
+"use strict";var _createClass=function(){function defineProperties(target,props){for(var i=0;i<props.length;i++){var descriptor=props[i];descriptor.enumerable=descriptor.enumerable||!1,descriptor.configurable=!0,"value"in descriptor&&(descriptor.writable=!0),Object.defineProperty(target,descriptor.key,descriptor)}}return function(Constructor,protoProps,staticProps){return protoProps&&defineProperties(Constructor.prototype,protoProps),staticProps&&defineProperties(Constructor,staticProps),Constructor}}();function _classCallCheck(instance,Constructor){if(!(instance instanceof Constructor))throw new TypeError("Cannot call a class as a function")}var RocketBrowserCompatibilityChecker=function(){function RocketBrowserCompatibilityChecker(options){_classCallCheck(this,RocketBrowserCompatibilityChecker),this.passiveSupported=!1,this._checkPassiveOption(this),this.options=!!this.passiveSupported&&options}return _createClass(RocketBrowserCompatibilityChecker,[{key:"_checkPassiveOption",value:function(self){try{var options={get passive(){return!(self.passiveSupported=!0)}};window.addEventListener("test",null,options),window.removeEventListener("test",null,options)}catch(err){self.passiveSupported=!1}}},{key:"initRequestIdleCallback",value:function(){!1 in window&&(window.requestIdleCallback=function(cb){var start=Date.now();return setTimeout(function(){cb({didTimeout:!1,timeRemaining:function(){return Math.max(0,50-(Date.now()-start))}})},1)}),!1 in window&&(window.cancelIdleCallback=function(id){return clearTimeout(id)})}},{key:"isDataSaverModeOn",value:function(){return"connection"in navigator&&!0===navigator.connection.saveData}},{key:"supportsLinkPrefetch",value:function(){var elem=document.createElement("link");return elem.relList&&elem.relList.supports&&elem.relList.supports("prefetch")&&window.IntersectionObserver&&"isIntersecting"in IntersectionObserverEntry.prototype}},{key:"isSlowConnection",value:function(){return"connection"in navigator&&"effectiveType"in navigator.connection&&("2g"===navigator.connection.effectiveType||"slow-2g"===navigator.connection.effectiveType)}}]),RocketBrowserCompatibilityChecker}();
+/* ]]> */
+</script>
+<script type="text/javascript" id="rocket-preload-links-js-extra">
+/* <![CDATA[ */
+var RocketPreloadLinksConfig = {"excludeUris":"\/(?:.+\/)?feed(?:\/(?:.+\/?)?)?$|\/(?:.+\/)?embed\/|\/(index.php\/)?(.*)wp-json(\/.*|$)|\/refer\/|\/go\/|\/recommend\/|\/recommends\/","usesTrailingSlash":"1","imageExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php","fileExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|pdf|doc|docx|xls|xlsx|php|html|htm","siteUrl":"https:\/\/www.velocidadcuchara.com","onHoverDelay":"100","rateThrottle":"3"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="rocket-preload-links-js-after">
+/* <![CDATA[ */
+(function() {
+"use strict";var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},e=function(){function i(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}return function(e,t,n){return t&&i(e.prototype,t),n&&i(e,n),e}}();function i(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var t=function(){function n(e,t){i(this,n),this.browser=e,this.config=t,this.options=this.browser.options,this.prefetched=new Set,this.eventTime=null,this.threshold=1111,this.numOnHover=0}return e(n,[{key:"init",value:function(){!this.browser.supportsLinkPrefetch()||this.browser.isDataSaverModeOn()||this.browser.isSlowConnection()||(this.regex={excludeUris:RegExp(this.config.excludeUris,"i"),images:RegExp(".("+this.config.imageExt+")$","i"),fileExt:RegExp(".("+this.config.fileExt+")$","i")},this._initListeners(this))}},{key:"_initListeners",value:function(e){-1<this.config.onHoverDelay&&document.addEventListener("mouseover",e.listener.bind(e),e.listenerOptions),document.addEventListener("mousedown",e.listener.bind(e),e.listenerOptions),document.addEventListener("touchstart",e.listener.bind(e),e.listenerOptions)}},{key:"listener",value:function(e){var t=e.target.closest("a"),n=this._prepareUrl(t);if(null!==n)switch(e.type){case"mousedown":case"touchstart":this._addPrefetchLink(n);break;case"mouseover":this._earlyPrefetch(t,n,"mouseout")}}},{key:"_earlyPrefetch",value:function(t,e,n){var i=this,r=setTimeout(function(){if(r=null,0===i.numOnHover)setTimeout(function(){return i.numOnHover=0},1e3);else if(i.numOnHover>i.config.rateThrottle)return;i.numOnHover++,i._addPrefetchLink(e)},this.config.onHoverDelay);t.addEventListener(n,function e(){t.removeEventListener(n,e,{passive:!0}),null!==r&&(clearTimeout(r),r=null)},{passive:!0})}},{key:"_addPrefetchLink",value:function(i){return this.prefetched.add(i.href),new Promise(function(e,t){var n=document.createElement("link");n.rel="prefetch",n.href=i.href,n.onload=e,n.onerror=t,document.head.appendChild(n)}).catch(function(){})}},{key:"_prepareUrl",value:function(e){if(null===e||"object"!==(void 0===e?"undefined":r(e))||!1 in e||-1===["http:","https:"].indexOf(e.protocol))return null;var t=e.href.substring(0,this.config.siteUrl.length),n=this._getPathname(e.href,t),i={original:e.href,protocol:e.protocol,origin:t,pathname:n,href:t+n};return this._isLinkOk(i)?i:null}},{key:"_getPathname",value:function(e,t){var n=t?e.substring(this.config.siteUrl.length):e;return n.startsWith("/")||(n="/"+n),this._shouldAddTrailingSlash(n)?n+"/":n}},{key:"_shouldAddTrailingSlash",value:function(e){return this.config.usesTrailingSlash&&!e.endsWith("/")&&!this.regex.fileExt.test(e)}},{key:"_isLinkOk",value:function(e){return null!==e&&"object"===(void 0===e?"undefined":r(e))&&(!this.prefetched.has(e.href)&&e.origin===this.config.siteUrl&&-1===e.href.indexOf("?")&&-1===e.href.indexOf("#")&&!this.regex.excludeUris.test(e.href)&&!this.regex.images.test(e.href))}}],[{key:"run",value:function(){"undefined"!=typeof RocketPreloadLinksConfig&&new n(new RocketBrowserCompatibilityChecker({capture:!0,passive:!0}),RocketPreloadLinksConfig).init()}}]),n}();t.run();
+}());
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads/admin/assets/js/advertisement.js?ver=1773428753" id="advanced-ads-find-adblocker-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro-main-js-extra">
+/* <![CDATA[ */
+var advanced_ads_cookies = {"cookie_path":"\/","cookie_domain":""};
+var advadsCfpInfo = {"cfpExpHours":"3","cfpClickLimit":"3","cfpBan":"7","cfpPath":"","cfpDomain":"www.velocidadcuchara.com","cfpEnabled":""};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/advanced-ads-pro.js?ver=1773428753" id="advanced-ads-pro-main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/js/postscribe.js?ver=1773428753" id="advanced-ads-pro/postscribe-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="advanced-ads-pro/cache_busting-js-extra">
+/* <![CDATA[ */
+var advanced_ads_pro_ajax_object = {"ajax_url":"https:\/\/www.velocidadcuchara.com\/wp-admin\/admin-ajax.php","lazy_load_module_enabled":"1","lazy_load":{"default_offset":0,"offsets":[]},"moveintohidden":"","wp_timezone_offset":"7200","the_id":"59817","is_singular":"1"};
+var advanced_ads_responsive = {"reload_on_resize":"1"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/advanced-ads-pro/assets/dist/front.js?ver=1773428753" id="advanced-ads-pro/cache_busting-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/comment-reply.min.js?ver=6.8.2" id="comment-reply-js" async="async" data-wp-strategy="async"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/imagesloaded.min.js?ver=5.0.0" id="imagesloaded-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/masonry.min.js?ver=4.2.2" id="masonry-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/themes/virtue/assets/js/min/plugins-min.js?ver=303" id="kadence_plugins-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/themes/virtue/assets/js/main.js?ver=1773428753" id="kadence_main-js" data-rocket-defer defer></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-includes/js/hoverIntent.min.js?ver=1.10.2" id="hoverIntent-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="megamenu-js-extra">
+/* <![CDATA[ */
+var megamenu = {"timeout":"300","interval":"100"};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/megamenu/js/maxmegamenu.js?ver=1773428753" id="megamenu-js" data-rocket-defer defer></script>
+<script type="text/javascript" id="cmplz-cookiebanner-js-extra">
+/* <![CDATA[ */
+var complianz = {"prefix":"cmplz_","user_banner_id":"1","set_cookies":[],"block_ajax_content":"0","banner_version":"48","version":"7.5.6.1","store_consent":"1","do_not_track_enabled":"","consenttype":"optin","region":"eu","geoip":"1","dismiss_timeout":"","disable_cookiebanner":"","soft_cookiewall":"","dismiss_on_scroll":"","cookie_expiry":"365","url":"https:\/\/www.velocidadcuchara.com\/wp-json\/complianz\/v1\/","locale":"lang=es&locale=es_ES","set_cookies_on_root":"0","cookie_domain":"","current_policy_id":"44","cookie_path":"\/","categories":{"statistics":"estad\u00edsticas","marketing":"m\u00e1rketing"},"tcf_active":"1","placeholdertext":"Haz clic para aceptar {category} cookies y habilitar este contenido","css_file":"https:\/\/www.velocidadcuchara.com\/wp-content\/uploads\/complianz\/css\/banner-{banner_id}-{type}.css?v=48","page_links":{"eu":{"cookie-statement":{"title":"Pol\u00edtica de cookies ","url":"https:\/\/www.velocidadcuchara.com\/politica-de-cookies-ue\/"},"privacy-statement":{"title":"Declaraci\u00f3n de privacidad ","url":"https:\/\/www.velocidadcuchara.com\/declaracion-de-privacidad-ue\/"}}},"tm_categories":"1","forceEnableStats":"","preview":"","clean_cookies":"","aria_label":"Haz clic para aceptar {category} cookies y habilitar este contenido","tcf_regions":["us","ca","eu","uk","au","za","br"]};
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/plugins/complianz-gdpr-premium/cookiebanner/js/complianz.min.js?ver=1768420286" id="cmplz-cookiebanner-js"></script>
+<script type="rocketlazyloadscript" data-rocket-type="text/javascript" id="cmplz-cookiebanner-js-after">
+/* <![CDATA[ */
+	let cmplzBlockedContent = document.querySelector('.cmplz-blocked-content-notice');
+	if ( cmplzBlockedContent) {
+	        cmplzBlockedContent.addEventListener('click', function(event) {
+            event.stopPropagation();
+        });
+	}
+    
+/* ]]> */
+</script>
+<script type="rocketlazyloadscript" data-minify="1" defer data-rocket-type="text/javascript" data-rocket-src="https://www.velocidadcuchara.com/wp-content/cache/min/1/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1773428753" id="akismet-frontend-js"></script>
+<!-- Statistics script Complianz GDPR/CCPA -->
+						<script type="rocketlazyloadscript" data-category="functional">
+							(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MBHRNJL');
+
+const revokeListeners = [];
+window.addRevokeListener = (callback) => {
+	revokeListeners.push(callback);
+};
+document.addEventListener("cmplz_revoke", function (e) {
+	cmplz_set_cookie('cmplz_consent_mode', 'revoked', false );
+	revokeListeners.forEach((callback) => {
+		callback();
+	});
+});
+
+const consentListeners = [];
+/**
+ * Called from GTM template to set callback to be executed when user consent is provided.
+ * @param callback
+ */
+window.addConsentUpdateListener = (callback) => {
+	consentListeners.push(callback);
+};
+document.addEventListener("cmplz_fire_categories", function (e) {
+	var consentedCategories = e.detail.categories;
+	const consent = {
+		'security_storage': "granted",
+		'functionality_storage': "granted",
+		'personalization_storage':  cmplz_in_array( 'preferences', consentedCategories ) ? 'granted' : 'denied',
+		'analytics_storage':  cmplz_in_array( 'statistics', consentedCategories ) ? 'granted' : 'denied',
+		'ad_storage': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_user_data': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+		'ad_personalization': cmplz_in_array( 'marketing', consentedCategories ) ? 'granted' : 'denied',
+	};
+
+	//don't use automatic prefixing, as the TM template needs to be sure it's cmplz_.
+	let consented = [];
+	for (const [key, value] of Object.entries(consent)) {
+		if (value === 'granted') {
+			consented.push(key);
+		}
+	}
+	cmplz_set_cookie('cmplz_consent_mode', consented.join(','), false );
+	consentListeners.forEach((callback) => {
+		callback(consent);
+	});
+});
+						</script><!--noptimize--><script type="rocketlazyloadscript">window.advads_admin_bar_items = [{"title":"ADS RECETA P\u00c1RRAFO 1","type":"ad","count":1},{"title":"Contenido","type":"placement","count":1},{"title":"Contenido 2","type":"placement","count":1},{"title":"ADS RECETA P\u00c1RRAFO 3","type":"ad","count":0},{"title":"ADS RECETA P\u00c1RRAFO 5","type":"ad","count":1},{"title":"Contenido 3","type":"placement","count":1},{"title":"PRP C&amp;J ESCRITORIO","type":"ad","count":1}];</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">window.advads_passive_placements = {"61268_1":{"elementid":["local-ed112ad6febd1813d9639d93e3eec1b1"],"ads":{"47608":{"id":47608,"title":"ADS RECETA P\u00c1RRAFO 3","expiry_date":0,"visitors":[{"type":"geo_targeting","geo_mode":"classic","operator":"is_not","country":"ES","region":"","city":"","distance_condition":"lte","distance":"","distance_unit":"km","lat":"","lon":"","latlon_city":""}],"content":"<script type=\"text\/plain\" data-tcf=\"waiting-for-consent\" data-id=\"47608\" data-bid=\"1\" data-placement=\"61268\">PGRpdiBpZD0ibG9jYWwtMjY5ODIwMDcyNSIgY2xhc3M9Imdhc19mYWxsYmFjay1hZF80NzYwOC0tcGxhY2VtZW50XzYxMjY4IiBzdHlsZT0ibWFyZ2luLXRvcDogMjBweDttYXJnaW4tYm90dG9tOiAyMHB4OyI+PHNjcmlwdCBhc3luYyBzcmM9Ii8vcGFnZWFkMi5nb29nbGVzeW5kaWNhdGlvbi5jb20vcGFnZWFkL2pzL2Fkc2J5Z29vZ2xlLmpzP2NsaWVudD1jYS1wdWItMDQzMjcyNjA0MDAwOTY3NiIgY3Jvc3NvcmlnaW49ImFub255bW91cyI+PC9zY3JpcHQ+PGlucyBjbGFzcz0iYWRzYnlnb29nbGUiIHN0eWxlPSJkaXNwbGF5OmJsb2NrOyIgZGF0YS1hZC1jbGllbnQ9ImNhLXB1Yi0wNDMyNzI2MDQwMDA5Njc2IiAKZGF0YS1hZC1zbG90PSIyMDI5NjEwOTc4IiAKZGF0YS1hZC1mb3JtYXQ9ImF1dG8iPjwvaW5zPgo8c2NyaXB0PiAKKGFkc2J5Z29vZ2xlID0gd2luZG93LmFkc2J5Z29vZ2xlIHx8IFtdKS5wdXNoKHt9KTsgCjwvc2NyaXB0Pgo8L2Rpdj4=<\/script>","once_per_page":0,"debugmode":false,"blog_id":1,"type":"adsense","position":"center_nofloat","day_indexes":false,"privacy":{"ignore":false,"needs_consent":false}}},"type":"ad","id":47608,"placement_info":{"id":"61268","title":"Contenido 2","content":"New placement content goes here","type":"post_content","slug":"contenido-2","status":"publish","item":"ad_47608","display":[],"visitors":[],"ad_label":"disabled","placement_position":"","inline-css":"","parallax":{"height":{"value":"200","unit":"px"}},"pro_minimum_length":"0","words_between_repeats":"0","position":"after","index":3,"tag":"p","xpath":"","lazy_load":"disabled","cache-busting":"auto"},"test_id":null,"ajax_query":{"id":61268,"method":"placement","params":{"title":"Contenido 2","content":"New placement content goes here","type":"post_content","slug":"contenido-2","status":"publish","item":"ad_47608","display":[],"visitors":[],"ad_label":"disabled","inline-css":"","parallax":{"height":{"value":"200","unit":"px"}},"position":"after","index":3,"tag":"p","xpath":"","cache-busting":"auto","previous_id":61268,"previous_method":"placement","post":"r0","url_parameter":"\/salsa-cremosa-de-calabaza-y-curry\/","placement_type":"post_content","output":{"class":["local-contenido-2"],"placement_id":61268},"cache_busting_elementid":"local-ed112ad6febd1813d9639d93e3eec1b1"},"elementid":"local-ed112ad6febd1813d9639d93e3eec1b1","server_conditions":{"fb0761cc21":{"type":"geo_targeting"}},"blog_id":1},"server_info_duration":2592000,"server_conditions":{"fb0761cc21":{"type":"geo_targeting"}},"inject_before":[""]}};
+window.advads_has_ads = [["45718","ad","ADS RECETA P\u00c1RRAFO 1","off"],["55554","ad","ADS RECETA P\u00c1RRAFO 5","off"],["49235","ad","PRP C&J ESCRITORIO","off"]];
+window.advads_ajax_queries_args = {"r0":{"id":59817,"author":"1","post_type":"post"}};
+( window.advanced_ads_ready || jQuery( document ).ready ).call( null, function() {if ( !window.advanced_ads_pro ) {console.log("Advanced Ads Pro: cache-busting can not be initialized");} });</script><!--/noptimize--><!--noptimize--><script type="rocketlazyloadscript">!function(){window.advanced_ads_ready_queue=window.advanced_ads_ready_queue||[],advanced_ads_ready_queue.push=window.advanced_ads_ready;for(var d=0,a=advanced_ads_ready_queue.length;d<a;d++)advanced_ads_ready(advanced_ads_ready_queue[d])}();</script><!--/noptimize-->
+      <script type="rocketlazyloadscript" data-rocket-type="text/javascript">
+        window._taboola = window._taboola || [];
+        _taboola.push({flush: true});
+      </script>
+
+  </body>
+</html>
+
+<!-- This website is like a Rocket, isn't it? Performance optimized by WP Rocket. Learn more: https://wp-rocket.me - Debug: cached@1776938643 -->


### PR DESCRIPTION
## What sites does this PR add support for?
- velocidadcuchara.com

## Brief description of how the site stores recipes
Velocidad Cuchara is a Spanish Thermomix recipe blog built on WordPress. Recipes are stored as schema.org/Recipe structured data, which the SchemaOrgFillPlugin handles for most fields (title, author, description, instructions, times, yields, image, ratings, cuisine, category).

One thing required custom handling:

- **Ingredient groups**: The site uses .ERSIngredients li.ingredient elements from the Easy Recipe Suite plugin. Group headers are `<li>` elements whose entire visible text is wrapped in a `<strong>` tag (e.g. `<li><strong>`Para el sofrito:`</strong></li>`). The scraper detects these by comparing the normalized text of the `<li>` against the normalized text of its `<strong>` child, skips them in ingredients(), and uses them as group boundaries in ingredient_groups().

## Tested recipes
- https://www.velocidadcuchara.com/salsa-bolonesa/
- https://www.velocidadcuchara.com/albondigas-de-berenjena-con-tomate/
- https://www.velocidadcuchara.com/bizcocho-de-naranja-thermomix/
- https://www.velocidadcuchara.com/salsa-cremosa-de-calabaza-y-curry/

## Checklist
- [x] All mandatory fields are covered in the testjson
- [x] python scripts/reorder_json_keys.py has been run
- [x] Tests pass locally
- [x] pre-commit hooks pass
