### PR TITLE
Fix: filter Arla placeholder instruction titles

### DIFF
--- a/recipe_scrapers/arla.py
+++ b/recipe_scrapers/arla.py
@@ -22,6 +22,18 @@ class Arla(AbstractScraper):
 
         return ingredients
 
+    def instructions(self):
+        placeholder_titles = {
+            "Första instruktionen",
+            "Nästa instruktion",
+            "Sista instruktionen",
+        }
+        return "\n".join(
+            instruction
+            for instruction in self.schema.instructions().splitlines()
+            if instruction not in placeholder_titles
+        )
+
     def ingredient_groups(self):
 
         groups = []

--- a/tests/test_data/arla.se/arla_1.json
+++ b/tests/test_data/arla.se/arla_1.json
@@ -46,9 +46,7 @@
     }
   ],
   "instructions_list": [
-    "Första instruktionen",
     "Skala och finhacka löken till dressingen. Finhacka även paprikan. Blanda med övriga ingredienser och ställ dressingen åt sidan.",
-    "Sista instruktionen",
     "Skär köttet i tunna skivor. Låt surkålen rinna av ordentligt och blanda med osten.",
     "Bred smör på båda sidor av bröden. Lägg surkål och ost på hälften av bröden. Lägg på köttet. Klicka dressingen över köttet och lägg på resterande bröd.",
     "Stek på båda sidor i enstek- eller het grillpanna.",

--- a/tests/test_data/arla.se/arla_2.json
+++ b/tests/test_data/arla.se/arla_2.json
@@ -49,13 +49,10 @@
     }
   ],
   "instructions_list": [
-    "Första instruktionen",
     "Skala, kärna ur och skär äpplena i ca 1x1 cm tärningar. Lägg dem i en kastrull.",
     "Dela och skrapa ur vaniljstången, lägg ner i kastrullen. Tillsätt vatten och socker, sjud ca 10 min. Ställ kallt.",
-    "Nästa instruktion",
     "Sätt ugnen på 175° eller 160° varmluft.",
     "Nyp ihop alla ingredienser till smulkrispet. Lägg på en plåt med bakplåtspapper och baka i mitten av ugnen ca 10 min.",
-    "Sista instruktionen",
     "Vispa den syrade grädden, rör i vaniljsockret.",
     "Varva kompott, smulkrisp, syrad grädde och glass i portionsglas. Börja med äppelkompott, avsluta med smulkrisp och toppa med glass."
   ],


### PR DESCRIPTION
## Summary
- filter Arla's CMS-generated `HowToSection` placeholder titles from scraped instructions
- preserve the actual instruction steps and keep the behavior scoped to `arla.se`
- update both existing Arla fixtures to cover the regression

The stored pages contain these labels in JSON-LD, but they are not rendered as recipe instructions in the visible page content.

## Testing
- `unittest-parallel --level test` (1151 tests)
- `pre-commit run --all-files`

Closes #2045

## AI disclosure
AI assistance was used to help identify the relevant code path and draft the change. I reviewed the repository guidelines and existing site-specific behavior, reproduced the failure before implementation, reviewed the final diff, and ran the full test and lint suites locally.
