### PR TITLE
Introducing new method to reverse ingredients

### DIFF
--- a/recipe_scrapers/_abstract.py
+++ b/recipe_scrapers/_abstract.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 from collections import OrderedDict
 from typing import Optional
 from urllib.parse import urljoin
@@ -205,3 +206,18 @@ class AbstractScraper:
             except Exception:
                 pass
         return json_dict
+
+    def _reverse_ingredient(self, value):
+        # Regex here is designed to match some string (ingredient name) followed by either:
+        # a) A singular number where no unit make sense
+        # b) A number followed by a unit of measurement of some kind
+        # c) HTML fractions (&frac...) with no units
+        # d) HTML fractions (&frac...) with units after
+        split_string = [
+            ingredient_line
+            for ingredient_line in re.split(
+                r"(\d+(?:,\d+)?(?:\s+\S+)?|&frac\d+;(?:\s+\S+)?)", value.strip()
+            )
+            if ingredient_line
+        ]
+        return " ".join(split_string[1:] + split_string[:1]).strip()

--- a/recipe_scrapers/giallozafferano.py
+++ b/recipe_scrapers/giallozafferano.py
@@ -6,6 +6,14 @@ class GialloZafferano(AbstractScraper):
     def host(cls):
         return "ricette.giallozafferano.it"
 
+    def ingredients(self):
+        ingredients = (
+            self.schema.data.get("recipeIngredient")
+            or self.schema.data.get("ingredients")
+            or []
+        )
+        return [self._reverse_ingredient(ingredient) for ingredient in ingredients]
+
     def nutrients(self):
         nutrients = self.schema.data.get("nutrition", {})
         nutrient_keys = [

--- a/tests/test_data/ricette.giallozafferano.it/giallozafferano.json
+++ b/tests/test_data/ricette.giallozafferano.it/giallozafferano.json
@@ -6,17 +6,17 @@
   "language": "it",
   "title": "Bavarese alle fragole",
   "ingredients": [
-    "Latte intero 200 ml",
-    "Tuorli 3",
-    "Zucchero 105 g",
-    "Baccello di vaniglia ½",
-    "Limoni ½",
-    "Sale fino 1 pizzico",
-    "Fragole 1,1 kg",
-    "Gelatina in fogli 18 g",
-    "Panna fresca liquida 500 ml",
-    "Panna fresca liquida 150 ml",
-    "Zucchero a velo 30 g"
+    "200 ml Latte intero",
+    "3 Tuorli",
+    "105 g Zucchero",
+    "½ Baccello di vaniglia",
+    "½ Limoni",
+    "1 pizzico Sale fino",
+    "1,1 kg Fragole",
+    "18 g Gelatina in fogli",
+    "500 ml Panna fresca liquida",
+    "150 ml Panna fresca liquida",
+    "30 g Zucchero a velo"
   ],
   "instructions_list": [
     "Per preparare la bavarese alle fragole, iniziate dalla crema inglese che è la base del dolce: incidete mezza bacca di vaniglia e raschiate con la punta di un coltellino per estrarre i semini 1 . Prelevate la scorza del limone facendo attenzione a non sbucciare anche la parte bianca 2 e unite i due aromi nel pentolino con il latte 3 : scaldate a fuoco dolce fino a sfiorare il bollore poi spegnete il fuoco.",


### PR DESCRIPTION
Fixes Bug #1940 
* There is now a `_reverse_ingredient` method at the `AbstractScraper` class that can be used by any scraper implementations
* Implementing the `ingredients` method for the `GialloZafferano` scraper
* Updating test to have the reversed ingredients list to run against with new code updates