### PR TITLE
Fix metric gram yields

### DIFF
--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -96,6 +96,11 @@ RECIPE_YIELD_TYPES = (
     # ... add more types as needed, in (singular, plural) format ...
 )
 
+RECIPE_YIELD_ABBREVIATIONS = (
+    ("kg", "kilogram", "kilograms"),
+    ("g", "gram", "grams"),
+)
+
 # Pre-compile regex patterns for yield type matching with word boundaries
 _YIELD_TYPE_PATTERNS = [
     (
@@ -105,6 +110,16 @@ _YIELD_TYPE_PATTERNS = [
         plural,
     )
     for singular, plural in RECIPE_YIELD_TYPES
+]
+
+
+_YIELD_ABBREVIATION_PATTERNS = [
+    (
+        re.compile(rf"^\D*\d+(?:\.\d*)?\s*{re.escape(abbreviation)}\b", re.IGNORECASE),
+        singular,
+        plural,
+    )
+    for abbreviation, singular, plural in RECIPE_YIELD_ABBREVIATIONS
 ]
 
 
@@ -299,6 +314,10 @@ def get_yields(element):
 
     if best_match:
         return best_match
+
+    for abbreviation_pattern, singular, plural in _YIELD_ABBREVIATION_PATTERNS:
+        if abbreviation_pattern.search(serve_text_lower):
+            return format_count_label(matched, singular, plural)
 
     plural = "s" if matched != 1 else ""
     if SERVE_REGEX_ITEMS.search(serve_text) is not None:

--- a/recipe_scrapers/_utils.py
+++ b/recipe_scrapers/_utils.py
@@ -96,6 +96,11 @@ RECIPE_YIELD_TYPES = (
     # ... add more types as needed, in (singular, plural) format ...
 )
 
+RECIPE_YIELD_ABBREVIATIONS = (
+    ("kg", "kilogram", "kilograms"),
+    ("g", "gram", "grams"),
+)
+
 # Pre-compile regex patterns for yield type matching with word boundaries
 _YIELD_TYPE_PATTERNS = [
     (
@@ -105,6 +110,16 @@ _YIELD_TYPE_PATTERNS = [
         plural,
     )
     for singular, plural in RECIPE_YIELD_TYPES
+]
+
+
+_YIELD_ABBREVIATION_PATTERNS = [
+    (
+        re.compile(rf"^\D*\d+(?:\.\d*)?\s*{re.escape(abbreviation)}\b", re.IGNORECASE),
+        singular,
+        plural,
+    )
+    for abbreviation, singular, plural in RECIPE_YIELD_ABBREVIATIONS
 ]
 
 
@@ -306,6 +321,10 @@ def get_yields(element):
 
     if best_match:
         return best_match
+
+    for abbreviation_pattern, singular, plural in _YIELD_ABBREVIATION_PATTERNS:
+        if abbreviation_pattern.search(serve_text_lower):
+            return format_count_label(matched, singular, plural)
 
     plural = "s" if matched != 1 else ""
     if SERVE_REGEX_ITEMS.search(serve_text) is not None:

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -216,3 +216,14 @@ class TestUtils(unittest.TestCase):
         self.assertIsNone(format_diet_name(None))
         self.assertIsNone(format_diet_name(42))
         self.assertIsNone(format_diet_name("https://schema.org/"))
+
+    def test_get_yields_metric_weight_abbreviations(self):
+        test_cases = [
+            ("750g", "750 grams"),
+            ("750 g di crema pasticcera", "750 grams"),
+            ("1 kg dough", "1 kilogram"),
+            ("2kg dough", "2 kilograms"),
+        ]
+        for input_text, expected in test_cases:
+            with self.subTest(input_text=input_text):
+                self.assertEqual(expected, get_yields(input_text))

--- a/tests/library/test_utils.py
+++ b/tests/library/test_utils.py
@@ -182,3 +182,14 @@ class TestUtils(unittest.TestCase):
         for input_text, expected in test_cases:
             with self.subTest(input_text=input_text):
                 self.assertEqual(expected, get_yields(input_text))
+
+    def test_get_yields_metric_weight_abbreviations(self):
+        test_cases = [
+            ("750g", "750 grams"),
+            ("750 g di crema pasticcera", "750 grams"),
+            ("1 kg dough", "1 kilogram"),
+            ("2kg dough", "2 kilograms"),
+        ]
+        for input_text, expected in test_cases:
+            with self.subTest(input_text=input_text):
+                self.assertEqual(expected, get_yields(input_text))

--- a/tests/test_data/ricetteperbimby.it/ricetteperbimby_1.json
+++ b/tests/test_data/ricetteperbimby.it/ricetteperbimby_1.json
@@ -17,7 +17,7 @@
     "Lasciar freddare in una ciotola coperta da pellicola e riporre in frigo."
   ],
   "category": "Dolci e Dessert",
-  "yields": "750 servings",
+  "yields": "750 grams",
   "description": "Pronta in pochi minuti e perfetta per farcire i tuoi dolci o essere gustata da sola, la crema pasticcera Bimby è una ricetta veloce che ti conquisterà.",
   "total_time": 15,
   "cook_time": 10,


### PR DESCRIPTION
## Summary

Fixes metric weight yields such as `750g` and `750 g di crema pasticcera` being normalized as servings.

## Why

`get_yields()` already recognizes full words such as `gram`/`grams`, but not the common metric abbreviations used by ricetteperbimby and many recipe sites. As a result, the ricetteperbimby fixture from #1223 returned `750 servings` even though the page describes `750 g` of crema pasticcera.

This keeps the change intentionally narrow: only `g` and `kg` are added as strict post-number abbreviations, avoiding broader/ambiguous units like `CL` that were discussed in the issue.

Fixes #1223.

## Test plan

- [x] RED before fix: `python -m unittest tests.library.test_utils.TestUtils.test_get_yields_metric_weight_abbreviations -v` failed with `750 servings` / `1 serving` instead of gram/kilogram yields
- [x] `python -m unittest tests.library.test_utils -v`
- [x] ricetteperbimby fixture smoke:

```sh
python - <<'PY'
import json
from pathlib import Path
from recipe_scrapers import scrape_html
html = Path('tests/test_data/ricetteperbimby.it/ricetteperbimby_1.testhtml').read_text(encoding='utf-8')
expected = json.loads(Path('tests/test_data/ricetteperbimby.it/ricetteperbimby_1.json').read_text(encoding='utf-8'))['yields']
s = scrape_html(html, org_url='ricetteperbimby.it', online=False, supported_only=True)
actual = s.yields()
print('expected', expected)
print('actual', actual)
assert actual == expected == '750 grams'
PY
```

- [x] `python -m py_compile recipe_scrapers/_utils.py tests/library/test_utils.py`
- [x] `python -m json.tool tests/test_data/ricetteperbimby.it/ricetteperbimby_1.json >/tmp/recipe-json-check`
- [x] `git diff --check`
- [x] `python -m unittest tests -q` — 1125 tests passed; existing StaticValue/FieldNotProvidedByWebsite warnings only
