### PR TITLE
Add workaround for malformed nytimes data

### DIFF
--- a/recipe_scrapers/_schemaorg.py
+++ b/recipe_scrapers/_schemaorg.py
@@ -289,7 +289,12 @@ class SchemaOrg:
             name = schema_item.get("name") or schema_item.get("Name")
             if name is not None:
                 instructions_gist.append(name)
-            for item in schema_item.get("itemListElement"):
+            elements = schema_item.get("itemListElement") or []
+            # Some sites (e.g. NYTimes) wrap a single HowToStep in a HowToSection
+            # using a dict instead of a list, so normalize before iterating.
+            if isinstance(elements, dict):
+                elements = [elements]
+            for item in elements:
                 instructions_gist += self._extract_howto_instructions_text(item)
         return instructions_gist
 

--- a/tests/library/test_schemaorg.py
+++ b/tests/library/test_schemaorg.py
@@ -66,6 +66,35 @@ PROPERTY_VALUE_INGREDIENTS_SCHEMA = """
 }
 """
 
+HOWTO_SECTION_DICT_ITEM_LIST_ELEMENT_SCHEMA = """
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "name": "Section Dict Recipe",
+  "recipeIngredient": [],
+  "recipeInstructions": [
+    {"@type": "HowToStep", "text": "First step."},
+    {
+      "@type": "HowToSection",
+      "itemListElement": {"@type": "HowToStep", "text": "Wrapped step."}
+    }
+  ]
+}
+"""
+
+HOWTO_SECTION_EMPTY_SCHEMA = """
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "name": "Empty Section Recipe",
+  "recipeIngredient": [],
+  "recipeInstructions": [
+    {"@type": "HowToStep", "text": "First step."},
+    {"@type": "HowToSection"}
+  ]
+}
+"""
+
 BEST_IMAGE_SCHEMA = """
 {
   "@context": "https://schema.org",
@@ -117,6 +146,18 @@ class TestSchemaOrg(unittest.TestCase):
         self.assertIn("1 egg", ingredients)
         self.assertIn("3/4 G21 sugar", ingredients)
         self.assertIn("1/2 cup flour", ingredients)
+
+    def test_howto_section_with_dict_item_list_element(self):
+        page_data = JSONLD_PAGE_TEMPLATE.format(
+            jsonld=HOWTO_SECTION_DICT_ITEM_LIST_ELEMENT_SCHEMA
+        )
+        parser = SchemaOrg(page_data)
+        self.assertEqual("First step.\nWrapped step.", parser.instructions())
+
+    def test_howto_section_with_missing_item_list_element(self):
+        page_data = JSONLD_PAGE_TEMPLATE.format(jsonld=HOWTO_SECTION_EMPTY_SCHEMA)
+        parser = SchemaOrg(page_data)
+        self.assertEqual("First step.", parser.instructions())
 
     def test_best_image_selection(self):
         page_data = JSONLD_PAGE_TEMPLATE.format(jsonld=BEST_IMAGE_SCHEMA)

--- a/tests/library/test_schemaorg.py
+++ b/tests/library/test_schemaorg.py
@@ -95,6 +95,31 @@ HOWTO_SECTION_EMPTY_SCHEMA = """
 }
 """
 
+HOWTO_SECTION_MIXED_ITEM_LIST_ELEMENT_SCHEMA = """
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "name": "Mixed Section Recipe",
+  "recipeIngredient": [],
+  "recipeInstructions": [
+    {"@type": "HowToStep", "text": "Prep."},
+    {
+      "@type": "HowToSection",
+      "name": "Standard section",
+      "itemListElement": [
+        {"@type": "HowToStep", "text": "List step one."},
+        {"@type": "HowToStep", "text": "List step two."}
+      ]
+    },
+    {
+      "@type": "HowToSection",
+      "name": "Wrapped section",
+      "itemListElement": {"@type": "HowToStep", "text": "Dict step."}
+    }
+  ]
+}
+"""
+
 BEST_IMAGE_SCHEMA = """
 {
   "@context": "https://schema.org",
@@ -158,6 +183,21 @@ class TestSchemaOrg(unittest.TestCase):
         page_data = JSONLD_PAGE_TEMPLATE.format(jsonld=HOWTO_SECTION_EMPTY_SCHEMA)
         parser = SchemaOrg(page_data)
         self.assertEqual("First step.", parser.instructions())
+
+    def test_howto_section_with_mixed_item_list_element_shapes(self):
+        page_data = JSONLD_PAGE_TEMPLATE.format(
+            jsonld=HOWTO_SECTION_MIXED_ITEM_LIST_ELEMENT_SCHEMA
+        )
+        parser = SchemaOrg(page_data)
+        self.assertEqual(
+            "Prep.\n"
+            "Standard section\n"
+            "List step one.\n"
+            "List step two.\n"
+            "Wrapped section\n"
+            "Dict step.",
+            parser.instructions(),
+        )
 
     def test_best_image_selection(self):
         page_data = JSONLD_PAGE_TEMPLATE.format(jsonld=BEST_IMAGE_SCHEMA)


### PR DESCRIPTION
```python
from recipe_scrapers import scrape_me

scraper = scrape_me("https://cooking.nytimes.com/recipes/777654990-cheeseburger-sliders")
print("Instructions:")
print(scraper.instructions())
```

Before:
```
Instructions:
Prepare the buns: Heat the broiler to high, with a rack positioned 6 inches from the heat source. Separate and cut the Hawaiian rolls into halves, arranging them evenly cut-side down across a baking sheet. Brush the top portions of the buns with melted butter and sprinkle with sesame seeds.
Place the baking sheet under the broiler for 30 to 45 seconds, until toasty and golden brown. Keep a careful eye on the rolls so they don’t burn. Remove from the oven, flip the bottom buns cut-side up and set the baking sheet aside in a warm place.
@type
text
url
@type
text
url
@type
text
url
```

After:
```
Instructions:
Prepare the buns: Heat the broiler to high, with a rack positioned 6 inches from the heat source. Separate and cut the Hawaiian rolls into halves, arranging them evenly cut-side down across a baking sheet. Brush the top portions of the buns with melted butter and sprinkle with sesame seeds.
Place the baking sheet under the broiler for 30 to 45 seconds, until toasty and golden brown. Keep a careful eye on the rolls so they don’t burn. Remove from the oven, flip the bottom buns cut-side up and set the baking sheet aside in a warm place.
Divide the beef into 8 equal portions, then roll each portion into a large meatball. Place the meatballs on a large sheet pan lined with parchment paper. Cover the meatballs with a second sheet of parchment and use a sturdy spatula to flatten each meatball into a patty, about 3 inches wide and ½-inch thick. Remove the top layer of parchment and liberally season both sides of the patties with salt and pepper. (You can also flatten the patties by hand to save a bit of time!)
Add the oil to a 12-inch skillet (not non-stick) and heat over medium until hot. Working in batches if needed, add 8 patties to the pan and cook until the underside is browned with a slight char, 3 to 4 minutes. Flip the burgers and cook until almost done to your liking, 2 to 3 minutes more. When patties have about 1 minute remaining, arrange 2 squares of cheese on each patty and cover the pan with a lid until cheese is fully melted.
Assemble the sliders and garnish with your favorite toppings and condiments. Enjoy the sliders warm.
```