### PR TITLE
Add scraper for 30seconds.com

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -604,6 +604,7 @@ from .thevintagemixer import TheVintageMixer
 from .thewoksoflife import Thewoksoflife
 from .thewoodenskillet import TheWoodenSkillet
 from .thinlicious import Thinlicious
+from .thirtyseconds import ThirtySeconds
 from .thishealthytable import ThisHealthyTable
 from .threesixfivedaysofbakingandmore import ThreeSixFiveDaysOfBakingAndMore
 from .tidymom import TidyMom
@@ -1255,6 +1256,7 @@ SCRAPERS = {
     Thewoksoflife.host(): Thewoksoflife,
     TheWoodenSkillet.host(): TheWoodenSkillet,
     Thinlicious.host(): Thinlicious,
+    ThirtySeconds.host(): ThirtySeconds,
     ThisHealthyTable.host(): ThisHealthyTable,
     ThreeSixFiveDaysOfBakingAndMore.host(): ThreeSixFiveDaysOfBakingAndMore,
     TidyMom.host(): TidyMom,

--- a/recipe_scrapers/thirtyseconds.py
+++ b/recipe_scrapers/thirtyseconds.py
@@ -1,0 +1,107 @@
+import json
+import re
+
+from ._abstract import AbstractScraper
+from ._utils import get_minutes, get_yields, normalize_string
+
+
+class ThirtySeconds(AbstractScraper):
+    """Scraper for 30seconds.com (30Seconds Food).
+
+    Most recipe pages expose only an ``Article`` schema, with the recipe itself
+    living in the page markup: an ``Ingredients`` list (a ``<ul>`` that follows a
+    ``<strong>Ingredients</strong>`` header, or — on pages without that header —
+    the ``<ul>`` right after the ``Servings:`` line) and a directions ``<ol>``
+    that follows a "Here's how to make it" / "Directions" header. Some pages also
+    carry a full ``Recipe`` schema; where that exists the SchemaOrg plugin covers
+    it, but these overrides parse the markup so both layouts work.
+    """
+
+    @classmethod
+    def host(cls):
+        return "30seconds.com"
+
+    def _article(self):
+        """First JSON-LD node carrying a name/headline (the Article, usually)."""
+        if getattr(self, "_article_cache", None) is not None:
+            return self._article_cache
+        node = {}
+        for block in re.findall(
+            r"<script[^>]+type=['\"]application/ld\+json['\"][^>]*>(.*?)</script>",
+            self.page_data,
+            re.S,
+        ):
+            try:
+                obj = json.loads(block)
+            except json.JSONDecodeError:
+                continue
+            for candidate in obj if isinstance(obj, list) else [obj]:
+                if isinstance(candidate, dict) and (
+                    candidate.get("name") or candidate.get("headline")
+                ):
+                    node = candidate
+                    break
+            if node:
+                break
+        self._article_cache = node
+        return node
+
+    def author(self):
+        author = self._article().get("author")
+        if isinstance(author, list):
+            author = author[0] if author else None
+        if isinstance(author, dict):
+            return author.get("name")
+        return author
+
+    def title(self):
+        article = self._article()
+        return normalize_string(article.get("name") or article.get("headline") or "")
+
+    def site_name(self):
+        return self.opengraph.site_name()
+
+    def image(self):
+        image = self._article().get("image")
+        if isinstance(image, list):
+            image = image[0] if image else None
+        if isinstance(image, dict):
+            image = image.get("url")
+        return image or self.opengraph.image()
+
+    def total_time(self):
+        match = re.search(r"Total Time:\s*([^<\n]+)", self.page_data, re.I)
+        return get_minutes(match.group(1)) if match else 0
+
+    def yields(self):
+        match = re.search(r"Servings:\s*([0-9]+)", self.page_data, re.I)
+        return get_yields(f"{match.group(1)} servings") if match else None
+
+    def _directions_ol(self):
+        return re.search(
+            r"(?:Here.{0,4}s how to make it|Directions|Instructions|Method|Steps)\b"
+            r".*?<ol>(.*?)</ol>",
+            self.page_data,
+            re.S | re.I,
+        )
+
+    def ingredients(self):
+        start = re.search(
+            r"<strong>\s*Ingredients\s*</strong>", self.page_data, re.I
+        ) or re.search(r"Servings:.*?</p>", self.page_data, re.S | re.I)
+        if not start:
+            return []
+        directions = self._directions_ol()
+        end = directions.start() if directions else len(self.page_data)
+        ordered = self.page_data.find("<ol", start.end())
+        if ordered != -1:
+            end = min(end, ordered)
+        items = re.findall(r"<li>(.*?)</li>", self.page_data[start.end() : end], re.S)
+        return [i for i in (normalize_string(item) for item in items) if i]
+
+    def instructions(self):
+        directions = self._directions_ol()
+        if not directions:
+            return ""
+        items = re.findall(r"<li>(.*?)</li>", directions.group(1), re.S)
+        return "\n".join(i for i in (normalize_string(item) for item in items) if i)

--- a/tests/test_data/30seconds.com/30seconds.json
+++ b/tests/test_data/30seconds.com/30seconds.json
@@ -1,0 +1,29 @@
+{
+    "author": "30Seconds Food",
+    "canonical_url": "https://30seconds.com/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food",
+    "site_name": "30Seconds Food",
+    "host": "30seconds.com",
+    "language": "en",
+    "title": "20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food",
+    "total_time": 20,
+    "yields": "4 servings",
+    "image": "https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg",
+    "ingredients": [
+        "1 pound chicken tenders, cut into bite-sized pieces",
+        "1/4 cup flour",
+        "1 teaspoon garlic powder",
+        "2 tablespoons olive oil",
+        "1 small onion, chopped",
+        "1 small green bell pepper, red bell pepper or poblano pepper, diced (try a combination)",
+        "3/4 cup chicken broth",
+        "2 chipotle peppers in adobo sauce, minced",
+        "1/2 cup sour cream",
+        "1/3 cup chopped fresh cilantro"
+    ],
+    "instructions_list": [
+        "Combine the flour and garlic powder in a bowl. Season the chicken tenders with salt and pepper, then dredge in the seasoned flour. Put on a plate and set aside.",
+        "Heat the olive oil in a large skillet. Add the onion and peppers and cook until soft.",
+        "Add the chicken pieces to the skillet and continue to cook until chicken is browned and almost cooked through.",
+        "Add the chicken broth and chipotle peppers. Bring to a boil, reduce heat and cook until reduced a little and thick. Stir in the cilantro and sour cream."
+    ]
+}

--- a/tests/test_data/30seconds.com/30seconds.json
+++ b/tests/test_data/30seconds.com/30seconds.json
@@ -1,29 +1,29 @@
 {
-    "author": "30Seconds Food",
-    "canonical_url": "https://30seconds.com/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food",
-    "site_name": "30Seconds Food",
-    "host": "30seconds.com",
-    "language": "en",
-    "title": "20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food",
-    "total_time": 20,
-    "yields": "4 servings",
-    "image": "https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg",
-    "ingredients": [
-        "1 pound chicken tenders, cut into bite-sized pieces",
-        "1/4 cup flour",
-        "1 teaspoon garlic powder",
-        "2 tablespoons olive oil",
-        "1 small onion, chopped",
-        "1 small green bell pepper, red bell pepper or poblano pepper, diced (try a combination)",
-        "3/4 cup chicken broth",
-        "2 chipotle peppers in adobo sauce, minced",
-        "1/2 cup sour cream",
-        "1/3 cup chopped fresh cilantro"
-    ],
-    "instructions_list": [
-        "Combine the flour and garlic powder in a bowl. Season the chicken tenders with salt and pepper, then dredge in the seasoned flour. Put on a plate and set aside.",
-        "Heat the olive oil in a large skillet. Add the onion and peppers and cook until soft.",
-        "Add the chicken pieces to the skillet and continue to cook until chicken is browned and almost cooked through.",
-        "Add the chicken broth and chipotle peppers. Bring to a boil, reduce heat and cook until reduced a little and thick. Stir in the cilantro and sour cream."
-    ]
+  "author": "30Seconds Food",
+  "canonical_url": "https://30seconds.com/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food",
+  "site_name": "30Seconds Food",
+  "host": "30seconds.com",
+  "language": "en",
+  "title": "20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food",
+  "ingredients": [
+    "1 pound chicken tenders, cut into bite-sized pieces",
+    "1/4 cup flour",
+    "1 teaspoon garlic powder",
+    "2 tablespoons olive oil",
+    "1 small onion, chopped",
+    "1 small green bell pepper, red bell pepper or poblano pepper, diced (try a combination)",
+    "3/4 cup chicken broth",
+    "2 chipotle peppers in adobo sauce, minced",
+    "1/2 cup sour cream",
+    "1/3 cup chopped fresh cilantro"
+  ],
+  "instructions_list": [
+    "Combine the flour and garlic powder in a bowl. Season the chicken tenders with salt and pepper, then dredge in the seasoned flour. Put on a plate and set aside.",
+    "Heat the olive oil in a large skillet. Add the onion and peppers and cook until soft.",
+    "Add the chicken pieces to the skillet and continue to cook until chicken is browned and almost cooked through.",
+    "Add the chicken broth and chipotle peppers. Bring to a boil, reduce heat and cook until reduced a little and thick. Stir in the cilantro and sour cream."
+  ],
+  "yields": "4 servings",
+  "total_time": 20,
+  "image": "https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg"
 }

--- a/tests/test_data/30seconds.com/30seconds.testhtml
+++ b/tests/test_data/30seconds.com/30seconds.testhtml
@@ -1,0 +1,1737 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">
+
+    
+    <link rel="shortcut icon" href="https://media.30seconds.com/static/img/favicon/favicon-food.c1ef8563f1fa.ico" type="image/x-icon">
+    <link rel="icon" href="https://media.30seconds.com/static/img/favicon/favicon-food.c1ef8563f1fa.ico" type="image/x-icon">
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="/food/feed/">
+
+
+<title>20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food | Chicken Recipes | 30Seconds Food</title>
+
+<meta property="fb:app_id" content="981829471899576">
+<meta property="fb:admins" content="100005758416232">
+<meta property="fb:admins" content="100001777946730">
+<meta property="og:locale" content="en_us">
+<meta property="og:site_name" content="30Seconds Food">
+
+<meta name="description" content="Think of this easy chipotle cream chicken recipe as chicken a la king with attitude. Serve this comforting recipe over rice, toast points, tortilla chips or..."/>
+    <meta property="og:url" content="https://30seconds.com/tip/15182">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food | Chicken Recipes | 30Seconds Food">
+    <meta property="og:description" content="Think of this easy chipotle cream chicken recipe as chicken a la king with attitude. Serve this comforting recipe over rice, toast points, tortilla chips or even pasta. Cuisine: American Prep Time: 5 minutes Cook Time: 15 minutes Total Time: 20 minutes Servings: 4 Ingredients 1 pound chicken...">
+    <meta property="og:image" content="https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg">
+        
+            <meta property="og:image:width" content="960">
+            <meta property="og:image:height" content="640">
+        
+    <meta name="twitter:url" content="https://30seconds.com/tip/15182">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@30seconds">
+    <meta name="twitter:title" content="Think of this easy chipotle cream chicken recipe as chicken a la king with attitude. Get the recipe! #30Seconds #creamedchicken #chicken #recipe #chipotle #food #delicious #yum #whatsfordinner">
+    <meta name="twitter:description" content="20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food | Chicken Recipes | 30Seconds Food">
+    <meta name="twitter:image" content="https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg">
+    
+    <link href="https://30seconds.com/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food" rel="canonical"/>
+    
+
+<!-- Mobile app manifests and icons -->
+<link rel="apple-touch-icon" sizes="180x180" href="https://media.30seconds.com/static/img/favicon/apple-touch-icon.83ed7350ecf1.png">
+<meta name="apple-mobile-web-app-title" content="30Seconds">
+<meta name="application-name" content="30Seconds">
+<link rel="mask-icon" href="https://media.30seconds.com/static/img/favicon/safari-pinned-tab.f0187dc36ed6.svg" color="#d83844">
+<meta name="theme-color" content="#D83844">
+<link rel="manifest" href="https://media.30seconds.com/static/img/favicon/manifest.927a7e89e559.json">
+<!-- MSIE -->
+<meta name="msapplication-TileColor" content="#D83844">
+<meta name="msapplication-TileImage" content="https://media.30seconds.com/static/img/favicon/mstile-144x144.5e7aae276730.png">
+<meta name="msapplication-square70x70logo" content="https://media.30seconds.com/static/img/favicon/mstile-70x70.a00c29580dc9.png">
+<meta name="msapplication-square150x150logo" content="https://media.30seconds.com/static/img/favicon/mstile-150x150.62ec577a786b.png">
+<meta name="msapplication-wide310x150logo" content="https://media.30seconds.com/static/img/favicon/mstile-310x150.cf436ccf3531.png">
+<meta name="msapplication-square310x310logo" content="https://media.30seconds.com/static/img/favicon/mstile-310x310.b5aad8ef8789.png">
+
+
+<!-- Search -->
+<link rel="search" type="application/opensearchdescription+xml" title="30Seconds Food" href="https://static.30seconds.com/static/opensearch.xml">
+
+<style type="text/css">
+    @font-face {
+        font-family: "30sec";
+        src: url("https://media.30seconds.com/static/fonts/30sec.c96d5865dcd1.eot");
+        src: url("https://media.30seconds.com/static/fonts/30sec.c96d5865dcd1.eot?#iefix") format("embedded-opentype"),
+        url("https://media.30seconds.com/static/fonts/30sec.5da790d9b824.woff") format("woff"),
+        url("https://media.30seconds.com/static/fonts/30sec.c69a9323e9e4.ttf") format("truetype"),
+        url("https://media.30seconds.com/static/fonts/30sec.851ce0c82826.svg#30sec") format("svg");
+        font-weight: normal;
+        font-style: normal;
+    }
+</style>
+
+<script data-no-optimize="1" data-cfasync="false">
+    (function(w, d) {
+        w.adthrive = w.adthrive || {};
+        w.adthrive.cmd = w.adthrive.cmd || [];
+        w.adthrive.plugin = 'adthrive-ads-manual';
+        w.adthrive.host = 'ads.adthrive.com';
+    
+        var s = d.createElement('script');
+        s.async = true;
+        s.referrerpolicy='no-referrer-when-downgrade';
+        s.src = 'https://' + w.adthrive.host + '/sites/6377e7e3d8ebe21a3cbb95a9/ads.min.js?referrer=' + w.encodeURIComponent(w.location.href) + '&cb=' + (Math.floor(Math.random() * 100) + 1);
+        var n = d.getElementsByTagName('script')[0];
+        n.parentNode.insertBefore(s, n);
+    })(window, document);
+</script>
+    
+
+    
+        <link href="https://media.30seconds.com/static/css/app.68914bf8c049.css" rel='stylesheet' type='text/css'>
+    
+
+    
+    
+        <link rel="amphtml" href="https://30seconds.com/food/tip/amp-15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food"/>
+    
+
+    
+    <script type="application/ld+json">
+      {
+        "@context": "http://schema.org",
+        "@type": "Article",
+        "name": "20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food",
+        "headline": "20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food",
+        "datePublished": "2022-01-24T15:09:31+00:00",
+        "image": {
+            "@type": "ImageObject",
+            "url": "https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg",
+            "width": 960,
+            "height": 640
+        },
+        "author": {
+            "@type": "Person",
+            "name": "30Seconds Food"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "30Seconds",
+            "url": "https://30seconds.com/",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://media.30seconds.com/static/img/30seconds-logo-red.png",
+                "width": 456,
+                "height": 288
+            }
+        }
+      }
+    </script>
+    
+
+
+    <!-- Raptive adt_ei script -->
+    <script>
+        !function(){"use strict";var e=window.location.search.substring(1).split("&");const t=e=>e.replace(/\s/g,""),o=e=>new Promise((t=>{if(!("msCrypto"in window)&&"https:"===location.protocol&&"crypto"in window&&"TextEncoder"in window){const o=(new TextEncoder).encode(e);crypto.subtle.digest("SHA-256",o).then((e=>{const o=Array.from(new Uint8Array(e)).map((e=>("00"+e.toString(16)).slice(-2))).join("");t(o)}))}else t("")}));for(var n=0;n<e.length;n++){var r="adt_ei",i=decodeURIComponent(e[n]);if(0===i.indexOf(r)){var a=i.split(r+"=")[1];if((e=>{const t=e.match(/((?=([a-zA-Z0-9._!#$%+^&*()[\]<>-]+))\2@[a-zA-Z0-9._-]+\.[a-zA-Z0-9._-]+)/gi);return t?t[0]:""})(t(a.toLowerCase()))){o(a).then((t=>{t.length&&(localStorage.setItem(r,t),localStorage.setItem("adt_emsrc","url"),e.splice(n,1),history.replaceState(null,"","?"+e.join("&")))}));break}}}}();
+    </script>
+</head>
+
+<body class="body-food ">
+<!--[if lt IE 10]>
+<p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/?locale=en">upgrade
+  your browser</a> to improve your experience.</p>
+<![endif]-->
+
+
+    <header class="header">
+    <div class="channels-bar">
+        <div class="container">
+            
+            <a href="/" class="logo-link">
+                <img src="https://media.30seconds.com/static/img/30seconds-logo.3e7318381277.svg" alt="30Seconds food">
+                
+            </a>
+
+            <div class="mobile-user">
+                
+                    
+                    <a href="/accounts/signup/" class="white-text">sign up</a>
+                    <span class="white-text separator">∕</span>
+                    <a href="/accounts/login/" class="white-text">login</a>
+                
+            </div>
+            <div class="bg-overlay" id="menuBgOverlay"></div>
+            <div class="menus" id="menus">
+                <div class="mobile-menu-logo mobile-menu-item">
+                    <a href="/" class="mobile-logo-link"><span class="icon icon-30seconds-logo"></span></a>
+                </div>
+                <ul class="channels-menu">
+                    
+                        
+                            <li class="chan-food active">
+                                <a href="/food/">food</a></li>
+                        
+                    
+                        
+                            <li class="chan-health ">
+                                <a href="/health/">health</a></li>
+                        
+                    
+                        
+                            <li class="chan-parenting ">
+                                <a href="/parenting/">parenting</a></li>
+                        
+                    
+                </ul>
+                
+                <div id="SearchForm" data-search-value="" class="search-form"></div>
+                
+                <div class="user-item">
+                    
+                        
+                        <div class="sign-in">
+                            <a href="/accounts/login/" class="white-text">Login</a>
+                            <span class="white-text">∕</span>
+                            <a href="/accounts/signup/" class="white-text">Sign Up</a>
+                        </div>
+                    
+                </div>
+
+                
+                    <a href="/food/submit-tip/" class="mobile-menu-item btn btn-lg btn-primary mobile-submit-tip" id="submitTip">
+                        <span class="icon icon-plus"></span>
+                        Submit a Tip
+                    </a>
+                
+                
+            </div>
+            <div class="menu-toggle" id="menuToggle">
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </div>
+        </div>
+    </div>
+    <div class="menu-bar">
+        <div class="container">
+            
+                <div class="tagline">
+                    Food, Fun,  <br class="hidden-sm-down"/>
+                    Health, Happiness
+                </div>
+            
+            <a href="/" class="logo-sm" id="logoSm">
+                <span class="icon icon-30seconds-logo"></span>
+                <div class="logo-sm-channel">food</div>
+            </a>
+            
+                
+    
+    
+    
+    
+    <div class="tip-tools tip-tools-header">
+        <div class="tip-actions">
+            <button type="button" data-action="like" data-id="15182" data-action-url="/food/tip/15182/like"
+               class="tip-action tip-action-like user-action user-action-like user-action-like-15182">
+                <span class="icon icon-heart"></span>
+                <div class="text text-default">Like</div>
+                <div class="text text-bottom text-bottom-default">Like tip</div>
+                <div class="text text-bottom text-bottom-active">You liked</div>
+            </button>
+            
+                <a href="#comments" class="tip-action tip-action-comment smooth-scroll"
+                   rel="nofollow"><span
+                        class="icon icon-comment"></span>
+                    <div class="text text-default">Comments</div>
+                    <div class="text text-bottom">Add comment</div>
+                </a>
+                
+                    <a href="" data-toggle="modal" data-target="#collectionModal" class="tip-action tip-action-collection" rel="nofollow"><span class="icon icon-collection"></span>
+                        <span class="nr user-action-collection-15182-count">2</span>
+                        <div class="text text-default">Collections</div>
+                        <div class="text text-bottom text-bottom-default">Add to collection</div>
+                        <div class="text text-bottom text-bottom-active">In collection</div>
+                    </a>
+                
+
+                
+                    
+                        <a href="/accounts/signup/" class="hidden-md-down header-signup-msg">Sign up to join our community!</a>
+                    
+                
+
+                <div class="tip-text-tools">
+                    <a href="javascript:;" class="tip-text-tool tip-embed" id="tip_embed">
+                        <span class="icon icon-code"></span>
+                        <span class="text">Embed</span>
+                    </a>
+                    <a href="javascript:window.print()" class="tip-text-tool tip-print">
+                        <span class="icon icon-print"></span>
+                        <span class="text">Print</span>
+                    </a>
+                </div>
+            
+            
+            
+            
+            
+            
+            
+        </div>
+        
+    <div class="tip-share">
+        <div class="ssk-group" data-item-id="15182" data-url="https://30seconds.com/tip/15182">
+            <a href="javascript:;" rel="nofollow" class="ssk ssk-enabled ssk-facebook">
+                </a>
+            
+            <a href="javascript:;" rel="nofollow" class="ssk ssk-twitter">
+                </a>
+            <a href="javascript:;" rel="nofollow" data-text="20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food #30secondmom" class="ssk ssk-enabled ssk-pinterest">
+                </a>
+            <a href="javascript:;" rel="nofollow" class="ssk ssk-enabled ssk-email">
+                </a>
+        </div>
+    </div>
+
+    </div>
+
+            
+
+            
+                <a href="/food/submit-tip/" class="btn btn-primary-outline btn-primary-outline-full btn-sm btn-submit-tip">
+                    <span class="icon icon-plus"></span>
+                    Submit a Tip
+                </a>
+            
+        </div>
+    </div>
+</header>
+
+<div id="signupPopUp" tabindex="-1" class="modal fade">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-body">
+                <span class="icon icon-30seconds-logo color"></span>
+                <div>
+                    <p>Get the latest inspiration from 30Seconds, in about 30 seconds.</p>
+                    <p>Sign up now to receive our weekly updates!</p>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <a href="/accounts/signup/" class="float-xs-left btn btn-primary signup" data-dismiss="modal">Yes, please!</a>
+                <a href="" class="float-xs-right btn btn-primary-outline dismiss" data-dismiss="modal">No, thanks.</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<a id="top" name="top"></a>
+
+
+
+    
+
+
+
+
+    
+        <div class="container main-container tip-container">
+            <div class="row">
+
+                <div class="col-sm-12 col-md-12 col-lg-9">
+                    
+    
+    
+    <article class="tip-detail">
+        <div class="print-only print-logo">
+            <span class="icon icon-30seconds-logo"></span>
+            <span class="channel">food</span>
+            <span class="text-muted"><span class="icon icon-link"></span> 30seconds.com/food</span>
+            <hr>
+        </div>
+        <div class="tip-header">
+            <h1 class="tip-title">20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food
+                
+
+                
+
+                <small class="text-muted print-only"> by 30Seconds Food</small>
+            </h1>
+            <div class="tip-categories">
+                
+                    <a href="/food/category/chicken-recipes/">Chicken Recipes</a>
+                
+                    <a href="/food/category/dinner/">Dinner</a>
+                
+                <div class="hidden-sm-down tip-age">January 24, 2022</div>
+            </div>
+        </div>
+
+        
+
+        
+            
+    
+    
+    <hr/>
+    <div class="profile-byline">
+        <div class="user-avatar-container">
+            <a href="/30secondsfood/" class="user-link">
+                <div class="user-avatar-container">
+                    <div href="/30secondsfood/" class="user-avatar" id="userAvatar" style="background-image: url('https://media.30seconds.com/user/sm/30seconds-food-121326-c1832e7c48-1496950995.jpg');"></div>
+                </div>
+            </a>
+        </div>
+
+        <div class="user-byline-deatils">
+            <a href="/30secondsfood/" class="user-link">
+                <div class="user-name">30Seconds Food</div>
+            </a>
+
+            <div class="pad-box-multi author-stats">
+                
+                <a href="/30secondsfood/tips/" class="stat-tips hidden-sm-down">
+                    <span class="nr">1956</span>
+                    <span class="text">Tips</span>
+                </a>
+                <a href="/30secondsfood/followers/" class="stat-followers hidden-sm-down">
+                    <span class="nr user-action-follow-121326-count">11265</span>
+                    <span class="text">Followers</span>
+                </a>
+
+                <div class="user-follow-container">
+                    <button type="button" data-action="follow" data-id="121326" data-action-url="/30secondsfood/follow" class="btn btn-block btn-primary btn-round user-action user-action-follow user-action-follow-121326">
+                        <span class="text">Follow</span>
+                    </button>
+                </div>
+                
+                    <a href="https://twitter.com/30secondfood" target="_blank" class="ssk ssk-icon ssk-twitter"></a>
+                
+                
+                    <a href="https://www.facebook.com/30SecondFood/" target="_blank" class="ssk ssk-icon ssk-facebook"></a>
+                
+                
+                    <a href="https://30seconds.com/food/" target="_blank" class=""><span class="icon icon-link"></span></a>
+                
+            </div>
+        </div>
+    </div>
+
+        
+        
+            <figure class="tip-img"><img src="https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg" srcset="https://media.30seconds.com/tip/md/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-adcbbdd560-1643037036.jpg 510w, https://media.30seconds.com/tip/lg/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-c6275c91c8-1643037036.jpg 960w" sizes="(min-width: 992px) 65vw, (min-width: 768px) 80vw, 100vw" class="img-fluid" alt="20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food">
+                    <span class="tip-share" data-item-id="15182" data-url="https://30seconds.com/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food"><a href="javascript:;" rel="nofollow" data-text="20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food" class="ssk ssk-pinterest tip-share-pinterest"></a></span>
+
+                
+            </figure>
+        
+
+        
+            <div class="tip-body">
+                
+
+                
+                
+                    <p class="amazon-disclaimer alt-color" style="font-size: 13px">Note: 30Seconds is a participant in affiliate advertising programs and this post may contain affiliate links, which means we may earn a commission or fees if you make a purchase via those links.</p>
+                
+
+                <div class="print-content"><p>
+	<strong>Think of this easy chipotle cream <a href="https://30seconds.com/search/chicken%20recipe"target="_blank" onmousedown="return rwt(this)">chicken recipe</a></strong><strong> as chicken a la king with attitude. </strong>Serve this <a href="https://30seconds.com/search/comfort%20food"target="_blank" onmousedown="return rwt(this)">comforting recipe</a> over <a href="https://30seconds.com/search/rice%20recipe"target="_blank" onmousedown="return rwt(this)">rice</a>, toast points, <a href="https://30seconds.com/food/tip/9082/Easy-Homemade-Tortilla-Chips-Recipe-Make-These-Fresh-Restaurant-Style-Tortilla-Chips-in-Minutes"target="_blank" onmousedown="return rwt(this)">tortilla chips</a> or even <a href="https://30seconds.com/food/category/pasta/"target="_blank" onmousedown="return rwt(this)">pasta</a>.</p><p>
+	<strong>Cuisine: American</strong><br>
+	<strong>Prep Time: 5 minutes<br>
+	Cook Time: 15 minutes
+	<br>
+	Total Time: 20 minutes
+	<br>
+	Servings: 4
+	</strong></p><p>
+	<strong>Ingredients</strong></p><ul>
+	
+<li>1 pound chicken tenders, cut into bite-sized pieces</li>	
+<li>1/4 cup&nbsp;<a href="https://www.amazon.com/s?k=flour+all+purpose&tag=30secondmom09-20&ref=nb_sb_noss_2"target="_blank" onmousedown="return rwt(this)" rel="nofollow">flour</a></li>	
+<li>1 teaspoon&nbsp;<a href="https://www.amazon.com/s?k=garlic+powder&tag=30secondmom09-20&ref=nb_sb_noss_2"target="_blank" onmousedown="return rwt(this)" rel="nofollow">garlic powder</a></li>	
+<li>2 tablespoons&nbsp;<a href="https://www.amazon.com/s?k=olive+oil&tag=30secondmom09-20&ref=nb_sb_noss_2"target="_blank" onmousedown="return rwt(this)" rel="nofollow">olive oil</a></li>	
+<li>1 small onion, chopped</li>	
+<li>1 small green bell pepper, red bell pepper or poblano pepper, diced (try a combination)</li>	
+<li>3/4 cup&nbsp;<a href="https://www.amazon.com/s?k=chicken+broth&tag=30secondmom09-20&ref=nb_sb_noss_2"target="_blank" onmousedown="return rwt(this)" rel="nofollow">chicken broth</a></li>	
+<li>2&nbsp;<a href="https://www.amazon.com/s?k=chipotles+in+adobo&tag=30secondmom09-20&ref=nb_sb_noss_2"target="_blank" onmousedown="return rwt(this)" rel="nofollow">chipotle peppers in adobo sauce</a>, minced</li>	
+<li>1/2 cup sour cream</li>	
+<li>1/3 cup chopped fresh cilantro</li></ul><p>
+	<strong>Here’s how to make it:</strong></p><ol>
+	
+<li>Combine the flour and garlic powder in a bowl. Season the chicken tenders with salt and pepper, then dredge in the seasoned flour. Put on a plate and set aside.</li>	
+<li>Heat the olive oil in a large skillet. Add the onion and peppers and cook until soft.</li>	
+<li>Add the chicken pieces to the skillet and continue to cook until chicken is browned and almost cooked through.</li>	
+<li>Add the chicken broth and chipotle peppers. Bring to a boil, reduce heat and cook until reduced a little and thick. Stir in the cilantro and sour cream.&nbsp;</li></ol><p>
+	<strong>Take 30 seconds and </strong><a href="https://30seconds.com/accounts/signup/"target="_blank" onmousedown="return rwt(this)"><strong>join the 30Seconds community</strong></a><strong> and </strong><a href="https://www.facebook.com/30SecondFood"target="_blank" onmousedown="return rwt(this)" rel="nofollow"><strong>follow us on Facebook</strong></a><strong> to get recipes in your newsfeed daily. Inspire and be inspired.</strong></p><p>
+	<strong></strong></p></div>
+
+                
+    
+
+
+                
+                
+                    <p class="amazon-disclaimer alt-color">30Second Mobile, Inc. is a participant in the Amazon Services LLC Associates Program, an affiliate advertising program designed to provide a means for us to earn fees by linking to Amazon.com and affiliated sites.</p>
+                    <p><strong>Related Products on Amazon We Think You May Like:</strong></p>
+                
+                
+    
+        <div class="tip-items">
+            
+                
+                <div class="tip-item">
+                    <h5 class="tip-item-title">
+                        
+                            <a href="https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&amp;field-keywords=chipotles+in+adobo&amp;tag=30secondmom09-20" data-item-id="4393" target="_blank"
+                                     rel="nofollow" onmousedown="return rwt(this)">Chipotles in Adobo</a>
+                        
+                        
+                            <span class="price">$2 &amp; Up</span>
+                        
+                    </h5>
+
+                    <div class="tip-item-body">
+                        
+                    </div>
+
+                </div>
+            
+                
+                <div class="tip-item">
+                    <h5 class="tip-item-title">
+                        
+                            <a href="https://www.amazon.com/s?k=flour+all+purpose&amp;ref=nb_sb_noss_2&amp;tag=30secondmom09-20" data-item-id="21986" target="_blank"
+                                     rel="nofollow" onmousedown="return rwt(this)">Flour</a>
+                        
+                        
+                            <span class="price">$2 &amp; Up</span>
+                        
+                    </h5>
+
+                    <div class="tip-item-body">
+                        
+                    </div>
+
+                </div>
+            
+                
+                <div class="tip-item">
+                    <h5 class="tip-item-title">
+                        
+                            <a href="https://www.amazon.com/s?k=garlic+powder&amp;ref=nb_sb_noss_2&amp;tag=30secondmom09-20" data-item-id="21987" target="_blank"
+                                     rel="nofollow" onmousedown="return rwt(this)">Garlic Powder</a>
+                        
+                        
+                            <span class="price">$2 &amp; Up</span>
+                        
+                    </h5>
+
+                    <div class="tip-item-body">
+                        
+                    </div>
+
+                </div>
+            
+                
+                <div class="tip-item">
+                    <h5 class="tip-item-title">
+                        
+                            <a href="https://www.amazon.com/s?k=chicken+broth&amp;ref=nb_sb_noss_2&amp;tag=30secondmom09-20" data-item-id="21988" target="_blank"
+                                     rel="nofollow" onmousedown="return rwt(this)">Chicken Broth</a>
+                        
+                        
+                            <span class="price">$1 &amp; Up</span>
+                        
+                    </h5>
+
+                    <div class="tip-item-body">
+                        
+                    </div>
+
+                </div>
+            
+                
+                <div class="tip-item">
+                    <h5 class="tip-item-title">
+                        
+                            <a href="https://www.amazon.com/s?k=olive+oil&amp;ref=nb_sb_noss_2&amp;tag=30secondmom09-20" data-item-id="21989" target="_blank"
+                                     rel="nofollow" onmousedown="return rwt(this)">Olive Oil</a>
+                        
+                        
+                            <span class="price">$4 &amp; Up</span>
+                        
+                    </h5>
+
+                    <div class="tip-item-body">
+                        
+                    </div>
+
+                </div>
+            
+        </div>
+    
+
+
+                
+                
+                    <ul class="tip-tags">
+                        <li class="text">Tags</li>
+                        
+                            <li>
+                                <a href="/tag/20-minute-recipe" class="cc-bg">20-minute-recipe</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/chicken" class="cc-bg">chicken</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/chicken-recipes" class="cc-bg">chicken-recipes</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/chipotle" class="cc-bg">chipotle</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/chipotle-chicken" class="cc-bg">chipotle-chicken</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/chipotle-creamed-chicken" class="cc-bg">chipotle-creamed-chicken</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/chipotle-recipes" class="cc-bg">chipotle-recipes</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/creamed-chicken" class="cc-bg">creamed-chicken</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/creamed-chicken-recipes" class="cc-bg">creamed-chicken-recipes</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/food" class="cc-bg">food</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/recipes" class="cc-bg">recipes</a>
+                            </li>
+                        
+                            <li>
+                                <a href="/tag/whats-for-dinner" class="cc-bg">whats-for-dinner</a>
+                            </li>
+                        
+
+                    </ul>
+                
+
+
+
+            </div>
+        
+    </article>
+
+
+    
+        
+    
+        <div class="row grid-row">
+            
+                
+                
+                
+                <div class="col-xs-6 col-sm-6 col-lg-6">
+        <article class="tip tip-no-author">
+            <div class="tip-img">
+                <a href="/food/tip/19470/Authentic-Filipino-Adobo-Chicken-Recipe-6-Ingredients-60-Minutes">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/Filipino-Adobo-Chicken-Recipe-Make-This-Easy-Filipino-Chic-19470-383c1c1016-1617635057.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="Authentic Filipino Adobo Chicken Recipe (6 Ingredients, 60 Minutes)"></div>
+                </a>
+                
+                
+                    <a href="/food/category/filipino-recipes/" class="tip-category">Filipino Recipes</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/19470/Authentic-Filipino-Adobo-Chicken-Recipe-6-Ingredients-60-Minutes" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">Authentic Filipino Adobo Chicken Recipe (6 Ingredients, 60 Minutes)</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="19470" data-action-url="/food/tip/19470/like" class="user-action user-action-like user-action-like-19470">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/19470/Authentic-Filipino-Adobo-Chicken-Recipe-6-Ingredients-60-Minutes#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+            
+                
+                
+                
+                <div class="col-xs-6 col-sm-6 col-lg-6">
+        <article class="tip tip-no-author">
+            <div class="tip-img">
+                <a href="/food/tip/9946/How-to-Save-Chipotles-in-Adobo-Sauce-Dont-Waste-Another-Chipotle-Pepper-With-This-Hot-Cooking-Tip">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/Chipotles-in-Adobo-Dont-Waste-Another-Chile-With-This-Hot--9946-839a99e7c3-1502901679.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="How to Save Chipotles in Adobo Sauce: Don’t Waste Another Chipotle Pepper With This Hot Cooking Tip"></div>
+                </a>
+                
+                
+                    <a href="/food/category/cooking-tips/" class="tip-category">Cooking Tips</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/9946/How-to-Save-Chipotles-in-Adobo-Sauce-Dont-Waste-Another-Chipotle-Pepper-With-This-Hot-Cooking-Tip" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">How to Save Chipotles in Adobo Sauce: Don’t Waste Another Chipotle Pepper With This Hot Cooking Tip</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="9946" data-action-url="/food/tip/9946/like" class="user-action user-action-like user-action-like-9946">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/9946/How-to-Save-Chipotles-in-Adobo-Sauce-Dont-Waste-Another-Chipotle-Pepper-With-This-Hot-Cooking-Tip#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+            
+                
+                
+                
+                <div class="col-xs-6 col-sm-6 col-lg-6">
+        <article class="tip tip-no-author">
+            <div class="tip-img">
+                <a href="/food/tip/13126/Southwest-Tamale-Pie-Casserole-Recipe-Is-High-Fiber-High-Protein-Dates-Back-to-1911">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/A-Taste-of-Texas-How-to-Make-Southwestern-Turkey-Tamale-Pi-13126-a9531fd7c3-1482328786.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="Southwest Tamale Pie Casserole Recipe Is High-Fiber, High-Protein &amp; Dates Back to 1911"></div>
+                </a>
+                
+                
+                    <a href="/food/category/high-fiber-recipes/" class="tip-category">High Fiber Recipes</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/13126/Southwest-Tamale-Pie-Casserole-Recipe-Is-High-Fiber-High-Protein-Dates-Back-to-1911" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">Southwest Tamale Pie Casserole Recipe Is High-Fiber, High-Protein &amp; Dates Back to 1911</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="13126" data-action-url="/food/tip/13126/like" class="user-action user-action-like user-action-like-13126">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/13126/Southwest-Tamale-Pie-Casserole-Recipe-Is-High-Fiber-High-Protein-Dates-Back-to-1911#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+            
+                
+                
+                
+                <div class="col-xs-6 col-sm-6 col-lg-6">
+        <article class="tip tip-no-author">
+            <div class="tip-img">
+                <a href="/food/tip/5296/Creamy-Slow-Cooker-Chicken-Chili-Is-a-No-Stress-Dinner">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/Creamy-Slow-Cooker-Chicken-Chili-Is-a-No-Stress-Dinner-5296-78d88f2e06-1651502340.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="Creamy Slow Cooker Chicken Chili Is a No-Stress Dinner"></div>
+                </a>
+                
+                
+                    <a href="/food/category/chicken-recipes/" class="tip-category">Chicken Recipes</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/5296/Creamy-Slow-Cooker-Chicken-Chili-Is-a-No-Stress-Dinner" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">Creamy Slow Cooker Chicken Chili Is a No-Stress Dinner</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="5296" data-action-url="/food/tip/5296/like" class="user-action user-action-like user-action-like-5296">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/5296/Creamy-Slow-Cooker-Chicken-Chili-Is-a-No-Stress-Dinner#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+            
+        </div>
+    
+
+    
+
+    
+    
+        <a id="comments" name="comments" class="anchor-offset"></a>
+    
+        <a id="collections" name="collections" class="anchor-offset"></a>
+    
+
+    <ul id="tip_tabs" class="tip-tabs">
+        
+            <li class="tab-comments active">
+                <a id="comments" href="#comments" class="tip-tab">
+                    <span class="text">comments
+                    <span class="nr comment user-action-comment-15182-count">3</span>
+                    </span>
+                </a>
+            </li>
+        
+            <li class="tab-collections">
+                <a id="collections" href="#collections" class="tip-tab">
+                    <span class="text">collections
+                    <span class="nr collection user-action-collection-15182-count">2</span>
+                    </span>
+                </a>
+            </li>
+        
+        
+        <li class="tab-loader">
+            
+    <div class="loader-clock loader-clock-sm"
+            >
+        <div class="dot"></div>
+        <div class="dot"></div>
+        <div class="dot"></div>
+        <div class="dot"></div>
+        <div class="dot"></div>
+        <div class="dot"></div>
+        <div class="dot"></div>
+        <div class="tick-container">
+            <div class="tick"></div>
+        </div>
+    </div>
+
+        </li>
+    </ul>
+
+    
+
+    
+    <div id="tab_contents">
+        <div id="tab_comments" class="tab-content tab-comments show comments" data-tip-id="15182">
+            <div id="comments-15182" class="comments-list-container">
+                
+                    
+    
+        <div class="comments-list">
+            <div class="comments-section">
+                
+                    
+                    
+                    
+                    
+                    
+                    
+                    <div class="comment clearfix" id="comment-9522" data-comment-id="9522">
+                        
+                            <a href="/elisa/" class="avatar">
+                                <span class="user-avatar-sm" style="background-image: url('https://media.30seconds.com/user/xs/elisa-a-schmitz-30seconds-1-f2b6580274-1649882277.jpg')"></span>
+                            </a>
+                        
+
+                        <div class="body-cont">
+                            <a class="anchor-offset" name="c9522"></a>
+                            
+                                <a href="/elisa/" class="user">Elisa Schmitz</a>
+                            
+                            
+    <div class="body markup">
+        So yummy! 😋
+    </div>
+    
+    
+
+                            <div class="links-bar">
+                                
+                                    <a href="/user/action/comment/9522/like/1" data-type="comment" data-action="like" data-id="9522" class="tool user-action  user-action-like user-action-like-comment-9522" rel="nofollow" data-text="Like|Unlike">
+                                        Like
+                                    </a>
+                                
+
+                                
+                                    <a href="javascript:;" class="tool tool-reply" rel="nofollow">Reply</a>
+                                
+
+                                <span class="tool user-like-count color   tipsy--n" data-tipsy="None">
+                                    <span class="icon icon-heart"></span><span class="nr user-action-like-comment-9522-count"></span>
+                                </span>
+
+                                <a href="#c9522" class="tool date">8 years ago</a>
+
+                            </div>
+                        </div>
+                    </div>
+                    
+                
+                    
+                    
+                    
+                    
+                    
+                    
+                    <div class="comment clearfix" id="comment-29362" data-comment-id="29362">
+                        
+                            <a href="/donna/" class="avatar">
+                                <span class="user-avatar-sm" style="background-image: url('https://media.30seconds.com/user/xs/donna-john-273-0c1af7d00e-1536964251.jpg')"></span>
+                            </a>
+                        
+
+                        <div class="body-cont">
+                            <a class="anchor-offset" name="c29362"></a>
+                            
+                                <a href="/donna/" class="user">Donna John</a>
+                            
+                            
+    <div class="body markup">
+        Mmmmm!
+    </div>
+    
+    
+
+                            <div class="links-bar">
+                                
+                                    <a href="/user/action/comment/29362/like/1" data-type="comment" data-action="like" data-id="29362" class="tool user-action  user-action-like user-action-like-comment-29362" rel="nofollow" data-text="Like|Unlike">
+                                        Like
+                                    </a>
+                                
+
+                                
+                                    <a href="javascript:;" class="tool tool-reply" rel="nofollow">Reply</a>
+                                
+
+                                <span class="tool user-like-count color   tipsy--n" data-tipsy="None">
+                                    <span class="icon icon-heart"></span><span class="nr user-action-like-comment-29362-count"></span>
+                                </span>
+
+                                <a href="#c29362" class="tool date">5 years ago</a>
+
+                            </div>
+                        </div>
+                    </div>
+                    
+                
+                    
+                    
+                    
+                    
+                    
+                    
+                    <div class="comment clearfix" id="comment-35292" data-comment-id="35292">
+                        
+                            <a href="/Tribe/" class="avatar">
+                                <span class="user-avatar-sm" style="background-image: url('https://media.30seconds.com/user/xs/tribe-121607-81b4593076-1502116807.jpg')"></span>
+                            </a>
+                        
+
+                        <div class="body-cont">
+                            <a class="anchor-offset" name="c35292"></a>
+                            
+                                <a href="/Tribe/" class="user">Tribe</a>
+                            
+                            
+    <div class="body markup">
+        Such a flavorful recipe.
+    </div>
+    
+    
+
+                            <div class="links-bar">
+                                
+                                    <a href="/user/action/comment/35292/like/1" data-type="comment" data-action="like" data-id="35292" class="tool user-action  user-action-like user-action-like-comment-35292" rel="nofollow" data-text="Like|Unlike">
+                                        Like
+                                    </a>
+                                
+
+                                
+                                    <a href="javascript:;" class="tool tool-reply" rel="nofollow">Reply</a>
+                                
+
+                                <span class="tool user-like-count color   tipsy--n" data-tipsy="None">
+                                    <span class="icon icon-heart"></span><span class="nr user-action-like-comment-35292-count"></span>
+                                </span>
+
+                                <a href="#c35292" class="tool date">4 years ago</a>
+
+                            </div>
+                        </div>
+                    </div>
+                    
+                
+            </div>
+        </div>
+
+    
+
+                
+            </div>
+            
+    <div class="comments-list add-comment-form comment-form">
+        <h3>join discussion</h3>
+        <div class="comments-section">
+            <div class="comment clearfix">
+                
+                    <div class="body">
+                        Please
+                        <a href="/accounts/login/?next=/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food#comments">login</a> to comment.
+                    </div>
+                
+            </div>
+        </div>
+    </div>
+
+        </div>
+
+       
+
+        <div id="tab_collections" class="tab-content tab-collections">
+            <div class="tab-html"></div>
+        </div>
+
+        <div id="tab_shares" class="tab-content tab-shares">
+            <div class="tab-html"></div>
+        </div>
+    </div>
+
+    <!-- Root element of PhotoSwipe. Must have class pswp. -->
+<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+
+    <!-- Background of PhotoSwipe.
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+
+        <!-- Container that holds slides.
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <div class="pswp__counter"></div>
+
+                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                        <div class="pswp__preloader__cut">
+                            <div class="pswp__preloader__donut"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+            </button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+            </button>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+
+        </div>
+
+    </div>
+
+</div>
+
+
+
+
+
+                </div>
+
+                
+                    <div class="col-xs-12 col-md-12 col-lg-3 col-right">
+                        <div class="right-narrow-side ad-sidebar">
+                            
+                                <h4>recommended tips</h4>
+
+                                <div class="row grid-row">
+                                    
+                                        <div class="col-xs-12 col-sm-6 col-md-3 col-lg-12">
+        <article class="tip tip-no-author tip-narrow">
+            <div class="tip-img">
+                <a href="/food/tip/61521/Copycat-Napa-Chicken-Salad-Recipe-Tastes-Like-That-Sandwich-From-Panera">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/Fresh-Napa-Chicken-Salad-Recipe-Tastes-Like-That-Sandwich--61521-7c0d43acb3-1690469825.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="Copycat Napa Chicken Salad Recipe Tastes Like That Sandwich From Panera"></div>
+                </a>
+                
+                
+                    <a href="/food/category/sandwiches/" class="tip-category">Sandwiches</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/61521/Copycat-Napa-Chicken-Salad-Recipe-Tastes-Like-That-Sandwich-From-Panera" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">Copycat Napa Chicken Salad Recipe Tastes Like That Sandwich From Panera</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="61521" data-action-url="/food/tip/61521/like" class="user-action user-action-like user-action-like-61521">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/61521/Copycat-Napa-Chicken-Salad-Recipe-Tastes-Like-That-Sandwich-From-Panera#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+                                    
+                                        <div class="col-xs-12 col-sm-6 col-md-3 col-lg-12">
+        <article class="tip tip-no-author tip-narrow">
+            <div class="tip-img">
+                <a href="/food/tip/103072/Mediterranean-Peach-Salad-Recipe-With-Lemon-Basil-Vinaigrette-Is-So-Refreshing-15-Minutes">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/Peach-Blueberry-Cucumber-Salad-Recipe-With-Feta-In-a-Refre-103072-b6c00139fe-1784068536.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="Mediterranean Peach Salad Recipe With Lemon Basil Vinaigrette Is So Refreshing (15 Minutes)"></div>
+                </a>
+                
+                
+                    <a href="/food/category/mediterranean-diet-recipes/" class="tip-category">Mediterranean Diet Recipes</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/103072/Mediterranean-Peach-Salad-Recipe-With-Lemon-Basil-Vinaigrette-Is-So-Refreshing-15-Minutes" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">Mediterranean Peach Salad Recipe With Lemon Basil Vinaigrette Is So Refreshing (15 Minutes)</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="103072" data-action-url="/food/tip/103072/like" class="user-action user-action-like user-action-like-103072">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/103072/Mediterranean-Peach-Salad-Recipe-With-Lemon-Basil-Vinaigrette-Is-So-Refreshing-15-Minutes#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+                                    
+                                        <div class="col-xs-12 col-sm-6 col-md-3 col-lg-12">
+        <article class="tip tip-no-author tip-narrow">
+            <div class="tip-img">
+                <a href="/food/tip/103112/Coconut-Dill-Salmon-Recipe-With-Tomatoes-Corn-Green-Beans-for-the-Grill-or-Oven-34-Grams-of-Protein">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/Coconut-Dill-Salmon-with-Tomatoes-and-Green-Beans-On-the-G-103112-666d1a4223-1784155024.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="Coconut Dill Salmon Recipe With Tomatoes, Corn &amp; Green Beans for the Grill or Oven (34 Grams of Protein)"></div>
+                </a>
+                
+                
+                    <a href="/food/category/high-protein-recipes/" class="tip-category">High Protein Recipes</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/103112/Coconut-Dill-Salmon-Recipe-With-Tomatoes-Corn-Green-Beans-for-the-Grill-or-Oven-34-Grams-of-Protein" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">Coconut Dill Salmon Recipe With Tomatoes, Corn &amp; Green Beans for the Grill or Oven (34 Grams of Protein)</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="103112" data-action-url="/food/tip/103112/like" class="user-action user-action-like user-action-like-103112">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/103112/Coconut-Dill-Salmon-Recipe-With-Tomatoes-Corn-Green-Beans-for-the-Grill-or-Oven-34-Grams-of-Protein#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+                                    
+                                        <div class="col-xs-12 col-sm-6 col-md-3 col-lg-12">
+        <article class="tip tip-no-author tip-narrow">
+            <div class="tip-img">
+                <a href="/food/tip/86879/Peanut-Butter-Chocolate-Bars-Recipe-Tastes-Like-Reeses-Peanut-Butter-Cups-4-Ingredients">
+                    
+                        <div class="tip-img-shadow"><img data-src="https://media.30seconds.com/tip/md/Reeses-healthy-peanut-butter-chocolate-bars-4-Ingredients--86879-2bbd0a7c78-1749562803.jpg" src="https://static.30seconds.com/static/img/s.png" class="lazy img-fluid" alt="Peanut Butter Chocolate Bars Recipe Tastes Like Reese&#39;s Peanut Butter Cups (4 Ingredients)"></div>
+                </a>
+                
+                
+                    <a href="/food/category/high-protein-recipes/" class="tip-category">High Protein Recipes</a>
+                
+                
+
+                
+            </div>
+
+            <a href="/food/tip/86879/Peanut-Butter-Chocolate-Bars-Recipe-Tastes-Like-Reeses-Peanut-Butter-Cups-4-Ingredients" class="click-area"></a>
+            <div class="tip-content">
+                <h2 class="tip-title">Peanut Butter Chocolate Bars Recipe Tastes Like Reese&#39;s Peanut Butter Cups (4 Ingredients)</h2>
+                
+            </div>
+
+            <div class="tip-actions-row">
+                <div class="tip-actions">
+                    
+                        
+                        
+                        <button type="button" data-action="like" data-id="86879" data-action-url="/food/tip/86879/like" class="user-action user-action-like user-action-like-86879">
+                            <span class="icon icon-heart"></span></button>
+                        <a href="/food/tip/86879/Peanut-Butter-Chocolate-Bars-Recipe-Tastes-Like-Reeses-Peanut-Butter-Cups-4-Ingredients#comments" class="tip-action-comment" rel="nofollow">
+                            <span class="icon icon-comment"></span>
+
+
+
+                        </a>
+                        
+                        
+                    
+                </div>
+                
+            </div>
+        </article>
+    </div>
+
+                                    
+                                </div>
+                            
+                        </div>
+                    </div>
+                
+
+            </div>
+
+        </div>
+    
+
+    <div id="collectionModal" tabindex="-1" class="modal fade collection-modal" data-tip-id="15182"
+     data-list-url="/collection/list/" data-toggle-url="/collection/toggle/"
+     data-image="https://media.30seconds.com/tip/md/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-adcbbdd560-1643037036.jpg">
+    <div class="modal-dialog modal-lg" role="document">
+        <form action="/collection/save/" class="modal-content">
+            <input type="hidden" name="csrfmiddlewaretoken" value="AoAZ01tv5Wy9YlzhYH2nmU54SJxk8tauVMTuAJp1GvXa5oLLAmuuKRNyNs1TeXn4" />
+            <input type="hidden" id="collection_id" name="id" value="">
+            <input type="hidden" name="tip_id" value="15182">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h3 class="modal-title">Manage Collections</h3>
+            </div>
+            <div class="loader-sm"></div>
+            <div class="modal-body default-view">
+                <div class="text-xs-center instruction-empty hide">
+                    <br>
+                    <a href="#new" class="toggle-new-collection">+ Create your first collection</a>
+                </div>
+                <div class="text-xs-center instruction-exists hide">
+                    Click on collection you would like to add this tip to or create
+                    <a href="#new" class="toggle-new-collection"> New Collection</a>
+                </div>
+                <div class="container-fluid">
+                    <div class="row collections-row" id="collections-row"></div>
+                </div>
+            </div>
+            <div class="modal-body new-collection-view new-collection-form">
+                <div class="form-group row">
+                    <label for="collection_title" class="col-sm-2 col-form-label">Collection name</label>
+                    <div class="col-sm-10">
+                        <input type="text" name="title" required class="form-control" id="collection_title" placeholder="" maxlength="100">
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label class="col-sm-2 col-form-label">Visibility</label>
+                    <div class="col-sm-10">
+                        <label class="radio-inline">
+                          <input type="radio" name="visibility" value="1" checked> Public
+                        </label>
+                        <label class="radio-inline">
+                          <input type="radio" name="visibility" value="0"> Private
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer default-view">
+                <button type="button" class="btn btn-primary float-xs-left toggle-new-collection">+ New Collection</button>
+                <button type="button" class="btn btn-primary-outline" data-dismiss="modal">Close</button>
+            </div>
+            <div class="modal-footer new-collection-view">
+                <div class="row">
+                    <div class="col-sm-2"></div>
+                    <div class="col-sm-10">
+                        <button type="submit" class="btn btn-primary float-xs-left">Save collection</button>
+                        <button type="button" class="btn btn-primary-outline toggle-default-view">Cancel</button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+    <div id="embedModal" tabindex="-1" class="modal fade embed-modal" data-tip-id="15182"
+     data-list-url="/collection/list/" data-toggle-url="/collection/toggle/"
+     data-image="https://media.30seconds.com/tip/md/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spi-15182-adcbbdd560-1643037036.jpg">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h3 class="modal-title">Embed Tip on Your Site</h3>
+            </div>
+            <div class="modal-body new-collection-form">
+                Copy and paste this code where you want it to appear on your website:
+                <textarea readonly cols="30" rows="5" class="form-control" onclick="this.select()">&lt;a href=&#34;https://30seconds.com/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food&#34; target=&#34;_blank&#34; data-width=&#34;100%&#34; data-tipid=&#34;15182&#34; class=&#34;w30seconds&#34;&gt;20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food&lt;/a&gt;&lt;script src=&#34;https://static.30seconds.com/static/js/widget.min.js&#34;&gt;&lt;/script&gt;</textarea>
+
+                <small class="muted-note">PREVIEW:</small>
+                <div class="row">
+                    <div class="col-xs-12 col-md-10 col-lg-8">
+                        <a href="https://30seconds.com/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food" target="_blank" data-width="100%" data-tipid="15182" data-preview="1" class="w30seconds">20-Minute Chipotle Creamed Chicken Recipe Puts a Spicy Spin on Comfort Food</a>
+                    </div>
+                </div>
+
+            </div>
+            <div class="modal-footer text-xs-center">
+                <button type="button" class="btn btn-primary-outline" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+    <div class="footer">
+    <div class="container">
+
+        <div class="first-line">
+            <ul class="footer-nav">
+                
+                    <li>
+                        <a href="/page/about/">About</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/contact/">Contact</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/mediapress/">Media/Press</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/faq/">FAQ</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/help/">Help</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/terms-of-use/">Terms of Use</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/privacy-policy/">Privacy Policy</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/contributor-agreement/">Contributor Agreement</a>
+                    </li>
+                
+                    <li>
+                        <a href="/page/contest-rules/">Contest Rules</a>
+                    </li>
+                
+            </ul>
+
+            
+    <div class="social-icons">
+        <div class="ssk-group ssk-gray-icons">
+            <a href="https://twitter.com/30seconds" target="_blank" class="ssk ssk-icon ssk-twitter"></a>
+            <a href="https://www.facebook.com/30SecondsCom" target="_blank" class="ssk ssk-icon ssk-facebook"></a>
+            <a href="https://www.pinterest.com/30secondmom/" target="_blank" class="ssk ssk-icon ssk-pinterest"></a>
+
+            <a href="https://www.instagram.com/30secondmom/" target="_blank" class="ssk ssk-icon ssk-instagram"></a>
+            <a href="https://www.youtube.com/user/30secondmom/videos" target="_blank" class="ssk ssk-icon ssk-youtube"></a>
+        </div>
+    </div>
+
+        </div>
+        <div class="second-line">
+            <span class="copy color">&copy; 2026 30Seconds<span style="font-size: large;">&reg;</span></span>
+
+            <div class="terms">
+                <a href="/page/terms-of-use/">Terms of Use</a>
+                <a href="/page/privacy-policy/">Privacy Policy</a>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+
+<div id="streamApp"></div>
+
+
+
+    <div id="fb-root"></div>
+
+    
+
+
+
+
+
+
+
+        <script type="text/javascript" src="https://media.30seconds.com/static/js/app.min.73d8857db7d1.js"></script>
+    
+
+    
+        <script src="https://js.sentry-cdn.com/4c1af4ef7f807933d69001e44136c157.min.js" crossorigin="anonymous"></script>
+        <script type="text/javascript">
+            Sentry.init({
+                beforeSend: function (event) {
+                    var tags = event && event.tags || {};
+                    if (tags.custom_message === 'true') {
+                        return event;
+                    }
+                    return null;
+                }
+            });
+        </script>
+    
+
+    
+    <script type="text/javascript">
+        TM.Settings = {
+            fb_app_id: 981829471899576,
+            channel: 'food',
+            loginUrl: '/accounts/login/',
+            signupUrl: '/accounts/signup/'
+        };
+        
+    </script>
+    
+
+    
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-LLB861SN89"></script>
+
+
+
+
+    
+
+    <script type="text/javascript">
+        WebFont.load({
+            google: {
+                families: [
+                    'Asap:400,700:latin',
+                    'Source+Sans+Pro:400,300,600,700,400italic:latin'
+                ]
+            }
+        });
+    </script>
+
+    <script type="text/javascript">
+        VueComponents.initGlobalComponents();
+    </script>
+
+    
+    
+    
+    
+
+    
+        <script type="text/javascript">
+            (function (i, s, o, g, r, a, m) {
+               i['GoogleAnalyticsObject'] = r;
+               i[r] = i[r] || function () {
+                           (i[r].q = i[r].q || []).push(arguments)
+                       }, i[r].l = 1 * new Date();
+               a = s.createElement(o),
+                       m = s.getElementsByTagName(o)[0];
+               a.async = 1;
+               a.src = g;
+               m.parentNode.insertBefore(a, m)
+            })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+            ga('create', 'UA-26094858-1', 'auto');
+
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-LLB861SN89');
+
+            ga('set', 'dimension1', 'Guest');
+            gtag('set', {'dimension1': 'Guest'});
+                ga('set', 'dimension3', 'food');
+                gtag('set', {'dimension3': 'food'});
+            
+
+            ga('send', 'pageview');
+
+            
+        </script>
+
+        <script type="module">
+            import {
+              onINP
+            } from 'https://unpkg.com/web-vitals@3.4.0/dist/web-vitals.attribution.js?module';
+        
+            function sendToGoogleAnalytics ({name, value, id, attribution}) {
+                // Destructure the attribution object:
+                const {eventEntry, eventTarget, eventType, loadState} = attribution;
+            
+                // Get timings from the event timing entry:
+                const {startTime, processingStart, processingEnd, duration, interactionId} = eventEntry;
+            
+                const eventParams = {
+                  // The page's INP value:
+                  metric_inp_value: value,
+                  // A unique ID for the page session, which is useful
+                  // for computing totals when you group by the ID.
+                  metric_id: id,
+                  // The event target (a CSS selector string pointing
+                  // to the element responsible for the interaction):
+                  metric_inp_event_target: eventTarget,
+                  // The type of event that triggered the interaction:
+                  metric_inp_event_type: eventType,
+                  // Whether the page was loaded when the interaction
+                  // took place. Useful for identifying startup versus
+                  // post-load interactions:
+                  metric_inp_load_state: loadState,
+                  // The time (in milliseconds) after page load when
+                  // the interaction took place:
+                  metric_inp_start_time: startTime,
+                  // When processing of the event callbacks in the
+                  // interaction started to run:
+                  metric_inp_processing_start: processingStart,
+                  // When processing of the event callbacks in the
+                  // interaction finished:
+                  metric_inp_processing_end: processingEnd,
+                  // The total duration of the interaction. Note: this
+                  // value is rounded to 8 milliseconds of granularity:
+                  metric_inp_duration: duration,
+                  // The interaction ID assigned to the interaction by
+                  // the Event Timing API. This could be useful in cases
+                  // where you might want to aggregate related events:
+                  metric_inp_interaction_id: interactionId
+                };
+            
+                // Send to Google Analytics
+                gtag('event', name, eventParams);
+            }
+        
+            // Pass the reporting function to the web-vitals INP reporter:
+            onINP(sendToGoogleAnalytics);
+        </script>
+    
+
+        <script async defer src="https://connect.facebook.net/en_US/sdk.js"></script>
+
+        <!-- Facebook Pixel Code -->
+        <script>
+        var fbPixelParams = {};
+        !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+        n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+        document,'script','https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '548670858670248', fbPixelParams);
+        fbq('track', 'PageView');
+        </script>
+        <noscript><img height="1" width="1" style="display:none"
+        src="https://www.facebook.com/tr?id=548670858670248&ev=PageView&noscript=1"
+        /></noscript>
+        <!-- DO NOT MODIFY -->
+        <!-- End Facebook Pixel Code -->
+
+        <!-- adblock recovery-->
+        <script type="text/javascript" async src="https://btloader.com/tag?o=5698917485248512&upapi=true&domain=30seconds.com"></script>
+        <script>!function(){"use strict";var e;e=document,function(){var t,n;function r(){var t=e.createElement("script");t.src="https://cafemedia-com.videoplayerhub.com/galleryplayer.js",e.head.appendChild(t)}function a(){var t=e.cookie.match("(^|[^;]+)\s*__adblocker\s*=\s*([^;]+)");return t&&t.pop()}function c(){clearInterval(n)}return{init:function(){var e;"true"===(t=a())?r():(e=0,n=setInterval((function(){100!==e&&"false"!==t||c(),"true"===t&&(r(),c()),t=a(),e++}),50))}}}().init()}();</script>
+
+
+    <script type="text/javascript">
+        TM.Facebook.init();
+
+        
+        $(function () {
+            TM.TipTabs.init({
+                'likes': '/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food/likes',
+                'collections': '/food/tip/15182/20-Minute-Chipotle-Creamed-Chicken-Recipe-Puts-a-Spicy-Spin-on-Comfort-Food/collections'
+            });
+            TM.Newsletter.init($('#newsletterEmail'), 'tip_side');
+            TM.Comments.init({
+                'list': '/food/comments/15182/',
+                'get': '/food/comment/0/',
+                'new': '/food/comments/15182/new/'
+            });
+            TM.CollectionModal.init();
+            TM.EmbedModal.init('https://media.30seconds.com/static/js/widget.min.c74f02975b0e.js');
+            
+
+            TM.Comments.initSwipe($('.tip-body'));
+
+
+            
+
+
+
+
+        });
+        TM.Settings.tipLinkClickUrl = '/tip/15182/click/';
+    </script>
+
+    
+
+
+
+
+    <!-- Must be after GA -->
+    <script type="text/javascript">
+        $(function () {
+            TM.SignupPopUp.init();
+        })
+    </script>
+
+
+
+
+</body>
+</html>


### PR DESCRIPTION
Adds a scraper for [30seconds.com](https://30seconds.com/food/) (30Seconds Food).

Their recipe pages mostly expose only an `Article` schema — the recipe itself lives in the page markup (an Ingredients `<ul>` and a directions `<ol>`), so wild mode comes back nearly empty. This scraper parses that markup, and still defers to the SchemaOrg plugin on the pages that do carry a full `Recipe`.

It handles the layout variations I ran into across their catalog:

- pages with an explicit `<strong>Ingredients</strong>` header, and pages that skip it and start the list right after the `Servings:` line
- multi-section ingredient lists (e.g. a chili paste plus the mains)
- times and servings read from the `Total Time` / `Servings` lines

Test data added under `tests/test_data/30seconds.com/`. Scraper test, flake8, black, and mypy all pass locally.