### PR TITLE
Add scraper for site: deliciousmagazine.co.uk

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -171,6 +171,7 @@ from .damndelicious import DamnDelicious
 from .daringgourmet import DaringGourmet
 from .dashfordinner import DashForDinner
 from .davidlebovitz import DavidLebovitz
+from .deliciousmagazine import DeliciousMagazine
 from .deliciouslyella import DeliciouslyElla
 from .deliciouslysprinkled import DeliciouslySprinkled
 from .delish import Delish
@@ -783,6 +784,7 @@ SCRAPERS = {
     DaringGourmet.host(): DaringGourmet,
     DashForDinner.host(): DashForDinner,
     DavidLebovitz.host(): DavidLebovitz,
+    DeliciousMagazine.host(): DeliciousMagazine,
     DeliciouslyElla.host(): DeliciouslyElla,
     DeliciouslySprinkled.host(): DeliciouslySprinkled,
     Delish.host(): Delish,

--- a/recipe_scrapers/deliciousmagazine.py
+++ b/recipe_scrapers/deliciousmagazine.py
@@ -1,0 +1,86 @@
+import re
+
+from ._abstract import AbstractScraper
+from ._exceptions import ElementNotFoundInHtml
+from ._utils import normalize_string
+
+
+class DeliciousMagazine(AbstractScraper):
+    @classmethod
+    def host(cls):
+        return "deliciousmagazine.co.uk"
+
+    def author(self):
+        for link in self.soup.select(
+            "p.recipe-author-details a, .author-name a[href*='/contributors/'], .author-name a[href*='/authors/']"
+        ):
+            text = normalize_string(link.get_text())
+            if text:
+                return text
+        plain = self.soup.select_one(".author-name")
+        if plain:
+            text = normalize_string(plain.get_text())
+            text = re.sub(r"^Recipe by:\s*", "", text, flags=re.IGNORECASE).strip()
+            if text:
+                return text
+        raise ElementNotFoundInHtml("Author not found.")
+
+    def site_name(self):
+        return self.opengraph.site_name()
+
+    def title(self):
+        title = self.soup.select_one(
+            ".recipe-title h1, article section.two-column h1.h2"
+        )
+        if title:
+            return normalize_string(title.get_text())
+        raise ElementNotFoundInHtml("Recipe title not found.")
+
+    def total_time(self):
+        for li in self.soup.select(".list-guidance li, .recipe-guidance li"):
+            text = li.get_text(" ", strip=True)
+            if "Prep time" not in text or "Cook time" not in text:
+                continue
+            prep = re.search(r"Prep time\s+(\d+)\s*min", text)
+            cook = re.search(r"Cook time\s+(\d+)\s*min", text)
+            if prep and cook:
+                return int(prep.group(1)) + int(cook.group(1))
+        raise ElementNotFoundInHtml("Prep and cook times not found.")
+
+    def yields(self):
+        for li in self.soup.select(".list-guidance li, .recipe-guidance li"):
+            text = li.get_text(" ", strip=True)
+            if "Serves" in text:
+                match = re.search(r"Serves\s+(\d+)", text)
+                if match:
+                    return f"{match.group(1)} servings"
+            if "Makes" in text:
+                match = re.search(r"Makes\s+(\d+)", text)
+                if match:
+                    return f"Makes {match.group(1)}"
+        raise ElementNotFoundInHtml("Yield (serves/makes) not found.")
+
+    def image(self):
+        return self.opengraph.image()
+
+    def ingredients(self):
+        items = [
+            normalize_string(li.get_text())
+            for li in self.soup.select("#ingredients ul li")
+        ]
+        items = [i for i in items if i]
+        if not items:
+            raise ElementNotFoundInHtml("No ingredients found.")
+        return items
+
+    def instructions(self):
+        steps = []
+        for li in self.soup.select("#method ol li"):
+            if "ad-li" in li.get("class", []):
+                continue
+            step = normalize_string(li.get_text())
+            if step:
+                steps.append(step)
+        if not steps:
+            raise ElementNotFoundInHtml("No method steps found.")
+        return "\n".join(steps)

--- a/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_1.json
+++ b/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_1.json
@@ -1,8 +1,8 @@
 {
-  "host": "deliciousmagazine.co.uk",
+  "author": "Mia Rodriguez",
   "canonical_url": "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/",
   "site_name": "delicious. magazine",
-  "author": "Mia Rodriguez",
+  "host": "deliciousmagazine.co.uk",
   "language": "en-GB",
   "title": "Chicken fajitas",
   "ingredients": [
@@ -28,7 +28,7 @@
     "Add the coated chicken to the griddle pan and cook for 5 minutes, turning occasionally, until cooked through, then set aside. Add the onions, red and orange pepper and remaining oil to the pan, then cook until softened and beginning to char in places. Sprinkle over the reserved spice mix, tip the chicken back into the pan and cook, stirring occasionally, for a few more minutes to warm through.",
     "Bring the fajita filling to the table – ideally in the griddle pan so it’s still sizzling – alongside the pico de gallo, grated cheddar, soured cream, mashed avocados, jalapeños and tortillas so everyone can build their own."
   ],
-  "total_time": 30,
   "yields": "4 servings",
+  "total_time": 30,
   "image": "https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3.jpg"
 }

--- a/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_1.json
+++ b/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_1.json
@@ -1,0 +1,34 @@
+{
+  "host": "deliciousmagazine.co.uk",
+  "canonical_url": "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/",
+  "site_name": "delicious. magazine",
+  "author": "Mia Rodriguez",
+  "language": "en-GB",
+  "title": "Chicken fajitas",
+  "ingredients": [
+    "1 tsp dried oregano",
+    "2 tsp smoked paprika",
+    "1 tsp ground cumin",
+    "1 tsp garlic powder",
+    "2 tsp fine salt",
+    "650g skinless chicken breasts (about 4 breasts), sliced into thick strips",
+    "2 tsp vegetable oil",
+    "2 onions, cut into thin petals",
+    "1 red pepper, deseeded and cut into strips",
+    "1 orange pepper, deseeded and cut into strips",
+    "100g mild cheddar, coarsely grated, to serve",
+    "100ml soured cream to serve",
+    "2 avocados, mashed with a pinch of salt, to serve",
+    "50g pickled jalapeños to serve",
+    "8 soft flour tortilla wraps to serve"
+  ],
+  "instructions_list": [
+    "Mix all the ingredients for the pico de gallo in a bowl with a pinch of salt and set aside.",
+    "Put a large griddle pan over a high heat. Mix the dried herbs and spices, garlic powder and salt in a large bowl, then set half aside for later. Add the chicken to the bowl with 1 tsp oil and toss to coat in the spice mixture.",
+    "Add the coated chicken to the griddle pan and cook for 5 minutes, turning occasionally, until cooked through, then set aside. Add the onions, red and orange pepper and remaining oil to the pan, then cook until softened and beginning to char in places. Sprinkle over the reserved spice mix, tip the chicken back into the pan and cook, stirring occasionally, for a few more minutes to warm through.",
+    "Bring the fajita filling to the table – ideally in the griddle pan so it’s still sizzling – alongside the pico de gallo, grated cheddar, soured cream, mashed avocados, jalapeños and tortillas so everyone can build their own."
+  ],
+  "total_time": 30,
+  "yields": "4 servings",
+  "image": "https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3.jpg"
+}

--- a/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_1.testhtml
+++ b/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_1.testhtml
@@ -1,0 +1,4554 @@
+<!DOCTYPE html>
+<html lang="en-GB" class="no-js no-svg">
+
+<head><script type="text/javascript" src="https://web-static.archive.org/_static/js/bundle-playback.js?v=2N_sDSC0" charset="utf-8"></script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script>window.RufflePlayer=window.RufflePlayer||{};window.RufflePlayer.config={"autoplay":"on","unmuteOverlay":"hidden","showSwfDownload":true};</script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/ruffle/ruffle.js"></script>
+<script type="text/javascript">
+    __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/","20250216021303","https://web.archive.org/","web","https://web-static.archive.org/_static/",
+	      "1739671983");
+</script>
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/banner-styles.css?v=1utQkbB3" />
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
+<!-- End Wayback Rewrite JS Include -->
+
+
+	<meta charset="UTF-8">
+<script type="text/javascript">
+/* <![CDATA[ */
+ var gform;gform||(document.addEventListener("gform_main_scripts_loaded",function(){gform.scriptsLoaded=!0}),document.addEventListener("gform/theme/scripts_loaded",function(){gform.themeScriptsLoaded=!0}),window.addEventListener("DOMContentLoaded",function(){gform.domLoaded=!0}),gform={domLoaded:!1,scriptsLoaded:!1,themeScriptsLoaded:!1,isFormEditor:()=>"function"==typeof InitializeEditor,callIfLoaded:function(o){return!(!gform.domLoaded||!gform.scriptsLoaded||!gform.themeScriptsLoaded&&!gform.isFormEditor()||(gform.isFormEditor()&&console.warn("The use of gform.initializeOnLoaded() is deprecated in the form editor context and will be removed in Gravity Forms 3.1."),o(),0))},initializeOnLoaded:function(o){gform.callIfLoaded(o)||(document.addEventListener("gform_main_scripts_loaded",()=>{gform.scriptsLoaded=!0,gform.callIfLoaded(o)}),document.addEventListener("gform/theme/scripts_loaded",()=>{gform.themeScriptsLoaded=!0,gform.callIfLoaded(o)}),window.addEventListener("DOMContentLoaded",()=>{gform.domLoaded=!0,gform.callIfLoaded(o)}))},hooks:{action:{},filter:{}},addAction:function(o,r,e,t){gform.addHook("action",o,r,e,t)},addFilter:function(o,r,e,t){gform.addHook("filter",o,r,e,t)},doAction:function(o){gform.doHook("action",o,arguments)},applyFilters:function(o){return gform.doHook("filter",o,arguments)},removeAction:function(o,r){gform.removeHook("action",o,r)},removeFilter:function(o,r,e){gform.removeHook("filter",o,r,e)},addHook:function(o,r,e,t,n){null==gform.hooks[o][r]&&(gform.hooks[o][r]=[]);var d=gform.hooks[o][r];null==n&&(n=r+"_"+d.length),gform.hooks[o][r].push({tag:n,callable:e,priority:t=null==t?10:t})},doHook:function(r,o,e){var t;if(e=Array.prototype.slice.call(e,1),null!=gform.hooks[r][o]&&((o=gform.hooks[r][o]).sort(function(o,r){return o.priority-r.priority}),o.forEach(function(o){"function"!=typeof(t=o.callable)&&(t=window[t]),"action"==r?t.apply(null,e):e[0]=t.apply(null,e)})),"filter"==r)return e[0]},removeHook:function(o,r,t,n){var e;null!=gform.hooks[o][r]&&(e=(e=gform.hooks[o][r]).filter(function(o,r,e){return!!(null!=n&&n!=o.tag||null!=t&&t!=o.priority)}),gform.hooks[o][r]=e)}}); 
+/* ]]> */
+</script>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+	<meta name="p:domain_verify" content="ae68e5e9603be6b1905dffaa2f520d28"/>
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+	<link rel="icon" href="/web/20250216021303im_/https://www.deliciousmagazine.co.uk/favicon.ico">
+
+	<link rel="apple-touch-icon" sizes="57x57" href="/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-57X57.png"/>
+	<link rel="apple-touch-icon" sizes="72x72" href="/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-72X72.png"/>
+	<link rel="apple-touch-icon" sizes="114x114" href="/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-114x114.png"/>
+	<link rel="apple-touch-icon" sizes="144x144" href="/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-144x144.png"/>
+
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://cdn.permutive.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://connect.facebook.net/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://scontent-lhr8-1.cdninstagram.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://cdn.tagdeliver.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://assets.shopthruapp.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://cdn.exitbee.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://cmp.inmobi.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216021303/https://www.clarity.ms/" crossorigin>
+	
+	<!-- preload fonts -->
+	<link rel="preload" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/fonts/ChronicleDisplay/ChronicleDisplay-Light.woff2" as="font" type="font/woff2">
+	<link rel="preload" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/fonts/DINOT/DINOT-Regular.woff2" as="font" type="font/woff2">
+	<!-- InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+<script type="text/javascript" async="true">
+(function() {
+  var host = window.location.hostname;
+  var element = document.createElement('script');
+  var firstScript = document.getElementsByTagName('script')[0];
+  var url = 'https://web.archive.org/web/20250216021303/https://cmp.inmobi.com'
+    .concat('/choice/', 'nFGY0BbANjqaP', '/', host, '/choice.js?tag_version=V3');
+  var uspTries = 0;
+  var uspTriesLimit = 3;
+  element.async = true;
+  element.type = 'text/javascript';
+  element.src = url;
+
+  firstScript.parentNode.insertBefore(element, firstScript);
+
+  function makeStub() {
+    var TCF_LOCATOR_NAME = '__tcfapiLocator';
+    var queue = [];
+    var win = window;
+    var cmpFrame;
+
+    function addFrame() {
+      var doc = win.document;
+      var otherCMP = !!(win.frames[TCF_LOCATOR_NAME]);
+
+      if (!otherCMP) {
+        if (doc.body) {
+          var iframe = doc.createElement('iframe');
+
+          iframe.style.cssText = 'display:none';
+          iframe.name = TCF_LOCATOR_NAME;
+          doc.body.appendChild(iframe);
+        } else {
+          setTimeout(addFrame, 5);
+        }
+      }
+      return !otherCMP;
+    }
+
+    function tcfAPIHandler() {
+      var gdprApplies;
+      var args = arguments;
+
+      if (!args.length) {
+        return queue;
+      } else if (args[0] === 'setGdprApplies') {
+        if (
+          args.length > 3 &&
+          args[2] === 2 &&
+          typeof args[3] === 'boolean'
+        ) {
+          gdprApplies = args[3];
+          if (typeof args[2] === 'function') {
+            args[2]('set', true);
+          }
+        }
+      } else if (args[0] === 'ping') {
+        var retr = {
+          gdprApplies: gdprApplies,
+          cmpLoaded: false,
+          cmpStatus: 'stub'
+        };
+
+        if (typeof args[2] === 'function') {
+          args[2](retr);
+        }
+      } else {
+        if(args[0] === 'init' && typeof args[3] === 'object') {
+          args[3] = Object.assign(args[3], { tag_version: 'V3' });
+        }
+        queue.push(args);
+      }
+    }
+
+    function postMessageEventHandler(event) {
+      var msgIsString = typeof event.data === 'string';
+      var json = {};
+
+      try {
+        if (msgIsString) {
+          json = JSON.parse(event.data);
+        } else {
+          json = event.data;
+        }
+      } catch (ignore) {}
+
+      var payload = json.__tcfapiCall;
+
+      if (payload) {
+        window.__tcfapi(
+          payload.command,
+          payload.version,
+          function(retValue, success) {
+            var returnMsg = {
+              __tcfapiReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: payload.callId
+              }
+            };
+            if (msgIsString) {
+              returnMsg = JSON.stringify(returnMsg);
+            }
+            if (event && event.source && event.source.postMessage) {
+              event.source.postMessage(returnMsg, '*');
+            }
+          },
+          payload.parameter
+        );
+      }
+    }
+
+    while (win) {
+      try {
+        if (win.frames[TCF_LOCATOR_NAME]) {
+          cmpFrame = win;
+          break;
+        }
+      } catch (ignore) {}
+
+      if (win === window.top) {
+        break;
+      }
+      win = win.parent;
+    }
+    if (!cmpFrame) {
+      addFrame();
+      win.__tcfapi = tcfAPIHandler;
+      win.addEventListener('message', postMessageEventHandler, false);
+    }
+  };
+
+  makeStub();
+
+  function makeGppStub() {
+    const CMP_ID = 10;
+    const SUPPORTED_APIS = [
+      '2:tcfeuv2',
+      '6:uspv1',
+      '7:usnatv1',
+      '8:usca',
+      '9:usvav1',
+      '10:uscov1',
+      '11:usutv1',
+      '12:usctv1'
+    ];
+
+    window.__gpp_addFrame = function (n) {
+      if (!window.frames[n]) {
+        if (document.body) {
+          var i = document.createElement("iframe");
+          i.style.cssText = "display:none";
+          i.name = n;
+          document.body.appendChild(i);
+        } else {
+          window.setTimeout(window.__gpp_addFrame, 10, n);
+        }
+      }
+    };
+    window.__gpp_stub = function () {
+      var b = arguments;
+      __gpp.queue = __gpp.queue || [];
+      __gpp.events = __gpp.events || [];
+
+      if (!b.length || (b.length == 1 && b[0] == "queue")) {
+        return __gpp.queue;
+      }
+
+      if (b.length == 1 && b[0] == "events") {
+        return __gpp.events;
+      }
+
+      var cmd = b[0];
+      var clb = b.length > 1 ? b[1] : null;
+      var par = b.length > 2 ? b[2] : null;
+      if (cmd === "ping") {
+        clb(
+          {
+            gppVersion: "1.1", // must be “Version.Subversion”, current: “1.1”
+            cmpStatus: "stub", // possible values: stub, loading, loaded, error
+            cmpDisplayStatus: "hidden", // possible values: hidden, visible, disabled
+            signalStatus: "not ready", // possible values: not ready, ready
+            supportedAPIs: SUPPORTED_APIS, // list of supported APIs
+            cmpId: CMP_ID, // IAB assigned CMP ID, may be 0 during stub/loading
+            sectionList: [],
+            applicableSections: [-1],
+            gppString: "",
+            parsedSections: {},
+          },
+          true
+        );
+      } else if (cmd === "addEventListener") {
+        if (!("lastId" in __gpp)) {
+          __gpp.lastId = 0;
+        }
+        __gpp.lastId++;
+        var lnr = __gpp.lastId;
+        __gpp.events.push({
+          id: lnr,
+          callback: clb,
+          parameter: par,
+        });
+        clb(
+          {
+            eventName: "listenerRegistered",
+            listenerId: lnr, // Registered ID of the listener
+            data: true, // positive signal
+            pingData: {
+              gppVersion: "1.1", // must be “Version.Subversion”, current: “1.1”
+              cmpStatus: "stub", // possible values: stub, loading, loaded, error
+              cmpDisplayStatus: "hidden", // possible values: hidden, visible, disabled
+              signalStatus: "not ready", // possible values: not ready, ready
+              supportedAPIs: SUPPORTED_APIS, // list of supported APIs
+              cmpId: CMP_ID, // list of supported APIs
+              sectionList: [],
+              applicableSections: [-1],
+              gppString: "",
+              parsedSections: {},
+            },
+          },
+          true
+        );
+      } else if (cmd === "removeEventListener") {
+        var success = false;
+        for (var i = 0; i < __gpp.events.length; i++) {
+          if (__gpp.events[i].id == par) {
+            __gpp.events.splice(i, 1);
+            success = true;
+            break;
+          }
+        }
+        clb(
+          {
+            eventName: "listenerRemoved",
+            listenerId: par, // Registered ID of the listener
+            data: success, // status info
+            pingData: {
+              gppVersion: "1.1", // must be “Version.Subversion”, current: “1.1”
+              cmpStatus: "stub", // possible values: stub, loading, loaded, error
+              cmpDisplayStatus: "hidden", // possible values: hidden, visible, disabled
+              signalStatus: "not ready", // possible values: not ready, ready
+              supportedAPIs: SUPPORTED_APIS, // list of supported APIs
+              cmpId: CMP_ID, // CMP ID
+              sectionList: [],
+              applicableSections: [-1],
+              gppString: "",
+              parsedSections: {},
+            },
+          },
+          true
+        );
+      } else if (cmd === "hasSection") {
+        clb(false, true);
+      } else if (cmd === "getSection" || cmd === "getField") {
+        clb(null, true);
+      }
+      //queue all other commands
+      else {
+        __gpp.queue.push([].slice.apply(b));
+      }
+    };
+    window.__gpp_msghandler = function (event) {
+      var msgIsString = typeof event.data === "string";
+      try {
+        var json = msgIsString ? JSON.parse(event.data) : event.data;
+      } catch (e) {
+        var json = null;
+      }
+      if (typeof json === "object" && json !== null && "__gppCall" in json) {
+        var i = json.__gppCall;
+        window.__gpp(
+          i.command,
+          function (retValue, success) {
+            var returnMsg = {
+              __gppReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: i.callId,
+              },
+            };
+            event.source.postMessage(msgIsString ? JSON.stringify(returnMsg) : returnMsg, "*");
+          },
+          "parameter" in i ? i.parameter : null,
+          "version" in i ? i.version : "1.1"
+        );
+      }
+    };
+    if (!("__gpp" in window) || typeof window.__gpp !== "function") {
+      window.__gpp = window.__gpp_stub;
+      window.addEventListener("message", window.__gpp_msghandler, false);
+      window.__gpp_addFrame("__gppLocator");
+    }
+  };
+
+  makeGppStub();
+
+  var uspStubFunction = function() {
+    var arg = arguments;
+    if (typeof window.__uspapi !== uspStubFunction) {
+      setTimeout(function() {
+        if (typeof window.__uspapi !== 'undefined') {
+          window.__uspapi.apply(window.__uspapi, arg);
+        }
+      }, 500);
+    }
+  };
+
+  var checkIfUspIsReady = function() {
+    uspTries++;
+    if (window.__uspapi === uspStubFunction && uspTries < uspTriesLimit) {
+      console.warn('USP is not accessible');
+    } else {
+      clearInterval(uspInterval);
+    }
+  };
+
+  if (typeof window.__uspapi === 'undefined') {
+    window.__uspapi = uspStubFunction;
+    var uspInterval = setInterval(checkIfUspIsReady, 6000);
+  }
+})();
+</script>
+<!-- End InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://web.archive.org/web/20250216021303js_/https://www.googletagmanager.com/gtag/js?id=UA-2737869-1"></script>
+	<script>
+	window.dataLayer = window.dataLayer || [];
+
+	function gtag() {
+		dataLayer.push(arguments);
+	}
+	gtag('js', new Date());
+	gtag('config', 'UA-2737869-1');
+	</script>
+
+	<!-- Google Tag Manager -->
+	<script>
+	(function(w, d, s, l, i) {
+		w[l] = w[l] || [];
+		w[l].push({
+			'gtm.start': new Date().getTime(),
+			event: 'gtm.js'
+		});
+		var f = d.getElementsByTagName(s)[0],
+			j = d.createElement(s),
+			dl = l != 'dataLayer' ? '&l=' + l : '';
+		j.async = true;
+		j.src =
+			'https://web.archive.org/web/20250216021303/https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+		f.parentNode.insertBefore(j, f);
+	})(window, document, 'script', 'dataLayer', 'GTM-PR23HDB');
+	</script>
+	<!-- End Google Tag Manager -->
+
+	<!-- Health check tag -->
+	<script src="https://web.archive.org/web/20250216021303js_/https://cdn.tagdeliver.com/cipt/18555.js" async="async"></script>
+
+		<link rel="amphtml" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/amp/">
+	
+	<!-- Permuative Tag -->
+<script>
+  !function(n,e,o,r,i){if(!e){e=e||{},window.permutive=e,e.q=[],e.config=i||{},e.config.projectId=o,e.config.apiKey=r,e.config.environment=e.config.environment||"production";for(var t=["addon","identify","track","trigger","query","segment","segments","ready","on","once","user","consent"],c=0;c<t.length;c++){var f=t[c];e[f]=function(n){return function(){var o=Array.prototype.slice.call(arguments,0);e.q.push({functionName:n,arguments:o})}}(f)}}}(document,window.permutive,"99db7a95-b06a-4ea9-857c-f73ba0a25c19","db07e0f0-8bb8-46c8-b714-291f2768d746",{});
+    permutive.addon("web", { page: {
+        category: ["recipe"],
+        title: "Chicken fajitas",
+                recipe: {
+            collections: ["30-minute meal recipes", "Chicken breast recipes", "Father's Day recipes", "Favourite chicken recipes", "Friday night dinners", "Midweek meal recipes"],
+            cooking_time: 15,
+            prep_time: 15,
+            serves: 4,
+            keywords: [
+            "chicken fajitas", "fajitas", "fajitas recipe"],
+                        nutrition_info: ["555kcals Calories", "33g (13g saturated) Fat", "52g Protein", "9.2g (13g sugars) Carbohydrate", "6.5g Fiber", "4.1g Salt"],
+            ingredients: [
+"1 tsp dried oregano",
+"2 tsp smoked paprika",
+"1 tsp ground cumin",
+"1 tsp garlic powder",
+"2 tsp fine salt",
+"650g skinless chicken breasts (about 4 breasts), sliced into thick strips",
+"2 tsp vegetable oil",
+"2 onions, cut into thin petals",
+"1 red pepper, deseeded and cut into strips",
+"1 orange pepper, deseeded and cut into strips",
+"100g mild cheddar, coarsely grated, to serve",
+"100ml soured cream to serve",
+"2 avocados, mashed with a pinch of salt, to serve",
+"50g pickled jalapeños to serve",
+"8 soft flour tortilla wraps to serve",
+
+""],
+            courses: ["Array"],            
+             cusine: "Mexican recipes",            
+                        skill_level: "Easy",
+            post_dates: "2025-01-28"
+        }
+            }
+  });
+</script>
+<script async src="https://web.archive.org/web/20250216021303js_/https://cdn.permutive.com/99db7a95-b06a-4ea9-857c-f73ba0a25c19-web.js"></script>
+<script type="text/javascript">
+    window.permutive.readyWithTimeout=function(e,i,t){var u=!1,n=function(){u||(e(),u=!0)};(t=t||1/0)!==1/0&&window.setTimeout(n,t),permutive.ready(n,i)};
+</script>
+	
+	<script type="text/javascript">
+	(function(c, l, a, r, i, t, y) {
+		c[a] = c[a] || function() {
+			(c[a].q = c[a].q || []).push(arguments)
+		};
+		t = l.createElement(r);
+		t.async = 1;
+		t.src = "https://web.archive.org/web/20250216021303/https://www.clarity.ms/tag/" + i;
+		y = l.getElementsByTagName(r)[0];
+		y.parentNode.insertBefore(t, y);
+	})(window, document, "clarity", "script", "o9770qd0kr");
+	</script>
+
+	<!-- Exit Bee Code Snippet for deliciousmagazine.co.uk <-- DO NOT MODIFY -->
+	<script>
+	(function(e, x, i, t, b) {
+		e["ExitBeeObject"] = b;
+		e[b] = e[b] ||
+			function() {
+				(e[b].args = e[b].args || []).push(arguments);
+			};
+		a = x.createElement(i), m = x.getElementsByTagName(i)[0];
+		a.async = 1;
+		a.src = t;
+		m.parentNode.insertBefore(a, m)
+	})
+	(window, document, "script", "https://web.archive.org/web/20250216021303/https://cdn.exitbee.com/xtb.min.js", "xtb")
+	xtb("loadSite", "8825");
+	</script>
+
+	<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"/>
+	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+	
+	<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.2) - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Chicken fajitas - delicious. magazine</title>
+	<meta name="description" content="Try our classic chicken fajitas. Sizzling from the griddle, this combo of spiced chicken, peppers and onions is the perfect tortilla filler."/>
+	<link rel="canonical" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/"/>
+	<meta property="og:locale" content="en_GB"/>
+	<meta property="og:type" content="article"/>
+	<meta property="og:title" content="Chicken fajitas"/>
+	<meta property="og:description" content="Try our classic chicken fajitas. Sizzling from the griddle, this combo of spiced chicken, peppers and onions is the perfect tortilla filler."/>
+	<meta property="og:url" content="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/"/>
+	<meta property="og:site_name" content="delicious. magazine"/>
+	<meta property="article:publisher" content="https://www.facebook.com/deliciousmagazineuk"/>
+	<meta property="article:modified_time" content="2025-02-14T11:20:48+00:00"/>
+	<meta property="og:image" content="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3.jpg"/>
+	<meta property="og:image:width" content="960"/>
+	<meta property="og:image:height" content="1200"/>
+	<meta property="og:image:type" content="image/jpeg"/>
+	<meta name="twitter:card" content="summary_large_image"/>
+	<meta name="twitter:site" content="@deliciousmag"/>
+	<meta name="twitter:label1" content="Estimated reading time"/>
+	<meta name="twitter:data1" content="1 minute"/>
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://web.archive.org/web/20250216021303/https://schema.org","@graph":[{"@type":"WebPage","@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/","url":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/","name":"Chicken fajitas - delicious. magazine","isPartOf":{"@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#website"},"primaryImageOfPage":{"@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/#primaryimage"},"image":{"@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/#primaryimage"},"thumbnailUrl":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3.jpg","datePublished":"2025-01-28T11:29:24+00:00","dateModified":"2025-02-14T11:20:48+00:00","description":"Try our classic chicken fajitas. Sizzling from the griddle, this combo of spiced chicken, peppers and onions is the perfect tortilla filler.","breadcrumb":{"@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/#breadcrumb"},"inLanguage":"en-GB","potentialAction":[{"@type":"ReadAction","target":["https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/"]}]},{"@type":"ImageObject","inLanguage":"en-GB","@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/#primaryimage","url":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3.jpg","contentUrl":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3.jpg","width":960,"height":1200,"caption":"Chicken fajitas"},{"@type":"BreadcrumbList","@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/"},{"@type":"ListItem","position":2,"name":"Recipes","item":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/"},{"@type":"ListItem","position":3,"name":"Chicken breast recipes","item":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/chicken-breast-recipes/"},{"@type":"ListItem","position":4,"name":"Chicken fajitas"}]},{"@type":"WebSite","@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#website","url":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/","name":"delicious. magazine","description":"","publisher":{"@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-GB"},{"@type":"Organization","@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#organization","name":"Delicious Magazine","url":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/","logo":{"@type":"ImageObject","inLanguage":"en-GB","@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#/schema/logo/image/","url":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/logo2x.png","contentUrl":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/logo2x.png","width":1000,"height":236,"caption":"Delicious Magazine"},"image":{"@id":"https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#/schema/logo/image/"},"sameAs":["https://web.archive.org/web/20250216021303/https://www.facebook.com/deliciousmagazineuk","https://web.archive.org/web/20250216021303/https://x.com/deliciousmag","https://web.archive.org/web/20250216021303/https://www.instagram.com/deliciousmag/","https://web.archive.org/web/20250216021303/https://www.pinterest.com/deliciousmaguk/","https://web.archive.org/web/20250216021303/http://www.youtube.com/user/deliciousmagazineuk"]},false]}</script>
+	<!-- / Yoast SEO Premium plugin. -->
+
+
+<link rel="dns-prefetch" href="//web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/"/>
+<link rel="alternate" type="application/rss+xml" title="delicious. magazine » Feed" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/feed/"/>
+<link rel="alternate" type="application/rss+xml" title="delicious. magazine » Comments Feed" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/comments/feed/"/>
+<link rel="alternate" type="application/rss+xml" title="delicious. magazine » Chicken fajitas Comments Feed" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/feed/"/>
+<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/72x72\/","ext":".png","svgUrl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.7.1"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83d\udc26\u200d\u2b1b","\ud83d\udc26\u200b\u2b1b")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+<link rel="stylesheet" id="sbi_styles-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/plugins/instagram-feed-pro/css/sbi-styles.min.css?ver=6.5.1" type="text/css" media="all"/>
+<style id="wp-emoji-styles-inline-css" type="text/css">
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel="stylesheet" id="normalize-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/normalize.min.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="bootstrap-grid-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/bootstrap-grid.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="bootstrap-components-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/bootstrap-components.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="slick-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/slick/slick.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="formstyler-css-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/jquery.formstyler.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="remodal-css-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/remodal.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="rstyler-css-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/rfiles/css/style.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="add-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/add.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="main-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/main.css?ver=6.37" type="text/css" media="all"/>
+<script type="text/javascript">
+            window._nslDOMReady = function (callback) {
+                if ( document.readyState === "complete" || document.readyState === "interactive" ) {
+                    callback();
+                } else {
+                    document.addEventListener( "DOMContentLoaded", callback );
+                }
+            };
+            </script><script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/vendor/jquery-3.1.1.min.js?ver=3.1.1" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/vendor/jquery-migrate-3.0.0.min.js?ver=3.0.0" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/jquery.hoverIntent.min.js?ver=1.9.0" id="hoverintent-js"></script>
+<link rel="https://api.w.org/" href="https://www.deliciousmagazine.co.uk/wp-json/"/><link rel="alternate" title="JSON" type="application/json" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-json/wp/v2/recipes/81265"/><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.deliciousmagazine.co.uk/xmlrpc.php?rsd"/>
+<meta name="generator" content="WordPress 6.7.1"/>
+<link rel="shortlink" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/?p=81265"/>
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fchicken-fajitas%2F"/>
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fchicken-fajitas%2F&amp;format=xml"/>
+		<script>
+			document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
+		</script>
+				<style>
+			.no-js img.lazyload {
+				display: none;
+			}
+
+			figure.wp-block-image img.lazyloading {
+				min-width: 150px;
+			}
+
+						.lazyload, .lazyloading {
+				opacity: 0;
+			}
+
+			.lazyloaded {
+				opacity: 1;
+				transition: opacity 200ms;
+				transition-delay: 0ms;
+			}
+
+					</style>
+		<style type="text/css">.recentcomments a{display:inline !important;padding:0 !important;margin:0 !important;}</style><style type="text/css">div.nsl-container[data-align="left"] {
+    text-align: left;
+}
+
+div.nsl-container[data-align="center"] {
+    text-align: center;
+}
+
+div.nsl-container[data-align="right"] {
+    text-align: right;
+}
+
+
+div.nsl-container div.nsl-container-buttons a[data-plugin="nsl"] {
+    text-decoration: none;
+    box-shadow: none;
+    border: 0;
+}
+
+div.nsl-container .nsl-container-buttons {
+    display: flex;
+    padding: 5px 0;
+}
+
+div.nsl-container.nsl-container-block .nsl-container-buttons {
+    display: inline-grid;
+    grid-template-columns: minmax(145px, auto);
+}
+
+div.nsl-container-block-fullwidth .nsl-container-buttons {
+    flex-flow: column;
+    align-items: center;
+}
+
+div.nsl-container-block-fullwidth .nsl-container-buttons a,
+div.nsl-container-block .nsl-container-buttons a {
+    flex: 1 1 auto;
+    display: block;
+    margin: 5px 0;
+    width: 100%;
+}
+
+div.nsl-container-inline {
+    margin: -5px;
+    text-align: left;
+}
+
+div.nsl-container-inline .nsl-container-buttons {
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+div.nsl-container-inline .nsl-container-buttons a {
+    margin: 5px;
+    display: inline-block;
+}
+
+div.nsl-container-grid .nsl-container-buttons {
+    flex-flow: row;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+div.nsl-container-grid .nsl-container-buttons a {
+    flex: 1 1 auto;
+    display: block;
+    margin: 5px;
+    max-width: 280px;
+    width: 100%;
+}
+
+@media only screen and (min-width: 650px) {
+    div.nsl-container-grid .nsl-container-buttons a {
+        width: auto;
+    }
+}
+
+div.nsl-container .nsl-button {
+    cursor: pointer;
+    vertical-align: top;
+    border-radius: 4px;
+}
+
+div.nsl-container .nsl-button-default {
+    color: #fff;
+    display: flex;
+}
+
+div.nsl-container .nsl-button-icon {
+    display: inline-block;
+}
+
+div.nsl-container .nsl-button-svg-container {
+    flex: 0 0 auto;
+    padding: 8px;
+    display: flex;
+    align-items: center;
+}
+
+div.nsl-container svg {
+    height: 24px;
+    width: 24px;
+    vertical-align: top;
+}
+
+div.nsl-container .nsl-button-default div.nsl-button-label-container {
+    margin: 0 24px 0 12px;
+    padding: 10px 0;
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 20px;
+    letter-spacing: .25px;
+    overflow: hidden;
+    text-align: center;
+    text-overflow: clip;
+    white-space: nowrap;
+    flex: 1 1 auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-transform: none;
+    display: inline-block;
+}
+
+div.nsl-container .nsl-button-google[data-skin="dark"] .nsl-button-svg-container {
+    margin: 1px;
+    padding: 7px;
+    border-radius: 3px;
+    background: #fff;
+}
+
+div.nsl-container .nsl-button-google[data-skin="light"] {
+    border-radius: 1px;
+    box-shadow: 0 1px 5px 0 rgba(0, 0, 0, .25);
+    color: RGBA(0, 0, 0, 0.54);
+}
+
+div.nsl-container .nsl-button-apple .nsl-button-svg-container {
+    padding: 0 6px;
+}
+
+div.nsl-container .nsl-button-apple .nsl-button-svg-container svg {
+    height: 40px;
+    width: auto;
+}
+
+div.nsl-container .nsl-button-apple[data-skin="light"] {
+    color: #000;
+    box-shadow: 0 0 0 1px #000;
+}
+
+div.nsl-container .nsl-button-facebook[data-skin="white"] {
+    color: #000;
+    box-shadow: inset 0 0 0 1px #000;
+}
+
+div.nsl-container .nsl-button-facebook[data-skin="light"] {
+    color: #1877F2;
+    box-shadow: inset 0 0 0 1px #1877F2;
+}
+
+div.nsl-container .nsl-button-spotify[data-skin="white"] {
+    color: #191414;
+    box-shadow: inset 0 0 0 1px #191414;
+}
+
+div.nsl-container .nsl-button-apple div.nsl-button-label-container {
+    font-size: 17px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+div.nsl-container .nsl-button-slack div.nsl-button-label-container {
+    font-size: 17px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+div.nsl-container .nsl-button-slack[data-skin="light"] {
+    color: #000000;
+    box-shadow: inset 0 0 0 1px #DDDDDD;
+}
+
+div.nsl-container .nsl-button-tiktok[data-skin="light"] {
+    color: #161823;
+    box-shadow: 0 0 0 1px rgba(22, 24, 35, 0.12);
+}
+
+
+div.nsl-container .nsl-button-kakao {
+    color: rgba(0, 0, 0, 0.85);
+}
+
+.nsl-clear {
+    clear: both;
+}
+
+.nsl-container {
+    clear: both;
+}
+
+.nsl-disabled-provider .nsl-button {
+    filter: grayscale(1);
+    opacity: 0.8;
+}
+
+/*Button align start*/
+
+div.nsl-container-inline[data-align="left"] .nsl-container-buttons {
+    justify-content: flex-start;
+}
+
+div.nsl-container-inline[data-align="center"] .nsl-container-buttons {
+    justify-content: center;
+}
+
+div.nsl-container-inline[data-align="right"] .nsl-container-buttons {
+    justify-content: flex-end;
+}
+
+
+div.nsl-container-grid[data-align="left"] .nsl-container-buttons {
+    justify-content: flex-start;
+}
+
+div.nsl-container-grid[data-align="center"] .nsl-container-buttons {
+    justify-content: center;
+}
+
+div.nsl-container-grid[data-align="right"] .nsl-container-buttons {
+    justify-content: flex-end;
+}
+
+div.nsl-container-grid[data-align="space-around"] .nsl-container-buttons {
+    justify-content: space-around;
+}
+
+div.nsl-container-grid[data-align="space-between"] .nsl-container-buttons {
+    justify-content: space-between;
+}
+
+/* Button align end*/
+
+/* Redirect */
+
+#nsl-redirect-overlay {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    z-index: 1000000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    backdrop-filter: blur(1px);
+    background-color: RGBA(0, 0, 0, .32);;
+}
+
+#nsl-redirect-overlay-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: white;
+    padding: 30px;
+    border-radius: 10px;
+}
+
+#nsl-redirect-overlay-spinner {
+    content: '';
+    display: block;
+    margin: 20px;
+    border: 9px solid RGBA(0, 0, 0, .6);
+    border-top: 9px solid #fff;
+    border-radius: 50%;
+    box-shadow: inset 0 0 0 1px RGBA(0, 0, 0, .6), 0 0 0 1px RGBA(0, 0, 0, .6);
+    width: 40px;
+    height: 40px;
+    animation: nsl-loader-spin 2s linear infinite;
+}
+
+@keyframes nsl-loader-spin {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(360deg)
+    }
+}
+
+#nsl-redirect-overlay-title {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    font-size: 18px;
+    font-weight: bold;
+    color: #3C434A;
+}
+
+#nsl-redirect-overlay-text {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    text-align: center;
+    font-size: 14px;
+    color: #3C434A;
+}
+
+/* Redirect END*/</style><style type="text/css">/* Notice fallback */
+#nsl-notices-fallback {
+    position: fixed;
+    right: 10px;
+    top: 10px;
+    z-index: 10000;
+}
+
+.admin-bar #nsl-notices-fallback {
+    top: 42px;
+}
+
+#nsl-notices-fallback > div {
+    position: relative;
+    background: #fff;
+    border-left: 4px solid #fff;
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .1);
+    margin: 5px 15px 2px;
+    padding: 1px 20px;
+}
+
+#nsl-notices-fallback > div.error {
+    display: block;
+    border-left-color: #dc3232;
+}
+
+#nsl-notices-fallback > div.updated {
+    display: block;
+    border-left-color: #46b450;
+}
+
+#nsl-notices-fallback p {
+    margin: .5em 0;
+    padding: 2px;
+}
+
+#nsl-notices-fallback > div:after {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    content: '\00d7';
+    display: block;
+    height: 16px;
+    width: 16px;
+    line-height: 16px;
+    text-align: center;
+    font-size: 20px;
+    cursor: pointer;
+}</style>		<style type="text/css" id="wp-custom-css">
+			.instagram-feeds #sb_instagram .sbi_photo {
+	padding-bottom: 100% !important;
+}
+#sb_instagram #sbi_images .sbi_item.sbi_num_diff_hide.slick-slide {
+    display: block !important;
+}
+.adsm-skin .sidebar .align-self-end {
+    background: transparent;
+}
+.instagram-feeds #sb_instagram #sbi_images {
+    padding: 0 !important;
+    float: left;
+    line-height: 0;
+    width: 100%;
+    display: block !important;
+}
+#main-menu .visible-tablet {
+    display: none  !important;
+}
+
+.recipe-wine .title-logo {
+    width: 37%;
+    margin: 20px 0 20px 0
+}
+
+ .recipe-author-wrapper .recipe-author-details,.recipe-author-wrapper .magazine-subscription {
+    float: left;
+    width: 50%
+}
+
+@media(max-width: 1024px) {
+    .recipe-author-wrapper .recipe-author-details,.recipe-author-wrapper .magazine-subscription {
+        width:100%
+    }
+}
+
+.recipe-author-wrapper .recipe-author-details p,.recipe-author-wrapper .magazine-subscription p {
+    margin: 0;
+    font-size: 1.8rem
+}
+
+.recipe-author-wrapper .recipe-author-details p:first-child,.recipe-author-wrapper .magazine-subscription p:first-child {
+    margin: 0 0 2rem 0;
+    font-size: 1.1rem;
+    font-weight: bold;
+    line-height: normal;
+    text-transform: uppercase
+}
+
+.recipe-author-wrapper .recipe-author-details a,.recipe-author-wrapper .magazine-subscription a {
+    border-bottom: 1px solid #fff;
+    color: #fff
+}
+
+.recipe-author-wrapper .recipe-author-details .post-date {
+    font-size: 1.1rem;
+    display: flex;
+    list-style: none;
+    padding-right: 5px;
+    margin-top: 15px;
+    line-height: 1.2;
+    margin-bottom: 5px;
+    text-transform: uppercase
+}
+
+.recipe-author-wrapper .recipe-author-details .post-date li:first-child {
+    border-right: 1px solid #fff;
+    padding-right: 12px;
+    margin-right: 12px
+}
+/* remove this code later after pushing through pipeline*/ 
+.ob-widget .ob-widget-header {
+    border: none;
+}
+
+/* remove this code later*/
+@media (max-width: 768px) {
+    .top-banner-ad-desktop {
+       display: none !important;
+    }
+	
+	.recipe-list .recipe-card-wrapper .recipe-card .card-body > p {
+			margin-bottom: 5px;
+			padding-bottom: 5px;
+	}
+}
+@media(min-width: 1025px) {
+    .recipe-author-wrapper.hide-mobile {
+        display:flex !important
+    }
+}
+
+.recipe-author-wrapper.hide-mobile .recipe-author-details {
+    align-self: center
+}
+
+.recipe-author-wrapper .magazine-subscription {
+    border-left: 1px solid #fff;
+    padding: 0 0 0 2rem
+}
+
+@media(max-width: 1024px) {
+    .recipe-author-wrapper .magazine-subscription {
+        border-top:1px solid #fff;
+        border-left: 0;
+        margin: 3rem 0 0 0;
+        padding: 3rem 0 0 0
+    }
+}
+
+.recipe-author-wrapper .magazine-subscription a {
+    font-size: 1.1rem;
+    font-weight: bold;
+    line-height: normal;
+    text-transform: uppercase
+}
+
+.recipe-author-wrapper .magazine-subscription .postal-magazine-cover {
+    width: 170px;
+    min-height: 106px;
+    height: 106px;
+    position: absolute;
+    bottom: 0;
+    right: 0
+}
+
+@media(max-width: 1024px) {
+    .recipe-author-wrapper .magazine-subscription .postal-magazine-cover {
+        display:none
+    }
+}
+
+.recipe-author-wrapper .magazine-subscription .postal-magazine-cover img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    object-fit: cover;
+    object-position: top
+}
+
+.recipe-author-wrapper .magazine-subscription.full-width {
+    border: 0;
+    margin: 0;
+    padding: 0
+}
+
+.recipe-author-details-with-img>span {
+    display: flex;
+    gap: 20px;
+    padding-right: 20px;
+    line-height: 1.4
+}
+
+.recipe-author-details-with-img>span>a {
+    border-bottom: none !important;
+    width: 55px
+}
+
+.recipe-author-details-with-img>span>a>img {
+    border-radius: 50%;
+    width: 55px;
+    height: 55px
+}
+
+.recipe-author-details-with-img>span>span {
+    width: calc(100% - 75px)
+}
+
+.recipe-author-details-with-img+.post-date {
+    margin-left: 76px
+}
+
+@media(max-width: 680px) {
+    .recipe-wine .title-logo {
+        width:100%
+    }
+}
+
+.recipe-wine.recipe-procook {
+    background-size: 40%
+}
+
+@media(min-width: 768px) {
+    .recipe-wine.recipe-procook p {
+        width:59%
+    }
+}
+
+@media(max-width: 767px) {
+    .recipe-wine.recipe-procook {
+        background:#fff !important
+    }
+}
+
+.recipe-wine.recipe-procook .procook-text p {
+    font-size: 1.2rem;
+    margin-bottom: 0
+}
+
+
+
+@media (min-width: 768px) and (max-width: 769px) {
+    .recipe-details {
+        padding: 0 20px 0 30px;
+    }
+}
+@media (max-width: 1024px) {
+#main-menu .visible-tablet {
+    display: block !important;
+}
+
+}
+
+@media (max-width: 1023px) {
+    .postid-76565 .recipe-header .hide-tablet {
+        display: block !important;
+    }
+.postid-76565 .recipe-header .hide-tablet .sponsorship
+ {
+        margin-bottom: 20px;
+    }
+}
+
+/* hide  privacy setting cmp */
+a#qc-cmp2-persistent-link {
+    display: none;
+}
+.home.admin-bar .main-content.content {
+    margin-top: 268px
+}
+
+@media(max-width: 1024px) {
+    .home.admin-bar .main-content.content {
+        margin-top:148px !important
+    }
+}
+
+@media(max-width: 768px) {
+    .home.admin-bar .main-content.content {
+        margin-top:70px !important
+    }
+}		</style>
+		
+	<style type="text/css">
+	.yasr-star-rating {
+		background-image: url(https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/off.svg);
+	}
+
+	.yasr-star-rating .yasr-star-value {
+		background-image: url(https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/on.svg);
+	}
+	</style>
+</head>
+
+
+<body class="recipes-template-default single single-recipes postid-81265 wp-custom-logo">
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe src="https://web.archive.org/web/20250216021303if_/https://www.googletagmanager.com/ns.html?id=GTM-PR23HDB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
+	<header class="sticky-header">
+		<div class="content-wrapper">
+			<div class="top-banner-ad-desktop top-banner-ad non-stick">
+    <div class="advert-content">
+        <div class="content-wrapper">
+            <div class="row justify-content-center no-gutters">
+                <div class="ad-title">Advertisement</div>
+				<div id="adslot-top-banner">
+					
+				</div>
+				<div id="dismiss-top-banner">
+					<img alt="Close menu" src="https://web.archive.org/web/20250216021303im_/https://deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-white.svg" width="25px" height="25px">
+				</div>
+				<!-- End AdSlot 1 -->
+            </div>
+        </div>
+    </div>
+</div>
+						<div id="header-desktop" class="content-wrapper">
+				<header id="header-content" class="below-ad">
+					<div class="header-wrapper">
+												<div class="header-elements">
+							<div class="row">
+								<div class="col">
+									<div class="links-functional links-user">
+										<nav class="nav-list">
+											<ul>
+												<li><a href="https://web.archive.org/web/20250216021303/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" rel="nofollow">Subscribe to magazine</a></li>
+											</ul>
+										</nav>
+									</div>
+								</div>
+
+								<div class="col">
+																											<a href="/web/20250216021303/https://www.deliciousmagazine.co.uk/" class="logo" style="background:url(https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Jan-25-LOGO-CHANGE-231x43-copy.png) no-repeat center center; background-size: 100%;"><span class="sr-only">delicious.</span></a>
+									<a href="/web/20250216021303/https://www.deliciousmagazine.co.uk/" class="logo-small" style="background:url(https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Jan-25-LOGO-CHANGE-MASTER-ROUNDEL.png) no-repeat center center; background-size: 100%;"><span class="sr-only">delicious.</span></a>
+									
+								</div>
+
+								<div class="col">
+									<div class="links-functional links-account">
+										<nav class="nav-list">
+											<ul>
+																								<li>
+													<a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login/" class="">Log in</a>
+												</li>
+												<li>
+													<a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/register/" class="">Register</a>
+												</li>
+																							</ul>
+										</nav>
+									</div>
+								</div>
+							</div>
+						</div>
+
+						<div class="content-block">
+							<div class="nav-main">
+								
+<nav class="nav-links">
+    <div class="menu-main-menu-container"><ul id="main-menu" class="menu"><button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button><div class="account-section visible-tablet">
+            <div class="account-buttons">
+            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login/" class=""><span>Log in</span></a>
+            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/register/" class=""><span>Register</span></a>
+        </div>
+    </div><li id="menu-item-29273" class="recipe-mega-menu menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-29273"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/">Recipes</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-29927" class="mob-title menu-item menu-item-type-post_type menu-item-object-page menu-item-29927"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/">Recipes</a></li>
+	<li id="menu-item-18895" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18895"><a href="#">Main ingredients</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29928" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29928"><a href="#">Main Ingredients</a></li>
+		<li id="menu-item-18896" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18896"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/beef-recipes/">Beef</a></li>
+		<li id="menu-item-65774" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65774"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/beef-mince-recipes/">Beef mince</a></li>
+		<li id="menu-item-18897" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18897"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/cheese-recipes/">Cheese</a></li>
+		<li id="menu-item-18898" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18898"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/chicken-recipes/">Chicken</a></li>
+		<li id="menu-item-18899" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18899"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/chocolate-recipes/">Chocolate</a></li>
+		<li id="menu-item-18900" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18900"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/egg-recipes/">Eggs</a></li>
+		<li id="menu-item-18901" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18901"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/fish-recipes/">Fish</a></li>
+		<li id="menu-item-18902" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18902"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/fruit-recipes/">Fruit</a></li>
+		<li id="menu-item-18903" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18903"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/lamb-recipes/">Lamb</a></li>
+		<li id="menu-item-18904" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18904"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/mushroom-recipes/">Mushrooms</a></li>
+		<li id="menu-item-18905" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18905"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/pasta-recipes/">Pasta</a></li>
+		<li id="menu-item-18906" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18906"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/pork-recipes/">Pork</a></li>
+		<li id="menu-item-18907" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18907"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/salmon-recipes/">Salmon</a></li>
+		<li id="menu-item-18908" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18908"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/sausage-recipes/">Sausages</a></li>
+		<li id="menu-item-18909" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18909"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/seafood-recipes/">Seafood</a></li>
+		<li id="menu-item-18911" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18911"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/vegetable-recipes/">Vegetables</a></li>
+	</ul>
+</li>
+	<li id="menu-item-56139" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-56139"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/drinks/">Drinks recipes</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-75584" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75584"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/non-alcoholic-drink-recipes/">Non-alcoholic drinks</a></li>
+		<li id="menu-item-58320" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58320"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/cocktail-recipes/">All cocktails</a></li>
+		<li id="menu-item-58319" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58319"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/champagne-cocktails/">Champagne cocktails</a></li>
+		<li id="menu-item-58321" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58321"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/gin-cocktail-recipes/">Gin cocktails</a></li>
+		<li id="menu-item-75581" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75581"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/spicy-cocktail-recipes/">Spicy cocktails</a></li>
+		<li id="menu-item-75582" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75582"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/summer-cocktail-recipes/">Summer cocktails</a></li>
+		<li id="menu-item-75583" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75583"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vodka-cocktail-recipes/">Vodka cocktails</a></li>
+		<li id="menu-item-58323" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58323"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/winter-cocktail-recipes/">Winter cocktails</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18960" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18960"><a href="#">Cuisine</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29929" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29929"><a href="#">Cuisine</a></li>
+		<li id="menu-item-65775" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65775"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/african-recipes/">African</a></li>
+		<li id="menu-item-18942" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18942"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/american-recipes/">American</a></li>
+		<li id="menu-item-60818" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-60818"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/australian-recipes/">Australian</a></li>
+		<li id="menu-item-18944" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18944"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/british-recipes/">British</a></li>
+		<li id="menu-item-65776" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65776"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/caribbean-recipes/">Caribbean</a></li>
+		<li id="menu-item-18946" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18946"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/chinese-recipes/">Chinese</a></li>
+		<li id="menu-item-18947" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18947"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/french-recipes/">French</a></li>
+		<li id="menu-item-18948" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18948"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/german-recipes/">German</a></li>
+		<li id="menu-item-18949" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18949"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/greek-recipes/">Greek</a></li>
+		<li id="menu-item-18950" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18950"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/indian-recipes/">Indian</a></li>
+		<li id="menu-item-18951" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18951"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/italian-recipes/">Italian</a></li>
+		<li id="menu-item-18952" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18952"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/japanese-recipes/">Japanese</a></li>
+		<li id="menu-item-66723" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-66723"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/korean-recipes/">Korean</a></li>
+		<li id="menu-item-18953" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18953"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/mediterranean-recipes/">Mediterranean</a></li>
+		<li id="menu-item-18954" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18954"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/mexican-recipes/">Mexican</a></li>
+		<li id="menu-item-37584" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-37584"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/middle-eastern/">Middle Eastern</a></li>
+		<li id="menu-item-18956" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18956"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/moroccan-recipes/">Moroccan</a></li>
+		<li id="menu-item-18957" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18957"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/scandinavian-recipes/">Scandinavian</a></li>
+		<li id="menu-item-18958" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18958"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/spanish-recipes/">Spanish</a></li>
+		<li id="menu-item-18959" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18959"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/vietnamese-recipes/">Vietnamese</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18913" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18913"><a href="#">Vegetarian &#038; vegan</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29930" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29930"><a href="#">Vegetarian &#038; vegan</a></li>
+		<li id="menu-item-21119" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-21119"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/dietary_requirements/vegetarian/">All vegetarian</a></li>
+		<li id="menu-item-78559" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78559"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/healthy-vegetarian-recipes/">Healthy vegetarian</a></li>
+		<li id="menu-item-78560" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78560"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/italian-vegetarian-recipes/">Italian vegetarian</a></li>
+		<li id="menu-item-47305" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-47305"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/quick-vegetarian-recipes/">Quick vegetarian</a></li>
+		<li id="menu-item-64947" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64947"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegetarian-bake-recipes/">Vegetarian one pots</a></li>
+		<li id="menu-item-78561" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78561"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegetarian-barbecue-recipes/">Vegetarian barbecue</a></li>
+		<li id="menu-item-78562" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78562"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegetarian-brunch-recipes/">Vegetarian brunch</a></li>
+		<li id="menu-item-78563" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78563"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegetarian-burger-recipes/">Vegetarian burgers</a></li>
+		<li id="menu-item-64948" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64948"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegetarian-casserole-recipes/">Vegetarian casseroles</a></li>
+		<li id="menu-item-78569" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78569"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegetarian-pasta-recipes/">Vegetarian pasta</a></li>
+		<li id="menu-item-21120" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-21120"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/dietary_requirements/vegan/">All vegan</a></li>
+		<li id="menu-item-64944" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64944"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegan-baking-recipes/">Vegan baking</a></li>
+		<li id="menu-item-78565" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78565"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegan-comfort-food/">Vegan comfort food</a></li>
+		<li id="menu-item-78566" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78566"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegan-curry-recipes/">Vegan curry</a></li>
+		<li id="menu-item-78568" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78568"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegan-pasta-recipes/">Vegan pasta</a></li>
+		<li id="menu-item-64946" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64946"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegan-roast-recipes/">Vegan roasts</a></li>
+		<li id="menu-item-64945" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64945"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegan-dessert-recipes/">Vegan desserts</a></li>
+		<li id="menu-item-78567" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78567"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/vegan-dinner-recipes/">Vegan dinners</a></li>
+		<li id="menu-item-78564" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78564"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/easy-vegan-recipes/">Easy vegan</a></li>
+	</ul>
+</li>
+	<li id="menu-item-32069" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-32069"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/baking-recipes/">Baking</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-65770" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65770"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/baking-recipes/">All baking</a></li>
+		<li id="menu-item-65771" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65771"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/cake-recipes/">Cakes</a></li>
+		<li id="menu-item-75577" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75577"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/birthday-cake-recipes/">Birthday cakes</a></li>
+		<li id="menu-item-32090" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32090"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/biscuit-recipes/">Biscuits</a></li>
+		<li id="menu-item-32083" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32083"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/brownie-recipes/">Brownies</a></li>
+		<li id="menu-item-32084" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32084"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/bundt-cake-recipes/">Bundt cakes</a></li>
+		<li id="menu-item-75578" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75578"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/carrot-cake-recipes/">Carrot cakes</a></li>
+		<li id="menu-item-32085" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32085"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/celebration-cake-recipes/">Celebration cakes</a></li>
+		<li id="menu-item-32086" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32086"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/chocolate-cake-recipes/">Chocolate cakes</a></li>
+		<li id="menu-item-32087" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32087"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/easy-cake-recipes/">Easy cakes</a></li>
+		<li id="menu-item-75579" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75579"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/flourless-baking-recipes/">Flourless baking</a></li>
+		<li id="menu-item-32088" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32088"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/loaf-cake-recipes/">Loaf cakes</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18915" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18915"><a href="#">Occasion</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29931" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29931"><a href="#">Occasion</a></li>
+		<li id="menu-item-81437" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-81437"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/chinese-new-year-recipes/">Chinese New Year</a></li>
+		<li id="menu-item-81438" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-81438"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/valentines-day-recipes/">Valentine&#8217;s Day</a></li>
+		<li id="menu-item-81439" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-81439"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/pancake-recipes/">Pancake Day</a></li>
+		<li id="menu-item-18968" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-18968"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/afternoon-tea-recipes/">Afternoon tea</a></li>
+		<li id="menu-item-64942" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64942"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/air-fryer-recipes/">Air fryer</a></li>
+		<li id="menu-item-75573" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75573"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/barbecue-recipes/">Barbecue</a></li>
+		<li id="menu-item-53244" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-53244"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/birthday-cake-recipes/">Birthday cakes</a></li>
+		<li id="menu-item-75576" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75576"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/brunch-recipes/">Brunch</a></li>
+		<li id="menu-item-73236" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-73236"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/comfort-food-recipes/">Comfort food</a></li>
+		<li id="menu-item-68269" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-68269"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/easy-dinner-party-mains/">Dinner party mains</a></li>
+		<li id="menu-item-65773" class="menu-item menu-item-type-taxonomy menu-item-object-collections current-recipes-ancestor current-menu-parent current-recipes-parent menu-item-65773"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/midweek-meal-recipes/">Midweek meals</a></li>
+		<li id="menu-item-75575" class="menu-item menu-item-type-taxonomy menu-item-object-collections current-recipes-ancestor current-menu-parent current-recipes-parent menu-item-75575"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/friday-night-dinners/">Friday night dinners</a></li>
+		<li id="menu-item-75574" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75574"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/weekend-dinner-recipes/">Weekend dinner ideas</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18912" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18912"><a href="#">Special diets</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29932" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29932"><a href="#">Special diets</a></li>
+		<li id="menu-item-18932" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-18932"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/dietary_requirements/dairy-free/">Dairy-free</a></li>
+		<li id="menu-item-19887" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-19887"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/dietary_requirements/gluten-free/">Gluten-free</a></li>
+		<li id="menu-item-78558" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-78558"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/dietary_requirements/vegetarian/">Vegetarian</a></li>
+		<li id="menu-item-78557" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-78557"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/dietary_requirements/vegan/">Vegan</a></li>
+		<li id="menu-item-52452" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-52452"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/diabetes-friendly-recipes/">Diabetes-friendly</a></li>
+		<li id="menu-item-49416" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-49416"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/low-calorie-dinner-recipes/">Lower-calorie</a></li>
+		<li id="menu-item-57863" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-57863"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/health/">Healthy recipes</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-81504" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-81504"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/february-recipes/">February inspiration</a></li>
+<li id="menu-item-75636" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-75636"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/skills/">Be a Better Cook</a></li>
+<li id="menu-item-62044" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-62044"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/features/">Features</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-70850" class="mob-title menu-item menu-item-type-taxonomy menu-item-object-category menu-item-70850"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/features/">Features</a></li>
+	<li id="menu-item-80820" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80820"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/features/">All features</a></li>
+	<li id="menu-item-62045" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62045"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/travel/">Travel</a></li>
+	<li id="menu-item-62047" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62047"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/reviews/">Reviews</a></li>
+	<li id="menu-item-62051" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-62051"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/features/interviews/">Interviews</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-80821" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80821"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/features/interviews/">Celebrity interviews</a></li>
+		<li id="menu-item-76196" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-76196"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/features/interviews/fridge-raid-interviews/">Fridge Raid interviews</a></li>
+	</ul>
+</li>
+	<li id="menu-item-72189" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-72189"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/round-ups/">Round-ups</a></li>
+	<li id="menu-item-73310" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73310"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/sustainability/">Sustainability</a></li>
+	<li id="menu-item-62049" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62049"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/features/events/">Events</a></li>
+	<li id="menu-item-62052" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62052"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/drinks/">Drinks</a></li>
+</ul>
+</li>
+<li id="menu-item-73158" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-73158"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/">Guides</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-73463" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73463"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/discoveries/">Discoveries</a></li>
+	<li id="menu-item-73162" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73162"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/leftovers/">Leftovers</a></li>
+	<li id="menu-item-73165" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73165"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/round-ups/">Round-ups</a></li>
+	<li id="menu-item-73160" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73160"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/menus/">Menu planning</a></li>
+	<li id="menu-item-73161" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73161"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/ingredients/">Ingredients</a></li>
+	<li id="menu-item-73163" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73163"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/in-the-garden/">In the garden</a></li>
+	<li id="menu-item-73164" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73164"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/health/">Health</a></li>
+	<li id="menu-item-73166" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73166"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/skills/">Skills</a></li>
+	<li id="menu-item-73167" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73167"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/guides/tips/">Tips</a></li>
+</ul>
+</li>
+<li id="menu-item-80441" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-80441"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/offers-competitions/">Offers &amp; Competitions</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-80442" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80442"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/offers-competitions/">Offers &amp; Competitions</a></li>
+	<li id="menu-item-80443" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80443"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/reviews/">Shopping &#038; Reviews</a></li>
+	<li id="menu-item-80444" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-80444"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/whats-inside-our-latest-issue/">Magazine subscriptions</a></li>
+	<li id="menu-item-80445" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80445"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/offers-competitions/competitions/">Competitions</a></li>
+</ul>
+</li>
+<li id="menu-item-79111" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-79111"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/reviews/">Shopping &#038; Reviews</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-80061" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80061"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/reviews/">Reviews</a></li>
+	<li id="menu-item-80062" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-80062"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/whats-inside-our-latest-issue/">How to subscribe to delicious. magazine</a></li>
+</ul>
+</li>
+<div class="external-links visible-tablet"><nav class="nav-list"><ul><li><a href="https://web.archive.org/web/20250216021303/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" rel="nofollow"><span>Subscribe to magazine</span><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/external-link.svg" width="20px" height="27px" alt="External link"/></a></li></ul></nav></div></ul></div></nav>
+								<div class="cta-search" id="desctopsearch">
+									<a href="#">
+										Search
+										<span class="icon-inline icon-search">
+																						<img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/search-green.svg" alt="Search icon" width="20" height="20"/>
+																					</span>
+									</a>
+								</div>
+								<div class="nav-mobile-cta visible-tablet">
+									<div class="burger-nav">
+										<span></span>
+										<span></span>
+										<span></span>
+										<span></span>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<div class="t_searchplace">
+						<div class="t_searchwrap">
+							<form class="hide-tablet" action="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/" method="get">
+								<input type="text" id="search_field" name="s" onfocus="this.placeholder = ''" onblur="this.placeholder = 'Type here to find recipes, collections, articles...'" placeholder="Type here to find recipes, collections, articles...">
+								<button class="t_search_desc" type="submit">
+									<img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/arrow-right-black.svg" class="Arrow-black"/>
+								</button>
+							</form>
+							<form class="visible-tablet" action="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/" method="get">
+								<input type="text" id="search_field_mobile" name="s" onfocus="this.placeholder = ''" onblur="this.placeholder = 'Tap here to search'" placeholder="Tap here to search">
+								<button class="t_search_desc" type="submit">
+									<img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/arrow-right-black.svg" class="Arrow-black"/>
+								</button>
+							</form>
+						</div>
+
+						<div class="t_search_box">
+													<div class="t_searchresult"></div>
+					</div>
+			</div>
+	</header>
+	</div>
+	</div>
+	</header>
+<!-- <meta name="keywords" content="chicken fajitas, fajitas, fajitas recipe"/> -->
+<main class="main-content content">
+    <div class="content-wrapper">
+        <!-- Recipe: Overview -->
+        <section id="recipe-overview">
+            <!-- Recipe: Header -->
+            <div class="recipe-header">
+                <div class="row no-gutters">
+                    <div class="col-sm-12 col-md-4 order-md-last  block">
+                        
+                    </div>
+
+                    <div class="col">
+                        <div class="recipe-heading text-standard">
+
+                            <div class="breadcrumbs">
+                                <p id="breadcrumbs"><span><span><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/">Home</a></span> <span class="seperator">&gt;</span> <span><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/">Recipes</a></span> <span class="seperator">&gt;</span> <span><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/chicken-breast-recipes/">Chicken breast</a></span> <span class="seperator">&gt;</span> <span class="breadcrumb_last" aria-current="page">Chicken fajitas</span></span></p>                            </div>
+
+                            <div class="recipe-title">
+                                <div class="print-logo">
+                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/logos/delicious-black.jpg" alt="Delicious print logo" class="print-logo-img"/>
+                                </div>
+                                <h1>Chicken fajitas</h1>
+                            </div>
+                        </div>
+
+                        <div class="visible-mobile">
+                                    <div class="recipe-stats nav-list mobile-view">
+
+				    	
+    		<p class="recipe-author-details"><span class="list-heading">By: </span>
+    			
+    			<span>
+    				<span itemprop="name"> 
+						<a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/authors/mia-rodriguezeyetoeyemedia-co-uk/"> 
+						<img data-del="avatar" data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/08/Mia-roundel-300x300-1-54x54.png" class="avatar pp-user-avatar avatar-30 photo lazyload" height="30" width="30" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 30px; --smush-placeholder-aspect-ratio: 30/30;"/> 
+						</a>
+						<span>
+						<a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/authors/mia-rodriguezeyetoeyemedia-co-uk/"> 
+						Mia Rodriguez </a>
+												</span>
+						</span>
+    			</span>
+
+    		</p>
+
+				    	
+    	<ul class="clearfix post-date">
+    		<li>
+    			<span class="list-heading">Published:&nbsp;</span>28 Jan 25    		</li>
+    		<li>
+    			<span class="list-heading">Updated:&nbsp;</span>14 Feb 25    		</li>
+    	</ul>
+    	<ul class="clearfix">
+    		<li class="recipe-rating">
+    			<a href="#reviews"><div id="yasr-vv-stars-stats-container-111be6788b120"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-111be6788b120" data-rating="0" data-rater-starsize="16" data-rater-postid="81265" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>    				<span>Rate &amp; comment<span>
+    			</a>
+    		</li>
+
+    		<li class="recipe-tka tka">
+    			    				<a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/meet-the-food-team/" target="">
+    				
+    				<img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/tka.svg" alt="Test kitchen approved logo" width="30" height="30" style="width:18px; height: 18px;">
+    				<span>Test kitchen approved</span>
+
+    				    				</a>
+    			    		</li>
+    	</ul>
+    </div>
+
+    
+    	    	    				    		
+
+    	                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- /Recipe: Header -->
+
+            <!-- Recipe: Details -->
+            <div class="recipe-detail-wrapper">
+                <div class="row no-gutters">
+                    <div class="col-md-6">
+                        <div class="hide-mobile">
+                            <div class="recipe-image">
+                                
+                                <img class="main-recipe-img disable-ll" src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3-768x960.jpg" alt="Chicken fajitas" width="768" height="960"/>
+
+                                                            </div>
+                        </div>
+
+                        <div class="visible-mobile">
+                            <div class="recipe-description text-standard" itemprop="description">
+                                <p>Still sizzling from the griddle, this classic combination of spiced <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/chicken-recipes/">chicken</a> strips, <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/pepper-recipes/">peppers</a> and onions is the perfect tortilla filler. Bring the components for these classic chicken fajitas to the table and let everyone add their favourite toppings. Mia Rodriguez, Deputy editor (audiences), shares her best recipe.</p>                                    <div class="recipe-image">
+                                                                                <img class="main-recipe-img disable-ll" src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3-768x960.jpg" alt="Chicken fajitas" width="768" height="960"/>
+                                                                            </div>
+                                    <p>
+<p>&#8220;Fajitas tend to get a bad rep because of the sachets of spice mixes that come in the kits you’ll find in every supermarket,&#8221; says Mia. &#8220;They’re usually too heavy on the cumin, a bit stale tasting and take over the whole dish so you can’t taste anything else. Make your own fajita spice mix, however, and you’ll realise exactly why this dish made it out of Texas and into the kitchens of Slough, Swansea, Fife – and everywhere in between. The quick pico de gallo salsa adds zingy fresh crunch to each bite, too.&#8221;</p><p>
+<p>Once you&#8217;ve mastered this classic fajitas recipe, check out our <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/crispy-chicken-fajitas-with-charred-spring-onions-and-tex-mex-slaw/">crispy chicken fajitas with charred spring onions and Tex-Mex slaw</a>.</p><p>
+</p>                            </div>
+
+                        </div>
+                    </div>
+
+                    <div class="col-md-6">
+                        <div class="recipe-details">
+                            <div class="hide-mobile">
+                                    <div class="recipe-stats nav-list">
+        <ul>
+            <li class="recipe-rating">
+                <a href="#reviews"><div id="yasr-vv-stars-stats-container-7b8b22101a1b6"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-7b8b22101a1b6" data-rating="0" data-rater-starsize="16" data-rater-postid="81265" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div></a>
+            </li>
+
+            <li class="recipe-skill">
+                <span class="icon-inline icon-effort-main">
+                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                </span>
+
+                                    <span>Easy</span>
+                            </li>
+
+                            <li class="recipe-date">
+                    <span class="icon-inline"></span>
+                    <span>February 2024</span>
+                </li>
+                    </ul>
+    </div>                                <div class="tka">
+                                                                        <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/meet-the-food-team/" target="">
+                                        
+                                        <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/tka.svg" alt="Test kitchen approved logo" width="30" height="30" style="width:30px; height: 30px;">
+                                        <span>Test kitchen approved</span>
+
+                                                                                </a>
+                                                                    </div>
+                            </div>
+
+                            <div class="recipe-info">
+                                <div class="recipe-guidance">
+                                    <ul class="list-guidance">
+                                                                                    <li>
+                                                <span class="icon-inline icon-serves-green">
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/serves-green.svg" alt="Serves icon" width="40" height="40"/>
+                                                </span>
+                                                <span>Serves 4</span>
+                                            </li>
+                                        
+                                                                                    <li>
+                                                <span class="icon-inline icon-time-green">
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/time-green.svg" alt="Time icon" width="40" height="40"/>
+                                                </span>
+                                                <span>Prep time 15 min. Cook time 15 min</span>
+                                            </li>
+                                                                            </ul>
+                                </div>
+                                
+                                <div class="hide-mobile">
+                                    <div class="recipe-description text-standard" itemprop="description">
+                                        <p>Still sizzling from the griddle, this classic combination of spiced <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/ingredients/chicken-recipes/">chicken</a> strips, <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/pepper-recipes/">peppers</a> and onions is the perfect tortilla filler. Bring the components for these classic chicken fajitas to the table and let everyone add their favourite toppings. Mia Rodriguez, Deputy editor (audiences), shares her best recipe.</p>
+<p>&#8220;Fajitas tend to get a bad rep because of the sachets of spice mixes that come in the kits you’ll find in every supermarket,&#8221; says Mia. &#8220;They’re usually too heavy on the cumin, a bit stale tasting and take over the whole dish so you can’t taste anything else. Make your own fajita spice mix, however, and you’ll realise exactly why this dish made it out of Texas and into the kitchens of Slough, Swansea, Fife – and everywhere in between. The quick pico de gallo salsa adds zingy fresh crunch to each bite, too.&#8221;</p>
+<p>Once you&#8217;ve mastered this classic fajitas recipe, check out our <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/crispy-chicken-fajitas-with-charred-spring-onions-and-tex-mex-slaw/">crispy chicken fajitas with charred spring onions and Tex-Mex slaw</a>.</p>
+                                    </div>
+
+                                </div>
+
+                                <div class="recipe-labels nav-list">
+                                    <ul>
+                                                                                </ul>
+                                </div>
+
+                                
+                                                                    <div class="visible-tablet">
+                                        
+                                                                                                                                                                                        </div>
+                                
+                                
+                                <div id="nutrition" class="recipe-nutrition text-standard">
+                                    <!-- Desktop Version -->
+                                                                            <div class="hide-tablet">
+                                            <h3 class="heading-alt">Nutrition: per serving</h3>
+
+                                            <dl class="list-two-column style-lined">
+                                                                                                    <dt>Calories</dt>
+                                                    <dd>555kcals</dd>
+                                                
+                                                                                                    <dt>Fat</dt>
+                                                    <dd>33g (13g saturated)</dd>
+                                                
+                                                                                                    <dt>Protein</dt>
+                                                    <dd>52g</dd>
+                                                
+                                                                                                    <dt>Carbohydrates</dt>
+                                                    <dd>9.2g (13g sugars)</dd>
+                                                
+                                                                                                    <dt>Fibre</dt>
+                                                    <dd>6.5g</dd>
+                                                
+                                                                                                    <dt>Salt</dt>
+                                                    <dd>4.1g</dd>
+                                                                                            </dl>
+                                        </div>
+                                    
+                                                                    </div>
+
+                                                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- /Recipe: Details -->
+        </section>
+        <!-- /Recipe: Overview -->
+
+        <!-- Recipe: Utilities - Mobile -->
+        <section id="utilities" class="visible-tablet content-block" style="margin-top: 1.5rem;">
+            <div class="recipe-utilities full-width">
+                <div class="row no-gutters">
+                    <div class="recipe-actions">
+                        <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login" title="Remove recipe" style="display: none;" class="bttn bttn-icon-remove btn-81265" post_id="81265" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-white.svg" alt="Remove recipe icon"/></span>
+                            Remove recipe
+                        </a>
+
+                        <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login" title="Save recipe" class="bttn bttn-icon-save btn-81265" post_id="81265" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" width="20" height="20"/></span>
+                            Save recipe
+                        </a>
+
+                    </div>
+
+                    <div class="recipe-actions">
+
+                        <a href="" title="Print recipe" class="bttn bttn-icon-print">
+                            <span></span>
+                            Print
+                        </a>
+
+                    </div>
+
+                    <div class="recipe-sharing mobile-only position-relative">
+                        <button class="bttn bttn-outline" data-toggle="collapse" data-target="#recipeSharing">
+                        <svg width="20" height="20" viewbox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M13.5602 5.00667C13.7446 5.32323 14.0283 5.57018 14.3672 5.70932C14.7061 5.84847 15.0815 5.87205 15.4352 5.77641C15.7889 5.68078 16.1012 5.47127 16.3238 5.18028C16.5465 4.8893 16.667 4.53306 16.6668 4.16667C16.6667 3.91078 16.6076 3.65835 16.4942 3.42895C16.3808 3.19956 16.2161 2.99935 16.0129 2.84386C15.8097 2.68836 15.5734 2.58175 15.3223 2.53229C15.0712 2.48282 14.8122 2.49184 14.5651 2.55863C14.3181 2.62542 14.0898 2.7482 13.8979 2.91744C13.7059 3.08669 13.5555 3.29785 13.4584 3.53458C13.3612 3.7713 13.3198 4.02722 13.3375 4.28251C13.3551 4.53779 13.4313 4.78558 13.5602 5.00667ZM13.5602 5.00667L6.44016 9.16001M6.44016 9.16001C6.25558 8.84369 5.97195 8.59698 5.63311 8.458C5.29427 8.31903 4.9191 8.29553 4.56556 8.39113C4.21203 8.48674 3.89983 8.69613 3.67722 8.98693C3.45461 9.27774 3.33398 9.63378 3.33398 10C3.33398 10.3662 3.45461 10.7223 3.67722 11.0131C3.89983 11.3039 4.21203 11.5133 4.56556 11.6089C4.9191 11.7045 5.29427 11.681 5.63311 11.542C5.97195 11.403 6.25558 11.1563 6.44016 10.84M6.44016 9.16001C6.58893 9.41495 6.66732 9.70483 6.66732 10C6.66732 10.2952 6.58893 10.5851 6.44016 10.84M6.44016 10.84L13.5602 14.9933M13.5602 14.9933C13.6668 14.7975 13.8116 14.6251 13.9861 14.4862C14.1606 14.3474 14.3611 14.245 14.5759 14.1851C14.7907 14.1251 15.0153 14.1089 15.2364 14.1373C15.4576 14.1658 15.6708 14.2383 15.8634 14.3506C16.056 14.4629 16.2241 14.6128 16.3578 14.7912C16.4915 14.9697 16.588 15.1731 16.6416 15.3896C16.6953 15.606 16.7049 15.831 16.67 16.0512C16.6351 16.2714 16.5564 16.4824 16.4385 16.6717C16.2092 17.0397 15.8456 17.3039 15.4247 17.4081C15.0038 17.5124 14.5589 17.4486 14.1844 17.2302C13.8098 17.0118 13.5351 16.656 13.4185 16.2384C13.302 15.8207 13.3528 15.3741 13.5602 14.9933Z" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                         <span>Share</span>           
+                        </button>
+                        <div id="recipeSharing" class="position-absolute collapse">
+                            <div class="sharing-links">
+    <ul>
+        <li><a class="facebook" href="https://web.archive.org/web/20250216021303/https://www.facebook.com/sharer/sharer.php?u=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/" target="_blank"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a class="twitter" href="https://web.archive.org/web/20250216021303/https://twitter.com/home?status=Chicken+fajitas+-+https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fchicken-fajitas%2F" target="_blank"><i class="fa-brands fa-x-twitter"></i></a></li>
+        <!-- <li><a class="linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/" target="_blank"><i class="fab fa-linkedin-in"></i></a></li> -->
+        <li><a class="whatsapp" href="https://web.archive.org/web/20250216021303/https://api.whatsapp.com/send?text=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/" target="_blank"><i class="fab fa-whatsapp"></i></a></li>
+        <li><a class="pinterest" href="https://web.archive.org/web/20250216021303/https://pinterest.com/pin/create/button/?url=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/&amp;media=https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3-768x960.jpg&amp;description=Chicken fajitas" target="_blank"><i class="fab fa-pinterest-p"></i></a></li>
+    </ul>
+</div>                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <!-- /Recipe: Utilities - Mobile -->
+
+        <!-- Recipe: Utilities - Desktop-->
+        <section id="utilities" class="hide-tablet content-block">
+            <div class="recipe-utilities">
+                <div class="row no-gutters">
+                    <div class="col-auto recipe-actions">
+                        <h3>Save</h3>
+
+                        <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login" title="Remove recipe" style="display: none;" class="bttn bttn-icon-remove btn-81265" post_id="81265" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-white.svg" alt="Remove recipe icon"/></span>
+                            Remove recipe
+                        </a>
+
+                        <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login" title="Save recipe" class="bttn bttn-icon-save btn-81265" post_id="81265" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" width="20" height="20"/></span>
+                            Save recipe
+                        </a>
+
+                        <a href="" title="Print recipe" class="bttn bttn-icon-print">
+                            <span></span>
+                            Print
+                        </a>
+                    </div>
+
+                    <div class="col-auto recipe-rating">
+                        <h3>Rate</h3>
+                        <a href="#reviews"><div id="yasr-vv-stars-stats-container-76201bd1b8052"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-76201bd1b8052" data-rating="0" data-rater-starsize="32" data-rater-postid="81265" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div></a>
+                    </div>
+
+                    <div class="col-auto recipe-sharing">
+                        <h3>Share</h3>
+
+                        <div class="sharing-links">
+    <ul>
+        <li><a class="facebook" href="https://web.archive.org/web/20250216021303/https://www.facebook.com/sharer/sharer.php?u=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/" target="_blank"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a class="twitter" href="https://web.archive.org/web/20250216021303/https://twitter.com/home?status=Chicken+fajitas+-+https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fchicken-fajitas%2F" target="_blank"><i class="fa-brands fa-x-twitter"></i></a></li>
+        <!-- <li><a class="linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/" target="_blank"><i class="fab fa-linkedin-in"></i></a></li> -->
+        <li><a class="whatsapp" href="https://web.archive.org/web/20250216021303/https://api.whatsapp.com/send?text=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/" target="_blank"><i class="fab fa-whatsapp"></i></a></li>
+        <li><a class="pinterest" href="https://web.archive.org/web/20250216021303/https://pinterest.com/pin/create/button/?url=https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/&amp;media=https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3-768x960.jpg&amp;description=Chicken fajitas" target="_blank"><i class="fab fa-pinterest-p"></i></a></li>
+    </ul>
+</div>                    </div>
+                </div>
+            </div>
+        </section>
+        <!-- /Recipe: Utilities - Desktop -->
+        
+        <section class="before-you-start visible-tablet">
+        <!-- This ad is only requested on mobile -->
+            <div class="visible-tablet" id="recipeMobileAd1">
+                <div class="row no-gutters row-deep">
+                    <div class="col-12 align-self-start">
+                        <div class="advert-content content-block double-margin">
+                            <div class="ad-title">Advertisement</div>
+                            <div id="adslot-recipe-2">
+                                
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row no-gutters">
+                <div class="col-md-12 col-lg-9">
+                    <div class="below-you-start-block content-block double-margin col-gutter">
+                                                    
+                            <div class=" text-standard">
+                                <h2>Before you start</h2>
+                                <p><strong>Know-how</strong> The secret to cooking chicken that’s juicy, tender and full of flavour is to rest it. Flash-frying chicken strips takes only 5 minutes. All too often the chicken is cooked with the vegetables, which create steam and lower the temperature, so cooking takes longer and you end up with dry, chewy chicken. While it’s resting after its flash-fry, you can focus your attention on cooking the vegetables properly. Frying them in a less crowded – and hotter – pan means you can get a decent char on them.</p>
+                            </div>
+                                            </div>
+                </div>
+            </div>
+
+        </section>
+
+        <!-- Recipe: Directions -->
+        <section id="recipe-main">
+            <div class="row no-gutters">
+                <div class="col-md-12 col-lg-9">
+                    
+                                    <!-- before you start desktop -->
+                    <div class="below-you-start-block content-block double-margin col-gutter hide-tablet"> 
+                        <div class=" text-standard">
+                            <h2>Before you start</h2>
+                            <p><strong>Know-how</strong> The secret to cooking chicken that’s juicy, tender and full of flavour is to rest it. Flash-frying chicken strips takes only 5 minutes. All too often the chicken is cooked with the vegetables, which create steam and lower the temperature, so cooking takes longer and you end up with dry, chewy chicken. While it’s resting after its flash-fry, you can focus your attention on cooking the vegetables properly. Frying them in a less crowded – and hotter – pan means you can get a decent char on them.</p>
+                        </div>
+                    </div>
+
+                
+                    <div class="recipe-directions content-block double-margin col-gutter">
+                                                    <div id="ingredients">
+                                <div class="recipe-ingredients text-standard">
+                                    <h2>Ingredients</h2>
+                                    <ul>
+<li>1 tsp dried oregano</li>
+<li>2 tsp smoked paprika</li>
+<li>1 tsp ground cumin</li>
+<li>1 tsp garlic powder</li>
+<li>2 tsp fine salt</li>
+<li>650g skinless chicken breasts (about 4 breasts), sliced into thick strips</li>
+<li>2 tsp vegetable oil</li>
+<li>2 onions, cut into thin petals</li>
+<li>1 red pepper, deseeded and cut into strips</li>
+<li>1 orange pepper, deseeded and cut into strips</li>
+<li>100g mild cheddar, coarsely grated, to serve</li>
+<li>100ml soured cream to serve</li>
+<li>2 avocados, mashed with a pinch of salt, to serve</li>
+<li>50g pickled jalapeños to serve</li>
+<li>8 soft flour tortilla wraps to serve</li>
+</ul>
+
+                                                                            <div class="advert-content visible-mobile">
+                                            <div class="ad-title">Advertisement</div>
+                                            <div id="adslot-recipe-12">
+                                                
+                                            </div>
+                                        </div>
+                                                                    </div>
+                            </div>
+                        
+                        <!-- Cook Mode -->
+                        <div class="visible-tablet">
+                            <div class="deli-nosleep deli-toggle-switch-container" style="">
+                                <label id="deli-toggle-switch" class="deli-toggle-switch deli-toggle-switch-rounded" aria-label="Toggle switch" style="width: 62px;height: 30px;">
+                                    <input type="checkbox" id="deli-nosleep-checkbox" class="deli-nosleep-checkbox">
+                                    <div class="deli-toggle-switch-slider" style="background-color: #ed6c4f;border-radius: 30px;">
+                                    <span></span>                  
+                                    </div>
+                                </label>
+                                <label for="deli-nosleep-checkbox" class="deli-nosleep-label deli-block-text-bold">Cook Mode</label>
+                                <span class="deli-nosleep-text">Sticky screen? No thanks! Tap to prevent your screen from going off while cooking.</span>
+                            </div>
+                        </div>                                
+
+                        <div id="gohere">
+                                                            <div id="method" class="recipe-method text-standard content-block double-margin col-gutter">
+                                    <h2>Method</h2>
+                                                                        <ol>
+<li>Mix all the ingredients for the pico de gallo in a bowl with a pinch of salt and set aside.</li>
+<li>Put a large griddle pan over a high heat. Mix the dried herbs and spices, garlic powder and salt in a large bowl, then set half aside for later. Add the chicken to the bowl with 1 tsp oil and toss to coat in the spice mixture.</li>
+<li>Add the coated chicken to the griddle pan and cook for 5 minutes, turning occasionally, until cooked through, then set aside. Add the onions, red and orange pepper and remaining oil to the pan, then cook until softened and beginning to char in places. Sprinkle over the reserved spice mix, tip the chicken back into the pan and cook, stirring occasionally, for a few more minutes to warm through.</li>
+                                        <div class="advert-content content-block double-margin visible-tablet" style="width: 100%; margin-bottom: 1.5rem;">
+                                            <div class="ad-sub_title" style="font-size: 1.1rem; color: #7f7f7f; margin-bottom:1rem">Recipe continues after advertising</div>
+                                            <div class="ad-title">Advertisement</div>
+                                            <div id="adslot-recipe-3">
+                                                
+                                            </div>
+                                        </div></li>
+<li>Bring the fajita filling to the table – ideally in the griddle pan so it’s still sizzling – alongside the pico de gallo, grated cheddar, soured cream, mashed avocados, jalapeños and tortillas so everyone can build their own.</li>
+</ol>
+
+                                </div>
+                            
+                                                                                        <div class="visible-tablet recipe-method text-standard content-block">
+                                <div class="recipe-labels nav-list" style="margin-top: 0;">
+                                        <ul>
+                                            <li style="padding-left: 0;">
+                                                <span>Recipe from <strong>February 2024</strong> Issue</span>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                
+                                </div>
+                            
+                        </div>
+                        
+                        <div class="zeddit-rcm" data-pid="1012" data-type="canvas-display" animation-type="none" variant="1"></div>
+
+                                                    <!-- Mobile Accordion Version -->
+                            <div class="nutrition content-block visible-tablet">
+                                <h2>Nutrition</h2>
+                                                                <div class="visible-tablet text-standard" style="margin-top: 2rem; margin-bottom: 40px;">
+
+                                    <div class="heading-alt">Nutrition: per serving</div>
+                                    
+                                    <div class="text-standard recipe-nutrition" id="nutritionContent" style="margin-top: 20px;">
+                                        <dl class="list-two-column style-lined">
+                                                                                            <dt>Calories</dt>
+                                                <dd>555kcals</dd>
+                                            
+                                                                                            <dt>Fat</dt>
+                                                <dd>33g (13g saturated)</dd>
+                                            
+                                                                                            <dt>Protein</dt>
+                                                <dd>52g</dd>
+                                            
+                                                                                            <dt>Carbohydrates</dt>
+                                                <dd>9.2g (13g sugars)</dd>
+                                            
+                                                                                            <dt>Fibre</dt>
+                                                <dd>6.5g</dd>
+                                            
+                                                                                            <dt>Salt</dt>
+                                                <dd>4.1g</dd>
+                                            
+                                        </dl>
+                                       
+                                    </div>
+                                </div>
+                            </div>
+                        
+
+                        
+                        
+                        
+                        
+                        
+                        <!-- START OF WHISK -->
+                        <div id="whisk-container">
+                            <h2 class="visible-tablet">Buy ingredients online</h2>
+                            <script async="true" src="https://web.archive.org/web/20250216021303js_/https://cdn.whisk.com/sdk/shopping-list-sp.js" type="text/javascript"></script>
+                            <script>
+                                var whisk = whisk || {};
+                                whisk.queue = whisk.queue || [];
+
+                                whisk.queue.push(function() {
+                                    whisk.config.set("global.trackingId", "5bdd6de5-be70-4a69-838d-cc8955b6a362");
+
+                                    whisk.shoppingList.defineWidget("WWID-WKXK-TAUC-WHQD", {
+                                        whiteLabel: "deliciouscouknew",
+                                        styles: {
+                                            size: "large",
+                                            align: "left",
+                                            linkColor: "#38C4A4",
+                                            button: {
+                                                color: "#38C4A4",
+                                                text: "Add to shopping list"
+                                            }
+                                        }
+                                    });
+
+                                    whisk.ads.defineBlock("whisk-sp-unit-block-1", {
+                                        whiteLabel: "deliciouscouknew",
+                                    });
+                                });
+                            </script>
+
+                            <div id="WWID-WKXK-TAUC-WHQD" class="content-block double-margin">
+                                <script>
+                                    whisk.queue.push(function() {
+                                        whisk.display('WWID-WKXK-TAUC-WHQD');
+                                    });
+                                </script>
+                            </div>
+
+                            <div id="whisk-sp-unit-block-1">
+                                <script>
+                                    whisk.queue.push(function() {
+                                        whisk.display("whisk-sp-unit-block-1");
+                                    });
+                                </script>
+                            </div>
+                        </div>
+                        <!-- END OF WHISK -->
+
+                            
+                            <div class="recipe-author-wrapper content-block double-margin hide-mobile">
+                            <div class="recipe-author-details">
+                                                        
+                                
+                                    <p class="list-heading"> Recipe By: </p>
+                                    
+                                    <div class="recipe-author-details-with-img">
+                                        <span itemprop="name"> 
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/authors/mia-rodriguezeyetoeyemedia-co-uk/"> 
+                                            <img data-del="avatar" data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/08/Mia-roundel-300x300-1-100x100.png" class="avatar pp-user-avatar avatar-60 photo lazyload" height="60" width="60" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 60px; --smush-placeholder-aspect-ratio: 60/60;"/> 
+                                            </a>
+                                            <span>
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/authors/mia-rodriguezeyetoeyemedia-co-uk/"> 
+                                            Mia Rodriguez </a>
+                                                                                        </span>
+                                        </span>
+                                    </div>
+
+
+                                
+                                <ul class="post-date">
+                                        <li>
+                                            <span class="list-heading">Published:&nbsp;</span>28 Jan 25                                        </li>
+                                        <li>
+                                            <span class="list-heading">Updated:&nbsp;</span>14 Feb 25                                        </li>
+                                </ul>
+                            </div>
+                        
+                        <div class="magazine-subscription">
+                                    <p>Subscribe</p>
+                                    <p>Fancy getting a copy in print?</p>
+                                    <a href="https://web.archive.org/web/20250216021303/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" title="Subscribe to Delicious magazine">Subscribe to our magazine</a>
+
+                                                                            <div class="postal-magazine-cover">
+                                            <img data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Feb-25-Delicious-magazine-footer.png" alt="" class="img-responsive lazyload" width="170px" height="106px" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 170px; --smush-placeholder-aspect-ratio: 170/106;"/>
+                                        </div>
+                                                                </div>
+                        </div>
+
+                                                    <div class="related-recipe-collections">
+                                <h2>Related recipe collections</h2>
+
+                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/30-minute-meal-recipes/">30-minute meals</a>
+                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/chicken-breast-recipes/">Chicken breast</a>
+                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/fathers-day-recipes/">Father&#039;s Day</a>
+                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/our-favourite-chicken-recipes/">Favourite chicken</a>
+                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/friday-night-dinners/">Friday night dinners</a>
+                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cuisine/mexican-recipes/">Mexican recipes</a>
+                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/midweek-meal-recipes/">Midweek meals</a>
+                                                            </div>
+                        
+                        <div id="reviews" class="rate-review text-standard content-block double-margin">
+                            <h2>Rate &amp; review</h2>
+
+                            <div class="rate">
+                                <p>Rate</p>
+                                <p class="login-message">You must be logged in to rate a recipe, <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login/">click here to login</a>.</p>                            </div>
+
+                            <div class="reviews">
+                                <p>Reviews</p>
+                                                                    <div class="comment-wrapper">
+                                        
+<div id="comments" class="comments-area">
+		<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Share a tip <small><a rel="nofollow" id="cancel-comment-reply-link" href="/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/#respond" style="display:none;">Cancel comment</a></small></h3><form id="commentform" class="comment-form login-required">
+    <div class="login-message"><p>You must be <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-login.php?redirect_to=https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fchicken-fajitas%2F">logged in</a> to post a comment.</p></div>
+    <p class="comment-form-comment" id="login-required">
+    <textarea disabled id="comment" name="comment" cols="45" rows="4" placeholder="Something to say? Tell us what you loved about this. Inspire others, get typing" aria-required="true"></textarea>
+    </p>
+    <p class="form-submit">
+    <input name="submit" type="submit" id="submit" class="submit" value="Submit" disabled>
+    </p>
+    </form>	</div><!-- #respond -->
+	
+</div><!-- #comments -->
+                                    </div>
+                                                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                                <div class="sidebar col-md-12 col-lg-3">
+                    <div class="side-top-ad">
+                        <aside class="sidebar ad" id="recipeAd1">
+                            <div class="row no-gutters row-deep">
+                                <div class="col-12 align-self-start">
+                                    <!-- Advertisement: Desktop > 1024 -->
+                                    <div class="advert-content content-block double-margin">
+                                        <div class="ad-title">Advertisement</div>
+                                        <div id="adslot-recipe-4">
+                                            
+                                        </div>
+                                        <div id="adslot-recipe-7">
+                                            
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                                                            <div class="related-recipe-card">
+                                    <h3>Related recipe</h3>
+                                    <div class="card-bg card-utilities rec-tab">
+                                        <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-enchiladas/">
+                                            <div class="card-img-wrapper">
+                                                <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="3225" user_id="">
+                                                    <span class="save-icons">
+                                                        <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                        <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                    </span>
+                                                    <span class="text">Save recipe</span>
+                                                </div>
+
+                                                <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/09/323787-1-eng-GB_4858-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                            </div>
+                                        </a>
+
+                                        <div class="card-body">
+                                            
+                                                <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/chicken-breast-recipes/">
+                                                    <p class="article-cat">Chicken breast</p>
+                                                </a>
+                                            
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-enchiladas/">
+                                                <h4 class="card-title heading-std-text">Chicken enchiladas</h4>
+                                            </a>
+                                        </div>
+
+                                        <div class="card-footer">
+                                            
+<div class="recipe-tags">
+        </div>                                            <div class="recipe-stats nav-list">
+                                                <ul>
+                                                    <li class="recipe-rating">
+                                                        <div id="yasr-vv-stars-stats-container-a011bb98287e6"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-a011bb98287e6" data-rating="5" data-rater-starsize="16" data-rater-postid="3225" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>                                                    </li>
+                                                    <li class="recipe-skill">
+                                                        <span class="icon-inline icon-effort-main">
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                        </span>
+
+                                                                                                                    <span>Easy</span>
+                                                                                                            </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                                    </aside>
+                    </div>
+
+                    <div class="side-bot-ad hide-tablet">
+                        <aside class="sidebar ad" id="recipeAd2">
+                            <div class="row no-gutters row-deep">
+                                <div class="col-12 align-self-start">
+                                    <div class="advert-content content-block double-margin">
+                                        <div class="ad-title">Advertisement</div>
+                                        <div id="adslot-recipe-5">
+                                            
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </aside>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+                    <section class="latest-recipes content-block">
+                <div class="row">
+                    <div class="slider-title">
+                        <div class="intro-text text-standard">
+                            <h2>Or, how about...?</h2>
+                        </div>
+                    </div>
+
+                    <div class="slider-wrapper">
+                        <div class="recipe-slider">
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/tex-mex-enchilada-bake/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="40757" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2019/11/tex-mex-enchilada-bake-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/beef-mince-recipes/">
+                                                        <p class="article-cat">Beef mince</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/tex-mex-enchilada-bake/">
+                                                    <h4 class="card-title heading-std-text">Tex-Mex enchilada bake</h4>
+                                                </a>
+
+                                                <p>Here&#8217;s a comforting enchiladas recipe to simplify weeknight dinner planning;...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-b68b1b1e3d071"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-b68b1b1e3d071" data-rating="3.7" data-rater-starsize="16" data-rater-postid="40757" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/tex-mex-beef-burritos/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="4470" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/09/490703-1-eng-GB_tex-mex-beef-burritos-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/spicy-recipes/">
+                                                        <p class="article-cat">Spicy recipes</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/tex-mex-beef-burritos/">
+                                                    <h4 class="card-title heading-std-text">Tex-Mex beef burritos</h4>
+                                                </a>
+
+                                                <p>These Tex-Mex burritos with beef, refried beans guacamole and salsa...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-6b7c1318b301e"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-6b7c1318b301e" data-rating="5" data-rater-starsize="16" data-rater-postid="4470" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/nachos-pulled-pork-sweetcorn-salsa/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="29288" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/09/pulled-pork-nachos-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/comfort-food-recipes/">
+                                                        <p class="article-cat">Comfort food</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/nachos-pulled-pork-sweetcorn-salsa/">
+                                                    <h4 class="card-title heading-std-text">Nachos with pulled pork and sweetcorn salsa</h4>
+                                                </a>
+
+                                                <p>Layer up nachos with succulent pulled pork, cheddar and a...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-b116bb60778f3"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-b116bb60778f3" data-rating="5" data-rater-starsize="16" data-rater-postid="29288" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Medium</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/crispy-chicken-fajitas-with-charred-spring-onions-and-tex-mex-slaw/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="81283" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TWIST_3-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/midweek-meal-recipes/">
+                                                        <p class="article-cat">Midweek meals</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/crispy-chicken-fajitas-with-charred-spring-onions-and-tex-mex-slaw/">
+                                                    <h4 class="card-title heading-std-text">Crispy chicken fajitas with charred spring onions and Tex-Mex slaw</h4>
+                                                </a>
+
+                                                <p>Amping up the crunch while staying true to what makes...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-369b301813b27"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-369b301813b27" data-rating="0" data-rater-starsize="16" data-rater-postid="81283" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas-with-tomato-salsa/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="1133" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/521729-1-eng-GB_chicken-fajitas-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/friday-night-dinners/">
+                                                        <p class="article-cat">Friday night dinners</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas-with-tomato-salsa/">
+                                                    <h4 class="card-title heading-std-text">Chicken fajitas with tomato salsa</h4>
+                                                </a>
+
+                                                <p>Our straightforward, healthy chicken fajitas make a fabulous Friday night...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-37a13b1b0b861"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-37a13b1b0b861" data-rating="5" data-rater-starsize="16" data-rater-postid="1133" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/refried-beans/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="3750" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/09/485085-1-eng-GB__refried-beans-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/storecupboard-recipes/">
+                                                        <p class="article-cat">Storecupboard</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/recipes/refried-beans/">
+                                                    <h4 class="card-title heading-std-text">Refried beans</h4>
+                                                </a>
+
+                                                <p>This traditional Mexican dish is the perfect accompaniment to fajitas...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-796807b1431bd"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-796807b1431bd" data-rating="5" data-rater-starsize="16" data-rater-postid="3750" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="9fc81bbf87"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                    </div>
+                    </div>
+                </div>
+            </section>
+            
+                    <section class="related-articles">
+                <div class="content-block">
+                    <div class="row">
+                        <div class="slider-title">
+                            <div class="intro-text text-standard">
+                                <h2>More food for thought...</h2>
+                            </div>
+                        </div>
+
+                        <div class="slider-wrapper">
+                            <div class="category-slider">
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/our-18-best-pepper-recipes/" class="card-utilities post-68975 post type-post status-publish format-standard has-post-thumbnail hentry category-guides category-ingredients category-round-ups tag-avjar tag-bell-pepper tag-bell-peppers tag-best-pepper-recipes tag-capsicum tag-delicious-pepper-recipes tag-green-pepper tag-green-pepper-recipes tag-paprika tag-pepper-pasta tag-pepper-recipes-uk tag-red-pepper tag-red-pepper-recipes tag-romano tag-romano-pepper-recipes tag-romesco tag-stuffed-peppers tag-yellow-pepper-recipes">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/04/2023D051_MIED_PEPPERS-copy-299x238.jpg" alt="Our 18 best pepper recipes" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Round-ups</p>
+
+                                                    <h4 class="card-title">Our 18 best pepper recipes</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Katy Salter</li>
+                                                            <li class="article-date">Aug 23</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/how-to-make-the-best-chicken-of-your-life/" class="card-utilities post-75224 post type-post status-publish format-standard has-post-thumbnail hentry category-features category-guides category-skills category-tips tag-be-a-better-cook tag-chicken tag-chicken-breasts tag-chicken-nicoise tag-chicken-thighs tag-cooking-chicken tag-how-to-cook-chicken-well tag-how-to-cook-the-best-chicken-thighs tag-how-to-roast-perfect-chicken tag-how-to-roast-the-best-chicken tag-pressed-chicken-thighs tag-roast-chicken tag-spatchcock-chicken">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/2024D029_CHICKEN_SPATCHCOCK_2__-299x238.jpg" alt="How to make the best chicken of your life" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Features</p>
+
+                                                    <h4 class="card-title">How to make the best chicken of your life</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Delicious. team</li>
+                                                            <li class="article-date">Apr 24</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/our-best-melted-cheese-recipes/" class="card-utilities post-45855 post type-post status-publish format-standard has-post-thumbnail hentry category-features category-guides category-round-ups tag-best-cheese-recipes tag-cheddar tag-cheese tag-cheese-fondue tag-cheese-on-toast tag-cheese-recipes tag-cheesy-recipes tag-comfort-food tag-fondue-recipe tag-macaroni-cheese-recipe tag-melted-cheese tag-melted-cheese-recipes tag-mozzarella tag-quesadilla tag-truffade tag-vegetarian-truffade">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2020/08/four-cheese-lasagne-768x960-1-299x238.jpg" alt="19 of our best melted cheese recipes" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Features</p>
+
+                                                    <h4 class="card-title">19 of our best melted cheese recipes</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Thea Everett</li>
+                                                            <li class="article-date">Sep 20</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/summer-burger-recipes/" class="card-utilities post-52443 post type-post status-publish format-standard has-post-thumbnail hentry category-features category-guides category-tips tag-4-great-summer-burger-recipes tag-alternative-barbecue-recipes tag-avocado-and-feta-cheeseburger tag-barbecue-recipes tag-california-burger tag-how-to-make-perfect-burgers tag-kimchi-burger tag-summer-burger-recipe tag-summer-burgers tag-tex-mex-inspired-cheeseburger">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2021/07/INSTA2021_Q3_096_097_098_BURGERS_DPS_KIMCHI_CALI_TEX_MEX-1-299x238.jpg" alt="4 great summer beef burger recipes" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Features</p>
+
+                                                    <h4 class="card-title">4 great summer beef burger recipes</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Delicious. team</li>
+                                                            <li class="article-date">Jul 21</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        
+                    <section class="related-collections">
+                <div class="row no-gutters">
+                    <div class="col-sm-12">
+                        <div class="collections content-block double-margin">
+                            <div class="row">
+                                <div class="slider-title">
+                                    <div class="intro-text text-standard">
+                                        <h2>Related collections</h2>
+                                    </div>
+                                </div>
+
+                                <div class="slider-wrapper">
+                                    <div class="collection-slider">
+                                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/chicken-breast-recipes/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/906178-1-eng-GB_470200-1-eng-gb_dijon-chicken-299x238.jpg" alt="Chicken breast recipes" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">Chicken breast</h4>
+
+                                                                                                                <p>The versatile chicken breast is anything but boring...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>100 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/spicy-recipes/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2020/10/532439-1-eng-GB_bang-bang-chicken-salad-768x1024-1-299x238.jpg" alt="" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">Spicy recipes</h4>
+
+                                                                                                                <p>Chasing that tingly chilli high? This collection is...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>169 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/taco-recipes/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2019/09/chicken-thigh-tacos-299x238.jpg" alt="chicken tinga tacos" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">Tacos</h4>
+
+                                                                                                                <p>Spice up a Mexican feast (or just a...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>28 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                                    <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/collections/30-minute-meal-recipes/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/DEL_2022_Q3_SEAN_CALITZ_SIMPLE_STICKY_POMEGRANATE_GLAZED-AUBERGINES-AND-COURGETTES-299x238.jpg" alt="Pomegranate glazed aubergines" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">30-minute meals</h4>
+
+                                                                                                                <p>When you want something tasty but you don't...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>216 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                            </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        
+        <section class="sponsored-content">
+            <div class="row no-gutters">
+                <div class="col-12">
+                    <div class="outbrain-wrapper content-block double-margin">
+                        <div class="intro-text text-standard">
+                            <h2>More to discover</h2>
+                        </div>
+
+                        <div class="OUTBRAIN" data-src="https://web.archive.org/web/20250216021303oe_/https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/" data-widget-id="AR_1" data-ob-template="RadioTimes"></div>
+                        <script type="text/javascript" defer src="https://web.archive.org/web/20250216021303js_/https://widgets.outbrain.com/outbrain.js"></script>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        
+    <section id="subscribe-section" class="content-block double-margin">
+        <div class="row">
+                        <!-- <div class="col-sm-12">
+                <div class="newsletter-wrapper">
+                    <h2>Sign up to our newsletter</h2>
+                    <p>Sign up for our newsletter to stay up to date with all the latest news, recipes and offers.</p>
+                    <script type="text/javascript"></script>
+                <div class='gf_browser_chrome gform_wrapper gform_legacy_markup_wrapper gform-theme--no-framework' data-form-theme='legacy' data-form-index='0' id='gform_wrapper_73' ><div id='gf_73' class='gform_anchor' tabindex='-1'></div><form method='post' enctype='multipart/form-data' target='gform_ajax_frame_73' id='gform_73'  action='/recipes/chicken-fajitas/#gf_73' data-formid='73' novalidate>
+                        <div class='gform-body gform_body'><ul id='gform_fields_73' class='gform_fields top_label form_sublabel_below description_below validation_below'><li id="field_73_1" class="gfield gfield--type-email gfield_contains_required field_sublabel_below gfield--no-description field_description_below field_validation_below gfield_visibility_visible"  data-js-reload="field_73_1" ><label class='gfield_label gform-field-label' for='input_73_1'>Email address<span class="gfield_required"><span class="gfield_required gfield_required_asterisk">*</span></span></label><div class='ginput_container ginput_container_email'>
+                            <input name='input_1' id='input_73_1' type='email' value='' class='large'   placeholder='Type your email here' aria-required="true" aria-invalid="false"  />
+                        </div></li></ul></div>
+        <div class='gform-footer gform_footer top_label'> <input type='submit' id='gform_submit_button_73' class='gform_button button' onclick='gform.submission.handleButtonClick(this);' value='Sign up now'  /> <input type='hidden' name='gform_ajax' value='form_id=73&amp;title=&amp;description=&amp;tabindex=0&amp;theme=legacy&amp;styles=[]&amp;hash=8e5bdf2c4ff61c3b1d141201e10d0174' />
+            <input type='hidden' class='gform_hidden' name='gform_submission_method' data-js='gform_submission_method_73' value='iframe' />
+            <input type='hidden' class='gform_hidden' name='gform_theme' data-js='gform_theme_73' id='gform_theme_73' value='legacy' />
+            <input type='hidden' class='gform_hidden' name='gform_style_settings' data-js='gform_style_settings_73' id='gform_style_settings_73' value='[]' />
+            <input type='hidden' class='gform_hidden' name='is_submit_73' value='1' />
+            <input type='hidden' class='gform_hidden' name='gform_submit' value='73' />
+            
+            <input type='hidden' class='gform_hidden' name='gform_unique_id' value='' />
+            <input type='hidden' class='gform_hidden' name='state_73' value='WyJbXSIsIjE4ODdmYWRhN2RhMzE1ODI5ZGY3NmZjYzY3ODM1MGE1Il0=' />
+            <input type='hidden' autocomplete='off' class='gform_hidden' name='gform_target_page_number_73' id='gform_target_page_number_73' value='0' />
+            <input type='hidden' autocomplete='off' class='gform_hidden' name='gform_source_page_number_73' id='gform_source_page_number_73' value='1' />
+            <input type='hidden' name='gform_field_values' value='' />
+            
+        </div>
+                        <p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="115"/><script>document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );</script></p></form>
+                        </div>
+		                <iframe style='display:none;width:0px;height:0px;' src='about:blank' name='gform_ajax_frame_73' id='gform_ajax_frame_73' title='This iframe contains the logic required to handle Ajax powered Gravity Forms.'></iframe>
+		                <script type="text/javascript">
+/* <![CDATA[ */
+ gform.initializeOnLoaded( function() {gformInitSpinner( 73, 'https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/images/spinner.svg', true );jQuery('#gform_ajax_frame_73').on('load',function(){var contents = jQuery(this).contents().find('*').html();var is_postback = contents.indexOf('GF_AJAX_POSTBACK') >= 0;if(!is_postback){return;}var form_content = jQuery(this).contents().find('#gform_wrapper_73');var is_confirmation = jQuery(this).contents().find('#gform_confirmation_wrapper_73').length > 0;var is_redirect = contents.indexOf('gformRedirect(){') >= 0;var is_form = form_content.length > 0 && ! is_redirect && ! is_confirmation;var mt = parseInt(jQuery('html').css('margin-top'), 10) + parseInt(jQuery('body').css('margin-top'), 10) + 100;if(is_form){jQuery('#gform_wrapper_73').html(form_content.html());if(form_content.hasClass('gform_validation_error')){jQuery('#gform_wrapper_73').addClass('gform_validation_error');} else {jQuery('#gform_wrapper_73').removeClass('gform_validation_error');}setTimeout( function() { /* delay the scroll by 50 milliseconds to fix a bug in chrome */ jQuery(document).scrollTop(jQuery('#gform_wrapper_73').offset().top - mt); }, 50 );if(window['gformInitDatepicker']) {gformInitDatepicker();}if(window['gformInitPriceFields']) {gformInitPriceFields();}var current_page = jQuery('#gform_source_page_number_73').val();gformInitSpinner( 73, 'https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/images/spinner.svg', true );jQuery(document).trigger('gform_page_loaded', [73, current_page]);window['gf_submitting_73'] = false;}else if(!is_redirect){var confirmation_content = jQuery(this).contents().find('.GF_AJAX_POSTBACK').html();if(!confirmation_content){confirmation_content = contents;}jQuery('#gform_wrapper_73').replaceWith(confirmation_content);jQuery(document).scrollTop(jQuery('#gf_73').offset().top - mt);jQuery(document).trigger('gform_confirmation_loaded', [73]);window['gf_submitting_73'] = false;wp.a11y.speak(jQuery('#gform_confirmation_message_73').text());}else{jQuery('#gform_73').append(contents);if(window['gformRedirect']) {gformRedirect();}}jQuery(document).trigger("gform_pre_post_render", [{ formId: "73", currentPage: "current_page", abort: function() { this.preventDefault(); } }]);                if (event && event.defaultPrevented) {                return;         }        const gformWrapperDiv = document.getElementById( "gform_wrapper_73" );        if ( gformWrapperDiv ) {            const visibilitySpan = document.createElement( "span" );            visibilitySpan.id = "gform_visibility_test_73";            gformWrapperDiv.insertAdjacentElement( "afterend", visibilitySpan );        }        const visibilityTestDiv = document.getElementById( "gform_visibility_test_73" );        let postRenderFired = false;                function triggerPostRender() {            if ( postRenderFired ) {                return;            }            postRenderFired = true;            jQuery( document ).trigger( 'gform_post_render', [73, current_page] );            gform.utils.trigger( { event: 'gform/postRender', native: false, data: { formId: 73, currentPage: current_page } } );            gform.utils.trigger( { event: 'gform/post_render', native: false, data: { formId: 73, currentPage: current_page } } );            if ( visibilityTestDiv ) {                visibilityTestDiv.parentNode.removeChild( visibilityTestDiv );            }        }        function debounce( func, wait, immediate ) {            var timeout;            return function() {                var context = this, args = arguments;                var later = function() {                    timeout = null;                    if ( !immediate ) func.apply( context, args );                };                var callNow = immediate && !timeout;                clearTimeout( timeout );                timeout = setTimeout( later, wait );                if ( callNow ) func.apply( context, args );            };        }        const debouncedTriggerPostRender = debounce( function() {            triggerPostRender();        }, 200 );        if ( visibilityTestDiv && visibilityTestDiv.offsetParent === null ) {            const observer = new MutationObserver( ( mutations ) => {                mutations.forEach( ( mutation ) => {                    if ( mutation.type === 'attributes' && visibilityTestDiv.offsetParent !== null ) {                        debouncedTriggerPostRender();                        observer.disconnect();                    }                });            });            observer.observe( document.body, {                attributes: true,                childList: false,                subtree: true,                attributeFilter: [ 'style', 'class' ],            });        } else {            triggerPostRender();        }    } );} ); 
+/* ]]> */
+</script>
+                </div>
+            </div> -->
+            
+            <div class="col-sm-12 col-md-6">
+                <div class="magazine-wrapper">
+                    
+                    <h3>Subscribe to our magazine</h3>
+
+                                            <p>Food stories, skills and tested recipes, straight to your door... Enjoy 5 issues for just £5 with our special introductory offer.</p>
+                    
+                                            <a href="https://web.archive.org/web/20250216021303/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" title="Subscribe to Delicious magazine" class="bttn">Subscribe</a>
+                    
+                                            <div class="postal-magazine-cover">
+                            <img data-src="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Feb-25-Delicious-magazine-footer-208x230.png" alt="" width="208px" height="230px" class="img-responsive lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 208px; --smush-placeholder-aspect-ratio: 208/230;"/>
+                        </div>
+                                    </div>
+            </div>
+
+            <div class="col-sm-12 col-md-6">
+                <div class="digital-download-wrapper">
+                    
+                    <h3>Unleash your inner chef</h3>
+
+                                            <p>Looking for inspiration? Receive the latest recipes with our newsletter</p>
+                    
+                                        
+                    <form method="POST">
+                        <input type="hidden" name="action" value="delish_subscribe_mailchimp"/>
+                        <input name="digital-magazine-email-address" type="email" placeholder="Email address">
+
+                                                    <div class="small-print"><p>We treat your data with care. See our <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/privacy-policy/">privacy policy</a>. By signing up, you are agreeing to delicious.&#8217; <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/terms-conditions/">terms and conditions</a>. Unsubscribe at any time.</p>
+</div>
+                        
+                        <input id="subscribeMailchimp" type="submit" value="Sign me up" class="bttn"/>
+                        <span class="response-container"></span>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </section>    </div>
+</main>
+
+
+<script type="application/ld+json">
+    {
+        "@type": "Recipe",
+        "@context": "https://web.archive.org/web/20250216021303/http://schema.org/",
+        "name": "Chicken fajitas",
+        "author": {
+            "@type": "Person",
+            "name": "delicious. magazine",
+                        "image" : [
+                {
+                    "@type" : "ImageObject",
+                    "inLanguage" : "en-UK",
+                    "@id"   : "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#/schema/person/image/",
+                    "name"  : "Mia Rodriguez",
+                    "url": "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/08/Mia-roundel-300x300-1-100x100.png",
+                    "contentUrl": "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/08/Mia-roundel-300x300-1-100x100.png",
+                    "caption" : "Mia Rodriguez"
+                }
+                ]
+                        },
+        "datePublished": "2025-01-28",
+                "dateModified": "2025-02-14",
+                "image": "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D182_TRADVSTWIST_TRAD_3.jpg",
+        "description": "Still sizzling from the griddle, this classic combination of spiced chicken strips, peppers and onions is the perfect tortilla filler. Bring the components for these classic chicken fajitas to the table and let everyone add their favourite toppings. Mia Rodriguez, Deputy editor (audiences), shares her best recipe. &#8220;Fajitas tend to get a bad rep because of the sachets of spice mixes that come in the kits you’ll find in every supermarket,&#8221; says Mia. &#8220;They’re usually too heavy on the cumin, a bit stale tasting and take over the whole dish so you can’t taste anything else. Make your own fajita spice mix, however, and you’ll realise exactly why this dish made it out of Texas and into the kitchens of Slough, Swansea, Fife – and everywhere in between. The quick pico de gallo salsa adds zingy fresh crunch to each bite, too.&#8221; Once you&#8217;ve mastered this classic fajitas recipe, check out our crispy chicken fajitas with charred spring onions and Tex-Mex slaw.",
+        "keywords": "chicken fajitas, fajitas, fajitas recipe, ",
+        "prepTime": "PT15M",
+        "cookTime": "PT15M",
+         "totalTime": "PT0H30M",
+        "recipeYield": "Serves 4",
+        "recipeCategory": "Storecupboard",
+         "recipeCuisine": "Mexican recipes",
+         "nutrition": {
+            "@type": "NutritionInformation",
+            "calories": "555kcals",
+            "fatContent": "33g (13g saturated)",
+            "proteinContent": "52g",
+            "carbohydrateContent": "9.2g (13g sugars)",
+            "fiberContent": "6.5g"
+        },
+        "recipeIngredient": ["1 tsp dried oregano",
+"2 tsp smoked paprika",
+"1 tsp ground cumin",
+"1 tsp garlic powder",
+"2 tsp fine salt",
+"650g skinless chicken breasts (about 4 breasts), sliced into thick strips",
+"2 tsp vegetable oil",
+"2 onions, cut into thin petals",
+"1 red pepper, deseeded and cut into strips",
+"1 orange pepper, deseeded and cut into strips",
+"100g mild cheddar, coarsely grated, to serve",
+"100ml soured cream to serve",
+"2 avocados, mashed with a pinch of salt, to serve",
+"50g pickled jalapeños to serve",
+"8 soft flour tortilla wraps to serve"],
+        "recipeInstructions": [
+                             {
+                        "@type": "HowToStep",
+                        "text": "Mix all the ingredients for the pico de gallo in a bowl with a pinch of salt and set aside."
+                    },
+                
+                             {
+                        "@type": "HowToStep",
+                        "text": "Put a large griddle pan over a high heat. Mix the dried herbs and spices, garlic powder and salt in a large bowl, then set half aside for later. Add the chicken to the bowl with 1 tsp oil and toss to coat in the spice mixture."
+                    },
+                
+                             {
+                        "@type": "HowToStep",
+                        "text": "Add the coated chicken to the griddle pan and cook for 5 minutes, turning occasionally, until cooked through, then set aside. Add the onions, red and orange pepper and remaining oil to the pan, then cook until softened and beginning to char in places. Sprinkle over the reserved spice mix, tip the chicken back into the pan and cook, stirring occasionally, for a few more minutes to warm through."
+                    },
+                
+                             {
+                        "@type": "HowToStep",
+                        "text": "Bring the fajita filling to the table – ideally in the griddle pan so it’s still sizzling – alongside the pico de gallo, grated cheddar, soured cream, mashed avocados, jalapeños and tortillas so everyone can build their own."
+                    }
+                
+                    ]     
+    }
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://web.archive.org/web/20250216021303/https://schema.org",
+  "@type": "Person",
+  "name": "Mia Rodriguez",    "image" : [
+    {
+        "@type" : "ImageObject",
+        "inLanguage" : "en-UK",
+        "@id"   : "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/#/schema/person/image/",
+        "name"  : "Mia Rodriguez",
+        "url": "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/08/Mia-roundel-300x300-1-100x100.png",
+        "contentUrl": "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/08/Mia-roundel-300x300-1-100x100.png",
+        "caption" : "Mia Rodriguez"
+    }
+    ]
+    }
+</script>
+
+
+<script type="text/javascript">
+    (function($) {
+        $(document).ready(function() {
+            //    event.preventDefault();
+            var page = 2;
+
+            $('.bttn-icon-save, .cta-icon-not-saved-white, .bttn-icon-remove').click(function(e) {
+                if ($(this).attr('href') != 'https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login') {
+                    e.defaultPrevented = false;
+                    return false;
+                }
+            });
+
+            $('a.bttn-icon-save').click(function(e) {
+                var post_id = $(this).attr('post_id');
+                var user_id = $(this).attr('user_id');
+                var field = 'recipes';
+                $(this).parent().parent().addClass('recipe-card--loading');
+                $.ajax({
+                    url: "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php",
+                    data: {
+                        'action': 'get_recipes_save',
+                        'post_id': post_id,
+                        'user_id': user_id
+                        //'field' : field,
+                    },
+                    success: function(data) {
+                        $('.btn-' + post_id).parent().parent().removeClass('recipe-card--loading');
+                        $('a.bttn-icon-save').hide();
+                        $('a.bttn-icon-remove').show();
+                    }
+                });
+            });
+
+            $('.cta-icon-not-saved-white').click(function(e) {
+                var post_id = $(this).attr('post_id');
+                var user_id = $(this).attr('user_id');
+                var field = 'recipes';
+                $(this).parent().parent().addClass('recipe-card--loading');
+                $.ajax({
+                    url: "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php",
+                    data: {
+                        'action': 'get_recipes_save',
+                        'post_id': post_id,
+                        'user_id': user_id
+                        //'field' : field,
+                    },
+                    success: function(data) {
+                        $('.btn-' + post_id).parent().parent().removeClass('recipe-card--loading');
+                        $('a.bttn-icon-save').hide();
+                        $('a.bttn-icon-remove').show();
+                    }
+                });
+            });
+
+            $('a.bttn-icon-remove').click(function(e) {
+                var post_id = $(this).attr('post_id');
+                var user_id = $(this).attr('user_id');
+                var field = 'recipes';
+                $(this).parent().parent().addClass('recipe-card--loading');
+                $.ajax({
+                    url: "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php",
+                    data: {
+                        'action': 'get_recipes_delete',
+                        'post_id': post_id,
+                        'user_id': user_id,
+                        'field': field,
+                    },
+                    success: function(data) {
+                        $('.btn-' + post_id).parent().parent().removeClass('recipe-card--loading');
+                        $('a.bttn-icon-remove').hide();
+                        $('a.bttn-icon-save').show();
+                    }
+                });
+            });
+
+        })
+
+    })(jQuery);
+</script>
+
+
+<footer class="content-wrapper">
+    <div class="footer-wrapper">
+        <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/">
+            <img src="https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/logos/delicious-black.svg" alt="Delicious logo" class="footer-logo" width="231" height="43"/>
+        </a>
+
+        <div class="social-links">
+            <p>Stay in touch - and share</p>
+
+            <div class="social-sharing-links">
+                <div class="row no-gutters">
+                    <ul>
+                                                    <li><a href="https://web.archive.org/web/20250216021303/https://www.facebook.com/deliciousmagazineuk/" target="_blank"><i class="fab fa-facebook-f"></i></a></li>
+                                                                            <li><a href="https://web.archive.org/web/20250216021303/https://www.instagram.com/deliciousmag/" target="_blank"><i class="fab fa-instagram"></i></a></li>
+                                                                                                    <li><a href="https://web.archive.org/web/20250216021303/https://www.tiktok.com/@deliciousmag/" target="_blank"><i class="fa-brands fa-tiktok"></i></a></li>
+                                                                            <li><a href="https://web.archive.org/web/20250216021303/https://www.pinterest.co.uk/deliciousmaguk/" target="_blank"><i class="fab fa-pinterest-p"></i></a></li>
+                                                                            <li><a href="https://web.archive.org/web/20250216021303/https://www.youtube.com/user/deliciousmagazineuk/" target="_blank"><i class="fab fa-youtube"></i></a></li>
+                                            </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="content-block">
+            <div class="footer-links">
+                
+    <nav class="nav-links">
+        <div class="menu-footer-links-container"><ul id="footer-links" class="menu"><li id="menu-item-16194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16194"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/about/">About</a></li>
+<li id="menu-item-48077" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48077"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/meet-the-food-team/">Food team</a></li>
+<li id="menu-item-63586" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-63586"><a href="https://web.archive.org/web/20250216021303/https://www.subscription.co.uk/EyeToEye/DLC/">Print issues</a></li>
+<li id="menu-item-73798" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-73798"><a href="https://web.archive.org/web/20250216021303/https://pocketmags.com/publishers/eye-to-eye/delicious-magazine#659d680146925">Digital issues</a></li>
+<li id="menu-item-16193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16193"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/contact/">Contact</a></li>
+<li id="menu-item-43781" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-43781"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/sitemap/">Sitemap</a></li>
+<li id="menu-item-16189" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16189"><a rel="nofollow" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/cookie-policy/">Cookies</a></li>
+<li id="menu-item-16190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16190"><a rel="nofollow" href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/privacy-policy/">Privacy policy</a></li>
+<li id="menu-item-46577" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-46577"><a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/want-to-advertise-with-delicious/">Advertise</a></li>
+</ul></div>    </nav>
+            </div>
+
+            <div class="eye-to-eye-copy">
+                <p>Delicious magazine is a part of Eye to Eye Media Ltd &copy; 2025</p>
+            </div>
+        </div>
+    </div>
+</footer>
+
+<footer class="print-footer">
+    <p>Find it online: https://www.deliciousmagazine.co.uk/recipes/chicken-fajitas/</p>
+</footer>
+
+
+<!-- Lost password Modal -->
+<div class="remodal small" data-remodal-id="forgot-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Lost my password</h2>
+    <p>
+        Enter the email address associated with your<br> account, and we'll send you a link to reset your<br> password.
+    </p>
+
+    
+    <div class="row remodal_form">
+        <form name="lostpasswordform" id="lostpasswordform" action="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login/?action=lostpassword" method="post">
+            <div class="col-12">
+                <label for="email">Email*</label>
+            </div>
+            <div class="col-12 col-md-8">
+                <input type="email" name="user_login" id="user_login" value="" placeholder="Type your email here">
+            </div>
+            <div class="col-12 col-md-8">
+                <div class="g-recaptcha" data-sitekey="6Ldevc4ZAAAAAKwipl4I1aW9Zy1SUHBzGp8ujT3w"></div>
+            </div>
+            <div class="col-12 col-md-4 text-center">
+                <input type="submit" name="wp-submit" id="wp-submit" value="Send me" class="greenbutton">
+            </div>
+        </form>
+    </div>
+</div>
+<!--// Lost password Modal -->
+
+<!-- Email Sent Modal -->
+<div class="remodal small" data-remodal-id="sent-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Email sent</h2>
+    <p>
+        If an account was found for this email address, <br>we've emailed you instructions to reset your <br>password.
+    </p>
+    <div class="row remodal_form">
+        <div class="col-12">
+            <a href="https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/login/#forgot-modal" class="greenborder">I didn't receive it</a>
+        </div>
+    </div>
+</div>
+<!--// Email Sent Modal -->
+
+<!-- Thanks Modal -->
+<div class="remodal small" data-remodal-id="thanks-modal" id="thanks-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Thank you for signing up to our newsletter</h2>
+    <p>
+        Now you can stay up to date with all the latest news, recipes and offers.
+    </p>
+    <div class="row remodal_form">
+        <div class="col-12">
+            <a href="#" class="greenbutton" data-remodal-action="confirm">Continue exploring</a>
+        </div>
+    </div>
+</div>
+<!--// Thanks Modal -->
+
+<!-- Subscribe Modal -->
+<div class="remodal small" data-remodal-id="subscribe-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Subscribe to our magazine</h2>
+    <p>
+        Subscribe to delicious. today for just £13.50 – that's HALF PRICE!
+    </p>
+    <div class="row remodal_form">
+        [mc4wp_form id="28909"]        <!-- <form name="subscribeform" id="subscribeform" action="/" method="post">
+                <div class="col-12">
+                    <label for="email">Email*</label>
+                </div>
+                <div class="col-12 col-md-12">
+                    <input type="email"  name="user_login" id="user_login" value="" placeholder="Type your email here">
+                </div>
+                <div class="col-12 col-md-12 text-center">
+                    <input type="submit"  name="wp-submit" id="wp-submit" value="Subscribe"  class="greenbutton">
+                </div>
+            </form> -->
+    </div>
+</div>
+<!--// Subscribe Modal -->
+
+<!-- Confirm Modal -->
+<div class="remodal confirm" data-remodal-id="confirm-modal" id="confirm-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Confirmation</h2>
+    <p>
+        We have sent you an activation link,<br>
+        please click this link to activate your account.
+
+    </p>
+    <div class="row remodal_form">
+        <div class="col-12">
+            <a data-remodal-target="#" href="#" class="greenbutton" data-remodal-action="confirm">Continue exploring</a>
+        </div>
+    </div>
+</div>
+
+<!-- ShopThru Code -->
+<script src="https://web.archive.org/web/20250216021303js_/https://assets.shopthruapp.com/e/9d540dbb-ed73-456e-89eb-006ec692c352/prod/embed.js" defer></script>
+
+
+<? //  SUBX CODE 
+?>
+<script type="text/javascript" src="//web.archive.org/web/20250216021303js_/https://d2ip7iv1l4ergv.cloudfront.net/embed/widget/ZITWidget.min.js" defer></script>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-panel" animation-type="popup"></div>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-panel" animation-type="slide"></div>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-email" animation-type="popup"></div>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-email" animation-type="slide"></div>
+
+
+<link rel="stylesheet" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/fontawesome/css/all.min.css?ver=5.5.1" media="print" onload="this.media='all'">
+
+<!-- Custom Feeds for Instagram JS -->
+<script type="text/javascript">
+var sbiajaxurl = "https://web.archive.org/web/20250216021303/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php";
+
+</script>
+<link rel="stylesheet" id="yasrcss-css" href="https://web.archive.org/web/20250216021303cs_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/css/yasr.css?ver=3.4.12" type="text/css" media="all"/>
+<style id="yasrcss-inline-css" type="text/css">
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216021303im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+</style>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/mobilemenu.js?ver=1.6.2" id="mobilemenu-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/bootstrap.min.js" id="bootstrap-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/vendor/slick/slick.min.js?ver=1.8.1" id="slick-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/jquery.formstyler.min.js?ver=6.7.1" id="formstyler-js-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/nosleep.min.js" id="nosleep-js"></script>
+<script type="text/javascript" id="scripts-js-extra">
+/* <![CDATA[ */
+var ajax_object = {"ajax_url":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/scripts.min.js?ver=1.11.0" id="scripts-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/cookie.js?ver=1.0.0" id="cookies-js"></script>
+<script type="text/javascript" id="yasr-window-var-js-extra">
+/* <![CDATA[ */
+var yasrWindowVar = {"siteUrl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk","adminUrl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/","ajaxurl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/admin-ajax.php","visitorStatsEnabled":"no","ajaxEnabled":"yes","loaderHtml":"<div id=\"yasr-loader\" style=\"display: inline-block\">\u00a0 <img src=\"https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/yet-another-stars-rating\/includes\/img\/loader.gif\" \n                 title=\"yasr-loader\" alt=\"yasr-loader\" height=\"16\" width=\"16\"><\/div>","loaderUrl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/yet-another-stars-rating\/includes\/img\/loader.gif","isUserLoggedIn":"false","isRtl":"false","starSingleForm":"\"star\"","starsPluralForm":"\"stars\"","textAfterVr":"\"%average% votes\"","textRating":"\"Rating\"","textLoadRanking":"\"Loading, please wait\"","textVvStats":"\"out of 5 stars\"","textOrderBy":"\"Order by\"","textMostRated":"\"Most Rated\"","textHighestRated":"\"Highest Rated\"","textLeftColumnHeader":"\"Post\""};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/wp-smush-pro/app/assets/js/smush-lazy-load.min.js?ver=3.16.11" id="smush-lazy-load-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/js/yasr-globals.js?ver=3.4.12" id="yasr-global-functions-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/js/shortcodes/overall-multiset.js?ver=3.4.12" id="yasr-ov-multi-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/dom-ready.min.js?ver=f77871ff7694fffea381" id="wp-dom-ready-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/hooks.min.js?ver=4d63a3d491d11ffd8ac6" id="wp-hooks-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/i18n.min.js?ver=5e580eb46a90c2b997e6" id="wp-i18n-js"></script>
+<script type="text/javascript" id="wp-i18n-js-after">
+/* <![CDATA[ */
+wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );
+/* ]]> */
+</script>
+<script type="text/javascript" id="wp-a11y-js-translations">
+/* <![CDATA[ */
+( function( domain, translations ) {
+	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
+	localeData[""].domain = domain;
+	wp.i18n.setLocaleData( localeData, domain );
+} )( "default", {"translation-revision-date":"2024-11-14 20:13:08+0000","generator":"GlotPress\/4.0.1","domain":"messages","locale_data":{"messages":{"":{"domain":"messages","plural-forms":"nplurals=2; plural=n != 1;","lang":"en_GB"},"Notifications":["Notifications"]}},"comment":{"reference":"wp-includes\/js\/dist\/a11y.js"}} );
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/a11y.min.js?ver=3156534cc54473497e14" id="wp-a11y-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/js/jquery.json.min.js?ver=2.9.3" id="gform_json-js"></script>
+<script type="text/javascript" id="gform_gravityforms-js-extra">
+/* <![CDATA[ */
+var gform_i18n = {"datepicker":{"days":{"monday":"Mo","tuesday":"Tu","wednesday":"We","thursday":"Th","friday":"Fr","saturday":"Sa","sunday":"Su"},"months":{"january":"January","february":"February","march":"March","april":"April","may":"May","june":"June","july":"July","august":"August","september":"September","october":"October","november":"November","december":"December"},"firstDay":1,"iconText":"Select date"}};
+var gf_legacy_multi = [];
+var gform_gravityforms = {"strings":{"invalid_file_extension":"This type of file is not allowed. Must be one of the following:","delete_file":"Delete this file","in_progress":"in progress","file_exceeds_limit":"File exceeds size limit","illegal_extension":"This type of file is not allowed.","max_reached":"Maximum number of files reached","unknown_error":"There was a problem while saving the file on the server","currently_uploading":"Please wait for the uploading to complete","cancel":"Cancel","cancel_upload":"Cancel this upload","cancelled":"Cancelled"},"vars":{"images_url":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms\/images"}};
+var gf_global = {"gf_currency_config":{"name":"Pound Sterling","symbol_left":"&#163;","symbol_right":"","symbol_padding":" ","thousand_separator":",","decimal_separator":".","decimals":2,"code":"GBP"},"base_url":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms","number_formats":[],"spinnerUrl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms\/images\/spinner.svg","version_hash":"e9ef442de89e16035c39e11d1a579aba","strings":{"newRowAdded":"New row added.","rowRemoved":"Row removed","formSaved":"The form has been saved.  The content contains the link to return and complete the form."}};
+/* ]]> */
+</script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/js/gravityforms.min.js?ver=2.9.3" id="gform_gravityforms-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/js/placeholders.jquery.min.js?ver=2.9.3" id="gform_placeholder-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/assets/js/dist/utils.min.js?ver=501a987060f4426fb517400c73c7fc1e" id="gform_gravityforms_utils-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/assets/js/dist/vendor-theme.min.js?ver=ddd2702ee024d421149a5e61416f1ff5" id="gform_gravityforms_theme_vendors-js"></script>
+<script type="text/javascript" id="gform_gravityforms_theme-js-extra">
+/* <![CDATA[ */
+var gform_theme_config = {"common":{"form":{"honeypot":{"version_hash":"e9ef442de89e16035c39e11d1a579aba"},"ajax":{"ajaxurl":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/admin-ajax.php","ajax_submission_nonce":"2cc2434a2c","i18n":{"step_announcement":"Step %1$s of %2$s, %3$s","unknown_error":"There was an unknown error processing your request. Please try again."}}}},"hmr_dev":"","public_path":"https:\/\/web.archive.org\/web\/20250216021303\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms\/assets\/js\/dist\/","config_nonce":"2e18f34040"};
+/* ]]> */
+</script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/assets/js/dist/scripts-theme.min.js?ver=cd31c16637eeae0b20e422009e5a8b28" id="gform_gravityforms_theme-js"></script>
+<script defer type="text/javascript" src="https://web.archive.org/web/20250216021303js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1739440842" id="akismet-frontend-js"></script>
+<script type="text/javascript">(function (undefined) {let scriptOptions={"_localizedStrings":{"redirect_overlay_title":"Hold On","redirect_overlay_text":"You are being redirected to another page,<br>it may take a few seconds.","webview_notification_text":"The selected provider doesn't support embedded browsers!"},"_targetWindow":"prefer-popup","_redirectOverlay":"overlay-with-spinner-and-message","_unsupportedWebviewBehavior":""};
+/**
+ * Used when Cross-Origin-Opener-Policy blocked the access to the opener. We can't have a reference of the opened windows, so we should attempt to refresh only the windows that has opened popups.
+ */
+window._nslHasOpenedPopup = false;
+window._nslWebViewNoticeElement = null;
+
+window.NSLPopup = function (url, title, w, h) {
+
+    /**
+     * Cross-Origin-Opener-Policy blocked the access to the opener
+     */
+    if (typeof BroadcastChannel === "function") {
+        const _nslLoginBroadCastChannel = new BroadcastChannel('nsl_login_broadcast_channel');
+        _nslLoginBroadCastChannel.onmessage = (event) => {
+            if (window?._nslHasOpenedPopup && event.data?.action === 'redirect') {
+                window._nslHasOpenedPopup = false;
+
+                const url = event.data?.href;
+                _nslLoginBroadCastChannel.close();
+                if (typeof window.nslRedirect === 'function') {
+                    window.nslRedirect(url);
+                } else {
+                    window.opener.location = url;
+                }
+            }
+        };
+    }
+
+    const userAgent = navigator.userAgent,
+        mobile = function () {
+            return /\b(iPhone|iP[ao]d)/.test(userAgent) ||
+                /\b(iP[ao]d)/.test(userAgent) ||
+                /Android/i.test(userAgent) ||
+                /Mobile/i.test(userAgent);
+        },
+        screenX = window.screenX !== undefined ? window.screenX : window.screenLeft,
+        screenY = window.screenY !== undefined ? window.screenY : window.screenTop,
+        outerWidth = window.outerWidth !== undefined ? window.outerWidth : document.documentElement.clientWidth,
+        outerHeight = window.outerHeight !== undefined ? window.outerHeight : document.documentElement.clientHeight - 22,
+        targetWidth = mobile() ? null : w,
+        targetHeight = mobile() ? null : h,
+        left = parseInt(screenX + (outerWidth - targetWidth) / 2, 10),
+        right = parseInt(screenY + (outerHeight - targetHeight) / 2.5, 10),
+        features = [];
+    if (targetWidth !== null) {
+        features.push('width=' + targetWidth);
+    }
+    if (targetHeight !== null) {
+        features.push('height=' + targetHeight);
+    }
+    features.push('left=' + left);
+    features.push('top=' + right);
+    features.push('scrollbars=1');
+
+    const newWindow = window.open(url, title, features.join(','));
+
+    if (window.focus) {
+        newWindow.focus();
+    }
+
+    window._nslHasOpenedPopup = true;
+
+    return newWindow;
+};
+
+let isWebView = null;
+
+function checkWebView() {
+    if (isWebView === null) {
+        function _detectOS(ua) {
+            if (/Android/.test(ua)) {
+                return "Android";
+            } else if (/iPhone|iPad|iPod/.test(ua)) {
+                return "iOS";
+            } else if (/Windows/.test(ua)) {
+                return "Windows";
+            } else if (/Mac OS X/.test(ua)) {
+                return "Mac";
+            } else if (/CrOS/.test(ua)) {
+                return "Chrome OS";
+            } else if (/Firefox/.test(ua)) {
+                return "Firefox OS";
+            }
+            return "";
+        }
+
+        function _detectBrowser(ua) {
+            let android = /Android/.test(ua);
+
+            if (/Opera Mini/.test(ua) || / OPR/.test(ua) || / OPT/.test(ua)) {
+                return "Opera";
+            } else if (/CriOS/.test(ua)) {
+                return "Chrome for iOS";
+            } else if (/Edge/.test(ua)) {
+                return "Edge";
+            } else if (android && /Silk\//.test(ua)) {
+                return "Silk";
+            } else if (/Chrome/.test(ua)) {
+                return "Chrome";
+            } else if (/Firefox/.test(ua)) {
+                return "Firefox";
+            } else if (android) {
+                return "AOSP";
+            } else if (/MSIE|Trident/.test(ua)) {
+                return "IE";
+            } else if (/Safari\//.test(ua)) {
+                return "Safari";
+            } else if (/AppleWebKit/.test(ua)) {
+                return "WebKit";
+            }
+            return "";
+        }
+
+        function _detectBrowserVersion(ua, browser) {
+            if (browser === "Opera") {
+                return /Opera Mini/.test(ua) ? _getVersion(ua, "Opera Mini/") :
+                    / OPR/.test(ua) ? _getVersion(ua, " OPR/") :
+                        _getVersion(ua, " OPT/");
+            } else if (browser === "Chrome for iOS") {
+                return _getVersion(ua, "CriOS/");
+            } else if (browser === "Edge") {
+                return _getVersion(ua, "Edge/");
+            } else if (browser === "Chrome") {
+                return _getVersion(ua, "Chrome/");
+            } else if (browser === "Firefox") {
+                return _getVersion(ua, "Firefox/");
+            } else if (browser === "Silk") {
+                return _getVersion(ua, "Silk/");
+            } else if (browser === "AOSP") {
+                return _getVersion(ua, "Version/");
+            } else if (browser === "IE") {
+                return /IEMobile/.test(ua) ? _getVersion(ua, "IEMobile/") :
+                    /MSIE/.test(ua) ? _getVersion(ua, "MSIE ")
+                        :
+                        _getVersion(ua, "rv:");
+            } else if (browser === "Safari") {
+                return _getVersion(ua, "Version/");
+            } else if (browser === "WebKit") {
+                return _getVersion(ua, "WebKit/");
+            }
+            return "0.0.0";
+        }
+
+        function _getVersion(ua, token) {
+            try {
+                return _normalizeSemverString(ua.split(token)[1].trim().split(/[^\w\.]/)[0]);
+            } catch (o_O) {
+            }
+            return "0.0.0";
+        }
+
+        function _normalizeSemverString(version) {
+            const ary = version.split(/[\._]/);
+            return (parseInt(ary[0], 10) || 0) + "." +
+                (parseInt(ary[1], 10) || 0) + "." +
+                (parseInt(ary[2], 10) || 0);
+        }
+
+        function _isWebView(ua, os, browser, version, options) {
+            switch (os + browser) {
+                case "iOSSafari":
+                    return false;
+                case "iOSWebKit":
+                    return _isWebView_iOS(options);
+                case "AndroidAOSP":
+                    return false;
+                case "AndroidChrome":
+                    return parseFloat(version) >= 42 ? /; wv/.test(ua) : /\d{2}\.0\.0/.test(version) ? true : _isWebView_Android(options);
+            }
+            return false;
+        }
+
+        function _isWebView_iOS(options) {
+            const document = (window["document"] || {});
+
+            if ("WEB_VIEW" in options) {
+                return options["WEB_VIEW"];
+            }
+            return !("fullscreenEnabled" in document || "webkitFullscreenEnabled" in document || false);
+        }
+
+        function _isWebView_Android(options) {
+            if ("WEB_VIEW" in options) {
+                return options["WEB_VIEW"];
+            }
+            return !("requestFileSystem" in window || "webkitRequestFileSystem" in window || false);
+        }
+
+        const options = {},
+            nav = window.navigator || {},
+            ua = nav.userAgent || "",
+            os = _detectOS(ua),
+            browser = _detectBrowser(ua),
+            browserVersion = _detectBrowserVersion(ua, browser);
+
+        isWebView = _isWebView(ua, os, browser, browserVersion, options);
+    }
+
+    return isWebView;
+}
+
+function isAllowedWebViewForUserAgent(provider) {
+    const facebookAllowedWebViews = [
+        'Instagram',
+        'FBAV',
+        'FBAN'
+    ];
+    let whitelist = [];
+
+    if (provider && provider === 'facebook') {
+        whitelist = facebookAllowedWebViews;
+    }
+
+    const nav = window.navigator || {},
+        ua = nav.userAgent || "";
+
+    if (whitelist.length && ua.match(new RegExp(whitelist.join('|')))) {
+        return true;
+    }
+
+    return false;
+}
+
+function disableButtonInWebView(providerButtonElement) {
+    if (providerButtonElement) {
+        providerButtonElement.classList.add('nsl-disabled-provider');
+        providerButtonElement.setAttribute('href', '#');
+
+        providerButtonElement.addEventListener('pointerdown', (e) => {
+            if (!window._nslWebViewNoticeElement) {
+                window._nslWebViewNoticeElement = document.createElement('div');
+                window._nslWebViewNoticeElement.id = "nsl-notices-fallback";
+                window._nslWebViewNoticeElement.addEventListener('pointerdown', function (e) {
+                    this.parentNode.removeChild(this);
+                    window._nslWebViewNoticeElement = null;
+                });
+                const webviewNoticeHTML = '<div class="error"><p>' + scriptOptions._localizedStrings.webview_notification_text + '</p></div>';
+
+                window._nslWebViewNoticeElement.insertAdjacentHTML("afterbegin", webviewNoticeHTML);
+                document.body.appendChild(window._nslWebViewNoticeElement);
+            }
+        });
+    }
+
+}
+
+window._nslDOMReady(function () {
+
+    window.nslRedirect = function (url) {
+        if (scriptOptions._redirectOverlay) {
+            const overlay = document.createElement('div');
+            overlay.id = "nsl-redirect-overlay";
+            let overlayHTML = '';
+            const overlayContainer = "<div id='nsl-redirect-overlay-container'>",
+                overlayContainerClose = "</div>",
+                overlaySpinner = "<div id='nsl-redirect-overlay-spinner'></div>",
+                overlayTitle = "<p id='nsl-redirect-overlay-title'>" + scriptOptions._localizedStrings.redirect_overlay_title + "</p>",
+                overlayText = "<p id='nsl-redirect-overlay-text'>" + scriptOptions._localizedStrings.redirect_overlay_text + "</p>";
+
+            switch (scriptOptions._redirectOverlay) {
+                case "overlay-only":
+                    break;
+                case "overlay-with-spinner":
+                    overlayHTML = overlayContainer + overlaySpinner + overlayContainerClose;
+                    break;
+                default:
+                    overlayHTML = overlayContainer + overlaySpinner + overlayTitle + overlayText + overlayContainerClose;
+                    break;
+            }
+
+            overlay.insertAdjacentHTML("afterbegin", overlayHTML);
+            document.body.appendChild(overlay);
+        }
+
+        window.location = url;
+    };
+
+    let targetWindow = scriptOptions._targetWindow || 'prefer-popup',
+        lastPopup = false;
+
+
+    document.addEventListener('click', function (e) {
+        if (e.target) {
+            const buttonLinkElement = e.target.closest('a[data-plugin="nsl"][data-action="connect"]') || e.target.closest('a[data-plugin="nsl"][data-action="link"]');
+            if (buttonLinkElement) {
+                if (lastPopup && !lastPopup.closed) {
+                    e.preventDefault();
+                    lastPopup.focus();
+                } else {
+
+                    let href = buttonLinkElement.href,
+                        success = false;
+                    if (href.indexOf('?') !== -1) {
+                        href += '&';
+                    } else {
+                        href += '?';
+                    }
+
+                    const redirectTo = buttonLinkElement.dataset.redirect;
+                    if (redirectTo === 'current') {
+                        href += 'redirect=' + encodeURIComponent(window.location.href) + '&';
+                    } else if (redirectTo && redirectTo !== '') {
+                        href += 'redirect=' + encodeURIComponent(redirectTo) + '&';
+                    }
+
+                    if (targetWindow !== 'prefer-same-window' && checkWebView()) {
+                        targetWindow = 'prefer-same-window';
+                    }
+
+                    if (targetWindow === 'prefer-popup') {
+                        lastPopup = NSLPopup(href + 'display=popup', 'nsl-social-connect', buttonLinkElement.dataset.popupwidth, buttonLinkElement.dataset.popupheight);
+                        if (lastPopup) {
+                            success = true;
+                            e.preventDefault();
+                        }
+                    } else if (targetWindow === 'prefer-new-tab') {
+                        const newTab = window.open(href + 'display=popup', '_blank');
+                        if (newTab) {
+                            if (window.focus) {
+                                newTab.focus();
+                            }
+                            success = true;
+                            window._nslHasOpenedPopup = true;
+                            e.preventDefault();
+                        }
+                    }
+
+                    if (!success) {
+                        window.location = href;
+                        e.preventDefault();
+                    }
+                }
+            }
+        }
+    });
+
+    let buttonCountChanged = false;
+
+    const googleLoginButtons = document.querySelectorAll(' a[data-plugin="nsl"][data-provider="google"]');
+    if (googleLoginButtons.length && checkWebView()) {
+        googleLoginButtons.forEach(function (googleLoginButton) {
+            if (scriptOptions._unsupportedWebviewBehavior === 'disable-button') {
+                disableButtonInWebView(googleLoginButton);
+            } else {
+                googleLoginButton.remove();
+                buttonCountChanged = true;
+            }
+        });
+    }
+
+    const facebookLoginButtons = document.querySelectorAll(' a[data-plugin="nsl"][data-provider="facebook"]');
+    if (facebookLoginButtons.length && checkWebView() && /Android/.test(window.navigator.userAgent) && !isAllowedWebViewForUserAgent('facebook')) {
+        facebookLoginButtons.forEach(function (facebookLoginButton) {
+            if (scriptOptions._unsupportedWebviewBehavior === 'disable-button') {
+                disableButtonInWebView(facebookLoginButton);
+            } else {
+                facebookLoginButton.remove();
+                buttonCountChanged = true;
+            }
+        });
+    }
+
+    const separators = document.querySelectorAll('div.nsl-separator');
+    if (buttonCountChanged && separators.length) {
+        separators.forEach(function (separator) {
+            const separatorParentNode = separator.parentNode;
+            if (separatorParentNode) {
+                const separatorButtonContainer = separatorParentNode.querySelector('div.nsl-container-buttons');
+                if (separatorButtonContainer && !separatorButtonContainer.hasChildNodes()) {
+                    separator.remove();
+                }
+            }
+        })
+    }
+});})();</script><script type="text/javascript">
+/* <![CDATA[ */
+ gform.initializeOnLoaded( function() { jQuery(document).on('gform_post_render', function(event, formId, currentPage){if(formId == 73) {if(typeof Placeholders != 'undefined'){
+                        Placeholders.enable();
+                    }} } );jQuery(document).on('gform_post_conditional_logic', function(event, formId, fields, isInit){} ) } ); 
+/* ]]> */
+</script>
+<script type="text/javascript">
+/* <![CDATA[ */
+ gform.initializeOnLoaded( function() {jQuery(document).trigger("gform_pre_post_render", [{ formId: "73", currentPage: "1", abort: function() { this.preventDefault(); } }]);                if (event && event.defaultPrevented) {                return;         }        const gformWrapperDiv = document.getElementById( "gform_wrapper_73" );        if ( gformWrapperDiv ) {            const visibilitySpan = document.createElement( "span" );            visibilitySpan.id = "gform_visibility_test_73";            gformWrapperDiv.insertAdjacentElement( "afterend", visibilitySpan );        }        const visibilityTestDiv = document.getElementById( "gform_visibility_test_73" );        let postRenderFired = false;                function triggerPostRender() {            if ( postRenderFired ) {                return;            }            postRenderFired = true;            jQuery( document ).trigger( 'gform_post_render', [73, 1] );            gform.utils.trigger( { event: 'gform/postRender', native: false, data: { formId: 73, currentPage: 1 } } );            gform.utils.trigger( { event: 'gform/post_render', native: false, data: { formId: 73, currentPage: 1 } } );            if ( visibilityTestDiv ) {                visibilityTestDiv.parentNode.removeChild( visibilityTestDiv );            }        }        function debounce( func, wait, immediate ) {            var timeout;            return function() {                var context = this, args = arguments;                var later = function() {                    timeout = null;                    if ( !immediate ) func.apply( context, args );                };                var callNow = immediate && !timeout;                clearTimeout( timeout );                timeout = setTimeout( later, wait );                if ( callNow ) func.apply( context, args );            };        }        const debouncedTriggerPostRender = debounce( function() {            triggerPostRender();        }, 200 );        if ( visibilityTestDiv && visibilityTestDiv.offsetParent === null ) {            const observer = new MutationObserver( ( mutations ) => {                mutations.forEach( ( mutation ) => {                    if ( mutation.type === 'attributes' && visibilityTestDiv.offsetParent !== null ) {                        debouncedTriggerPostRender();                        observer.disconnect();                    }                });            });            observer.observe( document.body, {                attributes: true,                childList: false,                subtree: true,                attributeFilter: [ 'style', 'class' ],            });        } else {            triggerPostRender();        }    } ); 
+/* ]]> */
+</script>
+
+
+<div id="adslot-out-of-page">
+	
+</div>
+<script defer src="https://web.archive.org/web/20250216021303js_/https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="" data-cf-beacon="{&quot;rayId&quot;:&quot;912a0428fbee82f9&quot;,&quot;version&quot;:&quot;2025.1.0&quot;,&quot;serverTiming&quot;:{&quot;name&quot;:{&quot;cfExtPri&quot;:true,&quot;cfL4&quot;:true,&quot;cfSpeedBrain&quot;:true,&quot;cfCacheStatus&quot;:true}},&quot;token&quot;:&quot;fbcf7c3d51214d95be58afaf83e77338&quot;,&quot;b&quot;:1}" crossorigin="anonymous"></script>
+</body>
+
+</html><!--
+     FILE ARCHIVED ON 02:13:03 Feb 16, 2025 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 02:11:10 Apr 18, 2026.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 0.471
+  exclusion.robots: 0.044
+  exclusion.robots.policy: 0.035
+  esindex: 0.009
+  cdx.remote: 280.772
+  LoadShardBlock: 416.618 (3)
+  PetaboxLoader3.datanode: 121.961 (4)
+  PetaboxLoader3.resolve: 347.979 (3)
+  load_resource: 108.986
+-->

--- a/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_2.json
+++ b/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_2.json
@@ -1,8 +1,8 @@
 {
-  "host": "deliciousmagazine.co.uk",
+  "author": "Emily Gussin",
   "canonical_url": "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/",
   "site_name": "delicious. magazine",
-  "author": "Emily Gussin",
+  "host": "deliciousmagazine.co.uk",
   "language": "en-GB",
   "title": "Double lemon chicken with charred leeks and dill polenta",
   "ingredients": [
@@ -25,7 +25,7 @@
     "Meanwhile, heat a griddle pan over a high heat. Brush the leeks with 2 tsp oil and season with salt and pepper. Cook for 7 minutes on each side until charred and tender.",
     "For the polenta, heat the milk and 200g water in a pan, then whisk in the polenta and cook for 3-4 minutes. Beat in the butter and most of the dill, plus salt and pepper. Cut 2 small wedges from the zested lemon, then juice the rest and stir into the chicken sauce. Divide the polenta between bowls and top with the saucy chicken, scattering over the remaining dill and adding the lemon wedges to the side of the plate for squeezing over."
   ],
-  "total_time": 45,
   "yields": "2 servings",
+  "total_time": 45,
   "image": "https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks.jpg"
 }

--- a/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_2.json
+++ b/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_2.json
@@ -1,0 +1,31 @@
+{
+  "host": "deliciousmagazine.co.uk",
+  "canonical_url": "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/",
+  "site_name": "delicious. magazine",
+  "author": "Emily Gussin",
+  "language": "en-GB",
+  "title": "Double lemon chicken with charred leeks and dill polenta",
+  "ingredients": [
+    "4 tsp vegetable oil",
+    "About 500g chicken thighs or thighs and drumsticks (skin on)",
+    "1 garlic clove, finely chopped",
+    "250ml chicken stock",
+    "1 preserved lemon, pulp removed, rind finely chopped",
+    "1 lemon",
+    "2 tbsp crème fraîche",
+    "175g baby leeks",
+    "250ml whole milk",
+    "100g quick-cook polenta",
+    "15g butter, plus extra to serve",
+    "20g dill, chopped"
+  ],
+  "instructions_list": [
+    "Heat 2 tsp oil in a medium frying pan or sauté pan over a medium-high heat (you want a pan that will fit the chicken fairly snugly in one layer). Season the chicken, add to the pan skin-side-down and cook for 8 minutes until golden and crisp, then turn over and cook on the other side for 2 minutes. Lift onto a plate.",
+    "Add the garlic to the pan, cook for 30 seconds, then pour in the stock and add the preserved lemon and lemon zest. Bring to a simmer, then stir in the crème fraîche and season with pepper. Return the chicken to the pan, keeping the skin on top so it stays crisp. Simmer gently for 18-20 minutes until the chicken is cooked through.",
+    "Meanwhile, heat a griddle pan over a high heat. Brush the leeks with 2 tsp oil and season with salt and pepper. Cook for 7 minutes on each side until charred and tender.",
+    "For the polenta, heat the milk and 200g water in a pan, then whisk in the polenta and cook for 3-4 minutes. Beat in the butter and most of the dill, plus salt and pepper. Cut 2 small wedges from the zested lemon, then juice the rest and stir into the chicken sauce. Divide the polenta between bowls and top with the saucy chicken, scattering over the remaining dill and adding the lemon wedges to the side of the plate for squeezing over."
+  ],
+  "total_time": 45,
+  "yields": "2 servings",
+  "image": "https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks.jpg"
+}

--- a/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_2.testhtml
+++ b/tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_2.testhtml
@@ -1,0 +1,4597 @@
+<!DOCTYPE html>
+<html lang="en-GB" class="no-js no-svg">
+
+<head><script type="text/javascript" src="https://web-static.archive.org/_static/js/bundle-playback.js?v=2N_sDSC0" charset="utf-8"></script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/wombat.js?v=txqj7nKC" charset="utf-8"></script>
+<script>window.RufflePlayer=window.RufflePlayer||{};window.RufflePlayer.config={"autoplay":"on","unmuteOverlay":"hidden","showSwfDownload":true};</script>
+<script type="text/javascript" src="https://web-static.archive.org/_static/js/ruffle/ruffle.js"></script>
+<script type="text/javascript">
+    __wm.init("https://web.archive.org/web");
+  __wm.wombat("https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/","20250216023536","https://web.archive.org/","web","https://web-static.archive.org/_static/",
+	      "1739673336");
+</script>
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/banner-styles.css?v=1utQkbB3" />
+<link rel="stylesheet" type="text/css" href="https://web-static.archive.org/_static/css/iconochive.css?v=3PDvdIFv" />
+<!-- End Wayback Rewrite JS Include -->
+
+
+	<meta charset="UTF-8">
+<script type="text/javascript">
+/* <![CDATA[ */
+ var gform;gform||(document.addEventListener("gform_main_scripts_loaded",function(){gform.scriptsLoaded=!0}),document.addEventListener("gform/theme/scripts_loaded",function(){gform.themeScriptsLoaded=!0}),window.addEventListener("DOMContentLoaded",function(){gform.domLoaded=!0}),gform={domLoaded:!1,scriptsLoaded:!1,themeScriptsLoaded:!1,isFormEditor:()=>"function"==typeof InitializeEditor,callIfLoaded:function(o){return!(!gform.domLoaded||!gform.scriptsLoaded||!gform.themeScriptsLoaded&&!gform.isFormEditor()||(gform.isFormEditor()&&console.warn("The use of gform.initializeOnLoaded() is deprecated in the form editor context and will be removed in Gravity Forms 3.1."),o(),0))},initializeOnLoaded:function(o){gform.callIfLoaded(o)||(document.addEventListener("gform_main_scripts_loaded",()=>{gform.scriptsLoaded=!0,gform.callIfLoaded(o)}),document.addEventListener("gform/theme/scripts_loaded",()=>{gform.themeScriptsLoaded=!0,gform.callIfLoaded(o)}),window.addEventListener("DOMContentLoaded",()=>{gform.domLoaded=!0,gform.callIfLoaded(o)}))},hooks:{action:{},filter:{}},addAction:function(o,r,e,t){gform.addHook("action",o,r,e,t)},addFilter:function(o,r,e,t){gform.addHook("filter",o,r,e,t)},doAction:function(o){gform.doHook("action",o,arguments)},applyFilters:function(o){return gform.doHook("filter",o,arguments)},removeAction:function(o,r){gform.removeHook("action",o,r)},removeFilter:function(o,r,e){gform.removeHook("filter",o,r,e)},addHook:function(o,r,e,t,n){null==gform.hooks[o][r]&&(gform.hooks[o][r]=[]);var d=gform.hooks[o][r];null==n&&(n=r+"_"+d.length),gform.hooks[o][r].push({tag:n,callable:e,priority:t=null==t?10:t})},doHook:function(r,o,e){var t;if(e=Array.prototype.slice.call(e,1),null!=gform.hooks[r][o]&&((o=gform.hooks[r][o]).sort(function(o,r){return o.priority-r.priority}),o.forEach(function(o){"function"!=typeof(t=o.callable)&&(t=window[t]),"action"==r?t.apply(null,e):e[0]=t.apply(null,e)})),"filter"==r)return e[0]},removeHook:function(o,r,t,n){var e;null!=gform.hooks[o][r]&&(e=(e=gform.hooks[o][r]).filter(function(o,r,e){return!!(null!=n&&n!=o.tag||null!=t&&t!=o.priority)}),gform.hooks[o][r]=e)}}); 
+/* ]]> */
+</script>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+	<meta name="p:domain_verify" content="ae68e5e9603be6b1905dffaa2f520d28"/>
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+	<link rel="icon" href="/web/20250216023536im_/https://www.deliciousmagazine.co.uk/favicon.ico">
+
+	<link rel="apple-touch-icon" sizes="57x57" href="/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-57X57.png"/>
+	<link rel="apple-touch-icon" sizes="72x72" href="/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-72X72.png"/>
+	<link rel="apple-touch-icon" sizes="114x114" href="/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-114x114.png"/>
+	<link rel="apple-touch-icon" sizes="144x144" href="/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/D-144x144.png"/>
+
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://cdn.permutive.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://connect.facebook.net/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://scontent-lhr8-1.cdninstagram.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://cdn.tagdeliver.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://assets.shopthruapp.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://cdn.exitbee.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://cmp.inmobi.com/" crossorigin>
+	<link rel="preconnect" href="https://web.archive.org/web/20250216023536/https://www.clarity.ms/" crossorigin>
+	
+	<!-- preload fonts -->
+	<link rel="preload" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/fonts/ChronicleDisplay/ChronicleDisplay-Light.woff2" as="font" type="font/woff2">
+	<link rel="preload" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/fonts/DINOT/DINOT-Regular.woff2" as="font" type="font/woff2">
+	<!-- InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+<script type="text/javascript" async="true">
+(function() {
+  var host = window.location.hostname;
+  var element = document.createElement('script');
+  var firstScript = document.getElementsByTagName('script')[0];
+  var url = 'https://web.archive.org/web/20250216023536/https://cmp.inmobi.com'
+    .concat('/choice/', 'nFGY0BbANjqaP', '/', host, '/choice.js?tag_version=V3');
+  var uspTries = 0;
+  var uspTriesLimit = 3;
+  element.async = true;
+  element.type = 'text/javascript';
+  element.src = url;
+
+  firstScript.parentNode.insertBefore(element, firstScript);
+
+  function makeStub() {
+    var TCF_LOCATOR_NAME = '__tcfapiLocator';
+    var queue = [];
+    var win = window;
+    var cmpFrame;
+
+    function addFrame() {
+      var doc = win.document;
+      var otherCMP = !!(win.frames[TCF_LOCATOR_NAME]);
+
+      if (!otherCMP) {
+        if (doc.body) {
+          var iframe = doc.createElement('iframe');
+
+          iframe.style.cssText = 'display:none';
+          iframe.name = TCF_LOCATOR_NAME;
+          doc.body.appendChild(iframe);
+        } else {
+          setTimeout(addFrame, 5);
+        }
+      }
+      return !otherCMP;
+    }
+
+    function tcfAPIHandler() {
+      var gdprApplies;
+      var args = arguments;
+
+      if (!args.length) {
+        return queue;
+      } else if (args[0] === 'setGdprApplies') {
+        if (
+          args.length > 3 &&
+          args[2] === 2 &&
+          typeof args[3] === 'boolean'
+        ) {
+          gdprApplies = args[3];
+          if (typeof args[2] === 'function') {
+            args[2]('set', true);
+          }
+        }
+      } else if (args[0] === 'ping') {
+        var retr = {
+          gdprApplies: gdprApplies,
+          cmpLoaded: false,
+          cmpStatus: 'stub'
+        };
+
+        if (typeof args[2] === 'function') {
+          args[2](retr);
+        }
+      } else {
+        if(args[0] === 'init' && typeof args[3] === 'object') {
+          args[3] = Object.assign(args[3], { tag_version: 'V3' });
+        }
+        queue.push(args);
+      }
+    }
+
+    function postMessageEventHandler(event) {
+      var msgIsString = typeof event.data === 'string';
+      var json = {};
+
+      try {
+        if (msgIsString) {
+          json = JSON.parse(event.data);
+        } else {
+          json = event.data;
+        }
+      } catch (ignore) {}
+
+      var payload = json.__tcfapiCall;
+
+      if (payload) {
+        window.__tcfapi(
+          payload.command,
+          payload.version,
+          function(retValue, success) {
+            var returnMsg = {
+              __tcfapiReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: payload.callId
+              }
+            };
+            if (msgIsString) {
+              returnMsg = JSON.stringify(returnMsg);
+            }
+            if (event && event.source && event.source.postMessage) {
+              event.source.postMessage(returnMsg, '*');
+            }
+          },
+          payload.parameter
+        );
+      }
+    }
+
+    while (win) {
+      try {
+        if (win.frames[TCF_LOCATOR_NAME]) {
+          cmpFrame = win;
+          break;
+        }
+      } catch (ignore) {}
+
+      if (win === window.top) {
+        break;
+      }
+      win = win.parent;
+    }
+    if (!cmpFrame) {
+      addFrame();
+      win.__tcfapi = tcfAPIHandler;
+      win.addEventListener('message', postMessageEventHandler, false);
+    }
+  };
+
+  makeStub();
+
+  function makeGppStub() {
+    const CMP_ID = 10;
+    const SUPPORTED_APIS = [
+      '2:tcfeuv2',
+      '6:uspv1',
+      '7:usnatv1',
+      '8:usca',
+      '9:usvav1',
+      '10:uscov1',
+      '11:usutv1',
+      '12:usctv1'
+    ];
+
+    window.__gpp_addFrame = function (n) {
+      if (!window.frames[n]) {
+        if (document.body) {
+          var i = document.createElement("iframe");
+          i.style.cssText = "display:none";
+          i.name = n;
+          document.body.appendChild(i);
+        } else {
+          window.setTimeout(window.__gpp_addFrame, 10, n);
+        }
+      }
+    };
+    window.__gpp_stub = function () {
+      var b = arguments;
+      __gpp.queue = __gpp.queue || [];
+      __gpp.events = __gpp.events || [];
+
+      if (!b.length || (b.length == 1 && b[0] == "queue")) {
+        return __gpp.queue;
+      }
+
+      if (b.length == 1 && b[0] == "events") {
+        return __gpp.events;
+      }
+
+      var cmd = b[0];
+      var clb = b.length > 1 ? b[1] : null;
+      var par = b.length > 2 ? b[2] : null;
+      if (cmd === "ping") {
+        clb(
+          {
+            gppVersion: "1.1", // must be “Version.Subversion”, current: “1.1”
+            cmpStatus: "stub", // possible values: stub, loading, loaded, error
+            cmpDisplayStatus: "hidden", // possible values: hidden, visible, disabled
+            signalStatus: "not ready", // possible values: not ready, ready
+            supportedAPIs: SUPPORTED_APIS, // list of supported APIs
+            cmpId: CMP_ID, // IAB assigned CMP ID, may be 0 during stub/loading
+            sectionList: [],
+            applicableSections: [-1],
+            gppString: "",
+            parsedSections: {},
+          },
+          true
+        );
+      } else if (cmd === "addEventListener") {
+        if (!("lastId" in __gpp)) {
+          __gpp.lastId = 0;
+        }
+        __gpp.lastId++;
+        var lnr = __gpp.lastId;
+        __gpp.events.push({
+          id: lnr,
+          callback: clb,
+          parameter: par,
+        });
+        clb(
+          {
+            eventName: "listenerRegistered",
+            listenerId: lnr, // Registered ID of the listener
+            data: true, // positive signal
+            pingData: {
+              gppVersion: "1.1", // must be “Version.Subversion”, current: “1.1”
+              cmpStatus: "stub", // possible values: stub, loading, loaded, error
+              cmpDisplayStatus: "hidden", // possible values: hidden, visible, disabled
+              signalStatus: "not ready", // possible values: not ready, ready
+              supportedAPIs: SUPPORTED_APIS, // list of supported APIs
+              cmpId: CMP_ID, // list of supported APIs
+              sectionList: [],
+              applicableSections: [-1],
+              gppString: "",
+              parsedSections: {},
+            },
+          },
+          true
+        );
+      } else if (cmd === "removeEventListener") {
+        var success = false;
+        for (var i = 0; i < __gpp.events.length; i++) {
+          if (__gpp.events[i].id == par) {
+            __gpp.events.splice(i, 1);
+            success = true;
+            break;
+          }
+        }
+        clb(
+          {
+            eventName: "listenerRemoved",
+            listenerId: par, // Registered ID of the listener
+            data: success, // status info
+            pingData: {
+              gppVersion: "1.1", // must be “Version.Subversion”, current: “1.1”
+              cmpStatus: "stub", // possible values: stub, loading, loaded, error
+              cmpDisplayStatus: "hidden", // possible values: hidden, visible, disabled
+              signalStatus: "not ready", // possible values: not ready, ready
+              supportedAPIs: SUPPORTED_APIS, // list of supported APIs
+              cmpId: CMP_ID, // CMP ID
+              sectionList: [],
+              applicableSections: [-1],
+              gppString: "",
+              parsedSections: {},
+            },
+          },
+          true
+        );
+      } else if (cmd === "hasSection") {
+        clb(false, true);
+      } else if (cmd === "getSection" || cmd === "getField") {
+        clb(null, true);
+      }
+      //queue all other commands
+      else {
+        __gpp.queue.push([].slice.apply(b));
+      }
+    };
+    window.__gpp_msghandler = function (event) {
+      var msgIsString = typeof event.data === "string";
+      try {
+        var json = msgIsString ? JSON.parse(event.data) : event.data;
+      } catch (e) {
+        var json = null;
+      }
+      if (typeof json === "object" && json !== null && "__gppCall" in json) {
+        var i = json.__gppCall;
+        window.__gpp(
+          i.command,
+          function (retValue, success) {
+            var returnMsg = {
+              __gppReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: i.callId,
+              },
+            };
+            event.source.postMessage(msgIsString ? JSON.stringify(returnMsg) : returnMsg, "*");
+          },
+          "parameter" in i ? i.parameter : null,
+          "version" in i ? i.version : "1.1"
+        );
+      }
+    };
+    if (!("__gpp" in window) || typeof window.__gpp !== "function") {
+      window.__gpp = window.__gpp_stub;
+      window.addEventListener("message", window.__gpp_msghandler, false);
+      window.__gpp_addFrame("__gppLocator");
+    }
+  };
+
+  makeGppStub();
+
+  var uspStubFunction = function() {
+    var arg = arguments;
+    if (typeof window.__uspapi !== uspStubFunction) {
+      setTimeout(function() {
+        if (typeof window.__uspapi !== 'undefined') {
+          window.__uspapi.apply(window.__uspapi, arg);
+        }
+      }, 500);
+    }
+  };
+
+  var checkIfUspIsReady = function() {
+    uspTries++;
+    if (window.__uspapi === uspStubFunction && uspTries < uspTriesLimit) {
+      console.warn('USP is not accessible');
+    } else {
+      clearInterval(uspInterval);
+    }
+  };
+
+  if (typeof window.__uspapi === 'undefined') {
+    window.__uspapi = uspStubFunction;
+    var uspInterval = setInterval(checkIfUspIsReady, 6000);
+  }
+})();
+</script>
+<!-- End InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://web.archive.org/web/20250216023536js_/https://www.googletagmanager.com/gtag/js?id=UA-2737869-1"></script>
+	<script>
+	window.dataLayer = window.dataLayer || [];
+
+	function gtag() {
+		dataLayer.push(arguments);
+	}
+	gtag('js', new Date());
+	gtag('config', 'UA-2737869-1');
+	</script>
+
+	<!-- Google Tag Manager -->
+	<script>
+	(function(w, d, s, l, i) {
+		w[l] = w[l] || [];
+		w[l].push({
+			'gtm.start': new Date().getTime(),
+			event: 'gtm.js'
+		});
+		var f = d.getElementsByTagName(s)[0],
+			j = d.createElement(s),
+			dl = l != 'dataLayer' ? '&l=' + l : '';
+		j.async = true;
+		j.src =
+			'https://web.archive.org/web/20250216023536/https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+		f.parentNode.insertBefore(j, f);
+	})(window, document, 'script', 'dataLayer', 'GTM-PR23HDB');
+	</script>
+	<!-- End Google Tag Manager -->
+
+	<!-- Health check tag -->
+	<script src="https://web.archive.org/web/20250216023536js_/https://cdn.tagdeliver.com/cipt/18555.js" async="async"></script>
+
+		<link rel="amphtml" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/amp/">
+	
+	<!-- Permuative Tag -->
+<script>
+  !function(n,e,o,r,i){if(!e){e=e||{},window.permutive=e,e.q=[],e.config=i||{},e.config.projectId=o,e.config.apiKey=r,e.config.environment=e.config.environment||"production";for(var t=["addon","identify","track","trigger","query","segment","segments","ready","on","once","user","consent"],c=0;c<t.length;c++){var f=t[c];e[f]=function(n){return function(){var o=Array.prototype.slice.call(arguments,0);e.q.push({functionName:n,arguments:o})}}(f)}}}(document,window.permutive,"99db7a95-b06a-4ea9-857c-f73ba0a25c19","db07e0f0-8bb8-46c8-b714-291f2768d746",{});
+    permutive.addon("web", { page: {
+        category: ["recipe"],
+        title: "Double lemon chicken with charred leeks and dill polenta",
+                recipe: {
+            collections: ["Chicken thigh recipes", "Dinner ideas for two", "Favourite chicken recipes", "February seasonal recipes", "Healthy chicken recipes", "Healthy dinner recipes", "Lemon recipes", "Midweek meal recipes", "Weeknight recipes"],
+            cooking_time: 30,
+            prep_time: 15,
+            serves: 2,
+            keywords: [
+            "Double lemon chicken with charred leeks and dill polenta"],
+            ratings: 5,
+                        nutrition_info: ["832kcals Calories", "48g (18g saturated) Fat", "50g Protein", "47g (10g sugars) Carbohydrate", "5.6g Fiber", "1g Salt"],
+            ingredients: [
+"4 tsp vegetable oil",
+"About 500g chicken thighs or thighs and drumsticks (skin on)",
+"1 garlic clove, finely chopped",
+"250ml chicken stock",
+"1 preserved lemon, pulp removed, rind finely chopped",
+"1 lemon",
+"2 tbsp crème fraîche",
+"175g baby leeks",
+
+"For the polenta",
+
+"250ml whole milk",
+"100g quick-cook polenta",
+"15g butter, plus extra to serve",
+"20g dill, chopped",
+
+""],
+                        
+                        
+                            diet_types: [
+                "Freezable","Gluten-free recipes",],
+                        skill_level: "Easy",
+            post_dates: "2025-02-04"
+        }
+            }
+  });
+</script>
+<script async src="https://web.archive.org/web/20250216023536js_/https://cdn.permutive.com/99db7a95-b06a-4ea9-857c-f73ba0a25c19-web.js"></script>
+<script type="text/javascript">
+    window.permutive.readyWithTimeout=function(e,i,t){var u=!1,n=function(){u||(e(),u=!0)};(t=t||1/0)!==1/0&&window.setTimeout(n,t),permutive.ready(n,i)};
+</script>
+	
+	<script type="text/javascript">
+	(function(c, l, a, r, i, t, y) {
+		c[a] = c[a] || function() {
+			(c[a].q = c[a].q || []).push(arguments)
+		};
+		t = l.createElement(r);
+		t.async = 1;
+		t.src = "https://web.archive.org/web/20250216023536/https://www.clarity.ms/tag/" + i;
+		y = l.getElementsByTagName(r)[0];
+		y.parentNode.insertBefore(t, y);
+	})(window, document, "clarity", "script", "o9770qd0kr");
+	</script>
+
+	<!-- Exit Bee Code Snippet for deliciousmagazine.co.uk <-- DO NOT MODIFY -->
+	<script>
+	(function(e, x, i, t, b) {
+		e["ExitBeeObject"] = b;
+		e[b] = e[b] ||
+			function() {
+				(e[b].args = e[b].args || []).push(arguments);
+			};
+		a = x.createElement(i), m = x.getElementsByTagName(i)[0];
+		a.async = 1;
+		a.src = t;
+		m.parentNode.insertBefore(a, m)
+	})
+	(window, document, "script", "https://web.archive.org/web/20250216023536/https://cdn.exitbee.com/xtb.min.js", "xtb")
+	xtb("loadSite", "8825");
+	</script>
+
+	<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"/>
+	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+	
+	<!-- This site is optimized with the Yoast SEO Premium plugin v24.2 (Yoast SEO v24.2) - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Double lemon chicken with charred leeks and dill polenta - delicious. magazine</title>
+	<meta name="description" content="Doubling up fresh and preserved lemons to lift this creamy sauce makes for a zesty chicken dinner. Serve with charred leeks and polenta."/>
+	<link rel="canonical" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/"/>
+	<meta property="og:locale" content="en_GB"/>
+	<meta property="og:type" content="article"/>
+	<meta property="og:title" content="Double lemon chicken with charred leeks and dill polenta"/>
+	<meta property="og:description" content="Doubling up fresh and preserved lemons to lift this creamy sauce makes for a zesty chicken dinner. Serve with charred leeks and polenta."/>
+	<meta property="og:url" content="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/"/>
+	<meta property="og:site_name" content="delicious. magazine"/>
+	<meta property="article:publisher" content="https://www.facebook.com/deliciousmagazineuk"/>
+	<meta property="article:modified_time" content="2025-02-12T11:14:29+00:00"/>
+	<meta property="og:image" content="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks.jpg"/>
+	<meta property="og:image:width" content="960"/>
+	<meta property="og:image:height" content="1200"/>
+	<meta property="og:image:type" content="image/jpeg"/>
+	<meta name="twitter:card" content="summary_large_image"/>
+	<meta name="twitter:site" content="@deliciousmag"/>
+	<meta name="twitter:label1" content="Estimated reading time"/>
+	<meta name="twitter:data1" content="1 minute"/>
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://web.archive.org/web/20250216023536/https://schema.org","@graph":[{"@type":"WebPage","@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/","url":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/","name":"Double lemon chicken with charred leeks and dill polenta - delicious. magazine","isPartOf":{"@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#website"},"primaryImageOfPage":{"@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/#primaryimage"},"image":{"@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/#primaryimage"},"thumbnailUrl":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks.jpg","datePublished":"2025-02-04T10:58:40+00:00","dateModified":"2025-02-12T11:14:29+00:00","description":"Doubling up fresh and preserved lemons to lift this creamy sauce makes for a zesty chicken dinner. Serve with charred leeks and polenta.","breadcrumb":{"@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/#breadcrumb"},"inLanguage":"en-GB","potentialAction":[{"@type":"ReadAction","target":["https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/"]}]},{"@type":"ImageObject","inLanguage":"en-GB","@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/#primaryimage","url":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks.jpg","contentUrl":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks.jpg","width":960,"height":1200,"caption":"Double lemon chicken with charred leeks and dill polenta"},{"@type":"BreadcrumbList","@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/"},{"@type":"ListItem","position":2,"name":"Recipes","item":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/"},{"@type":"ListItem","position":3,"name":"Chicken thigh recipes","item":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chicken-thigh-recipes/"},{"@type":"ListItem","position":4,"name":"Double lemon chicken with charred leeks and dill polenta"}]},{"@type":"WebSite","@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#website","url":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/","name":"delicious. magazine","description":"","publisher":{"@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-GB"},{"@type":"Organization","@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#organization","name":"Delicious Magazine","url":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/","logo":{"@type":"ImageObject","inLanguage":"en-GB","@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#/schema/logo/image/","url":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/logo2x.png","contentUrl":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/logo2x.png","width":1000,"height":236,"caption":"Delicious Magazine"},"image":{"@id":"https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#/schema/logo/image/"},"sameAs":["https://web.archive.org/web/20250216023536/https://www.facebook.com/deliciousmagazineuk","https://web.archive.org/web/20250216023536/https://x.com/deliciousmag","https://web.archive.org/web/20250216023536/https://www.instagram.com/deliciousmag/","https://web.archive.org/web/20250216023536/https://www.pinterest.com/deliciousmaguk/","https://web.archive.org/web/20250216023536/http://www.youtube.com/user/deliciousmagazineuk"]},false]}</script>
+	<!-- / Yoast SEO Premium plugin. -->
+
+
+<link rel="dns-prefetch" href="//web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/"/>
+<link rel="alternate" type="application/rss+xml" title="delicious. magazine » Feed" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/feed/"/>
+<link rel="alternate" type="application/rss+xml" title="delicious. magazine » Comments Feed" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/comments/feed/"/>
+<link rel="alternate" type="application/rss+xml" title="delicious. magazine » Double lemon chicken with charred leeks and dill polenta Comments Feed" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/feed/"/>
+<script type="text/javascript">
+/* <![CDATA[ */
+window._wpemojiSettings = {"baseUrl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/72x72\/","ext":".png","svgUrl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/s.w.org\/images\/core\/emoji\/15.0.3\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.7.1"}};
+/*! This file is auto-generated */
+!function(i,n){var o,s,e;function c(e){try{var t={supportTests:e,timestamp:(new Date).valueOf()};sessionStorage.setItem(o,JSON.stringify(t))}catch(e){}}function p(e,t,n){e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(t,0,0);var t=new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data),r=(e.clearRect(0,0,e.canvas.width,e.canvas.height),e.fillText(n,0,0),new Uint32Array(e.getImageData(0,0,e.canvas.width,e.canvas.height).data));return t.every(function(e,t){return e===r[t]})}function u(e,t,n){switch(t){case"flag":return n(e,"\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!n(e,"\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!n(e,"\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!n(e,"\ud83d\udc26\u200d\u2b1b","\ud83d\udc26\u200b\u2b1b")}return!1}function f(e,t,n){var r="undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?new OffscreenCanvas(300,150):i.createElement("canvas"),a=r.getContext("2d",{willReadFrequently:!0}),o=(a.textBaseline="top",a.font="600 32px Arial",{});return e.forEach(function(e){o[e]=t(a,e,n)}),o}function t(e){var t=i.createElement("script");t.src=e,t.defer=!0,i.head.appendChild(t)}"undefined"!=typeof Promise&&(o="wpEmojiSettingsSupports",s=["flag","emoji"],n.supports={everything:!0,everythingExceptFlag:!0},e=new Promise(function(e){i.addEventListener("DOMContentLoaded",e,{once:!0})}),new Promise(function(t){var n=function(){try{var e=JSON.parse(sessionStorage.getItem(o));if("object"==typeof e&&"number"==typeof e.timestamp&&(new Date).valueOf()<e.timestamp+604800&&"object"==typeof e.supportTests)return e.supportTests}catch(e){}return null}();if(!n){if("undefined"!=typeof Worker&&"undefined"!=typeof OffscreenCanvas&&"undefined"!=typeof URL&&URL.createObjectURL&&"undefined"!=typeof Blob)try{var e="postMessage("+f.toString()+"("+[JSON.stringify(s),u.toString(),p.toString()].join(",")+"));",r=new Blob([e],{type:"text/javascript"}),a=new Worker(URL.createObjectURL(r),{name:"wpTestEmojiSupports"});return void(a.onmessage=function(e){c(n=e.data),a.terminate(),t(n)})}catch(e){}c(n=f(s,u,p))}t(n)}).then(function(e){for(var t in e)n.supports[t]=e[t],n.supports.everything=n.supports.everything&&n.supports[t],"flag"!==t&&(n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&n.supports[t]);n.supports.everythingExceptFlag=n.supports.everythingExceptFlag&&!n.supports.flag,n.DOMReady=!1,n.readyCallback=function(){n.DOMReady=!0}}).then(function(){return e}).then(function(){var e;n.supports.everything||(n.readyCallback(),(e=n.source||{}).concatemoji?t(e.concatemoji):e.wpemoji&&e.twemoji&&(t(e.twemoji),t(e.wpemoji)))}))}((window,document),window._wpemojiSettings);
+/* ]]> */
+</script>
+<link rel="stylesheet" id="sbi_styles-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/plugins/instagram-feed-pro/css/sbi-styles.min.css?ver=6.5.1" type="text/css" media="all"/>
+<style id="wp-emoji-styles-inline-css" type="text/css">
+
+	img.wp-smiley, img.emoji {
+		display: inline !important;
+		border: none !important;
+		box-shadow: none !important;
+		height: 1em !important;
+		width: 1em !important;
+		margin: 0 0.07em !important;
+		vertical-align: -0.1em !important;
+		background: none !important;
+		padding: 0 !important;
+	}
+</style>
+<link rel="stylesheet" id="normalize-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/normalize.min.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="bootstrap-grid-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/bootstrap-grid.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="bootstrap-components-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/bootstrap-components.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="slick-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/slick/slick.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="formstyler-css-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/jquery.formstyler.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="remodal-css-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/remodal.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="rstyler-css-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/rfiles/css/style.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="add-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/add.css?ver=6.7.1" type="text/css" media="all"/>
+<link rel="stylesheet" id="main-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/main.css?ver=6.37" type="text/css" media="all"/>
+<script type="text/javascript">
+            window._nslDOMReady = function (callback) {
+                if ( document.readyState === "complete" || document.readyState === "interactive" ) {
+                    callback();
+                } else {
+                    document.addEventListener( "DOMContentLoaded", callback );
+                }
+            };
+            </script><script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/vendor/jquery-3.1.1.min.js?ver=3.1.1" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/vendor/jquery-migrate-3.0.0.min.js?ver=3.0.0" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/jquery.hoverIntent.min.js?ver=1.9.0" id="hoverintent-js"></script>
+<link rel="https://api.w.org/" href="https://www.deliciousmagazine.co.uk/wp-json/"/><link rel="alternate" title="JSON" type="application/json" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-json/wp/v2/recipes/81139"/><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.deliciousmagazine.co.uk/xmlrpc.php?rsd"/>
+<meta name="generator" content="WordPress 6.7.1"/>
+<link rel="shortlink" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/?p=81139"/>
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fdouble-lemon-chicken-with-charred-leeks-and-dill-polenta%2F"/>
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fdouble-lemon-chicken-with-charred-leeks-and-dill-polenta%2F&amp;format=xml"/>
+		<script>
+			document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
+		</script>
+				<style>
+			.no-js img.lazyload {
+				display: none;
+			}
+
+			figure.wp-block-image img.lazyloading {
+				min-width: 150px;
+			}
+
+						.lazyload, .lazyloading {
+				opacity: 0;
+			}
+
+			.lazyloaded {
+				opacity: 1;
+				transition: opacity 200ms;
+				transition-delay: 0ms;
+			}
+
+					</style>
+		<style type="text/css">.recentcomments a{display:inline !important;padding:0 !important;margin:0 !important;}</style><style type="text/css">div.nsl-container[data-align="left"] {
+    text-align: left;
+}
+
+div.nsl-container[data-align="center"] {
+    text-align: center;
+}
+
+div.nsl-container[data-align="right"] {
+    text-align: right;
+}
+
+
+div.nsl-container div.nsl-container-buttons a[data-plugin="nsl"] {
+    text-decoration: none;
+    box-shadow: none;
+    border: 0;
+}
+
+div.nsl-container .nsl-container-buttons {
+    display: flex;
+    padding: 5px 0;
+}
+
+div.nsl-container.nsl-container-block .nsl-container-buttons {
+    display: inline-grid;
+    grid-template-columns: minmax(145px, auto);
+}
+
+div.nsl-container-block-fullwidth .nsl-container-buttons {
+    flex-flow: column;
+    align-items: center;
+}
+
+div.nsl-container-block-fullwidth .nsl-container-buttons a,
+div.nsl-container-block .nsl-container-buttons a {
+    flex: 1 1 auto;
+    display: block;
+    margin: 5px 0;
+    width: 100%;
+}
+
+div.nsl-container-inline {
+    margin: -5px;
+    text-align: left;
+}
+
+div.nsl-container-inline .nsl-container-buttons {
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+div.nsl-container-inline .nsl-container-buttons a {
+    margin: 5px;
+    display: inline-block;
+}
+
+div.nsl-container-grid .nsl-container-buttons {
+    flex-flow: row;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+div.nsl-container-grid .nsl-container-buttons a {
+    flex: 1 1 auto;
+    display: block;
+    margin: 5px;
+    max-width: 280px;
+    width: 100%;
+}
+
+@media only screen and (min-width: 650px) {
+    div.nsl-container-grid .nsl-container-buttons a {
+        width: auto;
+    }
+}
+
+div.nsl-container .nsl-button {
+    cursor: pointer;
+    vertical-align: top;
+    border-radius: 4px;
+}
+
+div.nsl-container .nsl-button-default {
+    color: #fff;
+    display: flex;
+}
+
+div.nsl-container .nsl-button-icon {
+    display: inline-block;
+}
+
+div.nsl-container .nsl-button-svg-container {
+    flex: 0 0 auto;
+    padding: 8px;
+    display: flex;
+    align-items: center;
+}
+
+div.nsl-container svg {
+    height: 24px;
+    width: 24px;
+    vertical-align: top;
+}
+
+div.nsl-container .nsl-button-default div.nsl-button-label-container {
+    margin: 0 24px 0 12px;
+    padding: 10px 0;
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 20px;
+    letter-spacing: .25px;
+    overflow: hidden;
+    text-align: center;
+    text-overflow: clip;
+    white-space: nowrap;
+    flex: 1 1 auto;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-transform: none;
+    display: inline-block;
+}
+
+div.nsl-container .nsl-button-google[data-skin="dark"] .nsl-button-svg-container {
+    margin: 1px;
+    padding: 7px;
+    border-radius: 3px;
+    background: #fff;
+}
+
+div.nsl-container .nsl-button-google[data-skin="light"] {
+    border-radius: 1px;
+    box-shadow: 0 1px 5px 0 rgba(0, 0, 0, .25);
+    color: RGBA(0, 0, 0, 0.54);
+}
+
+div.nsl-container .nsl-button-apple .nsl-button-svg-container {
+    padding: 0 6px;
+}
+
+div.nsl-container .nsl-button-apple .nsl-button-svg-container svg {
+    height: 40px;
+    width: auto;
+}
+
+div.nsl-container .nsl-button-apple[data-skin="light"] {
+    color: #000;
+    box-shadow: 0 0 0 1px #000;
+}
+
+div.nsl-container .nsl-button-facebook[data-skin="white"] {
+    color: #000;
+    box-shadow: inset 0 0 0 1px #000;
+}
+
+div.nsl-container .nsl-button-facebook[data-skin="light"] {
+    color: #1877F2;
+    box-shadow: inset 0 0 0 1px #1877F2;
+}
+
+div.nsl-container .nsl-button-spotify[data-skin="white"] {
+    color: #191414;
+    box-shadow: inset 0 0 0 1px #191414;
+}
+
+div.nsl-container .nsl-button-apple div.nsl-button-label-container {
+    font-size: 17px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+div.nsl-container .nsl-button-slack div.nsl-button-label-container {
+    font-size: 17px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+
+div.nsl-container .nsl-button-slack[data-skin="light"] {
+    color: #000000;
+    box-shadow: inset 0 0 0 1px #DDDDDD;
+}
+
+div.nsl-container .nsl-button-tiktok[data-skin="light"] {
+    color: #161823;
+    box-shadow: 0 0 0 1px rgba(22, 24, 35, 0.12);
+}
+
+
+div.nsl-container .nsl-button-kakao {
+    color: rgba(0, 0, 0, 0.85);
+}
+
+.nsl-clear {
+    clear: both;
+}
+
+.nsl-container {
+    clear: both;
+}
+
+.nsl-disabled-provider .nsl-button {
+    filter: grayscale(1);
+    opacity: 0.8;
+}
+
+/*Button align start*/
+
+div.nsl-container-inline[data-align="left"] .nsl-container-buttons {
+    justify-content: flex-start;
+}
+
+div.nsl-container-inline[data-align="center"] .nsl-container-buttons {
+    justify-content: center;
+}
+
+div.nsl-container-inline[data-align="right"] .nsl-container-buttons {
+    justify-content: flex-end;
+}
+
+
+div.nsl-container-grid[data-align="left"] .nsl-container-buttons {
+    justify-content: flex-start;
+}
+
+div.nsl-container-grid[data-align="center"] .nsl-container-buttons {
+    justify-content: center;
+}
+
+div.nsl-container-grid[data-align="right"] .nsl-container-buttons {
+    justify-content: flex-end;
+}
+
+div.nsl-container-grid[data-align="space-around"] .nsl-container-buttons {
+    justify-content: space-around;
+}
+
+div.nsl-container-grid[data-align="space-between"] .nsl-container-buttons {
+    justify-content: space-between;
+}
+
+/* Button align end*/
+
+/* Redirect */
+
+#nsl-redirect-overlay {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    z-index: 1000000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    backdrop-filter: blur(1px);
+    background-color: RGBA(0, 0, 0, .32);;
+}
+
+#nsl-redirect-overlay-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: white;
+    padding: 30px;
+    border-radius: 10px;
+}
+
+#nsl-redirect-overlay-spinner {
+    content: '';
+    display: block;
+    margin: 20px;
+    border: 9px solid RGBA(0, 0, 0, .6);
+    border-top: 9px solid #fff;
+    border-radius: 50%;
+    box-shadow: inset 0 0 0 1px RGBA(0, 0, 0, .6), 0 0 0 1px RGBA(0, 0, 0, .6);
+    width: 40px;
+    height: 40px;
+    animation: nsl-loader-spin 2s linear infinite;
+}
+
+@keyframes nsl-loader-spin {
+    0% {
+        transform: rotate(0deg)
+    }
+    to {
+        transform: rotate(360deg)
+    }
+}
+
+#nsl-redirect-overlay-title {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    font-size: 18px;
+    font-weight: bold;
+    color: #3C434A;
+}
+
+#nsl-redirect-overlay-text {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    text-align: center;
+    font-size: 14px;
+    color: #3C434A;
+}
+
+/* Redirect END*/</style><style type="text/css">/* Notice fallback */
+#nsl-notices-fallback {
+    position: fixed;
+    right: 10px;
+    top: 10px;
+    z-index: 10000;
+}
+
+.admin-bar #nsl-notices-fallback {
+    top: 42px;
+}
+
+#nsl-notices-fallback > div {
+    position: relative;
+    background: #fff;
+    border-left: 4px solid #fff;
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .1);
+    margin: 5px 15px 2px;
+    padding: 1px 20px;
+}
+
+#nsl-notices-fallback > div.error {
+    display: block;
+    border-left-color: #dc3232;
+}
+
+#nsl-notices-fallback > div.updated {
+    display: block;
+    border-left-color: #46b450;
+}
+
+#nsl-notices-fallback p {
+    margin: .5em 0;
+    padding: 2px;
+}
+
+#nsl-notices-fallback > div:after {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+    content: '\00d7';
+    display: block;
+    height: 16px;
+    width: 16px;
+    line-height: 16px;
+    text-align: center;
+    font-size: 20px;
+    cursor: pointer;
+}</style>		<style type="text/css" id="wp-custom-css">
+			.instagram-feeds #sb_instagram .sbi_photo {
+	padding-bottom: 100% !important;
+}
+#sb_instagram #sbi_images .sbi_item.sbi_num_diff_hide.slick-slide {
+    display: block !important;
+}
+.adsm-skin .sidebar .align-self-end {
+    background: transparent;
+}
+.instagram-feeds #sb_instagram #sbi_images {
+    padding: 0 !important;
+    float: left;
+    line-height: 0;
+    width: 100%;
+    display: block !important;
+}
+#main-menu .visible-tablet {
+    display: none  !important;
+}
+
+.recipe-wine .title-logo {
+    width: 37%;
+    margin: 20px 0 20px 0
+}
+
+ .recipe-author-wrapper .recipe-author-details,.recipe-author-wrapper .magazine-subscription {
+    float: left;
+    width: 50%
+}
+
+@media(max-width: 1024px) {
+    .recipe-author-wrapper .recipe-author-details,.recipe-author-wrapper .magazine-subscription {
+        width:100%
+    }
+}
+
+.recipe-author-wrapper .recipe-author-details p,.recipe-author-wrapper .magazine-subscription p {
+    margin: 0;
+    font-size: 1.8rem
+}
+
+.recipe-author-wrapper .recipe-author-details p:first-child,.recipe-author-wrapper .magazine-subscription p:first-child {
+    margin: 0 0 2rem 0;
+    font-size: 1.1rem;
+    font-weight: bold;
+    line-height: normal;
+    text-transform: uppercase
+}
+
+.recipe-author-wrapper .recipe-author-details a,.recipe-author-wrapper .magazine-subscription a {
+    border-bottom: 1px solid #fff;
+    color: #fff
+}
+
+.recipe-author-wrapper .recipe-author-details .post-date {
+    font-size: 1.1rem;
+    display: flex;
+    list-style: none;
+    padding-right: 5px;
+    margin-top: 15px;
+    line-height: 1.2;
+    margin-bottom: 5px;
+    text-transform: uppercase
+}
+
+.recipe-author-wrapper .recipe-author-details .post-date li:first-child {
+    border-right: 1px solid #fff;
+    padding-right: 12px;
+    margin-right: 12px
+}
+/* remove this code later after pushing through pipeline*/ 
+.ob-widget .ob-widget-header {
+    border: none;
+}
+
+/* remove this code later*/
+@media (max-width: 768px) {
+    .top-banner-ad-desktop {
+       display: none !important;
+    }
+	
+	.recipe-list .recipe-card-wrapper .recipe-card .card-body > p {
+			margin-bottom: 5px;
+			padding-bottom: 5px;
+	}
+}
+@media(min-width: 1025px) {
+    .recipe-author-wrapper.hide-mobile {
+        display:flex !important
+    }
+}
+
+.recipe-author-wrapper.hide-mobile .recipe-author-details {
+    align-self: center
+}
+
+.recipe-author-wrapper .magazine-subscription {
+    border-left: 1px solid #fff;
+    padding: 0 0 0 2rem
+}
+
+@media(max-width: 1024px) {
+    .recipe-author-wrapper .magazine-subscription {
+        border-top:1px solid #fff;
+        border-left: 0;
+        margin: 3rem 0 0 0;
+        padding: 3rem 0 0 0
+    }
+}
+
+.recipe-author-wrapper .magazine-subscription a {
+    font-size: 1.1rem;
+    font-weight: bold;
+    line-height: normal;
+    text-transform: uppercase
+}
+
+.recipe-author-wrapper .magazine-subscription .postal-magazine-cover {
+    width: 170px;
+    min-height: 106px;
+    height: 106px;
+    position: absolute;
+    bottom: 0;
+    right: 0
+}
+
+@media(max-width: 1024px) {
+    .recipe-author-wrapper .magazine-subscription .postal-magazine-cover {
+        display:none
+    }
+}
+
+.recipe-author-wrapper .magazine-subscription .postal-magazine-cover img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    object-fit: cover;
+    object-position: top
+}
+
+.recipe-author-wrapper .magazine-subscription.full-width {
+    border: 0;
+    margin: 0;
+    padding: 0
+}
+
+.recipe-author-details-with-img>span {
+    display: flex;
+    gap: 20px;
+    padding-right: 20px;
+    line-height: 1.4
+}
+
+.recipe-author-details-with-img>span>a {
+    border-bottom: none !important;
+    width: 55px
+}
+
+.recipe-author-details-with-img>span>a>img {
+    border-radius: 50%;
+    width: 55px;
+    height: 55px
+}
+
+.recipe-author-details-with-img>span>span {
+    width: calc(100% - 75px)
+}
+
+.recipe-author-details-with-img+.post-date {
+    margin-left: 76px
+}
+
+@media(max-width: 680px) {
+    .recipe-wine .title-logo {
+        width:100%
+    }
+}
+
+.recipe-wine.recipe-procook {
+    background-size: 40%
+}
+
+@media(min-width: 768px) {
+    .recipe-wine.recipe-procook p {
+        width:59%
+    }
+}
+
+@media(max-width: 767px) {
+    .recipe-wine.recipe-procook {
+        background:#fff !important
+    }
+}
+
+.recipe-wine.recipe-procook .procook-text p {
+    font-size: 1.2rem;
+    margin-bottom: 0
+}
+
+
+
+@media (min-width: 768px) and (max-width: 769px) {
+    .recipe-details {
+        padding: 0 20px 0 30px;
+    }
+}
+@media (max-width: 1024px) {
+#main-menu .visible-tablet {
+    display: block !important;
+}
+
+}
+
+@media (max-width: 1023px) {
+    .postid-76565 .recipe-header .hide-tablet {
+        display: block !important;
+    }
+.postid-76565 .recipe-header .hide-tablet .sponsorship
+ {
+        margin-bottom: 20px;
+    }
+}
+
+/* hide  privacy setting cmp */
+a#qc-cmp2-persistent-link {
+    display: none;
+}
+.home.admin-bar .main-content.content {
+    margin-top: 268px
+}
+
+@media(max-width: 1024px) {
+    .home.admin-bar .main-content.content {
+        margin-top:148px !important
+    }
+}
+
+@media(max-width: 768px) {
+    .home.admin-bar .main-content.content {
+        margin-top:70px !important
+    }
+}		</style>
+		
+	<style type="text/css">
+	.yasr-star-rating {
+		background-image: url(https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/off.svg);
+	}
+
+	.yasr-star-rating .yasr-star-value {
+		background-image: url(https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/on.svg);
+	}
+	</style>
+</head>
+
+
+<body class="recipes-template-default single single-recipes postid-81139 wp-custom-logo">
+	<!-- Google Tag Manager (noscript) -->
+	<noscript><iframe src="https://web.archive.org/web/20250216023536if_/https://www.googletagmanager.com/ns.html?id=GTM-PR23HDB" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	<!-- End Google Tag Manager (noscript) -->
+	<header class="sticky-header">
+		<div class="content-wrapper">
+			<div class="top-banner-ad-desktop top-banner-ad non-stick">
+    <div class="advert-content">
+        <div class="content-wrapper">
+            <div class="row justify-content-center no-gutters">
+                <div class="ad-title">Advertisement</div>
+				<div id="adslot-top-banner">
+					
+				</div>
+				<div id="dismiss-top-banner">
+					<img alt="Close menu" src="https://web.archive.org/web/20250216023536im_/https://deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-white.svg" width="25px" height="25px">
+				</div>
+				<!-- End AdSlot 1 -->
+            </div>
+        </div>
+    </div>
+</div>
+						<div id="header-desktop" class="content-wrapper">
+				<header id="header-content" class="below-ad">
+					<div class="header-wrapper">
+												<div class="header-elements">
+							<div class="row">
+								<div class="col">
+									<div class="links-functional links-user">
+										<nav class="nav-list">
+											<ul>
+												<li><a href="https://web.archive.org/web/20250216023536/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" rel="nofollow">Subscribe to magazine</a></li>
+											</ul>
+										</nav>
+									</div>
+								</div>
+
+								<div class="col">
+																											<a href="/web/20250216023536/https://www.deliciousmagazine.co.uk/" class="logo" style="background:url(https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Jan-25-LOGO-CHANGE-231x43-copy.png) no-repeat center center; background-size: 100%;"><span class="sr-only">delicious.</span></a>
+									<a href="/web/20250216023536/https://www.deliciousmagazine.co.uk/" class="logo-small" style="background:url(https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Jan-25-LOGO-CHANGE-MASTER-ROUNDEL.png) no-repeat center center; background-size: 100%;"><span class="sr-only">delicious.</span></a>
+									
+								</div>
+
+								<div class="col">
+									<div class="links-functional links-account">
+										<nav class="nav-list">
+											<ul>
+																								<li>
+													<a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login/" class="">Log in</a>
+												</li>
+												<li>
+													<a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/register/" class="">Register</a>
+												</li>
+																							</ul>
+										</nav>
+									</div>
+								</div>
+							</div>
+						</div>
+
+						<div class="content-block">
+							<div class="nav-main">
+								
+<nav class="nav-links">
+    <div class="menu-main-menu-container"><ul id="main-menu" class="menu"><button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button><div class="account-section visible-tablet">
+            <div class="account-buttons">
+            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login/" class=""><span>Log in</span></a>
+            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/register/" class=""><span>Register</span></a>
+        </div>
+    </div><li id="menu-item-29273" class="recipe-mega-menu menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-29273"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/">Recipes</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-29927" class="mob-title menu-item menu-item-type-post_type menu-item-object-page menu-item-29927"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/">Recipes</a></li>
+	<li id="menu-item-18895" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18895"><a href="#">Main ingredients</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29928" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29928"><a href="#">Main Ingredients</a></li>
+		<li id="menu-item-18896" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18896"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/beef-recipes/">Beef</a></li>
+		<li id="menu-item-65774" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65774"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/beef-mince-recipes/">Beef mince</a></li>
+		<li id="menu-item-18897" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18897"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/cheese-recipes/">Cheese</a></li>
+		<li id="menu-item-18898" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18898"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/chicken-recipes/">Chicken</a></li>
+		<li id="menu-item-18899" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18899"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/chocolate-recipes/">Chocolate</a></li>
+		<li id="menu-item-18900" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18900"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/egg-recipes/">Eggs</a></li>
+		<li id="menu-item-18901" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18901"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/fish-recipes/">Fish</a></li>
+		<li id="menu-item-18902" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18902"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/fruit-recipes/">Fruit</a></li>
+		<li id="menu-item-18903" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18903"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/lamb-recipes/">Lamb</a></li>
+		<li id="menu-item-18904" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18904"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/mushroom-recipes/">Mushrooms</a></li>
+		<li id="menu-item-18905" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18905"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/pasta-recipes/">Pasta</a></li>
+		<li id="menu-item-18906" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18906"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/pork-recipes/">Pork</a></li>
+		<li id="menu-item-18907" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18907"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/salmon-recipes/">Salmon</a></li>
+		<li id="menu-item-18908" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18908"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/sausage-recipes/">Sausages</a></li>
+		<li id="menu-item-18909" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18909"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/seafood-recipes/">Seafood</a></li>
+		<li id="menu-item-18911" class="menu-item menu-item-type-taxonomy menu-item-object-ingredients menu-item-18911"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/vegetable-recipes/">Vegetables</a></li>
+	</ul>
+</li>
+	<li id="menu-item-56139" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-56139"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/drinks/">Drinks recipes</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-75584" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75584"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/non-alcoholic-drink-recipes/">Non-alcoholic drinks</a></li>
+		<li id="menu-item-58320" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58320"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/cocktail-recipes/">All cocktails</a></li>
+		<li id="menu-item-58319" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58319"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/champagne-cocktails/">Champagne cocktails</a></li>
+		<li id="menu-item-58321" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58321"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/gin-cocktail-recipes/">Gin cocktails</a></li>
+		<li id="menu-item-75581" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75581"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/spicy-cocktail-recipes/">Spicy cocktails</a></li>
+		<li id="menu-item-75582" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75582"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/summer-cocktail-recipes/">Summer cocktails</a></li>
+		<li id="menu-item-75583" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75583"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vodka-cocktail-recipes/">Vodka cocktails</a></li>
+		<li id="menu-item-58323" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-58323"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/winter-cocktail-recipes/">Winter cocktails</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18960" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18960"><a href="#">Cuisine</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29929" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29929"><a href="#">Cuisine</a></li>
+		<li id="menu-item-65775" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65775"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/african-recipes/">African</a></li>
+		<li id="menu-item-18942" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18942"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/american-recipes/">American</a></li>
+		<li id="menu-item-60818" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-60818"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/australian-recipes/">Australian</a></li>
+		<li id="menu-item-18944" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18944"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/british-recipes/">British</a></li>
+		<li id="menu-item-65776" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65776"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/caribbean-recipes/">Caribbean</a></li>
+		<li id="menu-item-18946" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18946"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/chinese-recipes/">Chinese</a></li>
+		<li id="menu-item-18947" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18947"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/french-recipes/">French</a></li>
+		<li id="menu-item-18948" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18948"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/german-recipes/">German</a></li>
+		<li id="menu-item-18949" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18949"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/greek-recipes/">Greek</a></li>
+		<li id="menu-item-18950" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18950"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/indian-recipes/">Indian</a></li>
+		<li id="menu-item-18951" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18951"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/italian-recipes/">Italian</a></li>
+		<li id="menu-item-18952" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18952"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/japanese-recipes/">Japanese</a></li>
+		<li id="menu-item-66723" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-66723"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/korean-recipes/">Korean</a></li>
+		<li id="menu-item-18953" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18953"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/mediterranean-recipes/">Mediterranean</a></li>
+		<li id="menu-item-18954" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18954"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/mexican-recipes/">Mexican</a></li>
+		<li id="menu-item-37584" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-37584"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/middle-eastern/">Middle Eastern</a></li>
+		<li id="menu-item-18956" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18956"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/moroccan-recipes/">Moroccan</a></li>
+		<li id="menu-item-18957" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18957"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/scandinavian-recipes/">Scandinavian</a></li>
+		<li id="menu-item-18958" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18958"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/spanish-recipes/">Spanish</a></li>
+		<li id="menu-item-18959" class="menu-item menu-item-type-taxonomy menu-item-object-cuisine menu-item-18959"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cuisine/vietnamese-recipes/">Vietnamese</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18913" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18913"><a href="#">Vegetarian &#038; vegan</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29930" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29930"><a href="#">Vegetarian &#038; vegan</a></li>
+		<li id="menu-item-21119" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-21119"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/vegetarian/">All vegetarian</a></li>
+		<li id="menu-item-78559" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78559"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/healthy-vegetarian-recipes/">Healthy vegetarian</a></li>
+		<li id="menu-item-78560" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78560"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/italian-vegetarian-recipes/">Italian vegetarian</a></li>
+		<li id="menu-item-47305" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-47305"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/quick-vegetarian-recipes/">Quick vegetarian</a></li>
+		<li id="menu-item-64947" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64947"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegetarian-bake-recipes/">Vegetarian one pots</a></li>
+		<li id="menu-item-78561" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78561"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegetarian-barbecue-recipes/">Vegetarian barbecue</a></li>
+		<li id="menu-item-78562" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78562"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegetarian-brunch-recipes/">Vegetarian brunch</a></li>
+		<li id="menu-item-78563" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78563"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegetarian-burger-recipes/">Vegetarian burgers</a></li>
+		<li id="menu-item-64948" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64948"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegetarian-casserole-recipes/">Vegetarian casseroles</a></li>
+		<li id="menu-item-78569" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78569"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegetarian-pasta-recipes/">Vegetarian pasta</a></li>
+		<li id="menu-item-21120" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-21120"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/vegan/">All vegan</a></li>
+		<li id="menu-item-64944" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64944"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegan-baking-recipes/">Vegan baking</a></li>
+		<li id="menu-item-78565" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78565"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegan-comfort-food/">Vegan comfort food</a></li>
+		<li id="menu-item-78566" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78566"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegan-curry-recipes/">Vegan curry</a></li>
+		<li id="menu-item-78568" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78568"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegan-pasta-recipes/">Vegan pasta</a></li>
+		<li id="menu-item-64946" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64946"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegan-roast-recipes/">Vegan roasts</a></li>
+		<li id="menu-item-64945" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64945"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegan-dessert-recipes/">Vegan desserts</a></li>
+		<li id="menu-item-78567" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78567"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/vegan-dinner-recipes/">Vegan dinners</a></li>
+		<li id="menu-item-78564" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-78564"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/easy-vegan-recipes/">Easy vegan</a></li>
+	</ul>
+</li>
+	<li id="menu-item-32069" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-32069"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/baking-recipes/">Baking</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-65770" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65770"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/baking-recipes/">All baking</a></li>
+		<li id="menu-item-65771" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-65771"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/cake-recipes/">Cakes</a></li>
+		<li id="menu-item-75577" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75577"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/birthday-cake-recipes/">Birthday cakes</a></li>
+		<li id="menu-item-32090" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32090"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/biscuit-recipes/">Biscuits</a></li>
+		<li id="menu-item-32083" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32083"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/brownie-recipes/">Brownies</a></li>
+		<li id="menu-item-32084" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32084"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/bundt-cake-recipes/">Bundt cakes</a></li>
+		<li id="menu-item-75578" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75578"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/carrot-cake-recipes/">Carrot cakes</a></li>
+		<li id="menu-item-32085" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32085"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/celebration-cake-recipes/">Celebration cakes</a></li>
+		<li id="menu-item-32086" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32086"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chocolate-cake-recipes/">Chocolate cakes</a></li>
+		<li id="menu-item-32087" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32087"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/easy-cake-recipes/">Easy cakes</a></li>
+		<li id="menu-item-75579" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75579"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/flourless-baking-recipes/">Flourless baking</a></li>
+		<li id="menu-item-32088" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-32088"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/loaf-cake-recipes/">Loaf cakes</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18915" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18915"><a href="#">Occasion</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29931" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29931"><a href="#">Occasion</a></li>
+		<li id="menu-item-81437" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-81437"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chinese-new-year-recipes/">Chinese New Year</a></li>
+		<li id="menu-item-81438" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-81438"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/valentines-day-recipes/">Valentine&#8217;s Day</a></li>
+		<li id="menu-item-81439" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-81439"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/pancake-recipes/">Pancake Day</a></li>
+		<li id="menu-item-18968" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-18968"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/afternoon-tea-recipes/">Afternoon tea</a></li>
+		<li id="menu-item-64942" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-64942"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/air-fryer-recipes/">Air fryer</a></li>
+		<li id="menu-item-75573" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75573"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/barbecue-recipes/">Barbecue</a></li>
+		<li id="menu-item-53244" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-53244"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/birthday-cake-recipes/">Birthday cakes</a></li>
+		<li id="menu-item-75576" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75576"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/brunch-recipes/">Brunch</a></li>
+		<li id="menu-item-73236" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-73236"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/comfort-food-recipes/">Comfort food</a></li>
+		<li id="menu-item-68269" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-68269"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/easy-dinner-party-mains/">Dinner party mains</a></li>
+		<li id="menu-item-65773" class="menu-item menu-item-type-taxonomy menu-item-object-collections current-recipes-ancestor current-menu-parent current-recipes-parent menu-item-65773"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/midweek-meal-recipes/">Midweek meals</a></li>
+		<li id="menu-item-75575" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75575"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/friday-night-dinners/">Friday night dinners</a></li>
+		<li id="menu-item-75574" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-75574"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/weekend-dinner-recipes/">Weekend dinner ideas</a></li>
+	</ul>
+</li>
+	<li id="menu-item-18912" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-18912"><a href="#">Special diets</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-29932" class="mob-title menu-item menu-item-type-custom menu-item-object-custom menu-item-29932"><a href="#">Special diets</a></li>
+		<li id="menu-item-18932" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-18932"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/dairy-free/">Dairy-free</a></li>
+		<li id="menu-item-19887" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-19887"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/gluten-free/">Gluten-free</a></li>
+		<li id="menu-item-78558" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-78558"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/vegetarian/">Vegetarian</a></li>
+		<li id="menu-item-78557" class="menu-item menu-item-type-taxonomy menu-item-object-dietary_requirements menu-item-78557"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/vegan/">Vegan</a></li>
+		<li id="menu-item-52452" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-52452"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/diabetes-friendly-recipes/">Diabetes-friendly</a></li>
+		<li id="menu-item-49416" class="menu-item menu-item-type-taxonomy menu-item-object-collections menu-item-49416"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/low-calorie-dinner-recipes/">Lower-calorie</a></li>
+		<li id="menu-item-57863" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-57863"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/health/">Healthy recipes</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-81504" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-81504"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/february-recipes/">February inspiration</a></li>
+<li id="menu-item-75636" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-75636"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/skills/">Be a Better Cook</a></li>
+<li id="menu-item-62044" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-62044"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/features/">Features</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-70850" class="mob-title menu-item menu-item-type-taxonomy menu-item-object-category menu-item-70850"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/features/">Features</a></li>
+	<li id="menu-item-80820" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80820"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/features/">All features</a></li>
+	<li id="menu-item-62045" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62045"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/travel/">Travel</a></li>
+	<li id="menu-item-62047" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62047"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/reviews/">Reviews</a></li>
+	<li id="menu-item-62051" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-62051"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/features/interviews/">Interviews</a>
+	<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>		<li id="menu-item-80821" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80821"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/features/interviews/">Celebrity interviews</a></li>
+		<li id="menu-item-76196" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-76196"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/features/interviews/fridge-raid-interviews/">Fridge Raid interviews</a></li>
+	</ul>
+</li>
+	<li id="menu-item-72189" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-72189"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/round-ups/">Round-ups</a></li>
+	<li id="menu-item-73310" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73310"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/sustainability/">Sustainability</a></li>
+	<li id="menu-item-62049" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62049"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/features/events/">Events</a></li>
+	<li id="menu-item-62052" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-62052"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/drinks/">Drinks</a></li>
+</ul>
+</li>
+<li id="menu-item-73158" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-73158"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/">Guides</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-73463" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73463"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/discoveries/">Discoveries</a></li>
+	<li id="menu-item-73162" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73162"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/leftovers/">Leftovers</a></li>
+	<li id="menu-item-73165" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73165"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/round-ups/">Round-ups</a></li>
+	<li id="menu-item-73160" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73160"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/menus/">Menu planning</a></li>
+	<li id="menu-item-73161" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73161"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/ingredients/">Ingredients</a></li>
+	<li id="menu-item-73163" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73163"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/in-the-garden/">In the garden</a></li>
+	<li id="menu-item-73164" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73164"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/health/">Health</a></li>
+	<li id="menu-item-73166" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73166"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/skills/">Skills</a></li>
+	<li id="menu-item-73167" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-73167"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/guides/tips/">Tips</a></li>
+</ul>
+</li>
+<li id="menu-item-80441" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-80441"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/offers-competitions/">Offers &amp; Competitions</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-80442" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80442"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/offers-competitions/">Offers &amp; Competitions</a></li>
+	<li id="menu-item-80443" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80443"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/reviews/">Shopping &#038; Reviews</a></li>
+	<li id="menu-item-80444" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-80444"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/whats-inside-our-latest-issue/">Magazine subscriptions</a></li>
+	<li id="menu-item-80445" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80445"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/offers-competitions/competitions/">Competitions</a></li>
+</ul>
+</li>
+<li id="menu-item-79111" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-79111"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/reviews/">Shopping &#038; Reviews</a>
+<ul class="sub-menu">
+<button class="close visible-tablet" type="button"><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-icon.svg" alt="Close menu" width="30px" height="30px"></button>	<li id="menu-item-80061" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-80061"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/reviews/">Reviews</a></li>
+	<li id="menu-item-80062" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-80062"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/whats-inside-our-latest-issue/">How to subscribe to delicious. magazine</a></li>
+</ul>
+</li>
+<div class="external-links visible-tablet"><nav class="nav-list"><ul><li><a href="https://web.archive.org/web/20250216023536/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" rel="nofollow"><span>Subscribe to magazine</span><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/external-link.svg" width="20px" height="27px" alt="External link"/></a></li></ul></nav></div></ul></div></nav>
+								<div class="cta-search" id="desctopsearch">
+									<a href="#">
+										Search
+										<span class="icon-inline icon-search">
+																						<img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/search-green.svg" alt="Search icon" width="20" height="20"/>
+																					</span>
+									</a>
+								</div>
+								<div class="nav-mobile-cta visible-tablet">
+									<div class="burger-nav">
+										<span></span>
+										<span></span>
+										<span></span>
+										<span></span>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<div class="t_searchplace">
+						<div class="t_searchwrap">
+							<form class="hide-tablet" action="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/" method="get">
+								<input type="text" id="search_field" name="s" onfocus="this.placeholder = ''" onblur="this.placeholder = 'Type here to find recipes, collections, articles...'" placeholder="Type here to find recipes, collections, articles...">
+								<button class="t_search_desc" type="submit">
+									<img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/arrow-right-black.svg" class="Arrow-black"/>
+								</button>
+							</form>
+							<form class="visible-tablet" action="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/" method="get">
+								<input type="text" id="search_field_mobile" name="s" onfocus="this.placeholder = ''" onblur="this.placeholder = 'Tap here to search'" placeholder="Tap here to search">
+								<button class="t_search_desc" type="submit">
+									<img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/arrow-right-black.svg" class="Arrow-black"/>
+								</button>
+							</form>
+						</div>
+
+						<div class="t_search_box">
+													<div class="t_searchresult"></div>
+					</div>
+			</div>
+	</header>
+	</div>
+	</div>
+	</header>
+<!-- <meta name="keywords" content="Double lemon chicken with charred leeks and dill polenta"/> -->
+<main class="main-content content">
+    <div class="content-wrapper">
+        <!-- Recipe: Overview -->
+        <section id="recipe-overview">
+            <!-- Recipe: Header -->
+            <div class="recipe-header">
+                <div class="row no-gutters">
+                    <div class="col-sm-12 col-md-4 order-md-last  block">
+                        
+                    </div>
+
+                    <div class="col">
+                        <div class="recipe-heading text-standard">
+
+                            <div class="breadcrumbs">
+                                <p id="breadcrumbs"><span><span><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/">Home</a></span> <span class="seperator">&gt;</span> <span><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/">Recipes</a></span> <span class="seperator">&gt;</span> <span><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chicken-thigh-recipes/">Chicken thighs</a></span> <span class="seperator">&gt;</span> <span class="breadcrumb_last" aria-current="page">Double lemon chicken with charred leeks and dill polenta</span></span></p>                            </div>
+
+                            <div class="recipe-title">
+                                <div class="print-logo">
+                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/logos/delicious-black.jpg" alt="Delicious print logo" class="print-logo-img"/>
+                                </div>
+                                <h1>Double lemon chicken with charred leeks and dill polenta</h1>
+                            </div>
+                        </div>
+
+                        <div class="visible-mobile">
+                                    <div class="recipe-stats nav-list mobile-view">
+
+				    	
+    		<p class="recipe-author-details"><span class="list-heading">By: </span>
+    			
+    			<span>
+    				<span itemprop="name"> 
+						<a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/contributors/emily-gussin/"> 
+						<img data-del="avatar" data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/Emily-Gussin-54x54.jpg" class="avatar pp-user-avatar avatar-30 photo lazyload" height="30" width="30" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 30px; --smush-placeholder-aspect-ratio: 30/30;"/> 
+						</a>
+						<span>
+						<a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/contributors/emily-gussin/"> 
+						Emily Gussin </a>
+												<br/> <span class="short-bio" style="margin-top: 4px; display:block"> Food producer and sustainability lead, delicious.</span>
+												</span>
+						</span>
+    			</span>
+
+    		</p>
+
+				    	
+    	<ul class="clearfix post-date">
+    		<li>
+    			<span class="list-heading">Published:&nbsp;</span>4 Feb 25    		</li>
+    		<li>
+    			<span class="list-heading">Updated:&nbsp;</span>12 Feb 25    		</li>
+    	</ul>
+    	<ul class="clearfix">
+    		<li class="recipe-rating">
+    			<a href="#reviews"><div id="yasr-vv-stars-stats-container-48670ebac789c"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-48670ebac789c" data-rating="4.5" data-rater-starsize="16" data-rater-postid="81139" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>    				<span>Rate &amp; comment<span>
+    			</a>
+    		</li>
+
+    		<li class="recipe-tka tka">
+    			    				<a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/meet-the-food-team/" target="">
+    				
+    				<img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/tka.svg" alt="Test kitchen approved logo" width="30" height="30" style="width:18px; height: 18px;">
+    				<span>Test kitchen approved</span>
+
+    				    				</a>
+    			    		</li>
+    	</ul>
+    </div>
+
+    
+    	    	    				    		
+
+    	                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- /Recipe: Header -->
+
+            <!-- Recipe: Details -->
+            <div class="recipe-detail-wrapper">
+                <div class="row no-gutters">
+                    <div class="col-md-6">
+                        <div class="hide-mobile">
+                            <div class="recipe-image">
+                                
+                                <img class="main-recipe-img disable-ll" src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks-768x960.jpg" alt="Double lemon chicken with charred leeks and dill polenta" width="768" height="960"/>
+
+                                                            </div>
+                        </div>
+
+                        <div class="visible-mobile">
+                            <div class="recipe-description text-standard" itemprop="description">
+                                <p>Doubling up fresh and preserved<a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/lemon-recipes/"> lemons</a> to lift this crème fraîche sauce makes for a zesty <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/chicken-recipes/">chicken</a> dinner. Serve with charred <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/leek-recipes/">leeks</a> and creamy polenta.</p>                                    <div class="recipe-image">
+                                                                                <img class="main-recipe-img disable-ll" src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks-768x960.jpg" alt="Double lemon chicken with charred leeks and dill polenta" width="768" height="960"/>
+                                                                            </div>
+                                    <p>
+<p>Polenta makes a great alternative to rice or potatoes. Discover more delicious <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/polenta-recipes/">polenta recipes</a>.</p><p>
+</p>                            </div>
+
+                        </div>
+                    </div>
+
+                    <div class="col-md-6">
+                        <div class="recipe-details">
+                            <div class="hide-mobile">
+                                    <div class="recipe-stats nav-list">
+        <ul>
+            <li class="recipe-rating">
+                <a href="#reviews"><div id="yasr-vv-stars-stats-container-b8767d7094eb8"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-b8767d7094eb8" data-rating="4.5" data-rater-starsize="16" data-rater-postid="81139" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div></a>
+            </li>
+
+            <li class="recipe-skill">
+                <span class="icon-inline icon-effort-main">
+                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                </span>
+
+                                    <span>Easy</span>
+                            </li>
+
+                            <li class="recipe-date">
+                    <span class="icon-inline"></span>
+                    <span>February 2025</span>
+                </li>
+                    </ul>
+    </div>                                <div class="tka">
+                                                                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/meet-the-food-team/" target="">
+                                        
+                                        <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/tka.svg" alt="Test kitchen approved logo" width="30" height="30" style="width:30px; height: 30px;">
+                                        <span>Test kitchen approved</span>
+
+                                                                                </a>
+                                                                    </div>
+                            </div>
+
+                            <div class="recipe-info">
+                                <div class="recipe-guidance">
+                                    <ul class="list-guidance">
+                                                                                    <li>
+                                                <span class="icon-inline icon-serves-green">
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/serves-green.svg" alt="Serves icon" width="40" height="40"/>
+                                                </span>
+                                                <span>Serves 2</span>
+                                            </li>
+                                        
+                                                                                    <li>
+                                                <span class="icon-inline icon-time-green">
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/time-green.svg" alt="Time icon" width="40" height="40"/>
+                                                </span>
+                                                <span>Prep time 15 min . Cook time 30 min
+</span>
+                                            </li>
+                                                                            </ul>
+                                </div>
+                                
+                                <div class="hide-mobile">
+                                    <div class="recipe-description text-standard" itemprop="description">
+                                        <p>Doubling up fresh and preserved<a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/lemon-recipes/"> lemons</a> to lift this crème fraîche sauce makes for a zesty <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/ingredients/chicken-recipes/">chicken</a> dinner. Serve with charred <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/leek-recipes/">leeks</a> and creamy polenta.</p>
+<p>Polenta makes a great alternative to rice or potatoes. Discover more delicious <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/polenta-recipes/">polenta recipes</a>.</p>
+                                    </div>
+
+                                </div>
+
+                                <div class="recipe-labels nav-list">
+                                    <ul>
+                                                                                        <li>
+                                                                                                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/freezable/" title="Freezable">
+                                                                                                            <span class="icon-inline">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/09/freezable-icon.svg" alt="" width="25px" height="25px"/>
+                                                                                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/05/freezable-icon-green.svg" alt="" class="disable-ll" width="25px" height="25px"/>
+                                                                                                                    </span>
+                                                                                                        
+                                                                                                                                                                        <span>Freezable</span>   
+                                                                                                                </a>
+                                                    </li>
+                                                                                            <li>
+                                                                                                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/dietary_requirements/gluten-free/" title="Gluten-free recipes">
+                                                                                                            <span class="icon-inline">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/09/gluten-free-icon.svg" alt="Gluten free" width="25px" height="25px"/>
+                                                                                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/05/gluten-free-icon-green.svg" alt="" class="disable-ll" width="25px" height="25px"/>
+                                                                                                                    </span>
+                                                                                                        
+                                                                                                                                                                        <span>Gluten-free</span>
+                                                                                                                </a>
+                                                    </li>
+                                                                                    </ul>
+                                </div>
+
+                                
+                                                                    <div class="visible-tablet">
+                                        
+                                                                                                                                                                                        </div>
+                                
+                                
+                                <div id="nutrition" class="recipe-nutrition text-standard">
+                                    <!-- Desktop Version -->
+                                                                            <div class="hide-tablet">
+                                            <h3 class="heading-alt">Nutrition: per serving</h3>
+
+                                            <dl class="list-two-column style-lined">
+                                                                                                    <dt>Calories</dt>
+                                                    <dd>832kcals</dd>
+                                                
+                                                                                                    <dt>Fat</dt>
+                                                    <dd>48g (18g saturated)</dd>
+                                                
+                                                                                                    <dt>Protein</dt>
+                                                    <dd>50g</dd>
+                                                
+                                                                                                    <dt>Carbohydrates</dt>
+                                                    <dd>47g (10g sugars)</dd>
+                                                
+                                                                                                    <dt>Fibre</dt>
+                                                    <dd>5.6g</dd>
+                                                
+                                                                                                    <dt>Salt</dt>
+                                                    <dd>1g</dd>
+                                                                                            </dl>
+                                        </div>
+                                    
+                                                                    </div>
+
+                                                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- /Recipe: Details -->
+        </section>
+        <!-- /Recipe: Overview -->
+
+        <!-- Recipe: Utilities - Mobile -->
+        <section id="utilities" class="visible-tablet content-block" style="margin-top: 1.5rem;">
+            <div class="recipe-utilities full-width">
+                <div class="row no-gutters">
+                    <div class="recipe-actions">
+                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login" title="Remove recipe" style="display: none;" class="bttn bttn-icon-remove btn-81139" post_id="81139" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-white.svg" alt="Remove recipe icon"/></span>
+                            Remove recipe
+                        </a>
+
+                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login" title="Save recipe" class="bttn bttn-icon-save btn-81139" post_id="81139" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" width="20" height="20"/></span>
+                            Save recipe
+                        </a>
+
+                    </div>
+
+                    <div class="recipe-actions">
+
+                        <a href="" title="Print recipe" class="bttn bttn-icon-print">
+                            <span></span>
+                            Print
+                        </a>
+
+                    </div>
+
+                    <div class="recipe-sharing mobile-only position-relative">
+                        <button class="bttn bttn-outline" data-toggle="collapse" data-target="#recipeSharing">
+                        <svg width="20" height="20" viewbox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M13.5602 5.00667C13.7446 5.32323 14.0283 5.57018 14.3672 5.70932C14.7061 5.84847 15.0815 5.87205 15.4352 5.77641C15.7889 5.68078 16.1012 5.47127 16.3238 5.18028C16.5465 4.8893 16.667 4.53306 16.6668 4.16667C16.6667 3.91078 16.6076 3.65835 16.4942 3.42895C16.3808 3.19956 16.2161 2.99935 16.0129 2.84386C15.8097 2.68836 15.5734 2.58175 15.3223 2.53229C15.0712 2.48282 14.8122 2.49184 14.5651 2.55863C14.3181 2.62542 14.0898 2.7482 13.8979 2.91744C13.7059 3.08669 13.5555 3.29785 13.4584 3.53458C13.3612 3.7713 13.3198 4.02722 13.3375 4.28251C13.3551 4.53779 13.4313 4.78558 13.5602 5.00667ZM13.5602 5.00667L6.44016 9.16001M6.44016 9.16001C6.25558 8.84369 5.97195 8.59698 5.63311 8.458C5.29427 8.31903 4.9191 8.29553 4.56556 8.39113C4.21203 8.48674 3.89983 8.69613 3.67722 8.98693C3.45461 9.27774 3.33398 9.63378 3.33398 10C3.33398 10.3662 3.45461 10.7223 3.67722 11.0131C3.89983 11.3039 4.21203 11.5133 4.56556 11.6089C4.9191 11.7045 5.29427 11.681 5.63311 11.542C5.97195 11.403 6.25558 11.1563 6.44016 10.84M6.44016 9.16001C6.58893 9.41495 6.66732 9.70483 6.66732 10C6.66732 10.2952 6.58893 10.5851 6.44016 10.84M6.44016 10.84L13.5602 14.9933M13.5602 14.9933C13.6668 14.7975 13.8116 14.6251 13.9861 14.4862C14.1606 14.3474 14.3611 14.245 14.5759 14.1851C14.7907 14.1251 15.0153 14.1089 15.2364 14.1373C15.4576 14.1658 15.6708 14.2383 15.8634 14.3506C16.056 14.4629 16.2241 14.6128 16.3578 14.7912C16.4915 14.9697 16.588 15.1731 16.6416 15.3896C16.6953 15.606 16.7049 15.831 16.67 16.0512C16.6351 16.2714 16.5564 16.4824 16.4385 16.6717C16.2092 17.0397 15.8456 17.3039 15.4247 17.4081C15.0038 17.5124 14.5589 17.4486 14.1844 17.2302C13.8098 17.0118 13.5351 16.656 13.4185 16.2384C13.302 15.8207 13.3528 15.3741 13.5602 14.9933Z" stroke="black" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                         <span>Share</span>           
+                        </button>
+                        <div id="recipeSharing" class="position-absolute collapse">
+                            <div class="sharing-links">
+    <ul>
+        <li><a class="facebook" href="https://web.archive.org/web/20250216023536/https://www.facebook.com/sharer/sharer.php?u=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/" target="_blank"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a class="twitter" href="https://web.archive.org/web/20250216023536/https://twitter.com/home?status=Double+lemon+chicken+with+charred+leeks+and+dill+polenta+-+https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fdouble-lemon-chicken-with-charred-leeks-and-dill-polenta%2F" target="_blank"><i class="fa-brands fa-x-twitter"></i></a></li>
+        <!-- <li><a class="linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/" target="_blank"><i class="fab fa-linkedin-in"></i></a></li> -->
+        <li><a class="whatsapp" href="https://web.archive.org/web/20250216023536/https://api.whatsapp.com/send?text=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/" target="_blank"><i class="fab fa-whatsapp"></i></a></li>
+        <li><a class="pinterest" href="https://web.archive.org/web/20250216023536/https://pinterest.com/pin/create/button/?url=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/&amp;media=https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks-768x960.jpg&amp;description=Double lemon chicken with charred leeks and dill polenta" target="_blank"><i class="fab fa-pinterest-p"></i></a></li>
+    </ul>
+</div>                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+        <!-- /Recipe: Utilities - Mobile -->
+
+        <!-- Recipe: Utilities - Desktop-->
+        <section id="utilities" class="hide-tablet content-block">
+            <div class="recipe-utilities">
+                <div class="row no-gutters">
+                    <div class="col-auto recipe-actions">
+                        <h3>Save</h3>
+
+                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login" title="Remove recipe" style="display: none;" class="bttn bttn-icon-remove btn-81139" post_id="81139" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/close-white.svg" alt="Remove recipe icon"/></span>
+                            Remove recipe
+                        </a>
+
+                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login" title="Save recipe" class="bttn bttn-icon-save btn-81139" post_id="81139" user_id="">
+                            <span><img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" width="20" height="20"/></span>
+                            Save recipe
+                        </a>
+
+                        <a href="" title="Print recipe" class="bttn bttn-icon-print">
+                            <span></span>
+                            Print
+                        </a>
+                    </div>
+
+                    <div class="col-auto recipe-rating">
+                        <h3>Rate</h3>
+                        <a href="#reviews"><div id="yasr-vv-stars-stats-container-e0975f67438b9"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-e0975f67438b9" data-rating="4.5" data-rater-starsize="32" data-rater-postid="81139" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div></a>
+                    </div>
+
+                    <div class="col-auto recipe-sharing">
+                        <h3>Share</h3>
+
+                        <div class="sharing-links">
+    <ul>
+        <li><a class="facebook" href="https://web.archive.org/web/20250216023536/https://www.facebook.com/sharer/sharer.php?u=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/" target="_blank"><i class="fab fa-facebook-f"></i></a></li>
+        <li><a class="twitter" href="https://web.archive.org/web/20250216023536/https://twitter.com/home?status=Double+lemon+chicken+with+charred+leeks+and+dill+polenta+-+https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fdouble-lemon-chicken-with-charred-leeks-and-dill-polenta%2F" target="_blank"><i class="fa-brands fa-x-twitter"></i></a></li>
+        <!-- <li><a class="linkedin" href="https://www.linkedin.com/sharing/share-offsite/?url=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/" target="_blank"><i class="fab fa-linkedin-in"></i></a></li> -->
+        <li><a class="whatsapp" href="https://web.archive.org/web/20250216023536/https://api.whatsapp.com/send?text=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/" target="_blank"><i class="fab fa-whatsapp"></i></a></li>
+        <li><a class="pinterest" href="https://web.archive.org/web/20250216023536/https://pinterest.com/pin/create/button/?url=https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/&amp;media=https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks-768x960.jpg&amp;description=Double lemon chicken with charred leeks and dill polenta" target="_blank"><i class="fab fa-pinterest-p"></i></a></li>
+    </ul>
+</div>                    </div>
+                </div>
+            </div>
+        </section>
+        <!-- /Recipe: Utilities - Desktop -->
+        
+        <section class="before-you-start visible-tablet">
+        <!-- This ad is only requested on mobile -->
+            <div class="visible-tablet" id="recipeMobileAd1">
+                <div class="row no-gutters row-deep">
+                    <div class="col-12 align-self-start">
+                        <div class="advert-content content-block double-margin">
+                            <div class="ad-title">Advertisement</div>
+                            <div id="adslot-recipe-2">
+                                
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row no-gutters">
+                <div class="col-md-12 col-lg-9">
+                    <div class="below-you-start-block content-block double-margin col-gutter">
+                                                    
+                            <div class=" text-standard">
+                                <h2>Before you start</h2>
+                                <p><strong>Know-how</strong> Preserved lemon is salty so you’re unlikely to need to add extra salt to the sauce – taste and adjust the seasoning at the end of cooking.</p>
+<p><strong>Don&#8217;t waste it</strong> Find out <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/what-to-do-with-leftover-preserved-lemons/">what you can do with leftover preserved lemons</a></p>
+<p><strong>Scale it up</strong> This recipe doubles easily – but use a pan where the chicken fits snugly in one layer to ensure the sauce surrounds it as it cooks.</p>
+                            </div>
+                                            </div>
+                </div>
+            </div>
+
+        </section>
+
+        <!-- Recipe: Directions -->
+        <section id="recipe-main">
+            <div class="row no-gutters">
+                <div class="col-md-12 col-lg-9">
+                    
+                                    <!-- before you start desktop -->
+                    <div class="below-you-start-block content-block double-margin col-gutter hide-tablet"> 
+                        <div class=" text-standard">
+                            <h2>Before you start</h2>
+                            <p><strong>Know-how</strong> Preserved lemon is salty so you’re unlikely to need to add extra salt to the sauce – taste and adjust the seasoning at the end of cooking.</p>
+<p><strong>Don&#8217;t waste it</strong> Find out <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/what-to-do-with-leftover-preserved-lemons/">what you can do with leftover preserved lemons</a></p>
+<p><strong>Scale it up</strong> This recipe doubles easily – but use a pan where the chicken fits snugly in one layer to ensure the sauce surrounds it as it cooks.</p>
+                        </div>
+                    </div>
+
+                
+                    <div class="recipe-directions content-block double-margin col-gutter">
+                                                    <div id="ingredients">
+                                <div class="recipe-ingredients text-standard">
+                                    <h2>Ingredients</h2>
+                                    <ul>
+<li>4 tsp vegetable oil</li>
+<li>About 500g chicken thighs or thighs and drumsticks (skin on)</li>
+<li>1 garlic clove, finely chopped</li>
+<li>250ml chicken stock</li>
+<li>1 preserved lemon, pulp removed, rind finely chopped</li>
+<li>1 lemon</li>
+<li>2 tbsp crème fraîche</li>
+<li>175g baby leeks</li>
+</ul>
+<p><strong>For the polenta</strong></p>
+<ul>
+<li>250ml whole milk</li>
+<li>100g quick-cook polenta</li>
+<li>15g butter, plus extra to serve</li>
+<li>20g dill, chopped</li>
+</ul>
+
+                                                                            <div class="advert-content visible-mobile">
+                                            <div class="ad-title">Advertisement</div>
+                                            <div id="adslot-recipe-12">
+                                                
+                                            </div>
+                                        </div>
+                                                                    </div>
+                            </div>
+                        
+                        <!-- Cook Mode -->
+                        <div class="visible-tablet">
+                            <div class="deli-nosleep deli-toggle-switch-container" style="">
+                                <label id="deli-toggle-switch" class="deli-toggle-switch deli-toggle-switch-rounded" aria-label="Toggle switch" style="width: 62px;height: 30px;">
+                                    <input type="checkbox" id="deli-nosleep-checkbox" class="deli-nosleep-checkbox">
+                                    <div class="deli-toggle-switch-slider" style="background-color: #ed6c4f;border-radius: 30px;">
+                                    <span></span>                  
+                                    </div>
+                                </label>
+                                <label for="deli-nosleep-checkbox" class="deli-nosleep-label deli-block-text-bold">Cook Mode</label>
+                                <span class="deli-nosleep-text">Sticky screen? No thanks! Tap to prevent your screen from going off while cooking.</span>
+                            </div>
+                        </div>                                
+
+                        <div id="gohere">
+                                                            <div id="method" class="recipe-method text-standard content-block double-margin col-gutter">
+                                    <h2>Method</h2>
+                                                                        <ol>
+<li>Heat 2 tsp oil in a medium frying pan or sauté pan over a medium-high heat (you want a pan that will fit the chicken fairly snugly in one layer). Season the chicken, add to the pan skin-side-down and cook for 8 minutes until golden and crisp, then turn over and cook on the other side for 2 minutes. Lift onto a plate.</li>
+<li>Add the garlic to the pan, cook for 30 seconds, then pour in the stock and add the preserved lemon and lemon zest. Bring to a simmer, then stir in the crème fraîche and season with pepper. Return the chicken to the pan, keeping the  skin on top so it stays crisp. Simmer gently for 18-20 minutes until the chicken is cooked through.</li>
+<li>Meanwhile, heat a griddle pan over a high heat. Brush the leeks with 2 tsp oil and season with salt and pepper. Cook for 7 minutes on each side until charred and tender.</li>
+                                        <div class="advert-content content-block double-margin visible-tablet" style="width: 100%; margin-bottom: 1.5rem;">
+                                            <div class="ad-sub_title" style="font-size: 1.1rem; color: #7f7f7f; margin-bottom:1rem">Recipe continues after advertising</div>
+                                            <div class="ad-title">Advertisement</div>
+                                            <div id="adslot-recipe-3">
+                                                
+                                            </div>
+                                        </div></li>
+<li>For the polenta, heat the milk and 200g water in a pan, then whisk in the polenta and cook for 3-4 minutes. Beat in the butter and most of the dill, plus salt and pepper. Cut 2 small wedges from the zested lemon, then juice the rest and stir into the chicken sauce. Divide the polenta between bowls and top with the saucy chicken, scattering over the remaining dill and adding the lemon wedges to the side of the plate for squeezing over.</li>
+</ol>
+
+                                </div>
+                            
+                                                                                        <div class="visible-tablet recipe-method text-standard content-block">
+                                <div class="recipe-labels nav-list" style="margin-top: 0;">
+                                        <ul>
+                                            <li style="padding-left: 0;">
+                                                <span>Recipe from <strong>February 2025</strong> Issue</span>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                
+                                </div>
+                            
+                        </div>
+                        
+                        <div class="zeddit-rcm" data-pid="1012" data-type="canvas-display" animation-type="none" variant="1"></div>
+
+                                                    <!-- Mobile Accordion Version -->
+                            <div class="nutrition content-block visible-tablet">
+                                <h2>Nutrition</h2>
+                                                                <div class="visible-tablet text-standard" style="margin-top: 2rem; margin-bottom: 40px;">
+
+                                    <div class="heading-alt">Nutrition: per serving</div>
+                                    
+                                    <div class="text-standard recipe-nutrition" id="nutritionContent" style="margin-top: 20px;">
+                                        <dl class="list-two-column style-lined">
+                                                                                            <dt>Calories</dt>
+                                                <dd>832kcals</dd>
+                                            
+                                                                                            <dt>Fat</dt>
+                                                <dd>48g (18g saturated)</dd>
+                                            
+                                                                                            <dt>Protein</dt>
+                                                <dd>50g</dd>
+                                            
+                                                                                            <dt>Carbohydrates</dt>
+                                                <dd>47g (10g sugars)</dd>
+                                            
+                                                                                            <dt>Fibre</dt>
+                                                <dd>5.6g</dd>
+                                            
+                                                                                            <dt>Salt</dt>
+                                                <dd>1g</dd>
+                                            
+                                        </dl>
+                                       
+                                    </div>
+                                </div>
+                            </div>
+                        
+
+                        
+                        
+                        
+                        
+                        
+                        <!-- START OF WHISK -->
+                        <div id="whisk-container">
+                            <h2 class="visible-tablet">Buy ingredients online</h2>
+                            <script async="true" src="https://web.archive.org/web/20250216023536js_/https://cdn.whisk.com/sdk/shopping-list-sp.js" type="text/javascript"></script>
+                            <script>
+                                var whisk = whisk || {};
+                                whisk.queue = whisk.queue || [];
+
+                                whisk.queue.push(function() {
+                                    whisk.config.set("global.trackingId", "5bdd6de5-be70-4a69-838d-cc8955b6a362");
+
+                                    whisk.shoppingList.defineWidget("WWID-WKXK-TAUC-WHQD", {
+                                        whiteLabel: "deliciouscouknew",
+                                        styles: {
+                                            size: "large",
+                                            align: "left",
+                                            linkColor: "#38C4A4",
+                                            button: {
+                                                color: "#38C4A4",
+                                                text: "Add to shopping list"
+                                            }
+                                        }
+                                    });
+
+                                    whisk.ads.defineBlock("whisk-sp-unit-block-1", {
+                                        whiteLabel: "deliciouscouknew",
+                                    });
+                                });
+                            </script>
+
+                            <div id="WWID-WKXK-TAUC-WHQD" class="content-block double-margin">
+                                <script>
+                                    whisk.queue.push(function() {
+                                        whisk.display('WWID-WKXK-TAUC-WHQD');
+                                    });
+                                </script>
+                            </div>
+
+                            <div id="whisk-sp-unit-block-1">
+                                <script>
+                                    whisk.queue.push(function() {
+                                        whisk.display("whisk-sp-unit-block-1");
+                                    });
+                                </script>
+                            </div>
+                        </div>
+                        <!-- END OF WHISK -->
+
+                            
+                            <div class="recipe-author-wrapper content-block double-margin hide-mobile">
+                            <div class="recipe-author-details">
+                                                        
+                                
+                                    <p class="list-heading"> Recipe By: </p>
+                                    
+                                    <div class="recipe-author-details-with-img">
+                                        <span itemprop="name"> 
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/contributors/emily-gussin/"> 
+                                            <img data-del="avatar" data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/Emily-Gussin-100x100.jpg" class="avatar pp-user-avatar avatar-60 photo lazyload" height="60" width="60" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 60px; --smush-placeholder-aspect-ratio: 60/60;"/> 
+                                            </a>
+                                            <span>
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/contributors/emily-gussin/"> 
+                                            Emily Gussin </a>
+                                                                                        <br/> <span class="short-bio" style="margin-top: 4px; display:block"> Food producer and sustainability lead, delicious.</span>
+                                                                                        </span>
+                                        </span>
+                                    </div>
+
+
+                                
+                                <ul class="post-date">
+                                        <li>
+                                            <span class="list-heading">Published:&nbsp;</span>4 Feb 25                                        </li>
+                                        <li>
+                                            <span class="list-heading">Updated:&nbsp;</span>12 Feb 25                                        </li>
+                                </ul>
+                            </div>
+                        
+                        <div class="magazine-subscription">
+                                    <p>Subscribe</p>
+                                    <p>Fancy getting a copy in print?</p>
+                                    <a href="https://web.archive.org/web/20250216023536/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" title="Subscribe to Delicious magazine">Subscribe to our magazine</a>
+
+                                                                            <div class="postal-magazine-cover">
+                                            <img data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Feb-25-Delicious-magazine-footer.png" alt="" class="img-responsive lazyload" width="170px" height="106px" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 170px; --smush-placeholder-aspect-ratio: 170/106;"/>
+                                        </div>
+                                                                </div>
+                        </div>
+
+                                                    <div class="related-recipe-collections">
+                                <h2>Related recipe collections</h2>
+
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chicken-thigh-recipes/">Chicken thighs</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/dinner-ideas-for-two/">Dinner ideas for two</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/our-favourite-chicken-recipes/">Favourite chicken</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/february-seasonal-food/">February seasonal</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/healthy-chicken-recipes/">Healthy chicken</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/healthy-dinner-recipes/">Healthy dinners</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/lemon-recipes/">Lemons</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/midweek-meal-recipes/">Midweek meals</a>
+                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/weeknight-recipes/">Weeknight</a>
+                                                            </div>
+                        
+                        <div id="reviews" class="rate-review text-standard content-block double-margin">
+                            <h2>Rate &amp; review</h2>
+
+                            <div class="rate">
+                                <p>Rate</p>
+                                <p class="login-message">You must be logged in to rate a recipe, <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login/">click here to login</a>.</p>                            </div>
+
+                            <div class="reviews">
+                                <p>Reviews</p>
+                                                                    <div class="comment-wrapper">
+                                        
+<div id="comments" class="comments-area">
+		<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Share a tip <small><a rel="nofollow" id="cancel-comment-reply-link" href="/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/#respond" style="display:none;">Cancel comment</a></small></h3><form id="commentform" class="comment-form login-required">
+    <div class="login-message"><p>You must be <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-login.php?redirect_to=https%3A%2F%2Fwww.deliciousmagazine.co.uk%2Frecipes%2Fdouble-lemon-chicken-with-charred-leeks-and-dill-polenta%2F">logged in</a> to post a comment.</p></div>
+    <p class="comment-form-comment" id="login-required">
+    <textarea disabled id="comment" name="comment" cols="45" rows="4" placeholder="Something to say? Tell us what you loved about this. Inspire others, get typing" aria-required="true"></textarea>
+    </p>
+    <p class="form-submit">
+    <input name="submit" type="submit" id="submit" class="submit" value="Submit" disabled>
+    </p>
+    </form>	</div><!-- #respond -->
+	
+</div><!-- #comments -->
+                                    </div>
+                                                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                                <div class="sidebar col-md-12 col-lg-3">
+                    <div class="side-top-ad">
+                        <aside class="sidebar ad" id="recipeAd1">
+                            <div class="row no-gutters row-deep">
+                                <div class="col-12 align-self-start">
+                                    <!-- Advertisement: Desktop > 1024 -->
+                                    <div class="advert-content content-block double-margin">
+                                        <div class="ad-title">Advertisement</div>
+                                        <div id="adslot-recipe-4">
+                                            
+                                        </div>
+                                        <div id="adslot-recipe-7">
+                                            
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                                                            <div class="related-recipe-card">
+                                    <h3>Related recipe</h3>
+                                    <div class="card-bg card-utilities rec-tab">
+                                        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/chicken-with-fennel-and-thyme/">
+                                            <div class="card-img-wrapper">
+                                                <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="863" user_id="">
+                                                    <span class="save-icons">
+                                                        <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                        <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                    </span>
+                                                    <span class="text">Save recipe</span>
+                                                </div>
+
+                                                <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/07/493709-1-eng-GB_chicken-with-fennel-and-thyme-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                            </div>
+                                        </a>
+
+                                        <div class="card-body">
+                                            
+                                                <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chicken-breast-recipes/">
+                                                    <p class="article-cat">Chicken breast</p>
+                                                </a>
+                                            
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/chicken-with-fennel-and-thyme/">
+                                                <h4 class="card-title heading-std-text">Chicken with fennel and thyme</h4>
+                                            </a>
+                                        </div>
+
+                                        <div class="card-footer">
+                                            
+<div class="recipe-tags">
+        </div>                                            <div class="recipe-stats nav-list">
+                                                <ul>
+                                                    <li class="recipe-rating">
+                                                        <div id="yasr-vv-stars-stats-container-eb869e071f752"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-eb869e071f752" data-rating="4.8" data-rater-starsize="16" data-rater-postid="863" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>                                                    </li>
+                                                    <li class="recipe-skill">
+                                                        <span class="icon-inline icon-effort-main">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                        </span>
+
+                                                                                                                    <span>Easy</span>
+                                                                                                            </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                                    </aside>
+                    </div>
+
+                    <div class="side-bot-ad hide-tablet">
+                        <aside class="sidebar ad" id="recipeAd2">
+                            <div class="row no-gutters row-deep">
+                                <div class="col-12 align-self-start">
+                                    <div class="advert-content content-block double-margin">
+                                        <div class="ad-title">Advertisement</div>
+                                        <div id="adslot-recipe-5">
+                                            
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </aside>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+                    <section class="latest-recipes content-block">
+                <div class="row">
+                    <div class="slider-title">
+                        <div class="intro-text text-standard">
+                            <h2>Or, how about...?</h2>
+                        </div>
+                    </div>
+
+                    <div class="slider-wrapper">
+                        <div class="recipe-slider">
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/swede-kale-and-ditaloni-broth-with-pistachio-pistou/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="81159" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Kale-and-swede-broth-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/swede-recipes/">
+                                                        <p class="article-cat">Swede</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/swede-kale-and-ditaloni-broth-with-pistachio-pistou/">
+                                                    <h4 class="card-title heading-std-text">Swede, kale and ditaloni broth with pistachio pistou</h4>
+                                                </a>
+
+                                                <p>A pistachio, parsley and lemon pistou adds a verdant vibrancy...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-f6b7f786098e0"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-f6b7f786098e0" data-rating="0" data-rater-starsize="16" data-rater-postid="81159" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/pan-fried-mackerel-and-caramelised-radicchio-with-crushed-butterbeans/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="81149" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Pan-fried-mackerel-and-butterbean-mash-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/mackerel-recipes/">
+                                                        <p class="article-cat">Mackerel</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/pan-fried-mackerel-and-caramelised-radicchio-with-crushed-butterbeans/">
+                                                    <h4 class="card-title heading-std-text">Pan-fried mackerel and caramelised radicchio with crushed butter beans</h4>
+                                                </a>
+
+                                                <p>Rich, oily mackerel stands up to sweet and bitter caramelised...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+                <span class="tag">Dairy-free</span>
+                <span class="tag">Gluten-free</span>
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-ea9b6f8207676"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-ea9b6f8207676" data-rating="0" data-rater-starsize="16" data-rater-postid="81149" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/tomato-and-mango-chutney-glazed-paneer-on-spinach-cashew-rice/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="81162" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Tomato-and-mango-chutney-glazed-paneer-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/paneer-recipes/">
+                                                        <p class="article-cat">Paneer</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/tomato-and-mango-chutney-glazed-paneer-on-spinach-cashew-rice/">
+                                                    <h4 class="card-title heading-std-text">Tomato and mango chutney-glazed paneer on spinach cashew rice</h4>
+                                                </a>
+
+                                                <p>Make a quick sticky glaze for fried paneer using mango...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+                <span class="tag">Gluten-free</span>
+                <span class="tag">Vegetarian</span>
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-3eb07864876e9"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-3eb07864876e9" data-rating="0" data-rater-starsize="16" data-rater-postid="81162" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/venison-steaks-with-sweet-potato-fries-and-pickled-rhubarb/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="81142" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Venison-steaks-with-pickled-rhubarb-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/venison-recipes/">
+                                                        <p class="article-cat">Venison</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/venison-steaks-with-sweet-potato-fries-and-pickled-rhubarb/">
+                                                    <h4 class="card-title heading-std-text">Venison steaks with sweet potato fries and pickled rhubarb</h4>
+                                                </a>
+
+                                                <p>Pretty pink forced rhubarb makes a tart, bright accompaniment for...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+                <span class="tag">Freezable</span>
+                <span class="tag">Gluten-free</span>
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-9e6bd87072662"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-9e6bd87072662" data-rating="5" data-rater-starsize="16" data-rater-postid="81142" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/chicken-with-capers-lemon-chillies-and-thyme/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="78231" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/08/MG_3466-Edit-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chicken-thigh-recipes/">
+                                                        <p class="article-cat">Chicken thighs</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/chicken-with-capers-lemon-chillies-and-thyme/">
+                                                    <h4 class="card-title heading-std-text">Chicken with capers, lemon, chillies and thyme</h4>
+                                                </a>
+
+                                                <p>Give chicken thighs and drumsticks an Italian spin with this...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-07b69f667998e"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-07b69f667998e" data-rating="4" data-rater-starsize="16" data-rater-postid="78231" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                                <div class="latest-recipe-card">
+                                        <div class="card-bg card-utilities rec-tab">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/chicken-piccata-al-limone/">
+                                                <div class="card-img-wrapper">
+                                                    <div class="cta-icon icon-only cta-icon-not-saved-white cta-save-recipe" post_id="49719" user_id="">
+                                                        <span class="save-icons">
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/not-saved-white.svg" alt="Save recipe icon" class="save-icon" width="20" height="20"/>
+                                                            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/saved-white.svg" alt="Save recipe icon" class="save-icon-selected" width="20" height="20"/>
+                                                        </span>
+                                                        <span class="text">Save recipe</span>
+                                                    </div>
+
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2021/03/960-DELICIOUS_2021_Q1_LETTER_FOOD_HERO_CHICKEN_ESCALOPES_LEMON-299x310.jpg" alt="" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+                                            </a>
+
+                                            <div class="card-body">
+                                                
+                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/italian-chicken-recipes/">
+                                                        <p class="article-cat">Italian chicken</p>
+                                                    </a>
+                                                
+                                                <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/recipes/chicken-piccata-al-limone/">
+                                                    <h4 class="card-title heading-std-text">Chicken piccata al limone (chicken escalopes with lemon)</h4>
+                                                </a>
+
+                                                <p>Jacob Kenedy, the chef and owner of acclaimed London restaurant...</p>                                            </div>
+
+                                            <div class="card-footer">
+                                                
+<div class="recipe-tags">
+        </div>                                                <div class="recipe-stats nav-list">
+                                                    <ul>
+                                                        <li class="recipe-rating">
+                                                            <div id="yasr-vv-stars-stats-container-c26b0b727689e"><div class="yasr-rater-stars" id="yasr-visitor-votes-readonly-rater-c26b0b727689e" data-rating="4" data-rater-starsize="16" data-rater-postid="49719" data-rater-readonly="true" data-readonly-attribute="true" data-rater-nonce="389085776e"></div></div>                                                        </li>
+                                                        <li class="recipe-skill">
+                                                            <span class="icon-inline icon-effort-main">
+                                                                <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/effort-green.svg" alt="Effort icon" width="20" height="20"/>
+                                                            </span>
+
+                                                                                                                            <span>Easy</span>
+                                                                                                                    </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                                    </div>
+                    </div>
+                </div>
+            </section>
+            
+                    <section class="related-articles">
+                <div class="content-block">
+                    <div class="row">
+                        <div class="slider-title">
+                            <div class="intro-text text-standard">
+                                <h2>More food for thought...</h2>
+                            </div>
+                        </div>
+
+                        <div class="slider-wrapper">
+                            <div class="category-slider">
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/how-to-make-the-best-chicken-of-your-life/" class="card-utilities post-75224 post type-post status-publish format-standard has-post-thumbnail hentry category-features category-guides category-skills category-tips tag-be-a-better-cook tag-chicken tag-chicken-breasts tag-chicken-nicoise tag-chicken-thighs tag-cooking-chicken tag-how-to-cook-chicken-well tag-how-to-cook-the-best-chicken-thighs tag-how-to-roast-perfect-chicken tag-how-to-roast-the-best-chicken tag-pressed-chicken-thighs tag-roast-chicken tag-spatchcock-chicken">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/2024D029_CHICKEN_SPATCHCOCK_2__-299x238.jpg" alt="How to make the best chicken of your life" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Features</p>
+
+                                                    <h4 class="card-title">How to make the best chicken of your life</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Delicious. team</li>
+                                                            <li class="article-date">Apr 24</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/52-midweek-dinner-recipes/" class="card-utilities post-27209 post type-post status-publish format-standard has-post-thumbnail hentry category-guides category-round-ups tag-dinner tag-easy tag-midweek tag-quick tag-recipes tag-seasonal tag-supper tag-tea tag-vegetarian">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/52-midweek-dinner-recipes-299x238.jpg" alt="52 midweek dinner recipes" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Guides</p>
+
+                                                    <h4 class="card-title">52 midweek dinner recipes</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Delicious. team</li>
+                                                            <li class="article-date">Jan 22</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/best-of-the-best-how-to-make-the-ultimate-chicken-kyiv/" class="card-utilities post-78953 post type-post status-publish format-standard has-post-thumbnail hentry category-features category-guides category-skills tag-best-breadcrumbs-for-chicken-kyiv tag-best-chicken-kiev-recipe tag-best-chicken-kyiv tag-best-of-the-best tag-best-of-the-best-chicken-kiev tag-best-of-the-best-delicious-magazine tag-chicken-kiev-panko-breadcrumbs tag-chicken-kyiv tag-chicken-kyiv-or-kiev tag-garlic-butter-recipe tag-homemade-chicken-kiev-recipe tag-homemade-chicken-kievs tag-how-to-breadcrumb-chicken tag-how-to-breadcrumb-chicken-kyiv tag-how-to-make-chicken-kievs tag-how-to-make-chicken-kyiv tag-retro-recipe tag-ultimate-chicken-kyiv-recipe">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/09/2024D033_BOTB_KYIV_3-299x238.jpg" alt="Best of the best: How to make the ultimate chicken kyiv" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Guides</p>
+
+                                                    <h4 class="card-title">Best of the best: How to make the ultimate chicken kyiv</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Pollyanna Coupland</li>
+                                                            <li class="article-date">Oct 24</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                                        <div class="category-card">
+                                            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/best-leek-recipes/" class="card-utilities post-63182 post type-post status-publish format-standard has-post-thumbnail hentry category-guides category-round-ups tag-best-leek-recipes tag-cheesy-leeks tag-leek tag-leek-and-potato-soup tag-leek-pie tag-leek-recipes tag-leek-risotto tag-leeks tag-love-leeks">
+                                                <div class="card-img-wrapper">
+                                                    <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/960_2021D8_POTATO_LEEK_PIE-299x238.jpg" alt="17 of our best leek recipes" class="img-responsive card-img-top"/>
+
+                                                                                                    </div>
+
+                                                <div class="card-body">
+                                                    <p>Guides</p>
+
+                                                    <h4 class="card-title">17 of our best leek recipes</h4>
+
+                                                                                                    </div>
+
+                                                <div class="card-footer">
+                                                    <div class="article-stats nav-list">
+                                                        <ul>
+                                                            <li class="article-author">Thea Everett</li>
+                                                            <li class="article-date">Nov 22</li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        </div>
+                                                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        
+                    <section class="related-collections">
+                <div class="row no-gutters">
+                    <div class="col-sm-12">
+                        <div class="collections content-block double-margin">
+                            <div class="row">
+                                <div class="slider-title">
+                                    <div class="intro-text text-standard">
+                                        <h2>Related collections</h2>
+                                    </div>
+                                </div>
+
+                                <div class="slider-wrapper">
+                                    <div class="collection-slider">
+                                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/dinner-ideas-for-two/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/08/906488-1-eng-GB_recipes-for-2-people-299x238.jpg" alt="Recipes for 2 people" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">Dinner ideas for two</h4>
+
+                                                                                                                <p>Never mind Valentines Day, if you need dinner...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>253 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/polenta-recipes/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2019/09/Roast-tomatoes-and-aubergines-with-polenta-cheese-and-sourdough-299x238.jpg" alt="aubergines with polenta" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">Polenta</h4>
+
+                                                                                                                <p>Packet of polenta hiding in the back of...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>39 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/chicken-thigh-recipes/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2018/10/chicken-traybake-299x238.jpg" alt="chicken" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">Chicken thighs</h4>
+
+                                                                                                                <p>The thigh's the limit with our collection of...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>119 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                                    <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/collections/weeknight-recipes/" class="collection-card">
+                                                <div class="card-bg card-utilities">
+                                                    <div class="card-img-wrapper">
+                                                                                                                    <img data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/02/960-2023D038_PASSIVE_MEATBALLS-299x238.jpg" alt="Air fryer meatballs" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload" style="--smush-placeholder-width: 299px; --smush-placeholder-aspect-ratio: 299/238;"/>
+                                                        
+                                                                                                            </div>
+
+                                                    <div class="card-body">
+                                                        <h4 class="card-title heading-std-text">Weeknight</h4>
+
+                                                                                                                <p>Get a delicious dinner on the table in...</p>
+                                                    </div>
+
+                                                    <div class="card-footer">
+                                                        <p>205 Recipes</p>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                                                            </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        
+        <section class="sponsored-content">
+            <div class="row no-gutters">
+                <div class="col-12">
+                    <div class="outbrain-wrapper content-block double-margin">
+                        <div class="intro-text text-standard">
+                            <h2>More to discover</h2>
+                        </div>
+
+                        <div class="OUTBRAIN" data-src="https://web.archive.org/web/20250216023536oe_/https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/" data-widget-id="AR_1" data-ob-template="RadioTimes"></div>
+                        <script type="text/javascript" defer src="https://web.archive.org/web/20250216023536js_/https://widgets.outbrain.com/outbrain.js"></script>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        
+    <section id="subscribe-section" class="content-block double-margin">
+        <div class="row">
+                        <!-- <div class="col-sm-12">
+                <div class="newsletter-wrapper">
+                    <h2>Sign up to our newsletter</h2>
+                    <p>Sign up for our newsletter to stay up to date with all the latest news, recipes and offers.</p>
+                    <script type="text/javascript"></script>
+                <div class='gf_browser_unknown gform_wrapper gform_legacy_markup_wrapper gform-theme--no-framework' data-form-theme='legacy' data-form-index='0' id='gform_wrapper_73' ><div id='gf_73' class='gform_anchor' tabindex='-1'></div><form method='post' enctype='multipart/form-data' target='gform_ajax_frame_73' id='gform_73'  action='/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/#gf_73' data-formid='73' novalidate>
+                        <div class='gform-body gform_body'><ul id='gform_fields_73' class='gform_fields top_label form_sublabel_below description_below validation_below'><li id="field_73_1" class="gfield gfield--type-email gfield_contains_required field_sublabel_below gfield--no-description field_description_below field_validation_below gfield_visibility_visible"  data-js-reload="field_73_1" ><label class='gfield_label gform-field-label' for='input_73_1'>Email address<span class="gfield_required"><span class="gfield_required gfield_required_asterisk">*</span></span></label><div class='ginput_container ginput_container_email'>
+                            <input name='input_1' id='input_73_1' type='email' value='' class='large'   placeholder='Type your email here' aria-required="true" aria-invalid="false"  />
+                        </div></li></ul></div>
+        <div class='gform-footer gform_footer top_label'> <input type='submit' id='gform_submit_button_73' class='gform_button button' onclick='gform.submission.handleButtonClick(this);' value='Sign up now'  /> <input type='hidden' name='gform_ajax' value='form_id=73&amp;title=&amp;description=&amp;tabindex=0&amp;theme=legacy&amp;styles=[]&amp;hash=8e5bdf2c4ff61c3b1d141201e10d0174' />
+            <input type='hidden' class='gform_hidden' name='gform_submission_method' data-js='gform_submission_method_73' value='iframe' />
+            <input type='hidden' class='gform_hidden' name='gform_theme' data-js='gform_theme_73' id='gform_theme_73' value='legacy' />
+            <input type='hidden' class='gform_hidden' name='gform_style_settings' data-js='gform_style_settings_73' id='gform_style_settings_73' value='[]' />
+            <input type='hidden' class='gform_hidden' name='is_submit_73' value='1' />
+            <input type='hidden' class='gform_hidden' name='gform_submit' value='73' />
+            
+            <input type='hidden' class='gform_hidden' name='gform_unique_id' value='' />
+            <input type='hidden' class='gform_hidden' name='state_73' value='WyJbXSIsIjE4ODdmYWRhN2RhMzE1ODI5ZGY3NmZjYzY3ODM1MGE1Il0=' />
+            <input type='hidden' autocomplete='off' class='gform_hidden' name='gform_target_page_number_73' id='gform_target_page_number_73' value='0' />
+            <input type='hidden' autocomplete='off' class='gform_hidden' name='gform_source_page_number_73' id='gform_source_page_number_73' value='1' />
+            <input type='hidden' name='gform_field_values' value='' />
+            
+        </div>
+                        <p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="200"/><script>document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );</script></p></form>
+                        </div>
+		                <iframe style='display:none;width:0px;height:0px;' src='about:blank' name='gform_ajax_frame_73' id='gform_ajax_frame_73' title='This iframe contains the logic required to handle Ajax powered Gravity Forms.'></iframe>
+		                <script type="text/javascript">
+/* <![CDATA[ */
+ gform.initializeOnLoaded( function() {gformInitSpinner( 73, 'https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/images/spinner.svg', true );jQuery('#gform_ajax_frame_73').on('load',function(){var contents = jQuery(this).contents().find('*').html();var is_postback = contents.indexOf('GF_AJAX_POSTBACK') >= 0;if(!is_postback){return;}var form_content = jQuery(this).contents().find('#gform_wrapper_73');var is_confirmation = jQuery(this).contents().find('#gform_confirmation_wrapper_73').length > 0;var is_redirect = contents.indexOf('gformRedirect(){') >= 0;var is_form = form_content.length > 0 && ! is_redirect && ! is_confirmation;var mt = parseInt(jQuery('html').css('margin-top'), 10) + parseInt(jQuery('body').css('margin-top'), 10) + 100;if(is_form){jQuery('#gform_wrapper_73').html(form_content.html());if(form_content.hasClass('gform_validation_error')){jQuery('#gform_wrapper_73').addClass('gform_validation_error');} else {jQuery('#gform_wrapper_73').removeClass('gform_validation_error');}setTimeout( function() { /* delay the scroll by 50 milliseconds to fix a bug in chrome */ jQuery(document).scrollTop(jQuery('#gform_wrapper_73').offset().top - mt); }, 50 );if(window['gformInitDatepicker']) {gformInitDatepicker();}if(window['gformInitPriceFields']) {gformInitPriceFields();}var current_page = jQuery('#gform_source_page_number_73').val();gformInitSpinner( 73, 'https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/images/spinner.svg', true );jQuery(document).trigger('gform_page_loaded', [73, current_page]);window['gf_submitting_73'] = false;}else if(!is_redirect){var confirmation_content = jQuery(this).contents().find('.GF_AJAX_POSTBACK').html();if(!confirmation_content){confirmation_content = contents;}jQuery('#gform_wrapper_73').replaceWith(confirmation_content);jQuery(document).scrollTop(jQuery('#gf_73').offset().top - mt);jQuery(document).trigger('gform_confirmation_loaded', [73]);window['gf_submitting_73'] = false;wp.a11y.speak(jQuery('#gform_confirmation_message_73').text());}else{jQuery('#gform_73').append(contents);if(window['gformRedirect']) {gformRedirect();}}jQuery(document).trigger("gform_pre_post_render", [{ formId: "73", currentPage: "current_page", abort: function() { this.preventDefault(); } }]);                if (event && event.defaultPrevented) {                return;         }        const gformWrapperDiv = document.getElementById( "gform_wrapper_73" );        if ( gformWrapperDiv ) {            const visibilitySpan = document.createElement( "span" );            visibilitySpan.id = "gform_visibility_test_73";            gformWrapperDiv.insertAdjacentElement( "afterend", visibilitySpan );        }        const visibilityTestDiv = document.getElementById( "gform_visibility_test_73" );        let postRenderFired = false;                function triggerPostRender() {            if ( postRenderFired ) {                return;            }            postRenderFired = true;            jQuery( document ).trigger( 'gform_post_render', [73, current_page] );            gform.utils.trigger( { event: 'gform/postRender', native: false, data: { formId: 73, currentPage: current_page } } );            gform.utils.trigger( { event: 'gform/post_render', native: false, data: { formId: 73, currentPage: current_page } } );            if ( visibilityTestDiv ) {                visibilityTestDiv.parentNode.removeChild( visibilityTestDiv );            }        }        function debounce( func, wait, immediate ) {            var timeout;            return function() {                var context = this, args = arguments;                var later = function() {                    timeout = null;                    if ( !immediate ) func.apply( context, args );                };                var callNow = immediate && !timeout;                clearTimeout( timeout );                timeout = setTimeout( later, wait );                if ( callNow ) func.apply( context, args );            };        }        const debouncedTriggerPostRender = debounce( function() {            triggerPostRender();        }, 200 );        if ( visibilityTestDiv && visibilityTestDiv.offsetParent === null ) {            const observer = new MutationObserver( ( mutations ) => {                mutations.forEach( ( mutation ) => {                    if ( mutation.type === 'attributes' && visibilityTestDiv.offsetParent !== null ) {                        debouncedTriggerPostRender();                        observer.disconnect();                    }                });            });            observer.observe( document.body, {                attributes: true,                childList: false,                subtree: true,                attributeFilter: [ 'style', 'class' ],            });        } else {            triggerPostRender();        }    } );} ); 
+/* ]]> */
+</script>
+                </div>
+            </div> -->
+            
+            <div class="col-sm-12 col-md-6">
+                <div class="magazine-wrapper">
+                    
+                    <h3>Subscribe to our magazine</h3>
+
+                                            <p>Food stories, skills and tested recipes, straight to your door... Enjoy 5 issues for just £5 with our special introductory offer.</p>
+                    
+                                            <a href="https://web.archive.org/web/20250216023536/https://checkout.eyetoeyemedia.co.uk/singleitem?item=DLC&amp;prom=IDLC0225" target="_blank" title="Subscribe to Delicious magazine" class="bttn">Subscribe</a>
+                    
+                                            <div class="postal-magazine-cover">
+                            <img data-src="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/Feb-25-Delicious-magazine-footer-208x230.png" alt="" width="208px" height="230px" class="img-responsive lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" style="--smush-placeholder-width: 208px; --smush-placeholder-aspect-ratio: 208/230;"/>
+                        </div>
+                                    </div>
+            </div>
+
+            <div class="col-sm-12 col-md-6">
+                <div class="digital-download-wrapper">
+                    
+                    <h3>Unleash your inner chef</h3>
+
+                                            <p>Looking for inspiration? Receive the latest recipes with our newsletter</p>
+                    
+                                        
+                    <form method="POST">
+                        <input type="hidden" name="action" value="delish_subscribe_mailchimp"/>
+                        <input name="digital-magazine-email-address" type="email" placeholder="Email address">
+
+                                                    <div class="small-print"><p>We treat your data with care. See our <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/privacy-policy/">privacy policy</a>. By signing up, you are agreeing to delicious.&#8217; <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/terms-conditions/">terms and conditions</a>. Unsubscribe at any time.</p>
+</div>
+                        
+                        <input id="subscribeMailchimp" type="submit" value="Sign me up" class="bttn"/>
+                        <span class="response-container"></span>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </section>    </div>
+</main>
+
+
+<script type="application/ld+json">
+    {
+        "@type": "Recipe",
+        "@context": "https://web.archive.org/web/20250216023536/http://schema.org/",
+        "name": "Double lemon chicken with charred leeks and dill polenta",
+        "author": {
+            "@type": "Person",
+            "name": "delicious. magazine",
+                        "image" : [
+                {
+                    "@type" : "ImageObject",
+                    "inLanguage" : "en-UK",
+                    "@id"   : "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#/schema/person/image/",
+                    "name"  : "Emily Gussin",
+                    "url": "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/Emily-Gussin-100x100.jpg",
+                    "contentUrl": "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/Emily-Gussin-100x100.jpg",
+                    "caption" : "Emily Gussin"
+                }
+                ]
+                        },
+        "datePublished": "2025-02-04",
+                "dateModified": "2025-02-12",
+                "image": "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2025/01/2024D185-Lemony-chicken-and-baby-leeks.jpg",
+        "description": "Doubling up fresh and preserved lemons to lift this crème fraîche sauce makes for a zesty chicken dinner. Serve with charred leeks and creamy polenta. Polenta makes a great alternative to rice or potatoes. Discover more delicious polenta recipes.",
+        "keywords": "Double lemon chicken with charred leeks and dill polenta, ",
+        "prepTime": "PT15M",
+        "cookTime": "PT30M",
+         "totalTime": "PT0H45M",
+        "recipeYield": "Serves 2",
+        "recipeCategory": "Italian chicken",
+         "nutrition": {
+            "@type": "NutritionInformation",
+            "calories": "832kcals",
+            "fatContent": "48g (18g saturated)",
+            "proteinContent": "50g",
+            "carbohydrateContent": "47g (10g sugars)",
+            "fiberContent": "5.6g"
+        },
+        "recipeIngredient": ["4 tsp vegetable oil",
+"About 500g chicken thighs or thighs and drumsticks (skin on)",
+"1 garlic clove, finely chopped",
+"250ml chicken stock",
+"1 preserved lemon, pulp removed, rind finely chopped",
+"1 lemon",
+"2 tbsp crème fraîche",
+"175g baby leeks",
+
+"For the polenta",
+
+"250ml whole milk",
+"100g quick-cook polenta",
+"15g butter, plus extra to serve",
+"20g dill, chopped"],
+        "recipeInstructions": [
+                             {
+                        "@type": "HowToStep",
+                        "text": "Heat 2 tsp oil in a medium frying pan or sauté pan over a medium-high heat (you want a pan that will fit the chicken fairly snugly in one layer). Season the chicken, add to the pan skin-side-down and cook for 8 minutes until golden and crisp, then turn over and cook on the other side for 2 minutes. Lift onto a plate."
+                    },
+                
+                             {
+                        "@type": "HowToStep",
+                        "text": "Add the garlic to the pan, cook for 30 seconds, then pour in the stock and add the preserved lemon and lemon zest. Bring to a simmer, then stir in the crème fraîche and season with pepper. Return the chicken to the pan, keeping the  skin on top so it stays crisp. Simmer gently for 18-20 minutes until the chicken is cooked through."
+                    },
+                
+                             {
+                        "@type": "HowToStep",
+                        "text": "Meanwhile, heat a griddle pan over a high heat. Brush the leeks with 2 tsp oil and season with salt and pepper. Cook for 7 minutes on each side until charred and tender."
+                    },
+                
+                             {
+                        "@type": "HowToStep",
+                        "text": "For the polenta, heat the milk and 200g water in a pan, then whisk in the polenta and cook for 3-4 minutes. Beat in the butter and most of the dill, plus salt and pepper. Cut 2 small wedges from the zested lemon, then juice the rest and stir into the chicken sauce. Divide the polenta between bowls and top with the saucy chicken, scattering over the remaining dill and adding the lemon wedges to the side of the plate for squeezing over."
+                    }
+                
+                    ] ,
+        "mainEntityOfPage" : true,
+        "aggregateRating": {
+            "@type": "AggregateRating",
+            "ratingValue": "5",
+
+            "reviewCount": "2"
+        }
+        
+    }
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://web.archive.org/web/20250216023536/https://schema.org",
+  "@type": "Person",
+  "name": "Emily Gussin",    "image" : [
+    {
+        "@type" : "ImageObject",
+        "inLanguage" : "en-UK",
+        "@id"   : "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/#/schema/person/image/",
+        "name"  : "Emily Gussin",
+        "url": "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/Emily-Gussin-100x100.jpg",
+        "contentUrl": "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-content/uploads/2024/03/Emily-Gussin-100x100.jpg",
+        "caption" : "Emily Gussin"
+    }
+    ]
+    }
+</script>
+
+
+<script type="text/javascript">
+    (function($) {
+        $(document).ready(function() {
+            //    event.preventDefault();
+            var page = 2;
+
+            $('.bttn-icon-save, .cta-icon-not-saved-white, .bttn-icon-remove').click(function(e) {
+                if ($(this).attr('href') != 'https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login') {
+                    e.defaultPrevented = false;
+                    return false;
+                }
+            });
+
+            $('a.bttn-icon-save').click(function(e) {
+                var post_id = $(this).attr('post_id');
+                var user_id = $(this).attr('user_id');
+                var field = 'recipes';
+                $(this).parent().parent().addClass('recipe-card--loading');
+                $.ajax({
+                    url: "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php",
+                    data: {
+                        'action': 'get_recipes_save',
+                        'post_id': post_id,
+                        'user_id': user_id
+                        //'field' : field,
+                    },
+                    success: function(data) {
+                        $('.btn-' + post_id).parent().parent().removeClass('recipe-card--loading');
+                        $('a.bttn-icon-save').hide();
+                        $('a.bttn-icon-remove').show();
+                    }
+                });
+            });
+
+            $('.cta-icon-not-saved-white').click(function(e) {
+                var post_id = $(this).attr('post_id');
+                var user_id = $(this).attr('user_id');
+                var field = 'recipes';
+                $(this).parent().parent().addClass('recipe-card--loading');
+                $.ajax({
+                    url: "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php",
+                    data: {
+                        'action': 'get_recipes_save',
+                        'post_id': post_id,
+                        'user_id': user_id
+                        //'field' : field,
+                    },
+                    success: function(data) {
+                        $('.btn-' + post_id).parent().parent().removeClass('recipe-card--loading');
+                        $('a.bttn-icon-save').hide();
+                        $('a.bttn-icon-remove').show();
+                    }
+                });
+            });
+
+            $('a.bttn-icon-remove').click(function(e) {
+                var post_id = $(this).attr('post_id');
+                var user_id = $(this).attr('user_id');
+                var field = 'recipes';
+                $(this).parent().parent().addClass('recipe-card--loading');
+                $.ajax({
+                    url: "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php",
+                    data: {
+                        'action': 'get_recipes_delete',
+                        'post_id': post_id,
+                        'user_id': user_id,
+                        'field': field,
+                    },
+                    success: function(data) {
+                        $('.btn-' + post_id).parent().parent().removeClass('recipe-card--loading');
+                        $('a.bttn-icon-remove').hide();
+                        $('a.bttn-icon-save').show();
+                    }
+                });
+            });
+
+        })
+
+    })(jQuery);
+</script>
+
+
+<footer class="content-wrapper">
+    <div class="footer-wrapper">
+        <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/">
+            <img src="https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/images/logos/delicious-black.svg" alt="Delicious logo" class="footer-logo" width="231" height="43"/>
+        </a>
+
+        <div class="social-links">
+            <p>Stay in touch - and share</p>
+
+            <div class="social-sharing-links">
+                <div class="row no-gutters">
+                    <ul>
+                                                    <li><a href="https://web.archive.org/web/20250216023536/https://www.facebook.com/deliciousmagazineuk/" target="_blank"><i class="fab fa-facebook-f"></i></a></li>
+                                                                            <li><a href="https://web.archive.org/web/20250216023536/https://www.instagram.com/deliciousmag/" target="_blank"><i class="fab fa-instagram"></i></a></li>
+                                                                                                    <li><a href="https://web.archive.org/web/20250216023536/https://www.tiktok.com/@deliciousmag/" target="_blank"><i class="fa-brands fa-tiktok"></i></a></li>
+                                                                            <li><a href="https://web.archive.org/web/20250216023536/https://www.pinterest.co.uk/deliciousmaguk/" target="_blank"><i class="fab fa-pinterest-p"></i></a></li>
+                                                                            <li><a href="https://web.archive.org/web/20250216023536/https://www.youtube.com/user/deliciousmagazineuk/" target="_blank"><i class="fab fa-youtube"></i></a></li>
+                                            </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="content-block">
+            <div class="footer-links">
+                
+    <nav class="nav-links">
+        <div class="menu-footer-links-container"><ul id="footer-links" class="menu"><li id="menu-item-16194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16194"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/about/">About</a></li>
+<li id="menu-item-48077" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48077"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/meet-the-food-team/">Food team</a></li>
+<li id="menu-item-63586" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-63586"><a href="https://web.archive.org/web/20250216023536/https://www.subscription.co.uk/EyeToEye/DLC/">Print issues</a></li>
+<li id="menu-item-73798" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-73798"><a href="https://web.archive.org/web/20250216023536/https://pocketmags.com/publishers/eye-to-eye/delicious-magazine#659d680146925">Digital issues</a></li>
+<li id="menu-item-16193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16193"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/contact/">Contact</a></li>
+<li id="menu-item-43781" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-43781"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/sitemap/">Sitemap</a></li>
+<li id="menu-item-16189" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16189"><a rel="nofollow" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/cookie-policy/">Cookies</a></li>
+<li id="menu-item-16190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16190"><a rel="nofollow" href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/privacy-policy/">Privacy policy</a></li>
+<li id="menu-item-46577" class="menu-item menu-item-type-post_type menu-item-object-post menu-item-46577"><a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/want-to-advertise-with-delicious/">Advertise</a></li>
+</ul></div>    </nav>
+            </div>
+
+            <div class="eye-to-eye-copy">
+                <p>Delicious magazine is a part of Eye to Eye Media Ltd &copy; 2025</p>
+            </div>
+        </div>
+    </div>
+</footer>
+
+<footer class="print-footer">
+    <p>Find it online: https://www.deliciousmagazine.co.uk/recipes/double-lemon-chicken-with-charred-leeks-and-dill-polenta/</p>
+</footer>
+
+
+<!-- Lost password Modal -->
+<div class="remodal small" data-remodal-id="forgot-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Lost my password</h2>
+    <p>
+        Enter the email address associated with your<br> account, and we'll send you a link to reset your<br> password.
+    </p>
+
+    
+    <div class="row remodal_form">
+        <form name="lostpasswordform" id="lostpasswordform" action="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login/?action=lostpassword" method="post">
+            <div class="col-12">
+                <label for="email">Email*</label>
+            </div>
+            <div class="col-12 col-md-8">
+                <input type="email" name="user_login" id="user_login" value="" placeholder="Type your email here">
+            </div>
+            <div class="col-12 col-md-8">
+                <div class="g-recaptcha" data-sitekey="6Ldevc4ZAAAAAKwipl4I1aW9Zy1SUHBzGp8ujT3w"></div>
+            </div>
+            <div class="col-12 col-md-4 text-center">
+                <input type="submit" name="wp-submit" id="wp-submit" value="Send me" class="greenbutton">
+            </div>
+        </form>
+    </div>
+</div>
+<!--// Lost password Modal -->
+
+<!-- Email Sent Modal -->
+<div class="remodal small" data-remodal-id="sent-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Email sent</h2>
+    <p>
+        If an account was found for this email address, <br>we've emailed you instructions to reset your <br>password.
+    </p>
+    <div class="row remodal_form">
+        <div class="col-12">
+            <a href="https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/login/#forgot-modal" class="greenborder">I didn't receive it</a>
+        </div>
+    </div>
+</div>
+<!--// Email Sent Modal -->
+
+<!-- Thanks Modal -->
+<div class="remodal small" data-remodal-id="thanks-modal" id="thanks-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Thank you for signing up to our newsletter</h2>
+    <p>
+        Now you can stay up to date with all the latest news, recipes and offers.
+    </p>
+    <div class="row remodal_form">
+        <div class="col-12">
+            <a href="#" class="greenbutton" data-remodal-action="confirm">Continue exploring</a>
+        </div>
+    </div>
+</div>
+<!--// Thanks Modal -->
+
+<!-- Subscribe Modal -->
+<div class="remodal small" data-remodal-id="subscribe-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Subscribe to our magazine</h2>
+    <p>
+        Subscribe to delicious. today for just £13.50 – that's HALF PRICE!
+    </p>
+    <div class="row remodal_form">
+        [mc4wp_form id="28909"]        <!-- <form name="subscribeform" id="subscribeform" action="/" method="post">
+                <div class="col-12">
+                    <label for="email">Email*</label>
+                </div>
+                <div class="col-12 col-md-12">
+                    <input type="email"  name="user_login" id="user_login" value="" placeholder="Type your email here">
+                </div>
+                <div class="col-12 col-md-12 text-center">
+                    <input type="submit"  name="wp-submit" id="wp-submit" value="Subscribe"  class="greenbutton">
+                </div>
+            </form> -->
+    </div>
+</div>
+<!--// Subscribe Modal -->
+
+<!-- Confirm Modal -->
+<div class="remodal confirm" data-remodal-id="confirm-modal" id="confirm-modal">
+    <div class="remodal_close_wrap">
+        <button data-remodal-action="close" class="remodal-close">Close</button>
+    </div>
+    <h2>Confirmation</h2>
+    <p>
+        We have sent you an activation link,<br>
+        please click this link to activate your account.
+
+    </p>
+    <div class="row remodal_form">
+        <div class="col-12">
+            <a data-remodal-target="#" href="#" class="greenbutton" data-remodal-action="confirm">Continue exploring</a>
+        </div>
+    </div>
+</div>
+
+<!-- ShopThru Code -->
+<script src="https://web.archive.org/web/20250216023536js_/https://assets.shopthruapp.com/e/9d540dbb-ed73-456e-89eb-006ec692c352/prod/embed.js" defer></script>
+
+
+<? //  SUBX CODE 
+?>
+<script type="text/javascript" src="//web.archive.org/web/20250216023536js_/https://d2ip7iv1l4ergv.cloudfront.net/embed/widget/ZITWidget.min.js" defer></script>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-panel" animation-type="popup"></div>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-panel" animation-type="slide"></div>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-email" animation-type="popup"></div>
+<div class="zeddit-rcm" data-pid="1012" data-type="canvas-email" animation-type="slide"></div>
+
+
+<link rel="stylesheet" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/css/fontawesome/css/all.min.css?ver=5.5.1" media="print" onload="this.media='all'">
+
+<!-- Custom Feeds for Instagram JS -->
+<script type="text/javascript">
+var sbiajaxurl = "https://web.archive.org/web/20250216023536/https://www.deliciousmagazine.co.uk/wp-admin/admin-ajax.php";
+
+</script>
+<link rel="stylesheet" id="yasrcss-css" href="https://web.archive.org/web/20250216023536cs_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/css/yasr.css?ver=3.4.12" type="text/css" media="all"/>
+<style id="yasrcss-inline-css" type="text/css">
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+
+            .yasr-star-rating {
+                background-image: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_2.svg');
+            }
+            .yasr-star-rating .yasr-star-value {
+                background: url('https://web.archive.org/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/img/star_3.svg') ;
+            }
+.rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.rateit .rateit-selected,
+.rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+div.bigstars .rateit-selected,
+div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important; 
+}
+div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+
+.star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left -36px !important;
+}
+.star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left 0px !important;
+}
+.yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+.yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_flat.png) left -74px !important;
+}
+
+/* GREEN NAV STYLES */
+.nav-page-utilities .rateit .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .rateit .rateit-selected,
+.nav-page-utilities .rateit .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -37px !important;
+}
+
+.nav-page-utilities div.bigstars .rateit-range {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities div.bigstars .rateit-selected,
+.nav-page-utilities div.bigstars .rateit-hover {
+  background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important; 
+}
+.nav-page-utilities div.medium .rateit-range{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities div.medium .rateit-selected{
+background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+
+.nav-page-utilities .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left -36px !important;
+}
+.nav-page-utilities .star-rating, .star-rating:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_16_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left 0px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+.nav-page-utilities .yasr-visitor-votes .star-rating .star-value:hover {
+    background: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/icons/stars_32_white.png) left -74px !important;
+}
+
+.yasr-star-rating {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2023/03/off.svg);
+}
+.yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/07/on.svg);
+}
+
+/* Christmas theme active star */
+.christmas-theme .yasr-star-rating .yasr-star-value {
+	background-image: url(/web/20250216023536im_/https://www.deliciousmagazine.co.uk/wp-content/uploads/2022/11/on-cranberry.svg);
+}
+</style>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/mobilemenu.js?ver=1.6.2" id="mobilemenu-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/bootstrap.min.js" id="bootstrap-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/vendor/slick/slick.min.js?ver=1.8.1" id="slick-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/jquery.formstyler.min.js?ver=6.7.1" id="formstyler-js-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/nosleep.min.js" id="nosleep-js"></script>
+<script type="text/javascript" id="scripts-js-extra">
+/* <![CDATA[ */
+var ajax_object = {"ajax_url":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/scripts.min.js?ver=1.11.0" id="scripts-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/themes/delicious/assets/js/cookie.js?ver=1.0.0" id="cookies-js"></script>
+<script type="text/javascript" id="yasr-window-var-js-extra">
+/* <![CDATA[ */
+var yasrWindowVar = {"siteUrl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk","adminUrl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/","ajaxurl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/admin-ajax.php","visitorStatsEnabled":"no","ajaxEnabled":"yes","loaderHtml":"<div id=\"yasr-loader\" style=\"display: inline-block\">\u00a0 <img src=\"https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/yet-another-stars-rating\/includes\/img\/loader.gif\" \n                 title=\"yasr-loader\" alt=\"yasr-loader\" height=\"16\" width=\"16\"><\/div>","loaderUrl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/yet-another-stars-rating\/includes\/img\/loader.gif","isUserLoggedIn":"false","isRtl":"false","starSingleForm":"\"star\"","starsPluralForm":"\"stars\"","textAfterVr":"\"%average% votes\"","textRating":"\"Rating\"","textLoadRanking":"\"Loading, please wait\"","textVvStats":"\"out of 5 stars\"","textOrderBy":"\"Order by\"","textMostRated":"\"Most Rated\"","textHighestRated":"\"Highest Rated\"","textLeftColumnHeader":"\"Post\""};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/wp-smush-pro/app/assets/js/smush-lazy-load.min.js?ver=3.16.11" id="smush-lazy-load-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/js/yasr-globals.js?ver=3.4.12" id="yasr-global-functions-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/yet-another-stars-rating/includes/js/shortcodes/overall-multiset.js?ver=3.4.12" id="yasr-ov-multi-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/dom-ready.min.js?ver=f77871ff7694fffea381" id="wp-dom-ready-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/hooks.min.js?ver=4d63a3d491d11ffd8ac6" id="wp-hooks-js"></script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/i18n.min.js?ver=5e580eb46a90c2b997e6" id="wp-i18n-js"></script>
+<script type="text/javascript" id="wp-i18n-js-after">
+/* <![CDATA[ */
+wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );
+/* ]]> */
+</script>
+<script type="text/javascript" id="wp-a11y-js-translations">
+/* <![CDATA[ */
+( function( domain, translations ) {
+	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
+	localeData[""].domain = domain;
+	wp.i18n.setLocaleData( localeData, domain );
+} )( "default", {"translation-revision-date":"2024-11-14 20:13:08+0000","generator":"GlotPress\/4.0.1","domain":"messages","locale_data":{"messages":{"":{"domain":"messages","plural-forms":"nplurals=2; plural=n != 1;","lang":"en_GB"},"Notifications":["Notifications"]}},"comment":{"reference":"wp-includes\/js\/dist\/a11y.js"}} );
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-includes/js/dist/a11y.min.js?ver=3156534cc54473497e14" id="wp-a11y-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/js/jquery.json.min.js?ver=2.9.3" id="gform_json-js"></script>
+<script type="text/javascript" id="gform_gravityforms-js-extra">
+/* <![CDATA[ */
+var gform_i18n = {"datepicker":{"days":{"monday":"Mo","tuesday":"Tu","wednesday":"We","thursday":"Th","friday":"Fr","saturday":"Sa","sunday":"Su"},"months":{"january":"January","february":"February","march":"March","april":"April","may":"May","june":"June","july":"July","august":"August","september":"September","october":"October","november":"November","december":"December"},"firstDay":1,"iconText":"Select date"}};
+var gf_legacy_multi = [];
+var gform_gravityforms = {"strings":{"invalid_file_extension":"This type of file is not allowed. Must be one of the following:","delete_file":"Delete this file","in_progress":"in progress","file_exceeds_limit":"File exceeds size limit","illegal_extension":"This type of file is not allowed.","max_reached":"Maximum number of files reached","unknown_error":"There was a problem while saving the file on the server","currently_uploading":"Please wait for the uploading to complete","cancel":"Cancel","cancel_upload":"Cancel this upload","cancelled":"Cancelled"},"vars":{"images_url":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms\/images"}};
+var gf_global = {"gf_currency_config":{"name":"Pound Sterling","symbol_left":"&#163;","symbol_right":"","symbol_padding":" ","thousand_separator":",","decimal_separator":".","decimals":2,"code":"GBP"},"base_url":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms","number_formats":[],"spinnerUrl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms\/images\/spinner.svg","version_hash":"e9ef442de89e16035c39e11d1a579aba","strings":{"newRowAdded":"New row added.","rowRemoved":"Row removed","formSaved":"The form has been saved.  The content contains the link to return and complete the form."}};
+/* ]]> */
+</script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/js/gravityforms.min.js?ver=2.9.3" id="gform_gravityforms-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/js/placeholders.jquery.min.js?ver=2.9.3" id="gform_placeholder-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/assets/js/dist/utils.min.js?ver=501a987060f4426fb517400c73c7fc1e" id="gform_gravityforms_utils-js"></script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/assets/js/dist/vendor-theme.min.js?ver=ddd2702ee024d421149a5e61416f1ff5" id="gform_gravityforms_theme_vendors-js"></script>
+<script type="text/javascript" id="gform_gravityforms_theme-js-extra">
+/* <![CDATA[ */
+var gform_theme_config = {"common":{"form":{"honeypot":{"version_hash":"e9ef442de89e16035c39e11d1a579aba"},"ajax":{"ajaxurl":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-admin\/admin-ajax.php","ajax_submission_nonce":"4022480613","i18n":{"step_announcement":"Step %1$s of %2$s, %3$s","unknown_error":"There was an unknown error processing your request. Please try again."}}}},"hmr_dev":"","public_path":"https:\/\/web.archive.org\/web\/20250216023536\/https:\/\/www.deliciousmagazine.co.uk\/wp-content\/plugins\/gravityforms\/assets\/js\/dist\/","config_nonce":"6e61a78c39"};
+/* ]]> */
+</script>
+<script type="text/javascript" defer="defer" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/gravityforms/assets/js/dist/scripts-theme.min.js?ver=cd31c16637eeae0b20e422009e5a8b28" id="gform_gravityforms_theme-js"></script>
+<script defer type="text/javascript" src="https://web.archive.org/web/20250216023536js_/https://www.deliciousmagazine.co.uk/wp-content/plugins/akismet/_inc/akismet-frontend.js?ver=1739440842" id="akismet-frontend-js"></script>
+<script type="text/javascript">(function (undefined) {let scriptOptions={"_localizedStrings":{"redirect_overlay_title":"Hold On","redirect_overlay_text":"You are being redirected to another page,<br>it may take a few seconds.","webview_notification_text":"The selected provider doesn't support embedded browsers!"},"_targetWindow":"prefer-popup","_redirectOverlay":"overlay-with-spinner-and-message","_unsupportedWebviewBehavior":""};
+/**
+ * Used when Cross-Origin-Opener-Policy blocked the access to the opener. We can't have a reference of the opened windows, so we should attempt to refresh only the windows that has opened popups.
+ */
+window._nslHasOpenedPopup = false;
+window._nslWebViewNoticeElement = null;
+
+window.NSLPopup = function (url, title, w, h) {
+
+    /**
+     * Cross-Origin-Opener-Policy blocked the access to the opener
+     */
+    if (typeof BroadcastChannel === "function") {
+        const _nslLoginBroadCastChannel = new BroadcastChannel('nsl_login_broadcast_channel');
+        _nslLoginBroadCastChannel.onmessage = (event) => {
+            if (window?._nslHasOpenedPopup && event.data?.action === 'redirect') {
+                window._nslHasOpenedPopup = false;
+
+                const url = event.data?.href;
+                _nslLoginBroadCastChannel.close();
+                if (typeof window.nslRedirect === 'function') {
+                    window.nslRedirect(url);
+                } else {
+                    window.opener.location = url;
+                }
+            }
+        };
+    }
+
+    const userAgent = navigator.userAgent,
+        mobile = function () {
+            return /\b(iPhone|iP[ao]d)/.test(userAgent) ||
+                /\b(iP[ao]d)/.test(userAgent) ||
+                /Android/i.test(userAgent) ||
+                /Mobile/i.test(userAgent);
+        },
+        screenX = window.screenX !== undefined ? window.screenX : window.screenLeft,
+        screenY = window.screenY !== undefined ? window.screenY : window.screenTop,
+        outerWidth = window.outerWidth !== undefined ? window.outerWidth : document.documentElement.clientWidth,
+        outerHeight = window.outerHeight !== undefined ? window.outerHeight : document.documentElement.clientHeight - 22,
+        targetWidth = mobile() ? null : w,
+        targetHeight = mobile() ? null : h,
+        left = parseInt(screenX + (outerWidth - targetWidth) / 2, 10),
+        right = parseInt(screenY + (outerHeight - targetHeight) / 2.5, 10),
+        features = [];
+    if (targetWidth !== null) {
+        features.push('width=' + targetWidth);
+    }
+    if (targetHeight !== null) {
+        features.push('height=' + targetHeight);
+    }
+    features.push('left=' + left);
+    features.push('top=' + right);
+    features.push('scrollbars=1');
+
+    const newWindow = window.open(url, title, features.join(','));
+
+    if (window.focus) {
+        newWindow.focus();
+    }
+
+    window._nslHasOpenedPopup = true;
+
+    return newWindow;
+};
+
+let isWebView = null;
+
+function checkWebView() {
+    if (isWebView === null) {
+        function _detectOS(ua) {
+            if (/Android/.test(ua)) {
+                return "Android";
+            } else if (/iPhone|iPad|iPod/.test(ua)) {
+                return "iOS";
+            } else if (/Windows/.test(ua)) {
+                return "Windows";
+            } else if (/Mac OS X/.test(ua)) {
+                return "Mac";
+            } else if (/CrOS/.test(ua)) {
+                return "Chrome OS";
+            } else if (/Firefox/.test(ua)) {
+                return "Firefox OS";
+            }
+            return "";
+        }
+
+        function _detectBrowser(ua) {
+            let android = /Android/.test(ua);
+
+            if (/Opera Mini/.test(ua) || / OPR/.test(ua) || / OPT/.test(ua)) {
+                return "Opera";
+            } else if (/CriOS/.test(ua)) {
+                return "Chrome for iOS";
+            } else if (/Edge/.test(ua)) {
+                return "Edge";
+            } else if (android && /Silk\//.test(ua)) {
+                return "Silk";
+            } else if (/Chrome/.test(ua)) {
+                return "Chrome";
+            } else if (/Firefox/.test(ua)) {
+                return "Firefox";
+            } else if (android) {
+                return "AOSP";
+            } else if (/MSIE|Trident/.test(ua)) {
+                return "IE";
+            } else if (/Safari\//.test(ua)) {
+                return "Safari";
+            } else if (/AppleWebKit/.test(ua)) {
+                return "WebKit";
+            }
+            return "";
+        }
+
+        function _detectBrowserVersion(ua, browser) {
+            if (browser === "Opera") {
+                return /Opera Mini/.test(ua) ? _getVersion(ua, "Opera Mini/") :
+                    / OPR/.test(ua) ? _getVersion(ua, " OPR/") :
+                        _getVersion(ua, " OPT/");
+            } else if (browser === "Chrome for iOS") {
+                return _getVersion(ua, "CriOS/");
+            } else if (browser === "Edge") {
+                return _getVersion(ua, "Edge/");
+            } else if (browser === "Chrome") {
+                return _getVersion(ua, "Chrome/");
+            } else if (browser === "Firefox") {
+                return _getVersion(ua, "Firefox/");
+            } else if (browser === "Silk") {
+                return _getVersion(ua, "Silk/");
+            } else if (browser === "AOSP") {
+                return _getVersion(ua, "Version/");
+            } else if (browser === "IE") {
+                return /IEMobile/.test(ua) ? _getVersion(ua, "IEMobile/") :
+                    /MSIE/.test(ua) ? _getVersion(ua, "MSIE ")
+                        :
+                        _getVersion(ua, "rv:");
+            } else if (browser === "Safari") {
+                return _getVersion(ua, "Version/");
+            } else if (browser === "WebKit") {
+                return _getVersion(ua, "WebKit/");
+            }
+            return "0.0.0";
+        }
+
+        function _getVersion(ua, token) {
+            try {
+                return _normalizeSemverString(ua.split(token)[1].trim().split(/[^\w\.]/)[0]);
+            } catch (o_O) {
+            }
+            return "0.0.0";
+        }
+
+        function _normalizeSemverString(version) {
+            const ary = version.split(/[\._]/);
+            return (parseInt(ary[0], 10) || 0) + "." +
+                (parseInt(ary[1], 10) || 0) + "." +
+                (parseInt(ary[2], 10) || 0);
+        }
+
+        function _isWebView(ua, os, browser, version, options) {
+            switch (os + browser) {
+                case "iOSSafari":
+                    return false;
+                case "iOSWebKit":
+                    return _isWebView_iOS(options);
+                case "AndroidAOSP":
+                    return false;
+                case "AndroidChrome":
+                    return parseFloat(version) >= 42 ? /; wv/.test(ua) : /\d{2}\.0\.0/.test(version) ? true : _isWebView_Android(options);
+            }
+            return false;
+        }
+
+        function _isWebView_iOS(options) {
+            const document = (window["document"] || {});
+
+            if ("WEB_VIEW" in options) {
+                return options["WEB_VIEW"];
+            }
+            return !("fullscreenEnabled" in document || "webkitFullscreenEnabled" in document || false);
+        }
+
+        function _isWebView_Android(options) {
+            if ("WEB_VIEW" in options) {
+                return options["WEB_VIEW"];
+            }
+            return !("requestFileSystem" in window || "webkitRequestFileSystem" in window || false);
+        }
+
+        const options = {},
+            nav = window.navigator || {},
+            ua = nav.userAgent || "",
+            os = _detectOS(ua),
+            browser = _detectBrowser(ua),
+            browserVersion = _detectBrowserVersion(ua, browser);
+
+        isWebView = _isWebView(ua, os, browser, browserVersion, options);
+    }
+
+    return isWebView;
+}
+
+function isAllowedWebViewForUserAgent(provider) {
+    const facebookAllowedWebViews = [
+        'Instagram',
+        'FBAV',
+        'FBAN'
+    ];
+    let whitelist = [];
+
+    if (provider && provider === 'facebook') {
+        whitelist = facebookAllowedWebViews;
+    }
+
+    const nav = window.navigator || {},
+        ua = nav.userAgent || "";
+
+    if (whitelist.length && ua.match(new RegExp(whitelist.join('|')))) {
+        return true;
+    }
+
+    return false;
+}
+
+function disableButtonInWebView(providerButtonElement) {
+    if (providerButtonElement) {
+        providerButtonElement.classList.add('nsl-disabled-provider');
+        providerButtonElement.setAttribute('href', '#');
+
+        providerButtonElement.addEventListener('pointerdown', (e) => {
+            if (!window._nslWebViewNoticeElement) {
+                window._nslWebViewNoticeElement = document.createElement('div');
+                window._nslWebViewNoticeElement.id = "nsl-notices-fallback";
+                window._nslWebViewNoticeElement.addEventListener('pointerdown', function (e) {
+                    this.parentNode.removeChild(this);
+                    window._nslWebViewNoticeElement = null;
+                });
+                const webviewNoticeHTML = '<div class="error"><p>' + scriptOptions._localizedStrings.webview_notification_text + '</p></div>';
+
+                window._nslWebViewNoticeElement.insertAdjacentHTML("afterbegin", webviewNoticeHTML);
+                document.body.appendChild(window._nslWebViewNoticeElement);
+            }
+        });
+    }
+
+}
+
+window._nslDOMReady(function () {
+
+    window.nslRedirect = function (url) {
+        if (scriptOptions._redirectOverlay) {
+            const overlay = document.createElement('div');
+            overlay.id = "nsl-redirect-overlay";
+            let overlayHTML = '';
+            const overlayContainer = "<div id='nsl-redirect-overlay-container'>",
+                overlayContainerClose = "</div>",
+                overlaySpinner = "<div id='nsl-redirect-overlay-spinner'></div>",
+                overlayTitle = "<p id='nsl-redirect-overlay-title'>" + scriptOptions._localizedStrings.redirect_overlay_title + "</p>",
+                overlayText = "<p id='nsl-redirect-overlay-text'>" + scriptOptions._localizedStrings.redirect_overlay_text + "</p>";
+
+            switch (scriptOptions._redirectOverlay) {
+                case "overlay-only":
+                    break;
+                case "overlay-with-spinner":
+                    overlayHTML = overlayContainer + overlaySpinner + overlayContainerClose;
+                    break;
+                default:
+                    overlayHTML = overlayContainer + overlaySpinner + overlayTitle + overlayText + overlayContainerClose;
+                    break;
+            }
+
+            overlay.insertAdjacentHTML("afterbegin", overlayHTML);
+            document.body.appendChild(overlay);
+        }
+
+        window.location = url;
+    };
+
+    let targetWindow = scriptOptions._targetWindow || 'prefer-popup',
+        lastPopup = false;
+
+
+    document.addEventListener('click', function (e) {
+        if (e.target) {
+            const buttonLinkElement = e.target.closest('a[data-plugin="nsl"][data-action="connect"]') || e.target.closest('a[data-plugin="nsl"][data-action="link"]');
+            if (buttonLinkElement) {
+                if (lastPopup && !lastPopup.closed) {
+                    e.preventDefault();
+                    lastPopup.focus();
+                } else {
+
+                    let href = buttonLinkElement.href,
+                        success = false;
+                    if (href.indexOf('?') !== -1) {
+                        href += '&';
+                    } else {
+                        href += '?';
+                    }
+
+                    const redirectTo = buttonLinkElement.dataset.redirect;
+                    if (redirectTo === 'current') {
+                        href += 'redirect=' + encodeURIComponent(window.location.href) + '&';
+                    } else if (redirectTo && redirectTo !== '') {
+                        href += 'redirect=' + encodeURIComponent(redirectTo) + '&';
+                    }
+
+                    if (targetWindow !== 'prefer-same-window' && checkWebView()) {
+                        targetWindow = 'prefer-same-window';
+                    }
+
+                    if (targetWindow === 'prefer-popup') {
+                        lastPopup = NSLPopup(href + 'display=popup', 'nsl-social-connect', buttonLinkElement.dataset.popupwidth, buttonLinkElement.dataset.popupheight);
+                        if (lastPopup) {
+                            success = true;
+                            e.preventDefault();
+                        }
+                    } else if (targetWindow === 'prefer-new-tab') {
+                        const newTab = window.open(href + 'display=popup', '_blank');
+                        if (newTab) {
+                            if (window.focus) {
+                                newTab.focus();
+                            }
+                            success = true;
+                            window._nslHasOpenedPopup = true;
+                            e.preventDefault();
+                        }
+                    }
+
+                    if (!success) {
+                        window.location = href;
+                        e.preventDefault();
+                    }
+                }
+            }
+        }
+    });
+
+    let buttonCountChanged = false;
+
+    const googleLoginButtons = document.querySelectorAll(' a[data-plugin="nsl"][data-provider="google"]');
+    if (googleLoginButtons.length && checkWebView()) {
+        googleLoginButtons.forEach(function (googleLoginButton) {
+            if (scriptOptions._unsupportedWebviewBehavior === 'disable-button') {
+                disableButtonInWebView(googleLoginButton);
+            } else {
+                googleLoginButton.remove();
+                buttonCountChanged = true;
+            }
+        });
+    }
+
+    const facebookLoginButtons = document.querySelectorAll(' a[data-plugin="nsl"][data-provider="facebook"]');
+    if (facebookLoginButtons.length && checkWebView() && /Android/.test(window.navigator.userAgent) && !isAllowedWebViewForUserAgent('facebook')) {
+        facebookLoginButtons.forEach(function (facebookLoginButton) {
+            if (scriptOptions._unsupportedWebviewBehavior === 'disable-button') {
+                disableButtonInWebView(facebookLoginButton);
+            } else {
+                facebookLoginButton.remove();
+                buttonCountChanged = true;
+            }
+        });
+    }
+
+    const separators = document.querySelectorAll('div.nsl-separator');
+    if (buttonCountChanged && separators.length) {
+        separators.forEach(function (separator) {
+            const separatorParentNode = separator.parentNode;
+            if (separatorParentNode) {
+                const separatorButtonContainer = separatorParentNode.querySelector('div.nsl-container-buttons');
+                if (separatorButtonContainer && !separatorButtonContainer.hasChildNodes()) {
+                    separator.remove();
+                }
+            }
+        })
+    }
+});})();</script><script type="text/javascript">
+/* <![CDATA[ */
+ gform.initializeOnLoaded( function() { jQuery(document).on('gform_post_render', function(event, formId, currentPage){if(formId == 73) {if(typeof Placeholders != 'undefined'){
+                        Placeholders.enable();
+                    }} } );jQuery(document).on('gform_post_conditional_logic', function(event, formId, fields, isInit){} ) } ); 
+/* ]]> */
+</script>
+<script type="text/javascript">
+/* <![CDATA[ */
+ gform.initializeOnLoaded( function() {jQuery(document).trigger("gform_pre_post_render", [{ formId: "73", currentPage: "1", abort: function() { this.preventDefault(); } }]);                if (event && event.defaultPrevented) {                return;         }        const gformWrapperDiv = document.getElementById( "gform_wrapper_73" );        if ( gformWrapperDiv ) {            const visibilitySpan = document.createElement( "span" );            visibilitySpan.id = "gform_visibility_test_73";            gformWrapperDiv.insertAdjacentElement( "afterend", visibilitySpan );        }        const visibilityTestDiv = document.getElementById( "gform_visibility_test_73" );        let postRenderFired = false;                function triggerPostRender() {            if ( postRenderFired ) {                return;            }            postRenderFired = true;            jQuery( document ).trigger( 'gform_post_render', [73, 1] );            gform.utils.trigger( { event: 'gform/postRender', native: false, data: { formId: 73, currentPage: 1 } } );            gform.utils.trigger( { event: 'gform/post_render', native: false, data: { formId: 73, currentPage: 1 } } );            if ( visibilityTestDiv ) {                visibilityTestDiv.parentNode.removeChild( visibilityTestDiv );            }        }        function debounce( func, wait, immediate ) {            var timeout;            return function() {                var context = this, args = arguments;                var later = function() {                    timeout = null;                    if ( !immediate ) func.apply( context, args );                };                var callNow = immediate && !timeout;                clearTimeout( timeout );                timeout = setTimeout( later, wait );                if ( callNow ) func.apply( context, args );            };        }        const debouncedTriggerPostRender = debounce( function() {            triggerPostRender();        }, 200 );        if ( visibilityTestDiv && visibilityTestDiv.offsetParent === null ) {            const observer = new MutationObserver( ( mutations ) => {                mutations.forEach( ( mutation ) => {                    if ( mutation.type === 'attributes' && visibilityTestDiv.offsetParent !== null ) {                        debouncedTriggerPostRender();                        observer.disconnect();                    }                });            });            observer.observe( document.body, {                attributes: true,                childList: false,                subtree: true,                attributeFilter: [ 'style', 'class' ],            });        } else {            triggerPostRender();        }    } ); 
+/* ]]> */
+</script>
+
+
+<div id="adslot-out-of-page">
+	
+</div>
+<script defer src="https://web.archive.org/web/20250216023536js_/https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="" data-cf-beacon="{&quot;rayId&quot;:&quot;912a252f7ee482f9&quot;,&quot;version&quot;:&quot;2025.1.0&quot;,&quot;serverTiming&quot;:{&quot;name&quot;:{&quot;cfExtPri&quot;:true,&quot;cfL4&quot;:true,&quot;cfSpeedBrain&quot;:true,&quot;cfCacheStatus&quot;:true}},&quot;token&quot;:&quot;fbcf7c3d51214d95be58afaf83e77338&quot;,&quot;b&quot;:1}" crossorigin="anonymous"></script>
+</body>
+
+</html><!--
+     FILE ARCHIVED ON 02:35:36 Feb 16, 2025 AND RETRIEVED FROM THE
+     INTERNET ARCHIVE ON 02:12:36 Apr 18, 2026.
+     JAVASCRIPT APPENDED BY WAYBACK MACHINE, COPYRIGHT INTERNET ARCHIVE.
+
+     ALL OTHER CONTENT MAY ALSO BE PROTECTED BY COPYRIGHT (17 U.S.C.
+     SECTION 108(a)(3)).
+-->
+<!--
+playback timings (ms):
+  captures_list: 0.44
+  exclusion.robots: 0.062
+  exclusion.robots.policy: 0.055
+  esindex: 0.008
+  cdx.remote: 6.993
+  LoadShardBlock: 174.962 (3)
+  PetaboxLoader3.datanode: 123.166 (4)
+  PetaboxLoader3.resolve: 129.779 (3)
+  load_resource: 118.118
+-->


### PR DESCRIPTION
Resolves https://github.com/hhursev/recipe-scrapers/issues/1542

This PR adds support for scraping recipes from the "Delicious Magazine" (deliciousmagazine.co.uk) website. It introduces a new scraper class, integrates it into the scraper registry, and provides two test data files (from original issue) to verify its functionality.

**New scraper integration:**

* Added a new `DeliciousMagazine` scraper in `recipe_scrapers/deliciousmagazine.py`, including a custom schema extraction for all fields. 
* Registered the new scraper in the `recipe_scrapers/__init__.py` module imports and the scraper registry dictionary, enabling automatic selection based on host.

**Testing support:**

* Added a sample recipe data files for "deliciousmagazine.co.uk" in `tests/test_data/deliciousmagazine.co.uk` folder to facilitate testing and validation of the new scraper.
* tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_1.json
* tests/test_data/deliciousmagazine.co.uk/deliciousmagazine_2.json