### PR TITLE
Fix: albert.cz instructions via GraphQL API

### DIFF
--- a/recipe_scrapers/albertcz.py
+++ b/recipe_scrapers/albertcz.py
@@ -1,4 +1,11 @@
+import re
+
+import requests
+
 from ._abstract import AbstractScraper
+
+GRAPHQL_ENDPOINT = "https://www.albert.cz/api/v1/"
+GRAPHQL_QUERY = "query getRecipe($code:String! $lang:String!) { getRecipe(code:$code lang:$lang) { recipeCookingSteps { description stepNumber } } }"
 
 
 class AlbertCz(AbstractScraper):
@@ -31,15 +38,43 @@ class AlbertCz(AbstractScraper):
         return self.schema.ingredients()
 
     def instructions(self):
-        instructions = self.schema.instructions()
+        schema_instructions = self.schema.instructions()
+        if schema_instructions:
+            filtered = [
+                line
+                for line in schema_instructions.split("\n")
+                if not line.strip().endswith(".") or not line.strip()[:-1].isdigit()
+            ]
+            return "\n".join(filtered)
 
-        filtered = [
-            line
-            for line in instructions.split("\n")
-            if not line.strip().endswith(".") or not line.strip()[:-1].isdigit()
-        ]
+        # albert.cz serves empty recipeInstructions in JSON-LD; fetch via GraphQL
+        match = re.search(r"/r/([A-Za-z0-9]+)(?:[/?#]|$)", self.canonical_url())
+        if not match:
+            return ""
 
-        return "\n".join(filtered)
+        code = match.group(1)
+        try:
+            response = requests.post(
+                GRAPHQL_ENDPOINT,
+                json={
+                    "operationName": "getRecipe",
+                    "variables": {"code": code, "lang": "cs"},
+                    "query": GRAPHQL_QUERY,
+                },
+                headers={
+                    "Content-Type": "application/json",
+                    "Origin": "https://www.albert.cz",
+                    "Referer": "https://www.albert.cz/",
+                },
+                timeout=10,
+            )
+            steps = sorted(
+                response.json()["data"]["getRecipe"]["recipeCookingSteps"],
+                key=lambda s: s["stepNumber"],
+            )
+            return "\n".join(step["description"] for step in steps)
+        except Exception:
+            return ""
 
     def ratings(self):
         return self.schema.ratings()


### PR DESCRIPTION
## Problem

`albert.cz` migrated to a Next.js + Apollo GraphQL architecture. As part of this migration, the site intentionally serves **empty `recipeInstructions`** in its JSON-LD:

```json
"recipeInstructions": []
```

The cooking steps are now loaded client-side via a public, unauthenticated GraphQL API — they are not present in the static HTML at all. This caused the scraper to silently return an empty string for `instructions()`.

## Investigation

The GraphQL endpoint was found in the Next.js `publicRuntimeConfig` (`clientGraphqlEndpoint`) embedded in every page's inline `<script>` block. It is public and requires no authentication — only standard HTTP headers (`Content-Type`, `Origin`, `Referer`).

The recipe code needed to query the API is already present in every recipe URL, after the `/r/` segment:

```
https://www.albert.cz/recepty/{slug}/r/{code}
```

Example: `.../r/R00008802` → code `R00008802`

## Solution

When `self.schema.instructions()` returns empty (new site format), the scraper:

1. Extracts the recipe code from `self.canonical_url()` using the pattern `/r/([A-Za-z0-9]+)`
2. POSTs a `getRecipe` GraphQL query to `https://www.albert.cz/api/v1/`
3. Sorts the returned `recipeCookingSteps` by `stepNumber` and joins them with newlines

**Why `self.canonical_url()` and not `self.url`:** in the test framework `self.url` is set to the bare hostname (`albert.cz`), while the canonical `<link>` tag in the HTML always contains the full URL including the recipe code. Using `canonical_url()` ensures the code extraction works both in tests and in production.

The old JSON-LD path is fully preserved: if `schema.instructions()` returns a non-empty string, it is used as before (with the existing numbered-marker filter). This keeps backwards compatibility.

Any network or parsing error in the GraphQL call is caught silently and an empty string is returned, preventing exceptions from propagating to callers.

## Why the test fixture was not updated

The existing test fixture (`albertcz.testhtml`) was captured before the site migration and still contains `recipeInstructions` in JSON-LD. The auto-generated test framework uses static HTML files and runs with `online=False` — adding live network calls inside scraper methods would be inconsistent with every other scraper in this project.

By keeping the old fixture, the schema path continues to be exercised without any network dependency. The GraphQL path was validated manually against multiple live recipe URLs and returns correct results in all cases.

## Checklist

- [x] `pre-commit` passes (black, flake8, mypy)
- [x] `python -m unittest -k albertcz` passes
- [x] Live testing on multiple recipe URLs confirms correct instructions are returned