### PR TITLE
Add curatedkitchenware.com scraper

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -170,6 +170,7 @@ from .cuisineaz import CuisineAZ
 from .cuisinezpourbebe import CuisinezPourBebe
 from .culinaryhill import CulinaryHill
 from .culy import Culy
+from .curatedkitchenware import CuratedKitchenware
 from .cybercook import Cybercook
 from .dagelijksekost import DagelijkseKost
 from .damndelicious import DamnDelicious
@@ -896,6 +897,7 @@ SCRAPERS = {
     CuisinezPourBebe.host(): CuisinezPourBebe,
     CulinaryHill.host(): CulinaryHill,
     Culy.host(): Culy,
+    CuratedKitchenware.host(): CuratedKitchenware,
     Cybercook.host(): Cybercook,
     DagelijkseKost.host(): DagelijkseKost,
     DamnDelicious.host(): DamnDelicious,

--- a/recipe_scrapers/curatedkitchenware.py
+++ b/recipe_scrapers/curatedkitchenware.py
@@ -1,0 +1,69 @@
+import json
+import re
+
+from ._abstract import AbstractScraper
+from ._grouping_utils import IngredientGroup
+from ._utils import normalize_string
+
+
+class CuratedKitchenware(AbstractScraper):
+    """Scraper for curatedkitchenware.com (Shopify, RecipeKit app).
+
+    RecipeKit renders this site's ingredient/direction group headings
+    client-side via JS — the static HTML's own group markers
+    (``h3.rk_group_heading``) carry no real text at all, just the literal
+    placeholder "blank". The real heading text only exists in a separate
+    ``<script type="application/json" id="recipe-data-*">`` block RecipeKit
+    ships for its own editor, alongside every ingredient/direction in
+    document order, each entry typed ``heading``/``ingredient``/
+    ``direction``. That JSON is the only reliable source for groups on
+    this site; schema.org's ``recipeIngredient``/``recipeInstructions``
+    are flat and lose all of it, same as the group markers do.
+    """
+
+    @classmethod
+    def host(cls):
+        return "curatedkitchenware.com"
+
+    def _recipe_data(self):
+        if getattr(self, "_recipe_data_cache", None) is not None:
+            return self._recipe_data_cache
+        match = re.search(
+            r'<script type="application/json" id="recipe-data-\d+">(.*?)</script>',
+            self.page_data,
+            re.S,
+        )
+        data = json.loads(match.group(1)) if match else {}
+        self._recipe_data_cache = data
+        return data
+
+    def ingredient_groups(self):
+        groups = []
+        current_purpose = None
+        current_ingredients = []
+        for item in self._recipe_data().get("recipe_ingredients", []):
+            if item.get("type") == "heading":
+                if current_ingredients:
+                    groups.append(IngredientGroup(current_ingredients, current_purpose))
+                current_purpose = normalize_string(item.get("heading_text", "")) or None
+                current_ingredients = []
+            else:
+                text = normalize_string(item.get("ingredient", ""))
+                if text:
+                    current_ingredients.append(text)
+        if current_ingredients:
+            groups.append(IngredientGroup(current_ingredients, current_purpose))
+        return groups
+
+    def instructions(self):
+        lines = []
+        for item in self._recipe_data().get("recipe_directions", []):
+            if item.get("type") == "heading":
+                text = normalize_string(item.get("heading_text", ""))
+                if text:
+                    lines.append(text)
+            else:
+                text = normalize_string(item.get("direction", ""))
+                if text:
+                    lines.append(text)
+        return "\n".join(lines)

--- a/tests/test_data/curatedkitchenware.com/curatedkitchenware_1.json
+++ b/tests/test_data/curatedkitchenware.com/curatedkitchenware_1.json
@@ -1,0 +1,80 @@
+{
+  "author": "Mandy Fu",
+  "canonical_url": "https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe",
+  "site_name": "Curated Kitchenware",
+  "host": "curatedkitchenware.com",
+  "language": "en",
+  "title": "The Best Homemade Chinese Scallion Pancakes Recipe",
+  "ingredients": [
+    "500g of high-protein flour AKA bread flour",
+    "270g of room temperature water",
+    "1 ¼ tsp of salt",
+    "2 tbsp of vegetable oil to add to the flour",
+    "5 scallions, diced",
+    "5 tbsp of vegetable oil",
+    "3.5 tbsp of high-protein flour AKA bread flour",
+    "1/2 tsp of thirteen spice powder",
+    "2-3 tbsp of vegetable oil to coat the dough",
+    "Additional vegetable oil, for applying the work surface and pan-frying the pancakes"
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "500g of high-protein flour AKA bread flour",
+        "270g of room temperature water",
+        "1 ¼ tsp of salt",
+        "2 tbsp of vegetable oil to add to the flour"
+      ],
+      "purpose": "For the dough"
+    },
+    {
+      "ingredients": [
+        "5 scallions, diced",
+        "5 tbsp of vegetable oil",
+        "3.5 tbsp of high-protein flour AKA bread flour",
+        "1/2 tsp of thirteen spice powder"
+      ],
+      "purpose": "For the scallion flour oil paste Yousu (油酥)"
+    },
+    {
+      "ingredients": [
+        "2-3 tbsp of vegetable oil to coat the dough",
+        "Additional vegetable oil, for applying the work surface and pan-frying the pancakes"
+      ],
+      "purpose": "For shaping and cooking"
+    }
+  ],
+  "instructions_list": [
+    "Make the dough",
+    "In a measuring cup, combine the water, salt, and 2 tbsp of cooking oil. Stir until the salt dissolves.",
+    "Gradually pour the mixture into the bread flour in batches. Stir at the same time until all the flour comes together.",
+    "Tip: I recommend using bread flour for this recipe because it has the highest gluten content. Gluten is an elastic protein network that binds starch together and builds the structure of the dough, so it fundamentally determines the texture and quality of your pancakes. I know some of you will ask me, will all-purpose flour work? The answer is year, but the pancakes will be slightly less airy and flaky.",
+    "If using a stand mixer, knead at medium-low speed for about 8 minutes or until a smooth dough forms. If kneading by hand, knead for 8-10 minutes. The dough is quite sticky so a stand mixer makes the process much easier.",
+    "Once the dough is done kneading, shape it into a round smooth ball. Cut it into 8 even pieces, about 100g each. No need to use a scale but you can if you want to be precise.",
+    "Shape each piece into a smooth ball. Add 2-3 tbsp of oil to a large tray. Place the dough balls in it one by one and use the oil to coat the surface.",
+    "Cover the dough with plastic wrap, push out all the air, and let the dough rest at room temperature for at least 2 hours. Make sure you leave enough space between each all the dough balls. Even though they are coated in oil, they can still stick.",
+    "For make-ahead dough, refrigerate it overnight. Take the dough out of the refrigerator 1 hour before shaping so it can get back to room temperature and regains its flexibility.",
+    "Make the scallion flour oil paste Yousu (油酥)",
+    "Finely dice the scallions. Reserve the green parts for later.",
+    "Add the scallion white parts and 5 tbsp pf vegetable to a small saucepan. Cook over low heat for 5-8 minutes, stirring occasionally until the scallion whites become lightly golden. This extra step of caramelizing is the key to infuse your pancakes double the fragrant.",
+    "Turn off the heat, add the high-protein flour and the thirteen-spice powder. Stir until completely smooth. Set it aside.",
+    "Tip: if this flour-oil paste sits for a white, the flour tends to settle at the bottom. Give it a good stir before spreading it onto the dough.",
+    "Shape the pancakes and cook",
+    "Lightly oiled the working surface, the rolling pin, and your hands to prevent sticking.",
+    "Take a piece of the dough and roll it into a large square sheet. Don't worry about making it perfectly straight. Just try to keep the thickness fairly even.",
+    "Imagine the dough sheet is a 3×3 nine-square grid, make a cut at one corner, and leave this section clean. Drizzle some of the yousu onto the remaining eight segments and brush it evenly across the surface. Sprinkle some diced green part of the scallions.",
+    "Use a scraper to loosen the edge of the sheet, carefully lift, and fold to the middle. Do the same to the other side and continue folding the sections over one another according to the nine-grid pattern. Keep the clean section untouched until your have 2 grids left.",
+    "Flip the clean grid and stretch it to wrap the folded dough. Make sure to seal all 4 edges so that later on, when you roll the pancakes, the filling will not leak out.",
+    "You should now have a small square of pastry. Push the four corners towards the center and tuck them underneath. Rotate the dough between your hands and you get a perfect round scallion pancake patty.",
+    "Repeat with the remaining dough.",
+    "Once done, cover the shaped dough and let them rest for 30 minutes. This allows the gluten to relax, making the pancakes much easier to roll without springing back.",
+    "Place one piece of dough on a sheet of parchment paper. Roll it into a panckae about 5-6 inches in diameter.",
+    "If making a large batch, you can freeze them. Place a sheet of parchment paper between each uncooked pancake and freeze them for up to 6 months. Do not use plastic wrap between the pancakes because they will stick. When you are ready to cook them, you can pan-fry them directly without defrosting.",
+    "To cook the pancakes, heat a frying pan over medium low heat and add a thin layer of vegetable oil. Place a pancake in the pan and cook over medium low heat until both sides are beautifully golden brown and crispy, about 6-8 minutes total. Flip and rotate the pancakes frequently for even browning.",
+    "Serve as a side dish."
+  ],
+  "total_time": 270,
+  "cook_time": 30,
+  "prep_time": 240,
+  "image": "https://curatedkitchenware.com/cdn/shop/articles/20260812092923-thumbnail.png?v=1787156682&width=1200"
+}

--- a/tests/test_data/curatedkitchenware.com/curatedkitchenware_1.testhtml
+++ b/tests/test_data/curatedkitchenware.com/curatedkitchenware_1.testhtml
@@ -1,0 +1,1500 @@
+<!doctype html>
+  <html class="no-js" lang="en">
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      <meta name="theme-color" content="#0E1B4D">
+      <meta name="theme-version-id" content="138244522192">
+      <link rel="canonical" href="https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+      <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
+      <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
+      <link rel="preconnect" href="https://fonts.shopify.com" crossorigin>
+      <link rel="preconnect" href="https://monorail-edge.shopifysvc.com"><script async src="https://www.googletagmanager.com/gtag/js?id=G-D325ETXKSJ"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-D325ETXKSJ');
+        gtag('config', 'AW-700295823');
+      </script><link rel="icon" type="image/png" href="//curatedkitchenware.com/cdn/shop/files/logo_1-fotor-bg-remover-20230916141431.png?v=1694888088&width=32">
+        <link rel="apple-touch-icon" href="//curatedkitchenware.com/cdn/shop/files/logo_1-fotor-bg-remover-20230916141431.png?v=1694888088&width=180"><link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin><title>
+        The Best Homemade Chinese Scallion Pancakes Recipe
+ &ndash; Curated Kitchenware</title>
+
+      
+        <meta name="description" content="These Chinese Scallion Pancakes are perfectly golden, crispy, and flaky on the outside, while the inside stays soft, moist, and pleasantly chewy. I first s">
+      
+
+
+<meta property="og:site_name" content="Curated Kitchenware">
+<meta property="og:url" content="https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<meta property="og:title" content="The Best Homemade Chinese Scallion Pancakes Recipe">
+<meta property="og:type" content="article">
+<meta property="og:description" content="These Chinese Scallion Pancakes are perfectly golden, crispy, and flaky on the outside, while the inside stays soft, moist, and pleasantly chewy. I first s"><meta property="og:image" content="https://curatedkitchenware.com/cdn/shop/articles/20260812092923-thumbnail.png?v=1787156682&width=1200">
+  <meta property="og:image:secure_url" content="https://curatedkitchenware.com/cdn/shop/articles/20260812092923-thumbnail.png?v=1787156682&width=1200"><meta property="og:image:width" content="1280">
+    <meta property="og:image:height" content="720"><meta name="twitter:image" content="https://curatedkitchenware.com/cdn/shop/articles/20260812092923-thumbnail.png?v=1787156682&width=1200"><meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The Best Homemade Chinese Scallion Pancakes Recipe">
+<meta name="twitter:description" content="These Chinese Scallion Pancakes are perfectly golden, crispy, and flaky on the outside, while the inside stays soft, moist, and pleasantly chewy. I first s">
+<script>window.performance && window.performance.mark && window.performance.mark('shopify.content_for_header.start');</script><meta name="facebook-domain-verification" content="9iwi4yae5qtjkmecx2xs54ws5j2ory">
+<meta name="google-site-verification" content="QzfX0e1RdZ0LpMXXgLDKpVOakxqD6HkPXqpv8H08l5M">
+<meta name="google-site-verification" content="d7jgP-qYRIHOoZhrv0q80kuEBgco2nkj03gpwjUtCbo">
+<meta name="google-site-verification" content="QzfX0e1RdZ0LpMXXgLDKpVOakxqD6HkPXqpv8H08l5M">
+<meta name="google-site-verification" content="EqG4lea1LWUaTCdxOCb1D1Okc5HX01POtwAP6yucK6o">
+<meta name="google-site-verification" content="xl5iQ_j-WVEPnEcXHuB3HuSv2FBrt6ej947JV1nu0oA">
+<meta id="shopify-digital-wallet" name="shopify-digital-wallet" content="/59538505936/digital_wallets/dialog">
+<meta name="shopify-checkout-api-token" content="66181be07deec2d5f7d3b016da0c0072">
+<meta id="in-context-paypal-metadata" data-shop-id="59538505936" data-venmo-supported="false" data-environment="production" data-locale="en_US" data-paypal-v4="true" data-currency="USD">
+<link rel="alternate" type="application/atom+xml" title="Feed" href="/blogs/soupeduprecipes.atom" />
+<link rel="alternate" hreflang="x-default" href="https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en" href="https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="de" href="https://curatedkitchenware.com/de/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-DE" href="https://curatedkitchenware.com/en-de/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="de-DE" href="https://curatedkitchenware.com/de-de/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-NZ" href="https://curatedkitchenware.com/en-nz/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-CN" href="https://curatedkitchenware.com/en-cn/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-IL" href="https://curatedkitchenware.com/en-mx/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-AE" href="https://curatedkitchenware.com/en-mx/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-HK" href="https://curatedkitchenware.com/en-cn/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-MX" href="https://curatedkitchenware.com/en-mx/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-RU" href="https://curatedkitchenware.com/en-mx/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-SG" href="https://curatedkitchenware.com/en-sg/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<link rel="alternate" hreflang="en-TW" href="https://curatedkitchenware.com/en-sg/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe">
+<script async="async" src="/checkouts/internal/preloads.js?locale=en-US"></script>
+<link rel="preconnect" href="https://shop.app" crossorigin="anonymous">
+<script async="async" src="https://shop.app/checkouts/internal/preloads.js?locale=en-US&shop_id=59538505936" crossorigin="anonymous"></script>
+<script id="apple-pay-shop-capabilities" type="application/json">{"shopId":59538505936,"countryCode":"US","currencyCode":"USD","merchantCapabilities":["supports3DS"],"merchantId":"gid:\/\/shopify\/Shop\/59538505936","merchantName":"Curated Kitchenware","requiredBillingContactFields":["postalAddress","email","phone"],"requiredShippingContactFields":["postalAddress","email","phone"],"shippingType":"shipping","supportedNetworks":["visa","masterCard","amex","discover","elo","jcb"],"total":{"type":"pending","label":"Curated Kitchenware","amount":"1.00"},"shopifyPaymentsEnabled":true,"supportsSubscriptions":true}</script>
+<script id="shopify-features" type="application/json">{"accessToken":"66181be07deec2d5f7d3b016da0c0072","betas":["rich-media-storefront-analytics"],"domain":"curatedkitchenware.com","predictiveSearch":true,"shopId":59538505936,"locale":"en"}</script>
+<script>var Shopify = Shopify || {};
+Shopify.shop = "curated-kitchenware.myshopify.com";
+Shopify.locale = "en";
+Shopify.currency = {"active":"USD","rate":"1.0"};
+Shopify.country = "US";
+Shopify.theme = {"name":"curated-kitchenware-german-prelaunch-review-v6","id":138244522192,"schema_name":"Shapes","schema_version":"2.2.5","theme_store_id":null,"role":"main"};
+Shopify.theme.handle = "null";
+Shopify.theme.style = {"id":null,"handle":null};
+Shopify.cdnHost = "curatedkitchenware.com/cdn";
+Shopify.routes = Shopify.routes || {};
+Shopify.routes.root = "/";
+Shopify.shopJsCdnBaseUrl = "https://cdn.shopify.com/shopifycloud/shop-js";
+Shopify.SignInWithShop = Shopify.SignInWithShop || {};
+Shopify.SignInWithShop.User = Shopify.SignInWithShop.User || {};
+Shopify.SignInWithShop.User.recognized = false;</script>
+<script type="module">!function(o){(o.Shopify=o.Shopify||{}).modules=!0}(window);</script>
+<script>!function(o){function n(){var o=[];function n(){o.push(Array.prototype.slice.apply(arguments))}return n.q=o,n}var t=o.Shopify=o.Shopify||{};t.loadFeatures=n(),t.autoloadFeatures=n()}(window);</script>
+<script>
+  window.ShopifyPay = window.ShopifyPay || {};
+  window.ShopifyPay.apiHost = "shop.app\/pay";
+  window.ShopifyPay.redirectState = null;
+</script>
+<script>
+  window.Shopify = window.Shopify || {};
+  window.Shopify.SignInWithShop = window.Shopify.SignInWithShop || {};
+  window.Shopify.SignInWithShop.assetMetrics = { sampleRate: 0.25 };
+  window.Shopify.SignInWithShop.eligible = true;
+</script>
+<script id="shop-js-analytics" type="application/json">{"pageType":"article"}</script>
+<script defer="defer" async type="module" src="//curatedkitchenware.com/cdn/shopifycloud/shop-js/modules/v2/loader.init-shop-cart-sync.en.esm.js"></script>
+<script type="module">
+  await import("//curatedkitchenware.com/cdn/shopifycloud/shop-js/modules/v2/loader.init-shop-cart-sync.en.esm.js");
+
+  window.Shopify.SignInWithShop?.initShopCartSync?.({"fedCMEnabled":true,"windoidEnabled":true});
+
+</script>
+<script>
+  window.Shopify = window.Shopify || {};
+  if (!window.Shopify.featureAssets) window.Shopify.featureAssets = {};
+  window.Shopify.featureAssets['shop-js'] = {"listener":["modules/v2/loader.listener.en.esm.js"],"init-windoid":["modules/v2/loader.init-windoid.en.esm.js"],"shop-toast-manager":["modules/v2/loader.shop-toast-manager.en.esm.js"],"init-shop-user-recognition":["modules/v2/loader.init-shop-user-recognition.en.esm.js"],"checkout-modal":["modules/v2/loader.checkout-modal.en.esm.js"],"shop-button":["modules/v2/loader.shop-button.en.esm.js"],"init-shop-cart-sync":["modules/v2/loader.init-shop-cart-sync.en.esm.js"],"init-fed-cm":["modules/v2/loader.init-fed-cm.en.esm.js"],"init-shop-email-lookup-coordinator":["modules/v2/loader.init-shop-email-lookup-coordinator.en.esm.js"],"avatar":["modules/v2/loader.avatar.en.esm.js"],"shop-cash-offers":["modules/v2/loader.shop-cash-offers.en.esm.js"],"init-customer-accounts-sign-up":["modules/v2/loader.init-customer-accounts-sign-up.en.esm.js"],"shop-login-button":["modules/v2/loader.shop-login-button.en.esm.js"],"init-shop-for-new-customer-accounts":["modules/v2/loader.init-shop-for-new-customer-accounts.en.esm.js"],"pay-button":["modules/v2/loader.pay-button.en.esm.js"],"init-customer-accounts":["modules/v2/loader.init-customer-accounts.en.esm.js"],"shop-user-recognition":["modules/v2/loader.shop-user-recognition.en.esm.js"],"shop-follow-button":["modules/v2/loader.shop-follow-button.en.esm.js"],"shop-cart-sync":["modules/v2/loader.shop-cart-sync.en.esm.js"],"shop-login":["modules/v2/loader.shop-login.en.esm.js"],"lead-capture":["modules/v2/loader.lead-capture.en.esm.js"],"payment-terms":["modules/v2/loader.payment-terms.en.esm.js"]};
+</script>
+<script>(function() {
+  var isLoaded = false;
+  function asyncLoad() {
+    if (isLoaded) return;
+    isLoaded = true;
+    var urls = ["https:\/\/cdn.ryviu.com\/v\/static\/js\/app.js?n=1\u0026shop=curated-kitchenware.myshopify.com"];
+    for (var i = 0; i < urls.length; i++) {
+      var s = document.createElement('script');
+      s.type = 'text/javascript';
+      s.async = true;
+      s.src = urls[i];
+      var x = document.getElementsByTagName('script')[0];
+      x.parentNode.insertBefore(s, x);
+    }
+  };
+  if(window.attachEvent) {
+    window.attachEvent('onload', asyncLoad);
+  } else {
+    window.addEventListener('load', asyncLoad, false);
+  }
+})();</script>
+<script id="__st">var __st={"a":59538505936,"offset":-14400,"reqid":"59a9e042-51f4-4c33-91eb-472c5d37b95b-1787442478","pageurl":"curatedkitchenware.com\/blogs\/soupeduprecipes\/the-best-homemade-chinese-scallion-pancakes-recipe","s":"articles-561902190800","u":"a0fcb6dc9c9a","p":"article","rtyp":"article","rid":561902190800};</script>
+<script>window.ShopifyPaypalV4VisibilityTracking = true;</script>
+<script id="captcha-bootstrap">!function(){'use strict';const t='contact',e='account',n='new_comment',o=[[t,t],['blogs',n],['comments',n],[t,'customer']],c=[[e,'customer_login'],[e,'guest_login'],[e,'recover_customer_password'],[e,'create_customer']],r=t=>t.map((([t,e])=>`form[action*='/${t}']:not([data-nocaptcha='true']) input[name='form_type'][value='${e}']`)).join(','),a=t=>()=>t?[...document.querySelectorAll(t)].map((t=>t.form)):[];function s(){const t=[...o],e=r(t);return a(e)}const i='password',u='form_key',d=['recaptcha-v3-token','g-recaptcha-response','h-captcha-response',i],f=()=>{try{return window.sessionStorage}catch{return}},m='__shopify_v',_=t=>t.elements[u];function p(t,e,n=!1){try{const o=window.sessionStorage,c=JSON.parse(o.getItem(e)),{data:r}=function(t){const{data:e,action:n}=t;return t[m]||n?{data:e,action:n}:{data:t,action:n}}(c);for(const[e,n]of Object.entries(r))t.elements[e]&&(t.elements[e].value=n);n&&o.removeItem(e)}catch(o){console.error('form repopulation failed',{error:o})}}const l='form_type',E='cptcha';function T(t){t.dataset[E]=!0}const w=window,h=w.document,L='Shopify',v='ce_forms',y='captcha';let A=!1;((t,e)=>{const n=(g='f06e6c50-85a8-45c8-87d0-21a2b65856fe',I='https://cdn.shopify.com/shopifycloud/storefront-forms-hcaptcha/ce_storefront_forms_captcha_hcaptcha.v1.5.2.iife.js',D={infoText:'Protected by hCaptcha',privacyText:'Privacy',termsText:'Terms'},(t,e,n)=>{const o=w[L][v],c=o.bindForm;if(c)return c(t,g,e,D).then(n);var r;o.q.push([[t,g,e,D],n]),r=I,A||(h.body.append(Object.assign(h.createElement('script'),{id:'captcha-provider',async:!0,src:r})),A=!0)});var g,I,D;w[L]=w[L]||{},w[L][v]=w[L][v]||{},w[L][v].q=[],w[L][y]=w[L][y]||{},w[L][y].protect=function(t,e){n(t,void 0,e),T(t)},Object.freeze(w[L][y]),function(t,e,n,w,h,L){const[v,y,A,g]=function(t,e,n){const i=e?o:[],u=t?c:[],d=[...i,...u],f=r(d),m=r(i),_=r(d.filter((([t,e])=>n.includes(e))));return[a(f),a(m),a(_),s()]}(w,h,L),I=t=>{const e=t.target;return e instanceof HTMLFormElement?e:e&&e.form},D=t=>v().includes(t);t.addEventListener('submit',(t=>{const e=I(t);if(!e)return;const n=D(e)&&!e.dataset.hcaptchaBound&&!e.dataset.recaptchaBound,o=_(e),c=g().includes(e)&&(!o||!o.value);(n||c)&&t.preventDefault(),c&&!n&&(function(t){try{if(!f())return;!function(t){const e=f();if(!e)return;const n=_(t);if(!n)return;const o=n.value;o&&e.removeItem(o)}(t);const e=Array.from(Array(32),(()=>Math.random().toString(36)[2])).join('');!function(t,e){_(t)||t.append(Object.assign(document.createElement('input'),{type:'hidden',name:u})),t.elements[u].value=e}(t,e),function(t,e){const n=f();if(!n)return;const o=[...t.querySelectorAll(`input[type='${i}']`)].map((({name:t})=>t)),c=[...d,...o],r={};for(const[a,s]of new FormData(t).entries())c.includes(a)||(r[a]=s);n.setItem(e,JSON.stringify({[m]:1,action:t.action,data:r}))}(t,e)}catch(e){console.error('failed to persist form',e)}}(e),e.submit())}));const S=(t,e)=>{t&&!t.dataset[E]&&(n(t,e.some((e=>e===t))),T(t))};for(const o of['focusin','change'])t.addEventListener(o,(t=>{const e=I(t);D(e)&&S(e,y())}));const B=e.get('form_key'),M=e.get(l),P=B&&M;t.addEventListener('DOMContentLoaded',(()=>{const t=y();if(P)for(const e of t)e.elements[l].value===M&&p(e,B);[...new Set([...A(),...v().filter((t=>'true'===t.dataset.shopifyCaptcha))])].forEach((e=>S(e,t)))}))}(h,new URLSearchParams(w.location.search),n,t,e,['guest_login'])})(!0,!0)}();</script>
+<script integrity="sha256-JjoPp5ZfB1sSAs5SQaol1x1GgvveM+BgmRzyDexInEQ=" data-source-attribution="shopify.loadfeatures" defer="defer" src="//curatedkitchenware.com/cdn/shopifycloud/storefront/assets/storefront/load_feature-1bd60354.js" crossorigin="anonymous"></script>
+<script>(function () {var userAgent = navigator.userAgent;var platform = navigator.platform;var maxTouchPoints = navigator.maxTouchPoints || 0;var isIOS = /iPad|iPhone|iPod/.test(platform) || (platform === 'MacIntel' && maxTouchPoints > 1);var isMacSafari = platform.indexOf('Mac') === 0 && /Safari/.test(userAgent) && !/Chrome|Chromium|CriOS|FxiOS|Edg|OPR|Android/.test(userAgent);var isAppleSafari = isIOS || isMacSafari;if (isAppleSafari) {fetch('/sf_private_access_tokens' + location.search).catch(function () {});}function browserMajorVersion(pattern) {var match = userAgent.match(pattern);return match ? parseInt(match[1], 10) : null;}function shouldLoadAutosizesPolyfill() {if (!window.PerformanceObserver?.supportedEntryTypes?.includes('paint')) {return false;}var chromeVersion = browserMajorVersion(/Chrome\/(\d+)/);if (chromeVersion !== null) {return chromeVersion < 126;}var firefoxVersion = browserMajorVersion(/Firefox\/(\d+)/);if (firefoxVersion !== null) {return firefoxVersion < 150;}var safariVersion = isAppleSafari ? browserMajorVersion(/Version\/(\d+).*Safari\//) : null;if (safariVersion !== null) {return safariVersion < 27;}return true;}if (shouldLoadAutosizesPolyfill()) {var autosizesScript = document.createElement('script');autosizesScript.async = true;autosizesScript.crossOrigin = 'anonymous';autosizesScript.src = "//curatedkitchenware.com/cdn/shopifycloud/storefront/assets/storefront/autosizes-84416378.js";(document.head || document.documentElement).appendChild(autosizesScript);}window.ShopifyAnalytics = window.ShopifyAnalytics || {};window.ShopifyAnalytics.performance = window.ShopifyAnalytics.performance || {};(function () {var LONG_FRAME_THRESHOLD = 50;var longAnimationFrames = [];var activeRafId = null;function collectLongFrames() {var previousTime = null;function rafMonitor(now) {if (activeRafId === null) {return;}var delta = now - previousTime;if (delta > LONG_FRAME_THRESHOLD) {longAnimationFrames.push({startTime: previousTime,endTime: now,});}previousTime = now;activeRafId = requestAnimationFrame(rafMonitor);}previousTime = performance.now();activeRafId = requestAnimationFrame(rafMonitor);}if (!window.PerformanceObserver?.supportedEntryTypes?.includes('long-animation-frame')) {collectLongFrames();var timeoutId = setTimeout(function () {cancelAnimationFrame(activeRafId);}, 10000);window.ShopifyAnalytics.performance.getLongAnimationFrames = function (stopCollection) {if (stopCollection === undefined) {stopCollection = false;}if (stopCollection) {clearTimeout(timeoutId);cancelAnimationFrame(activeRafId);}return longAnimationFrames;};}})();})();</script><script crossorigin="anonymous" defer="defer" src="//curatedkitchenware.com/cdn/shopifycloud/storefront/assets/shopify_pay/storefront-bf1cdb70.js?v=20250812"></script>
+<script id="shopify-origin-trials" async="async" integrity="sha256-mqQjA+yhr1DtPsW5MhDIq3zDu+LghfjNT49r/ttG3eY=" src="//cdn.shopify.com/shopifycloud/storefront/assets/storefront/origin_trials-5059b83f.js" crossorigin="anonymous" onload="window.__shopifyOriginTrialsDone = true" onerror="window.__shopifyOriginTrialsDone = true"></script>
+<script>
+  window.Shopify = window.Shopify || {};
+  window.Shopify.MCP = window.Shopify.MCP || {};
+  window.Shopify.MCP.enabled = true;
+  window.Shopify.MCP.shop = "curated-kitchenware.myshopify.com";
+  window.Shopify.MCP.mcpEndpoint = "https:\/\/curatedkitchenware.com\/api\/mcp";
+  window.Shopify.MCP.tools = [{"name":"search_shop_policies_and_faqs","description":"Used to get facts about the stores policies, products, or services.\nSome examples of questions you can ask are:\n  - What is your return policy?\n  - What is your shipping policy?\n  - What is your phone number?\n  - What are your hours of operation?\"\n","inputSchema":{"$schema":"https:\/\/json-schema.org\/draft\/2020-12\/schema","type":"object","properties":{"query":{"type":"string","description":"A natural language query."},"context":{"type":"string","description":"Additional information about the request such as user demographics, mood, location, or other relevant details that could help in tailoring the response appropriately."}},"required":["query"]}}];
+</script>
+<script>(()=>{var d="shopify:webmcp_adapter_loaded",n=Symbol.for("shopify.webmcp_adapter_loading");function s(c,a,{win:r=window,doc:o=document}={}){function p(){try{return r.localStorage.getItem(d)==="true"}catch{return!1}}function l(){try{r.localStorage.setItem(d,"true")}catch{}}function u(){return typeof(o.modelContext||r.navigator?.modelContext)?.registerTool=="function"}function f(){if(r[n]||!u())return;let t=o.head||o.getElementsByTagName("head")[0];if(!t)return;let e=o.createElement("script");e.type="module",e.crossOrigin="anonymous",a&&(e.integrity=a),e.src=c,e.addEventListener("load",l,{once:!0}),e.addEventListener("error",()=>{r[n]=!1},{once:!0}),t.appendChild(e),r[n]=!0}function _(t){let e=o.getElementById("shopify-origin-trials");if(!e||r.__shopifyOriginTrialsDone){t();return}e.addEventListener("load",t,{once:!0}),e.addEventListener("error",t,{once:!0})}function i(){_(()=>r.setTimeout(f,0))}function m(){o.addEventListener("DOMContentLoaded",i,{once:!0})}p()?i():m()}s("https:\/\/cdn.shopify.com\/storefront\/webmcp\/webmcp-0.1.1.js","");})();
+</script>
+<script data-source-attribution="shopify.dynamic_checkout.dynamic.init">var Shopify=Shopify||{};Shopify.PaymentButton=Shopify.PaymentButton||{isStorefrontPortableWallets:!0,init:function(){window.Shopify.PaymentButton.init=function(){};var t=document.createElement("script");t.src="https://curatedkitchenware.com/cdn/shopifycloud/portable-wallets/latest/portable-wallets.en.js",t.type="module",document.head.appendChild(t)}};
+</script>
+<script data-source-attribution="shopify.dynamic_checkout.buyer_consent">
+  function portableWalletsHideBuyerConsent(e){var t=document.getElementById("shopify-buyer-consent"),n=document.getElementById("shopify-subscription-policy-button");t&&n&&(t.classList.add("hidden"),t.setAttribute("aria-hidden","true"),n.removeEventListener("click",e))}function portableWalletsShowBuyerConsent(e){var t=document.getElementById("shopify-buyer-consent"),n=document.getElementById("shopify-subscription-policy-button");t&&n&&(t.classList.remove("hidden"),t.removeAttribute("aria-hidden"),n.addEventListener("click",e))}window.Shopify?.PaymentButton&&(window.Shopify.PaymentButton.hideBuyerConsent=portableWalletsHideBuyerConsent,window.Shopify.PaymentButton.showBuyerConsent=portableWalletsShowBuyerConsent);
+</script>
+<script data-source-attribution="shopify.dynamic_checkout.cart.bootstrap">document.addEventListener("DOMContentLoaded",(function(){function t(){return document.querySelector("shopify-accelerated-checkout-cart, shopify-accelerated-checkout")}if(t())Shopify.PaymentButton.init();else{new MutationObserver((function(e,n){t()&&(Shopify.PaymentButton.init(),n.disconnect())})).observe(document.body,{childList:!0,subtree:!0})}}));
+</script>
+<link id="shopify-accelerated-checkout-styles" rel="stylesheet" media="screen" href="https://curatedkitchenware.com/cdn/shopifycloud/portable-wallets/latest/accelerated-checkout-backwards-compat.css" crossorigin="anonymous">
+<style id="shopify-accelerated-checkout-cart">
+        #shopify-buyer-consent {
+  margin-top: 1em;
+  display: inline-block;
+  width: 100%;
+}
+
+#shopify-buyer-consent.hidden {
+  display: none;
+}
+
+#shopify-subscription-policy-button {
+  background: none;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  font-size: inherit;
+  cursor: pointer;
+}
+
+#shopify-subscription-policy-button::before {
+  box-shadow: none;
+}
+
+      </style>
+
+<script id="shopify-cfh-end">window.performance && window.performance.mark && window.performance.mark('shopify.content_for_header.end');</script>
+
+      <script>
+  window.THEMENAME = 'Shapes';
+  window.THEMEVERSION = '1.0.1';
+
+  document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
+
+  window.theme = {
+    strings: {
+      itemCountOne: "{{ count }} item",
+      itemCountOther: "{{ count }} items",
+      loading: "Loading",
+      addToCart: "Add to Cart",
+      preOrder: "Pre-order",
+      soldOut: "Sold Out",
+      unavailable: "Unavailable",
+      regularPrice: "Regular price",
+      salePrice: "Sale price",
+      sale: "On Sale",
+      unitPrice: "Unit price",
+      unitPriceSeparator: "per",
+      cartEmpty: "Your cart is currently empty.",
+      cartCookies: "Enable cookies to use the shopping cart",
+      update: "Update Cart",
+      quantity: "Quantity",
+      discountedTotal: "Discounted total",
+      regularTotal: "Regular total",
+      priceColumn: "See Price column for discount details.",
+      addedToCart: "Added to Cart!",
+      cartError: "There was an error while updating your cart. Please try again.",
+      cartAddError: "All {{ title }} are in your cart."
+    },
+    routes: {
+      root_url: "\/",
+      cart_url: "\/cart",
+      cart_add_url: "\/cart\/add",
+      cart_change_url: "\/cart\/change",
+      cart_update_url: "\/cart\/update",
+      cart_clear_url: "\/cart\/clear",
+      predictive_search_url: '/search/suggest'
+    },
+    moneyFormat: "\u003cspan class=money\u003e${{amount}}\u003c\/span\u003e",
+    moneyWithCurrencyFormat: "\u003cspan class=money\u003e${{amount}} USD\u003c\/span\u003e",
+    cartItemCount: 0,
+    settings: {
+      cart_type: "page",
+      open_modal_on_add_to_cart: false,
+      parallax_intensity: 50
+    },
+    info: {
+      name: 'Shapes',
+    }
+  };
+</script>
+
+
+      <script>document.documentElement.className = document.documentElement.className.replace('no-js', 'js');</script>
+      <script>
+        function debounce(fn, wait) {
+          let t;
+          return (...args) => {
+            clearTimeout(t);
+            t = setTimeout(() => fn.apply(this, args), wait);
+          };
+        }
+      </script>
+      <script src="//curatedkitchenware.com/cdn/shop/t/108/assets/utils.js?v=7831558957854122511786678740" defer></script>
+      <script src="//curatedkitchenware.com/cdn/shop/t/108/assets/global.bundle.min.js?v=26573387620342007991786678740" type="module"></script>
+      <script src="//curatedkitchenware.com/cdn/shop/t/108/assets/cart-count.js?v=51561485870383068741786678740" type="module"></script>
+      <script src="//curatedkitchenware.com/cdn/shop/t/108/assets/theme-version-check.js?v=153450072676811465561786678740" defer></script>
+      
+      
+      
+      <script src="//curatedkitchenware.com/cdn/shop/t/108/assets/alpine-extensions.js?v=130255111265633159301786678740" defer></script>
+      <link rel="stylesheet" href="//curatedkitchenware.com/cdn/shop/t/108/assets/base.bundle.min.css?v=123397607257700466991786678740">
+      
+      
+      <style>
+        :root {
+          --max-site-width: 1820px;
+        }
+      </style>
+      <style data-shopify>
+        @font-face {
+  font-family: Inter;
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+  src: url("//curatedkitchenware.com/cdn/fonts/inter/inter_n4.b2a3f24c19b4de56e8871f609e73ca7f6d2e2bb9.woff2") format("woff2"),
+       url("//curatedkitchenware.com/cdn/fonts/inter/inter_n4.af8052d517e0c9ffac7b814872cecc27ae1fa132.woff") format("woff");
+}
+
+        @font-face {
+  font-family: Fraunces;
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+  src: url("//curatedkitchenware.com/cdn/fonts/fraunces/fraunces_n6.69791a9f00600e5a1e56a6f64efc9d10a28b9c92.woff2") format("woff2"),
+       url("//curatedkitchenware.com/cdn/fonts/fraunces/fraunces_n6.e87d336d46d99db17df56f1dc77d222effffa1f3.woff") format("woff");
+}
+
+        
+@font-face {
+  font-family: Inter;
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+  src: url("//curatedkitchenware.com/cdn/fonts/inter/inter_n7.02711e6b374660cfc7915d1afc1c204e633421e4.woff2") format("woff2"),
+       url("//curatedkitchenware.com/cdn/fonts/inter/inter_n7.6dab87426f6b8813070abd79972ceaf2f8d3b012.woff") format("woff");
+}
+@font-face {
+  font-family: Inter;
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+  src: url("//curatedkitchenware.com/cdn/fonts/inter/inter_i4.feae1981dda792ab80d117249d9c7e0f1017e5b3.woff2") format("woff2"),
+       url("//curatedkitchenware.com/cdn/fonts/inter/inter_i4.62773b7113d5e5f02c71486623cf828884c85c6e.woff") format("woff");
+}
+@font-face {
+  font-family: Inter;
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+  src: url("//curatedkitchenware.com/cdn/fonts/inter/inter_i7.b377bcd4cc0f160622a22d638ae7e2cd9b86ea4c.woff2") format("woff2"),
+       url("//curatedkitchenware.com/cdn/fonts/inter/inter_i7.7c69a6a34e3bb44fcf6f975857e13b9a9b25beb4.woff") format("woff");
+}
+@font-face {
+  font-family: Inter;
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+  src: url("//curatedkitchenware.com/cdn/fonts/inter/inter_n7.02711e6b374660cfc7915d1afc1c204e633421e4.woff2") format("woff2"),
+       url("//curatedkitchenware.com/cdn/fonts/inter/inter_n7.6dab87426f6b8813070abd79972ceaf2f8d3b012.woff") format("woff");
+}
+:root {
+          --heading-font-stack: Fraunces, serif;
+          --heading-font-weight: 600;
+          --heading-font-style: normal;
+          --heading-letterspacing: 0.0;
+          --heading-capitalize: none;
+          --main-font-stack: Inter, sans-serif;
+          --main-font-weight: 400;
+          --main-font-style: normal;
+          --accent-font-stack: , ;
+          --accent-font-weight: ;
+          --accent-font-style: ;
+        }
+      </style>
+<style>
+  :root {
+    --payment-button-height: 48px;
+    --section-x-padding: 1.25rem;
+    --grid-gap: 1.25rem;
+    --icon-thickness: 1.1;
+    --header-height: 60px;
+
+    --global-scrolling-items-speed-multiplier: 1;
+
+    --transparent: transparent;
+
+    --color-primary-text: 14, 27, 77;
+    --color-primary-background: 255, 255, 255;
+    --color-primary-accent-1: 255, 153, 0;
+    --color-primary-accent-2: 14, 27, 77;
+    --color-primary-card: 255, 255, 255;
+    --color-primary-gradient: ;--color-primary-text-overlay: 255, 255, 255;
+--color-primary-card-text-overlay: 255, 255, 255;
+--color-primary-accent-1-overlay: 14, 27, 77;
+--color-primary-accent-2-overlay: 255, 255, 255;
+--color-secondary-text: 14, 27, 77;
+    --color-secondary-background: 245, 245, 245;
+    --color-secondary-accent-1: 255, 153, 0;
+    --color-secondary-accent-2: 160, 193, 182;
+    --color-secondary-card: 255, 255, 255;
+    --color-secondary-gradient: ;--color-secondary-text-overlay: 245, 245, 245;
+--color-secondary-card-text-overlay: 255, 255, 255;
+--color-secondary-accent-1-overlay: 14, 27, 77;
+--color-secondary-accent-2-overlay: 14, 27, 77;
+--color-tertiary-text: 14, 27, 77;
+    --color-tertiary-background: 255, 255, 255;
+    --color-tertiary-accent-1: 14, 27, 77;
+    --color-tertiary-accent-2: 14, 27, 77;
+    --color-tertiary-card: 255, 255, 255;
+    --color-tertiary-gradient: ;--color-tertiary-text-overlay: 255, 255, 255;
+--color-tertiary-card-text-overlay: 255, 255, 255;
+--color-tertiary-accent-1-overlay: 255, 255, 255;
+--color-tertiary-accent-2-overlay: 255, 255, 255;
+--color-quaternary-text: 255, 255, 255;
+    --color-quaternary-background: 14, 27, 77;
+    --color-quaternary-accent-1: 255, 255, 255;
+    --color-quaternary-accent-2: 160, 193, 182;
+    --color-quaternary-card: 255, 255, 255;
+    --color-quaternary-gradient: linear-gradient(127deg, rgba(245, 245, 245, 1) 14%, rgba(14, 27, 77, 1) 81%);--color-quaternary-text-overlay: 14, 27, 77;
+--color-quaternary-card-text-overlay: 14, 27, 77;
+--color-quaternary-accent-1-overlay: 14, 27, 77;
+--color-quaternary-accent-2-overlay: 14, 27, 77;
+--color-border: 0, 0, 0;
+    --section-border-thickness: 0px;
+    --drop-down-offset: 2px;
+    --shape-divider-offset: 2px;
+
+
+    --button-border-radius: 5px;
+    --textarea-border-radius: 5px;
+    --button-border-width: 0;
+    --input-border-width: 1px;
+    --button-shadow-border-width: var(--button-border-width);
+    --button-text-transform: none;
+    --button-drop-shadow-size:  00px;
+    --button-drop-shadow-top-size: 0px;
+    --button-drop-shadow-left-size: 0px;
+    --button-hover-top-size: -0.25rem;
+    --button-hover-left-size: var(--button-drop-shadow-left-size);
+    --button-shadow-display: none;
+    --sticker-border-radius: 0;
+    --sticker-border-width: 0;
+    --sticker-shadow-border-width: 0;
+    --sticker-text-transform: uppercase;
+    --sticker-drop-shadow-top-size: -0px;
+    --sticker-drop-shadow-left-size: -0px;
+    --card-border-radius: 2rem;
+    --card-drop-shadow-size: 0px;
+    --card-drop-shadow-top-size: 0px;
+    --card-drop-shadow-left-size: 0px;
+    --card-border-width: 0;
+    --card-shadow-border-width: 0;
+    --media-border-radius: 2rem;
+    --media-drop-shadow-size: 0px;
+    --media-drop-shadow-top-size: 0px;
+    --media-drop-shadow-left-size: 0px;
+    --media-drop-shadow-size-half: 0.0px;
+    --media-drop-shadow-top-size-half: 0.0px;
+    --media-drop-shadow-left-size-half: 0.0px;
+    --media-border-width: 0;
+    --media-shadow-border-width: var(--media-border-width);
+    --heading-shadow-spread: 6px;
+    --heading-stroke-thickness: 4px;
+    --product-tiles-text-transform: none;
+    --select-svg: url("data:image/svg+xml,%3Csvg width='48' height='48' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 12L23.2826 36.0527C23.3724 36.1542 23.4826 36.2354 23.6062 36.291C23.7297 36.3467 23.8636 36.3755 23.999 36.3755C24.1345 36.3755 24.2684 36.3467 24.3919 36.291C24.5154 36.2354 24.6257 36.1542 24.7155 36.0527L46 12' stroke='currentColor' stroke-width='1.1' stroke-linecap='round' stroke-linejoin='round' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E%0A");
+
+    --hover-effect-enlarge-shape: 1;
+    --hover-effect-lift-shape: 0;
+    --hover-effect-rotate-shape: 0deg;
+  }
+
+
+
+  [data-color-scheme="primary"] {
+    --color-scheme-text: var(--color-primary-text);
+    --color-scheme-background: var(--color-primary-background);
+    --color-scheme-accent-1: var(--color-primary-accent-1);
+    --color-scheme-accent-2: var(--color-primary-accent-2);
+    --color-scheme-card: var(--color-primary-card);
+    --color-scheme-gradient: var(--color-primary-gradient);
+    --color-scheme-text-overlay: var(--color-primary-text-overlay);
+    --color-scheme-card-text-overlay: var(--color-primary-card-text-overlay);
+    --color-scheme-accent-1-overlay: var(--color-primary-accent-1-overlay);
+    --color-scheme-accent-2-overlay: var(--color-primary-accent-2-overlay);
+    --color-scheme-secondary-background: var(--color-primary-background);
+    --select-svg: url("data:image/svg+xml,%3Csvg width='48' height='48' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 12L23.2826 36.0527C23.3724 36.1542 23.4826 36.2354 23.6062 36.291C23.7297 36.3467 23.8636 36.3755 23.999 36.3755C24.1345 36.3755 24.2684 36.3467 24.3919 36.291C24.5154 36.2354 24.6257 36.1542 24.7155 36.0527L46 12' stroke='%230e1b4d' stroke-width='1.1' stroke-linecap='round' stroke-linejoin='round' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E%0A");
+  }
+
+
+  [data-color-scheme="secondary"] {
+    --color-scheme-text: var(--color-secondary-text);
+    --color-scheme-background: var(--color-secondary-background);
+    --color-scheme-gradient: var(--color-secondary-gradient);
+    --color-scheme-accent-1: var(--color-secondary-accent-1);
+    --color-scheme-accent-2: var(--color-secondary-accent-2);
+    --color-scheme-card: var(--color-secondary-card);
+    --color-scheme-text-overlay: var(--color-secondary-text-overlay);
+    --color-scheme-card-text-overlay: var(--color-secondary-card-text-overlay);
+    --color-scheme-accent-1-overlay: var(--color-secondary-accent-1-overlay);
+    --color-scheme-accent-2-overlay: var(--color-secondary-accent-2-overlay);
+    --color-scheme-secondary-background: var(--color-secondary-background);
+    --select-svg: url("data:image/svg+xml,%3Csvg width='48' height='48' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 12L23.2826 36.0527C23.3724 36.1542 23.4826 36.2354 23.6062 36.291C23.7297 36.3467 23.8636 36.3755 23.999 36.3755C24.1345 36.3755 24.2684 36.3467 24.3919 36.291C24.5154 36.2354 24.6257 36.1542 24.7155 36.0527L46 12' stroke='%230e1b4d' stroke-width='1.1' stroke-linecap='round' stroke-linejoin='round' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E%0A");
+  }
+
+
+  [data-color-scheme="tertiary"] {
+    --color-scheme-text: var(--color-tertiary-text);
+    --color-scheme-background: var(--color-tertiary-background);
+    --color-scheme-accent-1: var(--color-tertiary-accent-1);
+    --color-scheme-accent-2: var(--color-tertiary-accent-2);
+    --color-scheme-card: var(--color-tertiary-card);
+    --color-scheme-gradient: var(--color-tertiary-gradient);
+    --color-scheme-text-overlay: var(--color-tertiary-text-overlay);
+    --color-scheme-card-text-overlay: var(--color-tertiary-card-text-overlay);
+    --color-scheme-accent-1-overlay: var(--color-tertiary-accent-1-overlay);
+    --color-scheme-accent-2-overlay: var(--color-tertiary-accent-2-overlay);
+    --color-scheme-secondary-background: var(--color-tertiary-background);
+    --select-svg: url("data:image/svg+xml,%3Csvg width='48' height='48' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 12L23.2826 36.0527C23.3724 36.1542 23.4826 36.2354 23.6062 36.291C23.7297 36.3467 23.8636 36.3755 23.999 36.3755C24.1345 36.3755 24.2684 36.3467 24.3919 36.291C24.5154 36.2354 24.6257 36.1542 24.7155 36.0527L46 12' stroke='%230e1b4d' stroke-width='1.1' stroke-linecap='round' stroke-linejoin='round' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E%0A");
+  }
+
+  [data-color-scheme="quaternary"] {
+    --color-scheme-text: var(--color-quaternary-text);
+    --color-scheme-background: var(--color-quaternary-background);
+    --color-scheme-accent-1: var(--color-quaternary-accent-1);
+    --color-scheme-accent-2: var(--color-quaternary-accent-2);
+    --color-scheme-card: var(--color-quaternary-card);
+    --color-scheme-gradient: var(--color-quaternary-gradient);
+    --color-scheme-text-overlay: var(--color-quaternary-text-overlay);
+    --color-scheme-card-text-overlay: var(--color-quaternary-card-text-overlay);
+    --color-scheme-accent-1-overlay: var(--color-quaternary-accent-1-overlay);
+    --color-scheme-accent-2-overlay: var(--color-quaternary-accent-2-overlay);
+    --color-scheme-secondary-background: var(--color-quaternary-background);
+    --select-svg: url("data:image/svg+xml,%3Csvg width='48' height='48' viewBox='0 0 48 48' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M2 12L23.2826 36.0527C23.3724 36.1542 23.4826 36.2354 23.6062 36.291C23.7297 36.3467 23.8636 36.3755 23.999 36.3755C24.1345 36.3755 24.2684 36.3467 24.3919 36.291C24.5154 36.2354 24.6257 36.1542 24.7155 36.0527L46 12' stroke='%23ffffff' stroke-width='1.1' stroke-linecap='round' stroke-linejoin='round' vector-effect='non-scaling-stroke'/%3E%3C/svg%3E%0A");
+  }
+
+  [data-color-scheme="white"] {
+    --color-scheme-text: 255,255,255;
+    --color-scheme-accent: 255,255,255;
+    --color-scheme-background: 0,0,0;
+    --color-scheme-card: 0,0,0;
+    --color-scheme-text-overlay: 0,0,0;
+    --color-scheme-accent-1-overlay: 0,0,0;
+    --color-border: 255,255,255;
+  }
+
+  [data-color-scheme="black"] {
+    --color-scheme-text: 0,0,0;
+    --color-scheme-accent: 0,0,0;
+    --color-scheme-background: 255,255,255;
+    --color-scheme-card: 255,255,255;
+    --color-scheme-text-overlay: 255,255,255;
+    --color-scheme-accent-1-overlay: 255,255,255;
+    --color-border: 0,0,0;
+  }
+
+
+  
+  [data-color-scheme="primary"] .card {
+    --color-scheme-secondary-background: var(--color-primary-card);
+  }
+
+  [data-color-scheme="secondary"] .card {
+    --color-scheme-secondary-background: var(--color-secondary-card);
+  }
+
+  [data-color-scheme="tertiary"] .card {
+    --color-scheme-secondary-background: var(--color-tertiary-card);
+  }
+
+  [data-color-scheme="quaternary"] .card {
+    --color-scheme-secondary-background: var(--color-quaternary-card);
+  }
+  
+[data-color-scheme] {
+    --color-heading-shadow: var(--color-scheme-accent-1);
+    --color-heading-stroke: var(--color-scheme-accent-1);
+    --color-button-background: var(--color-scheme-accent-1);
+    --color-button-text: var(--color-scheme-accent-1-overlay);
+    --color-button-border: var(--color-scheme-text);
+    --color-button-shadow: var(--color-scheme-gradient);
+    --color-card-border: var(--color-scheme-text);
+    --color-card-shadow: var(--color-scheme-gradient);
+    --color-sticker-border: var(--color-scheme-text);
+    --color-sticker-shadow: var(--transparent);
+    --color-media-border: var(--color-scheme-text);
+    --color-media-shadow: var(--color-scheme-gradient);
+    --color-media-shadow-fill: rgb(var(--color-scheme-gradient));
+    --color-sticker-shadow: var(--transparent);
+    --color-sticker-shadow-fill: rgb(var(--transparent));--color-sticker-shadow-fill: none;--heading-color: var(--color-scheme-accent-1);
+    --heading-text-shadow:}
+
+  [data-color-scheme] .card {
+    --color-scheme-text-overlay: var(--color-scheme-card-text-overlay);
+  }
+  
+
+
+  /*
+  Typography and spacing sizes
+  */:root {
+    --base-font-size: 137.5%;
+    --base-line-height: 1.2;
+    --line-height-heading: 1.1;
+    --font-size-ratio-xs: 0.7491535;
+    --font-size-ratio-sm: 0.8908985;
+    --font-size-ratio-base: 1;
+    --font-size-ratio-lg: 1.33484;
+    --font-size-ratio-xl: 1.498307;
+    --font-size-ratio-2xl: 1.681793;
+    --font-size-ratio-3xl: 2;
+    --font-size-ratio-4xl: 2.66968;
+    --font-size-ratio-5xl: 2.996614;
+    --font-size-ratio-6xl: 3.563594;
+    --font-size-ratio-7xl: 4;
+    --font-size-ratio-8xl: 4.519842;
+    --font-size-ratio-9xl: 4.996614;
+    --font-size-xs: calc(var(--font-size-ratio-xs) * 1rem);
+    --font-size-sm: calc(var(--font-size-ratio-sm) * 1rem);
+    --font-size-base: calc(var(--font-size-ratio-base) * 1rem);
+    --font-size-lg: calc(var(--font-size-ratio-lg) * 1rem);
+    --font-size-xl: calc(var(--font-size-ratio-xl) * 1rem);
+    --font-size-2xl: calc(var(--font-size-ratio-2xl) * 1rem);
+    --font-size-3xl: calc(var(--font-size-ratio-3xl) * 1rem);
+    --font-size-4xl: calc(var(--font-size-ratio-4xl) * 1rem);
+    --font-size-5xl: calc(var(--font-size-ratio-5xl) * 1rem);
+    --font-size-6xl: calc(var(--font-size-ratio-6xl) * 1rem);
+    --font-size-7xl: calc(var(--font-size-ratio-7xl) * 1rem);
+    --font-size-8xl: calc(var(--font-size-ratio-8xl) * 1rem);
+    --font-size-9xl: calc(var(--font-size-ratio-9xl) * 1rem);
+
+    --standard-heading-size: var(--font-size-xl);
+    --feature-heading-size: var(--font-size-3xl);
+    --secondary-heading-size: var(--font-size-lg);
+    --section-vertical-spacing: 1rem;
+  }
+  @media (min-width: 990px) {
+    :root {
+      --standard-heading-size: var(--font-size-4xl);
+      --feature-heading-size: var(--font-size-5xl);
+      --secondary-heading-size: var(--font-size-lg);
+      --section-vertical-spacing: 2rem;
+      --section-x-padding: 2.5rem;
+      --grid-gap: 2.5rem;
+    }
+  }
+
+
+  .heading-effects {
+    color: rgb(var(--heading-color));
+    text-shadow: var(--heading-text-shadow);
+    -webkit-text-stroke: var(--heading-stroke-thickness) rgb(var(--color-heading-stroke));
+    text-stroke: var(--heading-stroke-thickness) rgb(var(--color-heading-stroke));
+  }
+
+  .heading-standard {
+    font-size: var(--standard-heading-size);
+    
+  }
+
+  .heading-feature {
+    font-size: var(--feature-heading-size);
+    
+  }
+
+  .heading-secondary {
+    font-size: var(--secondary-heading-size);
+  }
+
+
+  /*
+  Cards
+  */
+  .card-container::after {-webkit-mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M24 0H20L0 20V24L24 0ZM24 24V20L20 24H24Z' fill='black'/%3E%3C/svg%3E%0A");
+        mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M24 0H20L0 20V24L24 0ZM24 24V20L20 24H24Z' fill='black'/%3E%3C/svg%3E%0A");-webkit-mask-position: right top;
+      mask-position: right top;}
+
+  /*
+  Media
+  */
+  .media-style-container::after,
+  .media-shape-drop-shadow {-webkit-mask-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_101_3)'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M21.7088 13.9473L10 2.29458L-1.70881 13.9473L0.0577438 15.7054L10 5.81077L19.9423 15.7054L21.7088 13.9473Z' fill='black'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_101_3'%3E%3Crect width='20' height='20' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E");
+        mask-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cg clip-path='url(%23clip0_101_3)'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M21.7088 13.9473L10 2.29458L-1.70881 13.9473L0.0577438 15.7054L10 5.81077L19.9423 15.7054L21.7088 13.9473Z' fill='black'/%3E%3C/g%3E%3Cdefs%3E%3CclipPath id='clip0_101_3'%3E%3Crect width='20' height='20' fill='white'/%3E%3C/clipPath%3E%3C/defs%3E%3C/svg%3E");}
+
+
+  /*
+  Custom cursor
+  */</style>
+
+
+      
+      <style id="generated-critical-css">
+.max-w-site{max-width:var(--max-site-width)}
+</style>
+      
+      <style id="manual-critical-css">
+        [x-cloak] {
+          display: none;
+        }
+        [data-parallax-container] {
+          will-change: opacity;
+          opacity: 0;
+          transition: opacity 0.2s cubic-bezier(0.215, 0.61, 0.355, 1);
+        }
+        .no-js [data-parallax-container],
+        [data-parallax-container].animated {
+          opacity: 1;
+        }
+
+        @media (prefers-reduced-motion) {
+          [data-parallax-container] {
+            opacity: 1;
+          }
+        }
+      </style>
+
+      
+      
+        <link rel="preload" as="font" href="//curatedkitchenware.com/cdn/fonts/fraunces/fraunces_n6.69791a9f00600e5a1e56a6f64efc9d10a28b9c92.woff2" type="font/woff2" crossorigin>
+      
+      
+        <link rel="preload" as="font" href="//curatedkitchenware.com/cdn/fonts/inter/inter_n4.b2a3f24c19b4de56e8871f609e73ca7f6d2e2bb9.woff2" type="font/woff2" crossorigin>
+      
+      
+      <script>
+        window.onYouTubeIframeAPIReady = () => {
+          document.body.dispatchEvent(new CustomEvent('youtubeiframeapiready'));
+        };
+      </script>
+    <link href="https://cdn.shopify.com/extensions/01a01bec-b6ff-7c1a-b3d2-6b099af3f859/recipe-kit-208/assets/recipekit-widget.css" rel="stylesheet" type="text/css" media="all">
+<link href="https://monorail-edge.shopifysvc.com" rel="dns-prefetch">
+<script>(function(){if ("sendBeacon" in navigator && "performance" in window) {try {var session_token_from_headers = performance.getEntriesByType('navigation')[0].serverTiming.find(x => x.name == '_s').description;} catch {var session_token_from_headers = undefined;}var session_cookie_matches = document.cookie.match(/_shopify_s=([^;]*)/);var session_token_from_cookie = session_cookie_matches && session_cookie_matches.length === 2 ? session_cookie_matches[1] : "";var session_token = session_token_from_headers || session_token_from_cookie || "";function handle_abandonment_event(e) {var entries = performance.getEntries().filter(function(entry) {return /monorail-edge.shopifysvc.com/.test(entry.name);});if (!window.abandonment_tracked && entries.length === 0) {window.abandonment_tracked = true;var currentMs = Date.now();var navigation_start = performance.timing.navigationStart;var payload = {shop_id: 59538505936,url: window.location.href,navigation_start,duration: currentMs - navigation_start,session_token,page_type: "article"};window.navigator.sendBeacon("https://monorail-edge.shopifysvc.com/v1/produce", JSON.stringify({schema_id: "online_store_buyer_site_abandonment/1.1",payload: payload,metadata: {event_created_at_ms: currentMs,event_sent_at_ms: currentMs}}));}}window.addEventListener('pagehide', handle_abandonment_event);}}());</script>
+<script>
+  window.__TREKKIE_SHIM_QUEUE = window.__TREKKIE_SHIM_QUEUE || [];
+</script>
+<script>(function(){var wpmLoader=function(){"use strict";var e=/Googlebot|Storebot-Google|bingbot|Baiduspider|YandexBot|DuckDuckBot|Slurp|facebookexternalhit|Twitterbot|LinkedInBot|Applebot|AdsBot-Google|Mediapartners-Google|APIs-Google|PetalBot|SemrushBot|AhrefsBot|MJ12bot|DotBot|Acunetix|PerplexityBot|Perplexity-User/i,r=/bytedance/i;function o(){try{var e=document.cookie;if(!e||"string"!=typeof e)return;for(var r=0,o=e.split(";");r<o.length;r++){var d=o[r],t=d.indexOf("=");if(-1!==t){var n=d.slice(0,t).trim();if(n){var i=void 0;try{i=decodeURIComponent(n)}catch(e){i=n}if("_shopify_s"===i){var a=d.slice(t+1).trim();try{return decodeURIComponent(a)}catch(e){return a}}}}}return}catch(e){return}}function d(e){try{"undefined"!=typeof console&&"function"==typeof console.warn&&console.warn(e)}catch(e){}}return function(t,n,i,a){var s,c,u,l,f=arguments.length>4&&void 0!==arguments[4]?arguments[4]:{},p=(c=(s={modern:/Edge?\/(1{2}[4-9]|1[2-9]\d|[2-9]\d{2}|\d{4,})\.\d+(\.\d+|)|Firefox\/(1{2}[4-9]|1[2-9]\d|[2-9]\d{2}|\d{4,})\.\d+(\.\d+|)|Chrom(ium|e)\/(9{2}|\d{3,})\.\d+(\.\d+|)|(Maci|X1{2}).+ Version\/(15\.\d+|(1[6-9]|[2-9]\d|\d{3,})\.\d+)([,.]\d+|)( \(\w+\)|)( Mobile\/\w+|) Safari\/|Chrome.+OPR\/(9{2}|\d{3,})\.\d+\.\d+|(CPU[ +]OS|iPhone[ +]OS|CPU[ +]iPhone|CPU IPhone OS|CPU iPad OS)[ +]+(15[._]\d+|(1[6-9]|[2-9]\d|\d{3,})[._]\d+)([._]\d+|)|Android:?[ /-](14[89]|1[5-9]\d|[2-9]\d{2}|\d{4,})(\.\d+|)(\.\d+|)|Android.+Firefox\/(15\d|1[6-9]\d|[2-9]\d{2}|\d{4,})\.\d+(\.\d+|)|Android.+Chrom(ium|e)\/(14[89]|1[5-9]\d|[2-9]\d{2}|\d{4,})\.\d+(\.\d+|)|SamsungBrowser\/([2-9]\d|\d{3,})\.\d+/,legacy:/Edge?\/(1[6-9]|[2-9]\d|\d{3,})\.\d+(\.\d+|)|Firefox\/(5[4-9]|[6-9]\d|\d{3,})\.\d+(\.\d+|)|Chrom(ium|e)\/(5[1-9]|[6-9]\d|\d{3,})\.\d+(\.\d+|)([\d.]+$|.*Safari\/(?![\d.]+ Edge\/[\d.]+$))|(Maci|X1{2}).+ Version\/(10\.\d+|(1[1-9]|[2-9]\d|\d{3,})\.\d+)([,.]\d+|)( \(\w+\)|)( Mobile\/\w+|) Safari\/|Chrome.+OPR\/(3[89]|[4-9]\d|\d{3,})\.\d+\.\d+|(CPU[ +]OS|iPhone[ +]OS|CPU[ +]iPhone|CPU IPhone OS|CPU iPad OS)[ +]+(10[._]\d+|(1[1-9]|[2-9]\d|\d{3,})[._]\d+)([._]\d+|)|Android:?[ /-](14[89]|1[5-9]\d|[2-9]\d{2}|\d{4,})(\.\d+|)(\.\d+|)|Mobile Safari.+OPR\/([89]\d|\d{3,})\.\d+\.\d+|Android.+Firefox\/(15\d|1[6-9]\d|[2-9]\d{2}|\d{4,})\.\d+(\.\d+|)|Android.+Chrom(ium|e)\/(14[89]|1[5-9]\d|[2-9]\d{2}|\d{4,})\.\d+(\.\d+|)|Android.+(UC? ?Browser|UCWEB|U3)[ /]?(15\.([5-9]|\d{2,})|(1[6-9]|[2-9]\d|\d{3,})\.\d+)\.\d+|SamsungBrowser\/(5\.\d+|([6-9]|\d{2,})\.\d+)|Android.+MQ{2}Browser\/(14(\.(9|\d{2,})|)|(1[5-9]|[2-9]\d|\d{3,})(\.\d+|))(\.\d+|)|K[Aa][Ii]OS\/(3\.\d+|([4-9]|\d{2,})\.\d+)(\.\d+|)/}).modern,u=s.legacy,(l=navigator.userAgent).match(e)?"bot":l.match(c)?"modern":l.match(u)?"legacy":l.match(r)?"bot":"unknown"),h=function(e){var r=e.version,t=e.browserTarget,n=e.surface,i=e.shopId,a=e.monorailEndpoint,s=window.location.href;return{emit:function(e){var c,u=e.status,l=e.errorMsg;if(!a)return d("[Web Pixels Manager] No Monorail endpoint provided, skipping logging."),!1;try{var f=(new Date).getTime();c=JSON.stringify({metadata:{event_sent_at_ms:f},events:[{schema_id:"web_pixels_manager_load/3.2",payload:{version:r,bundle_target:t,page_url:s,status:u,surface:n,error_msg:l,shop_id:i,visit_token:o()},metadata:{event_created_at_ms:f}}]})}catch(e){return!1}var p,h=!1;try{"function"==typeof window.navigator.sendBeacon&&-1===(p=window.navigator.userAgent).indexOf("iPhone; CPU iPhone OS 12_")&&-1===p.indexOf("iPad; CPU OS 12_")&&-1===p.indexOf("iPod touch; CPU iPhone OS 12_")&&(h=window.navigator.sendBeacon.bind(window.navigator)(a,c))}catch(e){h=!1}if(h)return!0;try{var m=new XMLHttpRequest;return m.open("POST",a,!0),m.setRequestHeader("Content-Type","text/plain"),m.send(c),!0}catch(e){return d("[Web Pixels Manager] Got an unhandled error while logging to Monorail."),!1}}}}({version:i,browserTarget:p,surface:t.surface,shopId:t.shopId,monorailEndpoint:t.monorailEndpoint});if(Boolean(null==(y=null==(m=window.Shopify)?void 0:m.analytics)?void 0:y.replayQueue))h.emit({status:"setup-skipped",errorMsg:"replay queue already initialized."});else{var m,y;h.emit({status:"setup-started"}),window.Shopify=window.Shopify||{};var g=window.Shopify;g.analytics=g.analytics||{};var v=g.analytics;v.replayQueue=[],v.publish=function(e,r,o){return v.replayQueue.push([e,r,o]),!0};try{self.performance.mark("wpm:start")}catch(e){}var w,b="modern"===p?"modern":"legacy",P=(null!=a?a:{modern:"",legacy:""})[b],S=[(w={baseUrl:n,hashVersion:i,buildTarget:b}).baseUrl,"/wpm","/b",w.hashVersion,"modern"===w.buildTarget?"m":"l",".js"].join("");try{f.browserTarget=p,O(function(){try{O(_)}catch(e){h.emit({status:"failed",errorMsg:U(e)})}}),h.emit({status:"loading"})}catch(e){h.emit({status:"failed",errorMsg:U(e)})}}function C(){if(!function(){var e,r;return Boolean(null==(r=null==(e=window.Shopify)?void 0:e.analytics)?void 0:r.initialized)}()){var e=window.webPixelsManager.init(t)||void 0;if(e){var r=window.Shopify.analytics;r.replayQueue.forEach(function(r){var o=r[0],d=r[1],t=r[2];e.publishCustomEvent(o,d,t)}),r.replayQueue=[],r.publish=e.publishCustomEvent,r.visitor=e.visitor,r.initialized=!0}}}function _(){return h.emit({status:"failed",errorMsg:"".concat(S," has failed to load")})}function O(e){var r;!function(e){var r=e.src,o=e.async,d=void 0===o||o,t=e.onload,n=e.onerror,i=e.sri,a=e.scriptDataAttributes,s=void 0===a?{}:a,c=document.createElement("script"),u=document.querySelector("head"),l=document.querySelector("body");if(c.async=d,c.src=r,i&&(c.integrity=i,c.crossOrigin="anonymous"),s)for(var f in s)if(Object.prototype.hasOwnProperty.call(s,f))try{c.dataset[f]=s[f]}catch(e){}if(t&&c.addEventListener("load",t),n&&c.addEventListener("error",n),u)u.appendChild(c);else{if(!l)throw new Error("Did not find a head or body element to append the script");l.appendChild(c)}}({src:S,async:!0,onload:C,onerror:e,sri:(r=P,"string"==typeof r&&/^sha384-[A-Za-z0-9+/=]+$/.test(r)?P:""),scriptDataAttributes:f})}function U(e){return e instanceof Error?e.message:"Unknown error"}}}();wpmLoader({shopId: 59538505936,storefrontBaseUrl: "https://curatedkitchenware.com",extensionsBaseUrl: "https://extensions.shopifycdn.com/cdn/shopifycloud/web-pixels-manager",monorailEndpoint: "https://curatedkitchenware.com/.well-known/shopify/monorail/unstable/produce_batch",surface: "storefront-renderer",enabledBetaFlags: ["d5bdd5d0","656605ce"],webPixelsConfigList: [{"id":"200900816","configuration":"{\"config\":\"{\\\"google_tag_ids\\\":[\\\"AW-11115344305\\\",\\\"GT-P3N6FKS\\\",\\\"AW-965682594\\\"],\\\"target_country\\\":\\\"US\\\",\\\"gtag_events\\\":[{\\\"type\\\":\\\"begin_checkout\\\",\\\"action_label\\\":[\\\"AW-11115344305\\\/UPQ4CI2fq5EYELHjmrQp\\\",\\\"AW-965682594\\\"]},{\\\"type\\\":\\\"search\\\",\\\"action_label\\\":[\\\"AW-11115344305\\\/BwgBCIefq5EYELHjmrQp\\\",\\\"AW-965682594\\\"]},{\\\"type\\\":\\\"view_item\\\",\\\"action_label\\\":[\\\"AW-11115344305\\\/PCWhCISfq5EYELHjmrQp\\\",\\\"MC-MYLN2EZ4GE\\\",\\\"AW-965682594\\\"]},{\\\"type\\\":\\\"purchase\\\",\\\"action_label\\\":[\\\"AW-11115344305\\\/NrfmCP6eq5EYELHjmrQp\\\",\\\"MC-MYLN2EZ4GE\\\",\\\"AW-965682594\\\/MixaCO_U3q4DEKLLvMwD\\\",\\\"AW-965682594\\\"]},{\\\"type\\\":\\\"page_view\\\",\\\"action_label\\\":[\\\"AW-11115344305\\\/RPKwCIGfq5EYELHjmrQp\\\",\\\"MC-MYLN2EZ4GE\\\",\\\"AW-965682594\\\"]},{\\\"type\\\":\\\"add_payment_info\\\",\\\"action_label\\\":[\\\"AW-11115344305\\\/IVqfCJCfq5EYELHjmrQp\\\",\\\"AW-965682594\\\"]},{\\\"type\\\":\\\"add_to_cart\\\",\\\"action_label\\\":[\\\"AW-11115344305\\\/z3r8CIqfq5EYELHjmrQp\\\",\\\"AW-965682594\\\"]}],\\\"enable_monitoring_mode\\\":false}\"}","eventPayloadVersion":"v1","runtimeContext":"OPEN","scriptVersion":"9120410995b7c9c6f4f039573265c0ea","type":"APP","apiClientId":1780363,"privacyPurposes":[],"dataSharingAdjustments":{"protectedCustomerApprovalScopes":["read_customer_address","read_customer_email","read_customer_name","read_customer_personal_data","read_customer_phone"],"dataSharingControls":["share_all_events"]},"dataSharingState":"optimized","enabledFlags":["9a3ed68a"]},{"id":"76316880","configuration":"{\"pixel_id\":\"549054209169805\",\"pixel_type\":\"facebook_pixel\",\"metaapp_system_user_token\":\"-\"}","eventPayloadVersion":"v1","runtimeContext":"OPEN","scriptVersion":"abff2a8add143ccb04deb20f0ebd74a9","type":"APP","apiClientId":2329312,"privacyPurposes":["ANALYTICS","MARKETING","SALE_OF_DATA"],"dataSharingAdjustments":{"protectedCustomerApprovalScopes":["read_customer_address","read_customer_email","read_customer_name","read_customer_personal_data","read_customer_phone"],"dataSharingControls":["share_all_events"]},"dataSharingState":"optimized","enabledFlags":["9a3ed68a"]},{"id":"44564688","configuration":"{\"tagID\":\"2612906234464\"}","eventPayloadVersion":"v1","runtimeContext":"STRICT","scriptVersion":"565fe5dd5db699c5a32547ff5c1df3c8","type":"APP","apiClientId":3009811,"privacyPurposes":["ANALYTICS","MARKETING","SALE_OF_DATA"],"dataSharingAdjustments":{"protectedCustomerApprovalScopes":["read_customer_address","read_customer_email","read_customer_name","read_customer_personal_data","read_customer_phone"],"dataSharingControls":["share_all_events"]},"dataSharingState":"optimized"},{"id":"31326416","eventPayloadVersion":"v1","runtimeContext":"LAX","scriptVersion":"1","type":"CUSTOM","privacyPurposes":["ANALYTICS"],"name":"Google Analytics tag (migrated)"},{"id":"shopify-app-pixel","configuration":"{}","eventPayloadVersion":"v1","runtimeContext":"STRICT","scriptVersion":"0510","apiClientId":"shopify-pixel","type":"APP","privacyPurposes":["ANALYTICS","MARKETING"]},{"id":"shopify-custom-pixel","eventPayloadVersion":"v1","runtimeContext":"LAX","scriptVersion":"0510","apiClientId":"shopify-pixel","type":"CUSTOM","privacyPurposes":["ANALYTICS","MARKETING"]}],isMerchantRequest: false,initData: {"shop":{"name":"Curated Kitchenware","paymentSettings":{"currencyCode":"USD"},"myshopifyDomain":"curated-kitchenware.myshopify.com","countryCode":"US","storefrontUrl":"https:\/\/curatedkitchenware.com"},"customer":null,"cart":null,"checkout":null,"productVariants":[],"products":[{"id":"8172174639312","handle":"souped-up-recipes-cookbook-168-better-than-takeout-chinese-recipes","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"44246629089488","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"6734609416400","handle":"carbon-steel-wok-with-flat-bottom","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"45038734803152","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"7700441268432","handle":"stainless-steel-pot-set","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"44347255455952","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"7733607366864","handle":"damascus-kitchen-knife-set","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"42826069639376","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"6734637695184","handle":"ceramic-chopsticks-set","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"40409582305488","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"6864576774352","handle":"asian-clay-pot-for-cooking-ceramic-cookware-4-8-quarts","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"44262316671184","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"7958619685072","handle":"chefs-knife","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"43663022817488","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"7958623256784","handle":"cleaver-knife","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"43663036514512","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"7959206691024","handle":"paring-knife","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"43667555582160","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"8376748638416","handle":"heavy-duty-claypot-replaces-both-a-dutch-oven-and-stock-pot-2-2-quart","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"44732570140880","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"8329247064272","handle":"souped-up-recipes-10-inch-carbon-steel-wok-for-electric-induction-and-gas-stoves-lid-and-user-guide-video-included","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"44620532515024","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"8154381451472","handle":"13-4-inch-carbon-steel-wok-for-electric-induction-and-gas-stoves-lid-spatula-and-user-guide-video-included","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"44173120766160","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"8138123313360","handle":"natural-wooden-wok-pan-wooden-lid-fits-for-woks-and-pans-with-an-inner-diameter-from12-48to12-87","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"44130192031952","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]},{"id":"8080087351504","handle":"carbon-steel-wok-handle-pot-handle-wooden-handle-for-wok-pan","isCollective":null,"title":null,"type":null,"untranslatedTitle":null,"url":null,"vendor":null,"remoteShopId":null,"variants":[{"id":"43999275122896","image":null,"price":null,"sku":null,"title":null,"untranslatedTitle":null}]}],"purchasingCompany":null},},"https://curatedkitchenware.com/cdn","2d9dfbe8w1156b718pbb247b16m64115e31",{"modern":"","legacy":""},{"trekkieShim":true,"agentContext":true,"apiClientId":"580111","facebookCapiEnabled":"true","themeId":"138244522192","themePublished":"true","eventMetadataId":"0b0f9a25-28d8-459d-bb7a-2639f838753c","pageType":"article","resourceId":"561902190800","shopId":"59538505936","storefrontBaseUrl":"https:\/\/curatedkitchenware.com","extensionBaseUrl":"https:\/\/extensions.shopifycdn.com\/cdn\/shopifycloud\/web-pixels-manager","surface":"storefront-renderer","enabledBetaFlags":"[\"d5bdd5d0\", \"656605ce\"]","isMerchantRequest":"false","hashVersion":"2d9dfbe8w1156b718pbb247b16m64115e31","publish":"custom","events":"[[\"page_viewed\",{}]]"});})();</script><script>
+  window.ShopifyAnalytics = window.ShopifyAnalytics || {};
+  window.ShopifyAnalytics.meta = window.ShopifyAnalytics.meta || {};
+  window.ShopifyAnalytics.meta.currency = 'USD';
+  var meta = {"page":{"pageType":"article","resourceType":"article","resourceId":561902190800,"requestId":"59a9e042-51f4-4c33-91eb-472c5d37b95b-1787442478"}};
+  for (var attr in meta) {
+    window.ShopifyAnalytics.meta[attr] = meta[attr];
+  }
+</script>
+<script class="analytics">
+  (function () {
+    var customDocumentWrite = function(content) {
+      var jquery = null;
+
+      if (window.jQuery) {
+        jquery = window.jQuery;
+      } else if (window.Checkout && window.Checkout.$) {
+        jquery = window.Checkout.$;
+      }
+
+      if (jquery) {
+        jquery('body').append(content);
+      }
+    };
+
+    var hasLoggedConversion = function(token) {
+      if (token) {
+        return document.cookie.indexOf('loggedConversion=' + token) !== -1;
+      }
+      return false;
+    }
+
+    var setCookieIfConversion = function(token) {
+      if (token) {
+        var twoMonthsFromNow = new Date(Date.now());
+        twoMonthsFromNow.setMonth(twoMonthsFromNow.getMonth() + 2);
+
+        document.cookie = 'loggedConversion=' + token + '; expires=' + twoMonthsFromNow;
+      }
+    }
+
+    var trekkie = window.ShopifyAnalytics.lib = window.trekkie = window.trekkie || [];
+    window.ShopifyAnalytics.lib.trekkie = window.trekkie;
+    if (trekkie.integrations) {
+      return;
+    }
+    trekkie.methods = [
+      'identify',
+      'page',
+      'ready',
+      'track',
+      'trackForm',
+      'trackLink'
+    ];
+    trekkie.factory = function(method) {
+      return function() {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift(method);
+        trekkie.push(args);
+        if (window.__TREKKIE_SHIM_QUEUE && (method == 'track' || method == 'page')) {
+          try {
+            window.__TREKKIE_SHIM_QUEUE.push({
+              from: 'trekkie-stub',
+              method: method,
+              args: args.slice(1)
+            });
+          } catch (e) {
+            // no-op
+          }
+        }
+        return trekkie;
+      };
+    };
+    for (var i = 0; i < trekkie.methods.length; i++) {
+      var key = trekkie.methods[i];
+      trekkie[key] = trekkie.factory(key);
+    }
+    trekkie.load = function(config) {
+      trekkie.config = config || {};
+      trekkie.config.initialDocumentCookie = document.cookie;
+      var first = document.getElementsByTagName('script')[0];
+var script = document.createElement('script');
+script.type = 'text/javascript';
+script.onerror = function(e) {
+  var scriptFallback = document.createElement('script');
+  scriptFallback.type = 'text/javascript';
+  scriptFallback.onerror = function(error) {
+          var Monorail = {
+      produce: function produce(monorailDomain, schemaId, payload) {
+        var currentMs = new Date().getTime();
+        var event = {
+          schema_id: schemaId,
+          payload: payload,
+          metadata: {
+            event_created_at_ms: currentMs,
+            event_sent_at_ms: currentMs
+          }
+        };
+        return Monorail.sendRequest("https://" + monorailDomain + "/v1/produce", JSON.stringify(event));
+      },
+      sendRequest: function sendRequest(endpointUrl, payload) {
+        // Try the sendBeacon API
+        if (window && window.navigator && typeof window.navigator.sendBeacon === 'function' && typeof window.Blob === 'function' && !Monorail.isIos12()) {
+          var blobData = new window.Blob([payload], {
+            type: 'text/plain'
+          });
+
+          if (window.navigator.sendBeacon(endpointUrl, blobData)) {
+            return true;
+          } // sendBeacon was not successful
+
+        } // XHR beacon
+
+        var xhr = new XMLHttpRequest();
+
+        try {
+          xhr.open('POST', endpointUrl);
+          xhr.setRequestHeader('Content-Type', 'text/plain');
+          xhr.send(payload);
+        } catch (e) {
+          console.log(e);
+        }
+
+        return false;
+      },
+      isIos12: function isIos12() {
+        return window.navigator.userAgent.lastIndexOf('iPhone; CPU iPhone OS 12_') !== -1 || window.navigator.userAgent.lastIndexOf('iPad; CPU OS 12_') !== -1;
+      }
+    };
+    Monorail.produce('monorail-edge.shopifysvc.com',
+      'trekkie_storefront_load_errors/1.1',
+      {shop_id: 59538505936,
+      theme_id: 138244522192,
+      app_name: "storefront",
+      context_url: window.location.href,
+      source_url: "//curatedkitchenware.com/cdn/s/trekkie.storefront.7bcd7bb8195e24c65a61d69d69eb32392ed0d53f.min.js"});
+
+  };
+  scriptFallback.async = true;
+  scriptFallback.src = '//curatedkitchenware.com/cdn/s/trekkie.storefront.7bcd7bb8195e24c65a61d69d69eb32392ed0d53f.min.js';
+  first.parentNode.insertBefore(scriptFallback, first);
+};
+script.async = true;
+script.src = '//curatedkitchenware.com/cdn/s/trekkie.storefront.7bcd7bb8195e24c65a61d69d69eb32392ed0d53f.min.js';
+first.parentNode.insertBefore(script, first);
+
+    };
+    trekkie.load(
+      {"Trekkie":{"appName":"storefront","development":false,"defaultAttributes":{"shopId":59538505936,"isMerchantRequest":null,"themeId":138244522192,"themeCityHash":"14459464568524783243","contentLanguage":"en","currency":"USD","eventMetadataId":"0b0f9a25-28d8-459d-bb7a-2639f838753c"},"isServerSideCookieWritingEnabled":true,"monorailRegion":"shop_domain","enabledBetaFlags":["f43e7f5e","b5387b81","d5bdd5d0"]},"Session Attribution":{},"S2S":{"facebookCapiEnabled":true,"source":"trekkie-storefront-renderer","apiClientId":580111}}
+    );
+
+    var loaded = false;
+    trekkie.ready(function() {
+      if (loaded) return;
+      loaded = true;
+
+      window.ShopifyAnalytics.lib = window.trekkie;
+
+      var originalDocumentWrite = document.write;
+      document.write = customDocumentWrite;
+      try { window.ShopifyAnalytics.merchantGoogleAnalytics.call(this); } catch(error) {};
+      document.write = originalDocumentWrite;
+
+      var match = window.location.pathname.match(/checkouts\/(.+)\/(thank_you|post_purchase)/)
+      var token = match? match[1]: undefined;
+      if (!hasLoggedConversion(token)) {
+        setCookieIfConversion(token);
+        
+      }
+    });
+
+    window.ShopifyAnalytics.lib.page(null,{"pageType":"article","resourceType":"article","resourceId":561902190800,"requestId":"59a9e042-51f4-4c33-91eb-472c5d37b95b-1787442478","shopifyEmitted":true});
+
+    var eventsListenerScript = document.createElement('script');
+    eventsListenerScript.async = true;
+    eventsListenerScript.src = "//curatedkitchenware.com/cdn/shopifycloud/storefront/assets/shop_events_listener-4e26a9ce.js";
+    document.getElementsByTagName('head')[0].appendChild(eventsListenerScript);
+})();</script>
+  <script>
+  if (!window.ga || (window.ga && typeof window.ga !== 'function')) {
+    window.ga = function ga() {
+      (window.ga.q = window.ga.q || []).push(arguments);
+      if (window.Shopify && window.Shopify.analytics && typeof window.Shopify.analytics.publish === 'function') {
+        window.Shopify.analytics.publish("ga_stub_called", {}, {sendTo: "google_osp_migration"});
+      }
+      console.error("Shopify's Google Analytics stub called with:", Array.from(arguments), "\nSee https://help.shopify.com/manual/promoting-marketing/pixels/pixel-migration#google for more information.");
+    };
+    if (window.Shopify && window.Shopify.analytics && typeof window.Shopify.analytics.publish === 'function') {
+      window.Shopify.analytics.publish("ga_stub_initialized", {}, {sendTo: "google_osp_migration"});
+    }
+  }
+</script>
+<script
+  defer
+  src="https://curatedkitchenware.com/cdn/shopifycloud/perf-kit/shopify-perf-kit-3.8.4.min.js"
+  data-application="storefront-renderer"
+  data-shop-id="59538505936"
+  data-render-region="gcp-asia-southeast1"
+  data-page-type="article"
+  data-theme-instance-id="138244522192"
+  data-theme-name="Shapes"
+  data-theme-version="2.2.5"
+  data-monorail-region="shop_domain"
+  data-resource-timing-sampling-rate="10"
+  data-shs="true"
+  data-shs-beacon="true"
+  data-shs-export-with-fetch="true"
+  data-shs-logs-sample-rate="1"
+  data-shs-beacon-endpoint="https://curatedkitchenware.com/api/collect"
+></script>
+<meta name="shopify-y" content="96934bf5-ea55-48f0-909d-87362f5b9bd4"><meta name="shopify-s" content="3b9ab763-eef2-4c1b-a57d-8b065142911b"><meta name="new-cookie-storage-activated" content="f">
+</head>
+
+    <body data-color-scheme="primary">
+      
+<svg width="0" height="0" viewBox="0 0 200 200">
+  <defs>
+    <clipPath id="clip-on-sale" clipPathUnits="objectBoundingBox">
+      <path clip-rule="evenodd" transform="scale(0.005,0.005)" d="M195 99.7858C195 99.7858 152.467 144.571 99.9997 144.571C47.5326 144.571 4.99999 99.7854 4.99999 99.7854C4.99999 99.7854 47.5326 55 99.9997 55C152.467 54.9999 195 99.7858 195 99.7858Z" fill="black"/>
+    </clipPath>
+    <path id="outline-on-sale" vector-effect="non-scaling-stroke"  d="M195 99.7858C195 99.7858 152.467 144.571 99.9997 144.571C47.5326 144.571 4.99999 99.7854 4.99999 99.7854C4.99999 99.7854 47.5326 55 99.9997 55C152.467 54.9999 195 99.7858 195 99.7858Z" />
+  </defs>
+</svg>
+<svg width="0" height="0" viewBox="0 0 200 200">
+  <defs>
+    <clipPath id="clip-sold-out" clipPathUnits="objectBoundingBox">
+      <path clip-rule="evenodd" transform="scale(0.005,0.005)" d="M195 45.0113C191.042 44.8164 187.276 47.1545 183.994 51.2461C181.291 54.6557 176.174 54.6557 173.471 51.2461C170.381 47.3493 166.712 45.0113 162.851 45.0113C158.989 45.0113 155.417 47.2519 152.327 51.2461C149.624 54.6557 144.507 54.6557 141.804 51.2461C138.714 47.3493 135.046 45.0113 131.28 45.0113C127.419 45.0113 123.847 47.2519 120.757 51.2461C118.054 54.6557 112.937 54.6557 110.234 51.2461C107.144 47.3493 103.476 45.0113 99.7104 45.0113C95.8486 45.0113 92.2764 47.2519 89.187 51.2461C86.4837 54.6557 81.3669 54.6557 78.6636 51.2461C75.5742 47.3493 71.9055 45.0113 68.1402 45.0113C64.2784 45.0113 60.7063 47.2519 57.6169 51.2461C54.9136 54.6557 49.7967 54.6557 47.0935 51.2461C44.0041 47.3493 40.3354 45.0113 36.5701 45.0113C32.7083 45.0113 29.1362 47.2519 26.0467 51.2461C23.3435 54.6557 18.2266 54.6557 15.5234 51.2461C12.4339 47.3493 8.76524 45.0113 5 45.0113V154.997C8.86179 154.997 12.4339 152.756 15.5234 148.762C18.2266 145.353 23.3435 145.353 26.0467 148.762C29.1362 152.659 32.8049 154.997 36.5701 154.997C40.4319 154.997 44.0041 152.756 47.0935 148.762C49.7967 145.353 54.9136 145.353 57.6169 148.762C60.7063 152.659 64.375 154.997 68.1402 154.997C72.002 154.997 75.5742 152.756 78.6636 148.762C81.3669 145.353 86.4837 145.353 89.187 148.762C92.2764 152.659 95.9451 154.997 99.7104 154.997C103.572 154.997 107.144 152.756 110.234 148.762C112.937 145.353 118.054 145.353 120.757 148.762C123.847 152.659 127.515 154.997 131.28 154.997C135.142 154.997 138.714 152.756 141.804 148.762C144.507 145.353 149.624 145.353 152.327 148.762C155.417 152.659 159.085 154.997 162.851 154.997C166.712 154.997 170.285 152.756 173.471 148.762C176.174 145.353 181.291 145.255 183.994 148.762C187.18 152.854 190.945 155.094 195 154.997V45.0113Z" fill="black"/>
+    </clipPath>
+    <path id="outline-sold-out" vector-effect="non-scaling-stroke"  d="M195 45.0113C191.042 44.8164 187.276 47.1545 183.994 51.2461C181.291 54.6557 176.174 54.6557 173.471 51.2461C170.381 47.3493 166.712 45.0113 162.851 45.0113C158.989 45.0113 155.417 47.2519 152.327 51.2461C149.624 54.6557 144.507 54.6557 141.804 51.2461C138.714 47.3493 135.046 45.0113 131.28 45.0113C127.419 45.0113 123.847 47.2519 120.757 51.2461C118.054 54.6557 112.937 54.6557 110.234 51.2461C107.144 47.3493 103.476 45.0113 99.7104 45.0113C95.8486 45.0113 92.2764 47.2519 89.187 51.2461C86.4837 54.6557 81.3669 54.6557 78.6636 51.2461C75.5742 47.3493 71.9055 45.0113 68.1402 45.0113C64.2784 45.0113 60.7063 47.2519 57.6169 51.2461C54.9136 54.6557 49.7967 54.6557 47.0935 51.2461C44.0041 47.3493 40.3354 45.0113 36.5701 45.0113C32.7083 45.0113 29.1362 47.2519 26.0467 51.2461C23.3435 54.6557 18.2266 54.6557 15.5234 51.2461C12.4339 47.3493 8.76524 45.0113 5 45.0113V154.997C8.86179 154.997 12.4339 152.756 15.5234 148.762C18.2266 145.353 23.3435 145.353 26.0467 148.762C29.1362 152.659 32.8049 154.997 36.5701 154.997C40.4319 154.997 44.0041 152.756 47.0935 148.762C49.7967 145.353 54.9136 145.353 57.6169 148.762C60.7063 152.659 64.375 154.997 68.1402 154.997C72.002 154.997 75.5742 152.756 78.6636 148.762C81.3669 145.353 86.4837 145.353 89.187 148.762C92.2764 152.659 95.9451 154.997 99.7104 154.997C103.572 154.997 107.144 152.756 110.234 148.762C112.937 145.353 118.054 145.353 120.757 148.762C123.847 152.659 127.515 154.997 131.28 154.997C135.142 154.997 138.714 152.756 141.804 148.762C144.507 145.353 149.624 145.353 152.327 148.762C155.417 152.659 159.085 154.997 162.851 154.997C166.712 154.997 170.285 152.756 173.471 148.762C176.174 145.353 181.291 145.255 183.994 148.762C187.18 152.854 190.945 155.094 195 154.997V45.0113Z" />
+  </defs>
+</svg>
+<svg width="0" height="0" viewBox="0 0 200 200">
+  <defs>
+    <clipPath id="clip-metafield-badge" clipPathUnits="objectBoundingBox">
+      <path clip-rule="evenodd" transform="scale(0.005,0.005)" d="M198 100.502C198 110.547 187.924 118.889 184.983 127.959C181.888 137.354 185.076 149.999 179.381 157.815C173.685 165.631 160.591 166.606 152.698 172.364C144.804 178.121 140.022 190.209 130.627 193.258C121.557 196.199 110.506 189.312 100.492 189.312C90.4784 189.312 79.4584 196.168 70.3422 193.258C60.9474 190.163 56.103 178.059 48.2869 172.364C40.4708 166.668 27.346 165.708 21.6039 157.815C15.8618 149.922 19.0965 137.354 16.0011 127.959C13.0604 118.889 3 110.547 3 100.502C3 90.4573 13.0604 82.115 16.0011 73.0452C19.0965 63.6349 16.0011 51.0054 21.6194 43.1738C27.2377 35.3422 40.3935 34.3826 48.3024 28.625C56.2114 22.8674 60.9629 10.795 70.3577 7.73051C79.4275 4.7898 90.4783 11.6773 100.508 11.6773C110.537 11.6773 121.573 4.7898 130.642 7.73051C140.037 10.826 144.882 22.9448 152.713 28.625C160.545 34.3052 173.639 35.2803 179.396 43.1738C185.154 51.0673 181.95 63.6349 184.999 73.0452C187.924 82.115 198 90.4418 198 100.502Z" fill="black"/>
+    </clipPath>
+    <path id="outline-metafield-badge" vector-effect="non-scaling-stroke"  d="M198 100.502C198 110.547 187.924 118.889 184.983 127.959C181.888 137.354 185.076 149.999 179.381 157.815C173.685 165.631 160.591 166.606 152.698 172.364C144.804 178.121 140.022 190.209 130.627 193.258C121.557 196.199 110.506 189.312 100.492 189.312C90.4784 189.312 79.4584 196.168 70.3422 193.258C60.9474 190.163 56.103 178.059 48.2869 172.364C40.4708 166.668 27.346 165.708 21.6039 157.815C15.8618 149.922 19.0965 137.354 16.0011 127.959C13.0604 118.889 3 110.547 3 100.502C3 90.4573 13.0604 82.115 16.0011 73.0452C19.0965 63.6349 16.0011 51.0054 21.6194 43.1738C27.2377 35.3422 40.3935 34.3826 48.3024 28.625C56.2114 22.8674 60.9629 10.795 70.3577 7.73051C79.4275 4.7898 90.4783 11.6773 100.508 11.6773C110.537 11.6773 121.573 4.7898 130.642 7.73051C140.037 10.826 144.882 22.9448 152.713 28.625C160.545 34.3052 173.639 35.2803 179.396 43.1738C185.154 51.0673 181.95 63.6349 184.999 73.0452C187.924 82.115 198 90.4418 198 100.502Z" />
+  </defs>
+</svg>
+
+
+      
+      <a class="skip-link" href="#MainContent">Skip to content</a><style>
+  .sur-head{--navy:#0E1B4D;--orange:#FF9900;--amber:#9A5B00;--hair:#E0E0E0;font-family:'Inter',Helvetica,Arial,sans-serif;display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 20px;border-bottom:1px solid var(--hair);background:#fff;position:relative;z-index:30;}
+  .sur-head a{text-decoration:none;color:var(--navy);}
+  .sur-head .brand{display:flex;align-items:baseline;gap:9px;}
+  .sur-head .brand .wm{font-family:'Fraunces',Georgia,serif;font-size:20px;font-weight:600;letter-spacing:-.01em;}
+  .sur-head .brand .since{font-size:11px;font-weight:700;letter-spacing:.1em;color:var(--amber);}
+  .sur-head nav{display:none;gap:26px;font-size:14.5px;font-weight:500;}
+  .sur-head nav a.active{font-weight:600;border-bottom:2px solid var(--orange);padding-bottom:2px;}
+  .sur-head .icons{display:flex;gap:12px;align-items:center;}
+  .sur-head .icons a{display:flex;align-items:center;color:var(--navy);position:relative;}
+  .sur-head .cartn{position:absolute;top:-7px;right:-9px;background:var(--navy);color:#fff;font-size:9px;font-weight:700;min-width:15px;height:15px;border-radius:100px;display:flex;align-items:center;justify-content:center;padding:0 3px;}
+  @media (min-width:900px){ .sur-head{padding:18px 64px;} .sur-head .brand .wm{font-size:24px;} .sur-head nav{display:flex;} }
+  .sur-ann{position:relative;background:#0E1B4D;color:#fff;text-align:center;padding:11px 48px;font-size:13.5px;font-family:'Inter',Helvetica,Arial,sans-serif;}
+  .sur-ann a{color:#fff;font-weight:500;text-decoration:none;}
+  .sur-ann a:hover{color:#FF9900;}
+  .sur-ann .x{position:absolute;right:14px;top:50%;transform:translateY(-50%);width:26px;height:26px;display:flex;align-items:center;justify-content:center;color:rgba(255,255,255,.65);font-size:16px;line-height:1;cursor:pointer;border:0;background:none;border-radius:4px;}
+  .sur-ann .x:hover{color:#fff;background:rgba(255,255,255,.12);}
+  .sur-ann.is-hidden{display:none;}
+</style><div class="sur-ann" data-sur-ann><span>FLASH SALE: 10% OFF orders $50+ with code SUMMER</span><button type="button" class="x" aria-label="Close announcement" data-sur-annclose>&times;</button>
+</div>
+<script>
+  (function(){
+    try{ if(localStorage.getItem('sur_blog_bar_dismissed')==='1'){var b=document.querySelector('[data-sur-ann]');if(b)b.classList.add('is-hidden');} }catch(e){}
+    document.addEventListener('click',function(e){
+      if(e.target.closest('[data-sur-annclose]')){var b=document.querySelector('[data-sur-ann]');if(b)b.classList.add('is-hidden');try{localStorage.setItem('sur_blog_bar_dismissed','1');}catch(e){}}
+    });
+  })();
+</script><header class="sur-head">
+  <a class="brand" href="/blogs/soupeduprecipes"><span class="wm">Souped Up Recipes</span><span class="since">SINCE 2016</span></a>
+  <nav>
+    <a class="active" href="/blogs/soupeduprecipes">Recipes</a>
+    <a href="https://www.youtube.com/soupeduprecipes" target="_blank" rel="noopener">Videos</a>
+    <a href="//products/souped-up-recipes-cookbook-168-better-than-takeout-chinese-recipes">Cookbook</a>
+    <a href="/">Shop</a>
+  </nav>
+  <div class="icons">
+    <style>
+    .ck-locale-form{display:inline-flex;align-items:center;margin:0;}
+    .ck-locale-form select{appearance:none;background:transparent;border:1px solid currentColor;border-radius:4px;color:inherit;cursor:pointer;font:600 11px/1 'Inter',Helvetica,Arial,sans-serif;letter-spacing:.04em;padding:6px 20px 6px 7px;background-image:linear-gradient(45deg,transparent 50%,currentColor 50%),linear-gradient(135deg,currentColor 50%,transparent 50%);background-position:calc(100% - 9px) 10px,calc(100% - 6px) 10px;background-size:3px 3px,3px 3px;background-repeat:no-repeat;}
+    .ck-locale-form select:focus-visible{outline:2px solid #FF9900;outline-offset:2px;}
+  </style><form method="post" action="/localization" id="BlogLocaleSelector" accept-charset="UTF-8" class="ck-locale-form" enctype="multipart/form-data"><input type="hidden" name="form_type" value="localization" /><input type="hidden" name="utf8" value="✓" /><input type="hidden" name="_method" value="put" /><input type="hidden" name="return_to" value="/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe" /><label class="visually-hidden" for="BlogLocaleSelector-locale">Language</label>
+    <select id="BlogLocaleSelector-locale" name="locale_code" aria-label="Language" onchange="this.form.submit()"><option value="en" lang="en" selected>EN</option><option value="de" lang="de">DE</option></select>
+    <input type="hidden" name="country_code" value="US"></form>
+    <a href="/search" aria-label="Search"><svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><circle cx="10.5" cy="10.5" r="6.5"/><path d="M15.5 15.5 21 21"/></svg></a>
+    <a href="/cart" aria-label="Cart"><svg width="23" height="23" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M2.5 3.5h2.2l1.5 10.4h11.6"/><path d="M6.2 6.6h15.3l-1.9 7.3"/><circle cx="9" cy="19.5" r="1.6" fill="currentColor" stroke="none"/><circle cx="17.5" cy="19.5" r="1.6" fill="currentColor" stroke="none"/></svg></a>
+  </div>
+</header>
+
+<main id="MainContent" class="overflow-hidden">
+        <section id="shopify-section-template--17962709188816__main" class="shopify-section cka-section"><link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  #cka-template--17962709188816__main{--navy:#0E1B4D;--orange:#FF9900;--amber:#9A5B00;--band:#F5F5F5;--hair:#E0E0E0;--body:#48505C;--muted:#5B6472;
+    font-family:'Inter',Helvetica,Arial,sans-serif;color:var(--navy);background:#fff;-webkit-font-smoothing:antialiased;}
+  #cka-template--17962709188816__main *{box-sizing:border-box;}
+  #cka-template--17962709188816__main h1,#cka-template--17962709188816__main h2,#cka-template--17962709188816__main h3{font-family:'Fraunces',Georgia,serif;font-weight:600;margin:0;font-variation-settings:"SOFT" 0,"WONK" 0;}
+  #cka-template--17962709188816__main a{color:var(--navy);}
+  #cka-template--17962709188816__main .wrap{max-width:760px;margin:0 auto;padding:0 20px;}
+  #cka-template--17962709188816__main .crumb{font-size:12px;color:var(--muted);padding:16px 0 0;}
+  #cka-template--17962709188816__main .crumb a{color:var(--muted);}
+  #cka-template--17962709188816__main h1{font-size:32px;line-height:1.1;margin:18px 0 12px;letter-spacing:-.01em;}
+  #cka-template--17962709188816__main .dek{font-size:18px;line-height:1.5;color:var(--body);margin-bottom:20px;}
+  #cka-template--17962709188816__main .byline{display:flex;flex-wrap:wrap;align-items:center;gap:14px;padding:16px 0;border-top:1px solid var(--hair);border-bottom:1px solid var(--hair);font-size:13px;color:var(--muted);margin-bottom:26px;}
+  #cka-template--17962709188816__main .byline .who{display:flex;align-items:center;gap:9px;color:var(--navy);font-weight:600;}
+  #cka-template--17962709188816__main .byline .who img{width:34px;height:34px;border-radius:50%;object-fit:cover;}
+  #cka-template--17962709188816__main .byline .jump{margin-left:auto;display:flex;gap:16px;}
+  #cka-template--17962709188816__main .byline .jump a{color:var(--amber);font-weight:700;}
+  #cka-template--17962709188816__main .body{font-size:16.5px;line-height:1.75;color:var(--body);}
+  #cka-template--17962709188816__main .body p{margin:0 0 18px;}
+  #cka-template--17962709188816__main .body img{max-width:100%;height:auto;border-radius:8px;}
+  #cka-template--17962709188816__main .body h2,#cka-template--17962709188816__main .body h3{color:var(--navy);margin:26px 0 12px;line-height:1.2;}
+  #cka-template--17962709188816__main .tips{background:var(--band);border-radius:10px;padding:26px;margin:28px 0;}
+  #cka-template--17962709188816__main .tips .lbl{font-size:12px;font-weight:700;letter-spacing:.08em;color:var(--amber);margin-bottom:14px;}
+  #cka-template--17962709188816__main .tips h2{font-size:22px;margin-bottom:14px;}
+  #cka-template--17962709188816__main .tips ol{margin:0;padding-left:20px;}
+  #cka-template--17962709188816__main .tips li{font-size:15px;line-height:1.6;margin-bottom:10px;color:var(--body);}
+  #cka-template--17962709188816__main .recipe-mount{margin:32px 0;}
+  #cka-template--17962709188816__main .email{background:var(--navy);color:#fff;border-radius:12px;padding:28px;margin:32px 0;}
+  #cka-template--17962709188816__main .email h2{font-size:24px;margin-bottom:8px;}
+  #cka-template--17962709188816__main .email p{font-size:14px;color:rgba(255,255,255,.8);margin:0 0 16px;}
+  #cka-template--17962709188816__main .email .row{display:flex;gap:10px;flex-wrap:wrap;}
+  #cka-template--17962709188816__main .email input{flex:1;min-width:180px;border:0;border-radius:6px;padding:14px 16px;font-family:inherit;font-size:15px;color:var(--navy);}
+  #cka-template--17962709188816__main .email button{background:var(--orange);color:var(--navy);border:0;border-radius:6px;padding:14px 22px;font-weight:700;font-family:inherit;cursor:pointer;}
+  #cka-template--17962709188816__main .email .ok{font-size:15px;}
+  #cka-template--17962709188816__main .steps h2{font-size:26px;margin:36px 0 20px;}
+  #cka-template--17962709188816__main .step{margin-bottom:28px;}
+  #cka-template--17962709188816__main .step img{width:100%;border-radius:10px;display:block;margin-bottom:12px;}
+  #cka-template--17962709188816__main .step .cap{font-size:15px;line-height:1.6;color:var(--body);}
+  #cka-template--17962709188816__main .step .num{display:inline-block;font-family:'Fraunces',Georgia,serif;font-size:14px;font-weight:700;color:#C2410C;margin-right:8px;}
+  #cka-template--17962709188816__main .pquote{font-family:'Fraunces',Georgia,serif;font-size:22px;line-height:1.35;color:var(--navy);border-left:3px solid var(--orange);padding:6px 0 6px 20px;margin:24px 0;}
+  #cka-template--17962709188816__main .toolcard{border:1px solid var(--hair);border-radius:12px;padding:18px;display:flex;gap:16px;align-items:center;margin:24px 0;}
+  #cka-template--17962709188816__main .toolcard img{width:74px;height:74px;object-fit:contain;mix-blend-mode:multiply;flex-shrink:0;}
+  #cka-template--17962709188816__main .toolcard .eye{font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--amber);}
+  #cka-template--17962709188816__main .toolcard .nm{font-family:'Fraunces',Georgia,serif;font-size:18px;font-weight:600;margin:2px 0 3px;}
+  #cka-template--17962709188816__main .toolcard .pr{font-size:13px;color:var(--muted);}
+  #cka-template--17962709188816__main .toolcard .shop{margin-left:auto;flex-shrink:0;background:var(--orange);color:var(--navy);font-weight:700;font-size:13px;padding:10px 16px;border-radius:6px;}
+  #cka-template--17962709188816__main .cookbook{display:flex;gap:20px;align-items:center;background:var(--band);border-radius:12px;padding:22px;margin:36px 0;}
+  #cka-template--17962709188816__main .cookbook img{width:110px;flex-shrink:0;mix-blend-mode:multiply;}
+  #cka-template--17962709188816__main .cookbook .eye{font-size:12px;font-weight:700;letter-spacing:.09em;color:var(--amber);text-transform:uppercase;}
+  #cka-template--17962709188816__main .cookbook h3{font-size:20px;margin:6px 0 8px;}
+  #cka-template--17962709188816__main .cookbook p{font-size:14px;color:var(--body);margin:0 0 14px;}
+  #cka-template--17962709188816__main .cookbook .btns{display:flex;gap:14px;flex-wrap:wrap;align-items:center;}
+  #cka-template--17962709188816__main .cookbook .add{background:var(--orange);color:var(--navy);font-weight:700;font-size:14px;padding:12px 20px;border-radius:6px;border:0;cursor:pointer;font-family:inherit;}
+  #cka-template--17962709188816__main .cookbook .more{font-weight:700;font-size:14px;text-decoration:underline;text-underline-offset:3px;}
+  #cka-template--17962709188816__main .related{max-width:1100px;margin:0 auto;padding:8px 20px 56px;}
+  #cka-template--17962709188816__main .related h2{font-size:28px;margin-bottom:22px;}
+  #cka-template--17962709188816__main .related .grid{display:grid;grid-template-columns:1fr;gap:22px;}
+  #cka-template--17962709188816__main .related a{display:block;color:inherit;}
+  #cka-template--17962709188816__main .related .ph{height:190px;border-radius:8px;overflow:hidden;background:var(--band);margin-bottom:12px;}
+  #cka-template--17962709188816__main .related .ph img{width:100%;height:100%;object-fit:cover;}
+  #cka-template--17962709188816__main .related .cat{font-size:11.5px;font-weight:700;letter-spacing:.06em;color:var(--amber);margin-bottom:5px;}
+  #cka-template--17962709188816__main .related .ti{font-family:'Fraunces',Georgia,serif;font-size:18px;font-weight:600;line-height:1.25;}
+  #cka-template--17962709188816__main .bs-sec{margin:34px 0;}
+  #cka-template--17962709188816__main .bs-head{display:flex;align-items:flex-end;justify-content:space-between;gap:14px;margin-bottom:16px;}
+  #cka-template--17962709188816__main .bs-eye{font-size:11px;font-weight:700;letter-spacing:.08em;color:var(--amber);margin-bottom:5px;}
+  #cka-template--17962709188816__main .bs-head h2{font-size:22px;}
+  #cka-template--17962709188816__main .bs-head a{font-size:13.5px;font-weight:700;color:var(--navy);text-decoration:underline;text-underline-offset:2px;white-space:nowrap;}
+  #cka-template--17962709188816__main .bs-roll{display:flex;gap:14px;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;padding:4px 20px 12px;margin:0 -20px;}
+  #cka-template--17962709188816__main .bs-roll::-webkit-scrollbar{height:6px;}
+  #cka-template--17962709188816__main .bs-roll::-webkit-scrollbar-thumb{background:var(--hair);border-radius:100px;}
+  #cka-template--17962709188816__main .bs-card{flex:0 0 190px;scroll-snap-align:start;background:#fff;border:1px solid var(--hair);border-radius:10px;overflow:hidden;display:flex;flex-direction:column;}
+  #cka-template--17962709188816__main .bs-link{display:block;color:inherit;}
+  #cka-template--17962709188816__main .bs-img{aspect-ratio:1/1;background:var(--band);display:flex;align-items:center;justify-content:center;padding:16px;}
+  #cka-template--17962709188816__main .bs-img img{max-width:100%;max-height:100%;object-fit:contain;mix-blend-mode:multiply;}
+  #cka-template--17962709188816__main .bs-ti{font-size:14px;font-weight:600;line-height:1.3;color:var(--navy);padding:12px 14px 0;}
+  #cka-template--17962709188816__main .bs-foot{margin-top:auto;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:12px 14px 14px;}
+  #cka-template--17962709188816__main .bs-pr{font-family:'Fraunces',Georgia,serif;font-variation-settings:"SOFT" 0,"WONK" 0;font-size:16px;font-weight:600;color:var(--navy);}
+  #cka-template--17962709188816__main .bs-add{background:var(--orange);color:var(--navy);border:0;border-radius:5px;font-weight:700;font-size:13px;padding:9px 16px;cursor:pointer;font-family:inherit;text-decoration:none;}
+  @media (min-width:900px){
+    #cka-template--17962709188816__main .bs-head h2{font-size:26px;}
+    #cka-template--17962709188816__main .bs-card{flex-basis:212px;}
+    #cka-template--17962709188816__main h1{font-size:44px;}
+    #cka-template--17962709188816__main .toolcard{margin:24px 0;}
+    #cka-template--17962709188816__main .related h2{font-size:34px;}
+    #cka-template--17962709188816__main .related .grid{grid-template-columns:repeat(3,1fr);gap:28px;}
+  }
+</style><div id="cka-template--17962709188816__main" data-cka-root>
+  <div class="wrap">
+    <nav class="crumb"><a href="/">Home</a> / <a href="/blogs/soupeduprecipes">Souped Up Recipes</a> / Freezer Friendly</nav>
+    <h1>The Best Homemade Chinese Scallion Pancakes Recipe</h1><div class="byline">
+      <span class="who">Mandy Fu</span>
+      <span>Last updated Aug 12, 2026</span><span class="jump"><a href="#recipe-template--17962709188816__main">Jump to recipe</a></span></div><div class="body"><p>These Chinese Scallion Pancakes are perfectly golden, crispy, and flaky on the outside, while the inside stays soft, moist, and pleasantly chewy. I first shared a scallion pancake recipe 9 years ago, and I loved it so much that I have been making it again and again. Over the years, I have improved a little bit here and there, and so this is an upgraded recipe, and it is truly next-level.</p>
+<p><img src="https://cdn.shopify.com/s/files/1/0595/3850/5936/files/Thumbnail_1.png?v=1786530122" alt=""></p>
+<p>This upgraded version has 2 special techniques. First, we lightly caramelize the scallion whites in oil before making the flour-oil paste (Yousu 油酥), which gives the pancakes double the fragrance. Second, I will show you a special 9-grid folding method that creates those beautiful, delicate layers. Honestly, this has to be the best scallion pancake recipe ever.</p>
+<p>This recipe is a bit time-consuming, but these pancakes are freezer-friendly, so you can make a big batch and freeze them for up to 6 months and pan-fry them without defrosting whenever you want. I doubt that they will last that long, though.</p>
+<p>Tip: I recommend using bread flour for this recipe because it has the highest gluten content. Gluten is an elastic protein network that binds starch together and builds the structure of the dough, so it fundamentally determines the texture and quality of your pancakes. I know some of you will ask me, will all-purpose flour work? The answer is year, but the pancakes will be slightly less airy and flaky.  </p></div><div class="cookbook" id="cka-cookbook-card"><img loading="lazy" src="//curatedkitchenware.com/cdn/shop/files/1_39e34f3c-a4c6-46f8-8213-d5c9b4578a88.jpg?v=1729113183&width=300" alt="168 Better Than Takeout Chinese Recipes"><div>
+          <div class="eye">Get the cookbook</div>
+          <h3>168 Better Than Takeout Chinese Recipes</h3>
+          <p>168 tested recipes, each with a demo video and step-by-step photos.</p>
+          <div class="btns"><button type="button" class="add" data-cka-add="44246629089488">Add to Cart &middot; <span class=money>$29.99</span></button><a class="more" href="/products/souped-up-recipes-cookbook-168-better-than-takeout-chinese-recipes">View details &rarr;</a></div>
+        </div>
+      </div><div id="recipe-template--17962709188816__main" class="recipe-mount"><div id="shopify-block-AQzkyeW1lQks4eFNrZ__recipe" class="shopify-block shopify-app-block"><!-- BEGIN app snippet: rk-svelte-widget --><script type="application/json" id="recipe-settings">{"plan":"business","enableRating":true,"enableSocial":true,"enablePrint":true,"showPoweredBy":false,"enableCookMode":false,"clickToConfirmRating":false,"lang":{"ingredients":"Ingredients","directions":"Directions","equipment":"Equipment","category":"Category","cuisine":"Cuisine","servings":"Servings","prepTime":"Prep Time","cookTime":"Cook Time","author":"Author: ","ratingThanks":"Thanks for rating!","ratingConfirm":"Click again to confirm your rating.","note":"Recipe Note","video":"Video","nutrition":"Nutrition","nutritionFacts":"Nutrition","servingSize":"Serving Size","amountPerServing":"Amount Per Serving","dailyValue":"% Daily Value","calories":"Calories","carbs":"Carbs","cholesterol":"Cholesterol","fat":"Fat","fiber":"Fiber","protein":"Protein","saturatedFat":"Saturated Fat","sodium":"Sodium","sugar":"Sugar","transFat":"Trans Fat","iron":"Iron","potassium":"Potassium","polyFat":"Polyunsaturated Fat","monoFat":"Monounsaturated Fat","addToCart":"Add To Cart","addAllToCart":"Add All To Cart","removeAll":"Remove All","viewCart":"View Cart","checkout":"Checkout","added":"Added","removed":"Removed","quantity":"Remove quantity in cart","cookMode":"Cook Mode","cookModeActive":"Cook Mode Active","ratingCount":"Rated current_rating stars by rating_count users","noRatings":"No ratings yet","minutes":"minutes","minute":"minute","hours":"hours","hour":"hour","grams":"grams","milligrams":"milligrams","micrograms":"micrograms","perServing":"Per serving","printRecipe":"Print Recipe","shareRecipe":"Share recipe","copyLink":"Copy link"}}</script><script type="application/json" id="recipe-data-2870475">{"recipe_title":"The Best Homemade Chinese Scallion Pancakes Recipe","recipe_author":"\u003cp\u003eMandy Fu\u003c\/p\u003e","recipe_description":"\u003cp\u003eI made a scallion pancake recipe 9 years ago. It was delicious, and I loved it so much that I have been making it again and again. Over the years, I have improved a little bit here and there, so this is an upgraded recipe, and it is truly next-level. They are perfectly golden, crispy, and flaky. The inside is soft, moist, and pleasantly chewy. I’ll show you my secret that can infuse your pancakes with double the scallion fragrance, alongside a special 9-grid folding method that creates those beautiful, delicate layers. Honestly, this has to be the best scallion pancake recipe ever.\u003c\/p\u003e","recipe_category":"","recipe_cuisine":"","recipe_ingredients":[{"index":1,"type":"heading","heading_text":"\u003cp\u003e\u003cstrong\u003eFor the dough\u003c\/strong\u003e\u003c\/p\u003e","ingredient":"blank","isNew":true,"id":1786526736289},{"index":2,"type":"ingredient","ingredient":"\u003cp\u003e500g of \u003ca target=\"_blank\" href=\"https:\/\/geni.us\/-bread-flour\"\u003ehigh-protein flour AKA bread flour\u003c\/a\u003e\u003c\/p\u003e","isNew":true,"selected_product":null,"id":"0-split-0-1786526744311"},{"index":3,"type":"ingredient","ingredient":"\u003cspan\u003e270\u003c\/span\u003e\u003cspan\u003eg of room temperature water\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"0-split-1-1786526744312"},{"index":4,"type":"ingredient","ingredient":"\u003cspan\u003e1\u003c\/span\u003e\u003cspan\u003e \u003c\/span\u003e\u003cspan\u003e¼\u003c\/span\u003e\u003cspan\u003e tsp of salt\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"0-split-2-1786526744312"},{"index":5,"type":"ingredient","ingredient":"\u003cspan\u003e2\u003c\/span\u003e\u003cspan\u003e tbsp of vegetable oil\u003c\/span\u003e\u003cspan\u003e to add to the flour\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"0-split-3-1786526744312"},{"index":6,"type":"heading","heading_text":"\u003cp\u003e\u003cstrong\u003eFor the scallion flour oil paste Yousu (油酥)\u003c\/strong\u003e\u003c\/p\u003e","ingredient":"blank","isNew":true,"id":1786526746279},{"index":8,"type":"ingredient","ingredient":"\u003cspan\u003e5 scallions, diced\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"7-split-0-1786526758183"},{"index":9,"type":"ingredient","ingredient":"\u003cspan\u003e5 tbsp of vegetable oil\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"7-split-1-1786526758183"},{"index":10,"type":"ingredient","ingredient":"\u003cspan\u003e3.5 tbsp of \u003c\/span\u003e\u003cspan\u003ehigh\u003c\/span\u003e\u003cspan\u003e-\u003c\/span\u003e\u003cspan\u003eprotein flour \u003c\/span\u003e\u003cspan\u003eAKA bread flour\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"7-split-2-1786526758183"},{"index":11,"type":"ingredient","ingredient":"\u003cspan\u003e1\/2 tsp of thirteen spice powder\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":{"availablePublicationCount":20,"createdAt":"2023-02-10T09:22:09Z","descriptionHtml":"\u003cp\u003e\u003cspan style=\"font-size: 0.875rem;\"\u003eA special Chinese food seasoning made with 13 spices. It is excellent\u003c\/span\u003e\u003cspan style=\"font-size: 0.875rem;\"\u003e for marinating meat, seasoning soups, and stir-fried veggies. 2 packs included, 45 grams each.\u003c\/span\u003e\u003c\/p\u003e\n\u003cp\u003e\u003cspan style=\"font-size: 0.875rem;\" data-mce-fragment=\"1\" class=\"a-list-item\" data-mce-style=\"font-size: 0.875rem;\"\u003e\u003cstrong\u003eSOME RECIPES YOU CAN MAKE -\u003c\/strong\u003e \u003c\/span\u003e\u003c\/p\u003e\n\u003cul\u003e\n\u003cli\u003e\u003ca style=\"font-size: 0.875rem;\" href=\"https:\/\/youtu.be\/z0ZxtbCRexc\" data-mce-style=\"font-size: 0.875rem;\" data-mce-href=\"https:\/\/youtu.be\/z0ZxtbCRexc\" target=\"_blank\"\u003e\u003cspan data-mce-fragment=\"1\" class=\"a-list-item\"\u003eChinese fried chicken wings\u003c\/span\u003e\u003c\/a\u003e\u003c\/li\u003e\n\u003cli\u003e\u003ca style=\"font-size: 0.875rem;\" href=\"https:\/\/youtu.be\/SU1orbV7vdo\" data-mce-style=\"font-size: 0.875rem;\" data-mce-href=\"https:\/\/youtu.be\/SU1orbV7vdo\" target=\"_blank\"\u003e\u003cspan data-mce-fragment=\"1\"\u003eSteamed Pork Belly Recipe (Mei Cai Kou Rou 梅菜扣肉)\u003c\/span\u003e\u003c\/a\u003e\u003c\/li\u003e\n\u003cli\u003e\n\u003ca style=\"font-size: 0.875rem;\" href=\"https:\/\/youtu.be\/fzfR8a0Z_Qg\" data-mce-style=\"font-size: 0.875rem;\" target=\"_blank\"\u003e\u003cspan data-mce-fragment=\"1\"\u003eFermented Tofu\u003c\/span\u003e\u003c\/a\u003e\u003cspan style=\"font-size: 0.875rem;\" data-mce-style=\"font-size: 0.875rem;\"\u003e \u003c\/span\u003e\n\u003c\/li\u003e\n\u003c\/ul\u003e\n\u003cul data-mce-fragment=\"1\" class=\"a-unordered-list a-vertical a-spacing-mini\"\u003e\u003c\/ul\u003e","handle":"thirteen-spice-powder","hasOnlyDefaultVariant":true,"id":"gid:\/\/shopify\/Product\/7865798000848","images":[{"id":"gid:\/\/shopify\/ProductImage\/38592842006736","originalSrc":"https:\/\/cdn.shopify.com\/s\/files\/1\/0595\/3850\/5936\/products\/86fd6c2626c4472b462be4a5f34cbd0.jpg?v=1676020931"},{"id":"gid:\/\/shopify\/ProductImage\/38616443388112","originalSrc":"https:\/\/cdn.shopify.com\/s\/files\/1\/0595\/3850\/5936\/products\/Untitleddesign_1_01a47d4c-1e49-4d47-8528-30ddb3c48d48.png?v=1676578650"},{"id":"gid:\/\/shopify\/ProductImage\/38616443617488","originalSrc":"https:\/\/cdn.shopify.com\/s\/files\/1\/0595\/3850\/5936\/products\/Untitleddesign_4c2b5519-802f-47bb-9b58-467d0b839a49.png?v=1676578653"}],"options":[{"id":"gid:\/\/shopify\/ProductOption\/10009309413584","name":"Title","position":1,"values":["Default Title"]}],"productType":"","publishedAt":"2023-02-16T20:20:06Z","tags":[],"templateSuffix":"","title":"Thirteen-Spice Powder (2 packs)","totalInventory":9,"totalVariants":1,"tracksInventory":true,"updatedAt":"2026-07-09T19:11:34Z","variants":[{"availableForSale":true,"barcode":null,"compareAtPrice":null,"createdAt":"2023-02-10T09:22:09Z","displayName":"Thirteen-Spice Powder (2 packs) - Default Title","fulfillmentService":{"id":"gid:\/\/shopify\/FulfillmentService\/manual","inventoryManagement":false,"productBased":true,"serviceName":"Manual","type":"MANUAL"},"id":"gid:\/\/shopify\/ProductVariant\/43272925741264","inventoryItem":{"__typename":"InventoryItem","id":"gid:\/\/shopify\/InventoryItem\/45367441653968"},"inventoryManagement":"SHOPIFY","inventoryPolicy":"CONTINUE","inventoryQuantity":8,"position":1,"price":"9.99","product":{"__typename":"Product","id":"gid:\/\/shopify\/Product\/7865798000848"},"requiresShipping":true,"selectedOptions":[{"__typename":"SelectedOption","value":"Default Title"}],"sku":"","taxable":true,"title":"Default Title","updatedAt":"2026-04-14T00:30:50Z","weight":0,"weightUnit":"POUNDS"}],"vendor":"Curated Kitchenware","status":"ACTIVE","variants_length":1},"id":"7-split-3-1786526758183"},{"index":12,"type":"heading","heading_text":"\u003cp\u003e\u003cstrong\u003eFor shaping and cooking\u003c\/strong\u003e\u003c\/p\u003e","ingredient":"blank","isNew":true,"id":1786526759164},{"index":14,"type":"ingredient","ingredient":"\u003cspan\u003e2-3 \u003c\/span\u003e\u003cspan\u003etbsp of vegetable oil to coat the dough\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"13-split-0-1786526770183"},{"index":15,"type":"ingredient","ingredient":"\u003cspan\u003eAdditional vegetable oil, for applying the work surface and pan-frying the pancakes\u003c\/span\u003e\u003cspan\u003e\u003c\/span\u003e","isNew":true,"selected_product":null,"id":"13-split-1-1786526770183"}],"recipe_equipment":[],"recipe_directions":[{"index":1,"type":"heading","heading_text":"\u003cp\u003e\u003cstrong\u003eMake the dough\u003c\/strong\u003e\u003c\/p\u003e","direction":"blank","id":1786526779717},{"index":2,"type":"direction","direction":"\u003cp\u003eIn a measuring cup, combine the water, salt, and 2 tbsp of cooking oil. Stir until the salt dissolves.\u003c\/p\u003e","image":null,"id":"0-split-0-1786526795001"},{"index":3,"type":"direction","direction":"\u003cp\u003eGradually pour the mixture into the bread flour in batches. Stir at the same time until all the flour comes together.\u003c\/p\u003e","image":null,"id":"0-split-1-1786526795001"},{"index":30,"type":"direction","direction":"\u003cp\u003eTip: I recommend using bread flour for this recipe because it has the highest gluten content. Gluten is an elastic protein network that binds starch together and builds the structure of the dough, so it fundamentally determines the texture and quality of your pancakes. I know some of you will ask me, will all-purpose flour work? The answer is year, but the pancakes will be slightly less airy and flaky.  \u003c\/p\u003e","image":null},{"index":5,"type":"direction","direction":"\u003cp\u003eIf using a stand mixer, knead at medium-low speed for about 8 minutes or until a smooth dough forms. If kneading by hand, knead for 8-10 minutes. The dough is quite sticky so a stand mixer makes the process much easier.\u003c\/p\u003e","image":null,"id":"0-split-3-1786526795001"},{"index":6,"type":"direction","direction":"\u003cp\u003eOnce the dough is done kneading, shape it into a round smooth ball. Cut it into 8 even pieces, about 100g each. No need to use a scale but you can if you want to be precise.\u003c\/p\u003e","image":null,"id":"0-split-4-1786526795001"},{"index":7,"type":"direction","direction":"\u003cp\u003eShape each piece into a smooth ball. Add 2-3 tbsp of oil to a large tray. Place the dough balls in it one by one and use the oil to coat the surface.\u003c\/p\u003e","image":null,"id":"0-split-5-1786526795001"},{"index":8,"type":"direction","direction":"\u003cp\u003eCover the dough with plastic wrap, push out all the air, and let the dough rest at room temperature for at least 2 hours. Make sure you leave enough space between each all the dough balls. Even though they are coated in oil, they can still stick.\u003c\/p\u003e","image":null,"id":"0-split-6-1786526795001"},{"index":9,"type":"direction","direction":"\u003cp\u003eFor make-ahead dough, refrigerate it overnight. Take the dough out of the refrigerator 1 hour before shaping so it can get back to room temperature and regains its flexibility.\u003c\/p\u003e","image":null,"id":"0-split-7-1786526795001"},{"index":10,"type":"heading","heading_text":"\u003cp\u003e\u003cstrong\u003eMake\u0026nbsp;the scallion flour oil paste Yousu (油酥)\u003c\/strong\u003e\u003c\/p\u003e","direction":"blank","id":1786526797131},{"index":12,"type":"direction","direction":"\u003cp\u003eFinely dice the scallions. Reserve the green parts for later.\u003c\/p\u003e","image":null,"id":"11-split-0-1786526823632"},{"index":13,"type":"direction","direction":"\u003cp\u003eAdd the scallion white parts and 5 tbsp pf vegetable to a small saucepan. Cook over low heat for 5-8 minutes, stirring occasionally until the scallion whites become lightly golden. This extra step of caramelizing is the key to infuse your pancakes double the fragrant.\u003c\/p\u003e","image":null,"id":"11-split-1-1786526823632"},{"index":14,"type":"direction","direction":"\u003cp\u003eTurn off the heat, add the high-protein flour and the thirteen-spice powder. Stir until completely smooth. Set it aside.\u003c\/p\u003e","image":null,"id":"11-split-2-1786526823632"},{"index":15,"type":"direction","direction":"\u003cp\u003eTip: if this flour-oil paste sits for a white, the flour tends to settle at the bottom. Give it a good stir before spreading it onto the dough.\u003c\/p\u003e","image":null,"id":"11-split-3-1786526823632"},{"index":16,"type":"heading","heading_text":"\u003cp\u003e\u003cstrong\u003eShape the pancakes and cook\u003c\/strong\u003e\u003c\/p\u003e","direction":"blank","id":1786526828610},{"index":18,"type":"direction","direction":"\u003cp\u003eLightly oiled the working surface, the rolling pin, and your hands to prevent sticking.\u003c\/p\u003e","image":null,"id":"17-split-0-1786526860733"},{"index":19,"type":"direction","direction":"\u003cp\u003eTake a piece of the dough and roll it into a large square sheet. Don't worry about making it perfectly straight. Just try to keep the thickness fairly even.\u003c\/p\u003e","image":null,"id":"17-split-1-1786526860733"},{"index":20,"type":"direction","direction":"\u003cp\u003eImagine the dough sheet is a 3×3 nine-square grid, make a cut at one corner, and leave this section clean. Drizzle some of the yousu onto the remaining eight segments and brush it evenly across the surface. Sprinkle some diced green part of the scallions.\u003c\/p\u003e","image":null,"id":"17-split-2-1786526860733"},{"index":21,"type":"direction","direction":"\u003cp\u003eUse a scraper to loosen the edge of the sheet, carefully lift, and fold to the middle. Do the same to the other side and continue folding the sections over one another according to the nine-grid pattern. Keep the clean section untouched until your have 2 grids left.\u003c\/p\u003e","image":null,"id":"17-split-3-1786526860733"},{"index":22,"type":"direction","direction":"\u003cp\u003eFlip the clean grid and stretch it to wrap the folded dough. Make sure to seal all 4 edges so that later on, when you roll the pancakes, the filling will not leak out.\u003c\/p\u003e","image":null,"id":"17-split-4-1786526860733"},{"index":23,"type":"direction","direction":"\u003cp\u003eYou should now have a small square of pastry. Push the four corners towards the center and tuck them underneath. Rotate the dough between your hands and you get a perfect round scallion pancake patty.\u003c\/p\u003e","image":null,"id":"17-split-5-1786526860733"},{"index":24,"type":"direction","direction":"\u003cp\u003eRepeat with the remaining dough.\u003c\/p\u003e","image":null,"id":"17-split-6-1786526860733"},{"index":25,"type":"direction","direction":"\u003cp\u003eOnce done, cover the shaped dough and let them rest for 30 minutes. This allows the gluten to relax, making the pancakes much easier to roll without springing back.\u003c\/p\u003e","image":null,"id":"17-split-7-1786526860733"},{"index":26,"type":"direction","direction":"\u003cp\u003ePlace one piece of dough on a sheet of parchment paper. Roll it into a panckae about 5-6 inches in diameter.\u003c\/p\u003e","image":null,"id":"17-split-8-1786526860733"},{"index":27,"type":"direction","direction":"\u003cp\u003eIf making a large batch, you can freeze them. Place a sheet of parchment paper between each uncooked pancake and freeze them for up to 6 months. Do not use plastic wrap between the pancakes because they will stick. When you are ready to cook them, you can pan-fry them directly without defrosting.\u003c\/p\u003e","image":null,"id":"17-split-9-1786526860733"},{"index":28,"type":"direction","direction":"\u003cp\u003eTo cook the pancakes, heat a frying pan over medium low heat and add a thin layer of vegetable oil. Place a pancake in the pan and cook over medium low heat until both sides are beautifully golden brown and crispy, about 6-8 minutes total. Flip and rotate the pancakes frequently for even browning.\u003c\/p\u003e","image":null,"id":"17-split-10-1786526860733"},{"index":29,"type":"direction","direction":"\u003cp\u003eServe as a side dish.\u003c\/p\u003e","image":null,"id":"17-split-11-1786526860733"}],"serving_size":"","prep_time":"4 hours","cook_time":"30 minutes","recipe_image":"https:\/\/f000.backblazeb2.com\/file\/recipekit-bucket\/20260812092923-thumbnail.png","recipe_image_alt_text":"The Best Homemade Chinese Scallion Pancakes Recipe","iso_prep_time":"PT4H","iso_cook_time":"PT30M","iso_total_time":"PT4H30M","recipe_rating":"5.0000000000000000","enable_rating":true,"rating_count":"1","recipe_note":"","recipe_video":"https:\/\/youtu.be\/RdxVNA9U3lA","video_upload_date":null,"video_content_url":"https:\/\/www.youtube.com\/watch?v=RdxVNA9U3lA","video_embed_url":"https:\/\/www.youtube.com\/embed\/RdxVNA9U3lA","video_type":"youtube","recipe_date":"2026-08-12T09:29:31.904+00:00","recipe_calories":"","recipe_tags":[],"nutrition_data":[],"nutrition_template":"horizontal","nutrition_serving_size":"","custom_fields":[],"recipe_id":"2870475"}</script><script type="application/ld+json">{"@context":"https://schema.org/","@type":"Recipe","name":"The Best Homemade Chinese Scallion Pancakes Recipe","image":["https:\/\/images.getrecipekit.com\/20260812092923-thumbnail.png"],"description":"I made a scallion pancake recipe 9 years ago. It was delicious, and I loved it so much that I have been making it again and again. Over the years, I have improved a little bit here and there, so this is an upgraded recipe, and it is truly next-level. They are perfectly golden, crispy, and flaky. The inside is soft, moist, and pleasantly chewy. I’ll show you my secret that can infuse your pancakes with double the scallion fragrance, alongside a special 9-grid folding method that creates those beautiful, delicate layers. Honestly, this has to be the best scallion pancake recipe ever.","author":{"@type":"Person","name":"Mandy Fu"},"datePublished":"2026-08-12","prepTime":"PT4H","cookTime":"PT30M","totalTime":"PT4H30M","recipeIngredient":["500g of high-protein flour AKA bread flour","270g of room temperature water","1 ¼ tsp of salt","2 tbsp of vegetable oil to add to the flour","5 scallions, diced","5 tbsp of vegetable oil","3.5 tbsp of high-protein flour AKA bread flour","1\/2 tsp of thirteen spice powder","2-3 tbsp of vegetable oil to coat the dough","Additional vegetable oil, for applying the work surface and pan-frying the pancakes"],"recipeInstructions":[{"@type":"HowToStep","text":"In a measuring cup, combine the water, salt, and 2 tbsp of cooking oil. Stir until the salt dissolves.","name":"In a measuring cup, combine the water, salt, and 2 tbsp of cooking oil. Stir until the salt dissolves.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-2"},{"@type":"HowToStep","text":"Gradually pour the mixture into the bread flour in batches. Stir at the same time until all the flour comes together.","name":"Gradually pour the mixture into the bread flour in batches. Stir at the same time until all the flour comes together.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-3"},{"@type":"HowToStep","text":"Tip: I recommend using bread flour for this recipe because it has the highest gluten content. Gluten is an elastic protein network that binds starch together and builds the structure of the dough, so it fundamentally determines the texture and quality of your pancakes. I know some of you will ask me, will all-purpose flour work? The answer is year, but the pancakes will be slightly less airy and flaky.  ","name":"Tip: I recommend using bread flour for this recipe because it has the highest gluten content. Gluten is an elastic protein network that binds starch together and builds the structure of the dough, so it fundamentally determines the texture and quality of your pancakes. I know some of you will ask me, will all-purpose flour work? The answer is year, but the pancakes will be slightly less airy and flaky.  ","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-4"},{"@type":"HowToStep","text":"If using a stand mixer, knead at medium-low speed for about 8 minutes or until a smooth dough forms. If kneading by hand, knead for 8-10 minutes. The dough is quite sticky so a stand mixer makes the process much easier.","name":"If using a stand mixer, knead at medium-low speed for about 8 minutes or until a smooth dough forms. If kneading by hand, knead for 8-10 minutes. The dough is quite sticky so a stand mixer makes the process much easier.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-5"},{"@type":"HowToStep","text":"Once the dough is done kneading, shape it into a round smooth ball. Cut it into 8 even pieces, about 100g each. No need to use a scale but you can if you want to be precise.","name":"Once the dough is done kneading, shape it into a round smooth ball. Cut it into 8 even pieces, about 100g each. No need to use a scale but you can if you want to be precise.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-6"},{"@type":"HowToStep","text":"Shape each piece into a smooth ball. Add 2-3 tbsp of oil to a large tray. Place the dough balls in it one by one and use the oil to coat the surface.","name":"Shape each piece into a smooth ball. Add 2-3 tbsp of oil to a large tray. Place the dough balls in it one by one and use the oil to coat the surface.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-7"},{"@type":"HowToStep","text":"Cover the dough with plastic wrap, push out all the air, and let the dough rest at room temperature for at least 2 hours. Make sure you leave enough space between each all the dough balls. Even though they are coated in oil, they can still stick.","name":"Cover the dough with plastic wrap, push out all the air, and let the dough rest at room temperature for at least 2 hours. Make sure you leave enough space between each all the dough balls. Even though they are coated in oil, they can still stick.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-8"},{"@type":"HowToStep","text":"For make-ahead dough, refrigerate it overnight. Take the dough out of the refrigerator 1 hour before shaping so it can get back to room temperature and regains its flexibility.","name":"For make-ahead dough, refrigerate it overnight. Take the dough out of the refrigerator 1 hour before shaping so it can get back to room temperature and regains its flexibility.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-9"},{"@type":"HowToStep","text":"Finely dice the scallions. Reserve the green parts for later.","name":"Finely dice the scallions. Reserve the green parts for later.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-11"},{"@type":"HowToStep","text":"Add the scallion white parts and 5 tbsp pf vegetable to a small saucepan. Cook over low heat for 5-8 minutes, stirring occasionally until the scallion whites become lightly golden. This extra step of caramelizing is the key to infuse your pancakes double the fragrant.","name":"Add the scallion white parts and 5 tbsp pf vegetable to a small saucepan. Cook over low heat for 5-8 minutes, stirring occasionally until the scallion whites become lightly golden. This extra step of caramelizing is the key to infuse your pancakes double the fragrant.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-12"},{"@type":"HowToStep","text":"Turn off the heat, add the high-protein flour and the thirteen-spice powder. Stir until completely smooth. Set it aside.","name":"Turn off the heat, add the high-protein flour and the thirteen-spice powder. Stir until completely smooth. Set it aside.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-13"},{"@type":"HowToStep","text":"Tip: if this flour-oil paste sits for a white, the flour tends to settle at the bottom. Give it a good stir before spreading it onto the dough.","name":"Tip: if this flour-oil paste sits for a white, the flour tends to settle at the bottom. Give it a good stir before spreading it onto the dough.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-14"},{"@type":"HowToStep","text":"Lightly oiled the working surface, the rolling pin, and your hands to prevent sticking.","name":"Lightly oiled the working surface, the rolling pin, and your hands to prevent sticking.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-16"},{"@type":"HowToStep","text":"Take a piece of the dough and roll it into a large square sheet. Don't worry about making it perfectly straight. Just try to keep the thickness fairly even.","name":"Take a piece of the dough and roll it into a large square sheet. Don't worry about making it perfectly straight. Just try to keep the thickness fairly even.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-17"},{"@type":"HowToStep","text":"Imagine the dough sheet is a 3×3 nine-square grid, make a cut at one corner, and leave this section clean. Drizzle some of the yousu onto the remaining eight segments and brush it evenly across the surface. Sprinkle some diced green part of the scallions.","name":"Imagine the dough sheet is a 3×3 nine-square grid, make a cut at one corner, and leave this section clean. Drizzle some of the yousu onto the remaining eight segments and brush it evenly across the surface. Sprinkle some diced green part of the scallions.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-18"},{"@type":"HowToStep","text":"Use a scraper to loosen the edge of the sheet, carefully lift, and fold to the middle. Do the same to the other side and continue folding the sections over one another according to the nine-grid pattern. Keep the clean section untouched until your have 2 grids left.","name":"Use a scraper to loosen the edge of the sheet, carefully lift, and fold to the middle. Do the same to the other side and continue folding the sections over one another according to the nine-grid pattern. Keep the clean section untouched until your have 2 grids left.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-19"},{"@type":"HowToStep","text":"Flip the clean grid and stretch it to wrap the folded dough. Make sure to seal all 4 edges so that later on, when you roll the pancakes, the filling will not leak out.","name":"Flip the clean grid and stretch it to wrap the folded dough. Make sure to seal all 4 edges so that later on, when you roll the pancakes, the filling will not leak out.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-20"},{"@type":"HowToStep","text":"You should now have a small square of pastry. Push the four corners towards the center and tuck them underneath. Rotate the dough between your hands and you get a perfect round scallion pancake patty.","name":"You should now have a small square of pastry. Push the four corners towards the center and tuck them underneath. Rotate the dough between your hands and you get a perfect round scallion pancake patty.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-21"},{"@type":"HowToStep","text":"Repeat with the remaining dough.","name":"Repeat with the remaining dough.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-22"},{"@type":"HowToStep","text":"Once done, cover the shaped dough and let them rest for 30 minutes. This allows the gluten to relax, making the pancakes much easier to roll without springing back.","name":"Once done, cover the shaped dough and let them rest for 30 minutes. This allows the gluten to relax, making the pancakes much easier to roll without springing back.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-23"},{"@type":"HowToStep","text":"Place one piece of dough on a sheet of parchment paper. Roll it into a panckae about 5-6 inches in diameter.","name":"Place one piece of dough on a sheet of parchment paper. Roll it into a panckae about 5-6 inches in diameter.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-24"},{"@type":"HowToStep","text":"If making a large batch, you can freeze them. Place a sheet of parchment paper between each uncooked pancake and freeze them for up to 6 months. Do not use plastic wrap between the pancakes because they will stick. When you are ready to cook them, you can pan-fry them directly without defrosting.","name":"If making a large batch, you can freeze them. Place a sheet of parchment paper between each uncooked pancake and freeze them for up to 6 months. Do not use plastic wrap between the pancakes because they will stick. When you are ready to cook them, you can pan-fry them directly without defrosting.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-25"},{"@type":"HowToStep","text":"To cook the pancakes, heat a frying pan over medium low heat and add a thin layer of vegetable oil. Place a pancake in the pan and cook over medium low heat until both sides are beautifully golden brown and crispy, about 6-8 minutes total. Flip and rotate the pancakes frequently for even browning.","name":"To cook the pancakes, heat a frying pan over medium low heat and add a thin layer of vegetable oil. Place a pancake in the pan and cook over medium low heat until both sides are beautifully golden brown and crispy, about 6-8 minutes total. Flip and rotate the pancakes frequently for even browning.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-26"},{"@type":"HowToStep","text":"Serve as a side dish.","name":"Serve as a side dish.","url":"https://curatedkitchenware.com/blogs/soupeduprecipes/the-best-homemade-chinese-scallion-pancakes-recipe#step-27"}],"nutrition":{"@type":"NutritionInformation"},"aggregateRating":{"@type":"AggregateRating","ratingValue":5,"bestRating":5,"worstRating":1,"ratingCount":1},"video":{"@type":"VideoObject","name":"The Best Homemade Chinese Scallion Pancakes Recipe","description":"I made a scallion pancake recipe 9 years ago. It was delicious, and I loved it so much that I have been making it again and again. Over the years, I have improved a little bit here and there, so this is an upgraded recipe, and it is truly next-level. They are perfectly golden, crispy, and flaky. The inside is soft, moist, and pleasantly chewy. I’ll show you my secret that can infuse your pancakes with double the scallion fragrance, alongside a special 9-grid folding method that creates those beautiful, delicate layers. Honestly, this has to be the best scallion pancake recipe ever.","thumbnailUrl":"https:\/\/images.getrecipekit.com\/20260812092923-thumbnail.png","contentUrl":"https:\/\/www.youtube.com\/watch?v=RdxVNA9U3lA","embedUrl":"https:\/\/www.youtube.com\/embed\/RdxVNA9U3lA","uploadDate":"2026-08-12T00:00:00Z"}}</script><recipe-kit recipeid="2870475" shop="curated-kitchenware.myshopify.com" design="rk_modern" color="#0E1B4D" designborder="true" enableatc="true" enableallatc="false" enableclicktocheck="false" enablecookmode="false" clicktoconfirmrating="false" apiurl="https://app.getrecipekit.com" showqtystepper="false" showingredientthumbnails="false" enableservingsadjuster="true" servingsaboveingredients="false" enableunittoggle="false" storefronttoken="" headingtag="h1"><div class="recipekit-fallback" id="rk_parent" style="--design-colour:#0E1B4D"><div class="rk_modern rk_modern_column"><div class="rk_container"><div class="rk_card"><div class="rk_header"><div class="rk_grid"><div class="rk_column rk_primary"><h1 class="rk_heading">The Best Homemade Chinese Scallion Pancakes Recipe</h1><div class="rk_subheading"><p>Mandy Fu</p></div></div></div><div class="rk_grid rk_secondary"><div class="rk_column rk_details rk_has_image"><div class="rk_grid"><div class="rk_column"><div class="rk_meta">Prep Time</div><p>4 hours</p></div><div class="rk_column"><div class="rk_meta">Cook Time</div><p>30 minutes</p></div></div><div><div class="rk_description"><p>I made a scallion pancake recipe 9 years ago. It was delicious, and I loved it so much that I have been making it again and again. Over the years, I have improved a little bit here and there, so this is an upgraded recipe, and it is truly next-level. They are perfectly golden, crispy, and flaky. The inside is soft, moist, and pleasantly chewy. I’ll show you my secret that can infuse your pancakes with double the scallion fragrance, alongside a special 9-grid folding method that creates those beautiful, delicate layers. Honestly, this has to be the best scallion pancake recipe ever.</p></div></div></div><div class="rk_column rk_image"><img src="https://images.getrecipekit.com/20260812092923-thumbnail.png?width=1200&quality=90" alt="The Best Homemade Chinese Scallion Pancakes Recipe"></div></div></div><div class="rk_body rk_grid"><div class="rk_column rk_column_third"><div class="rk_ingredients rk_column"><div class="rk_ingredients_header"><h2 class="rk_column_heading"><span>Ingredients</span></h2></div><ul></ul><h3 class="rk_group_heading">blank</h3><ul><li><span class="rk_ingredient_content"><p>500g of <a target="_blank" href="https://geni.us/-bread-flour">high-protein flour AKA bread flour</a></p></span></li><li><span class="rk_ingredient_content"><span>270</span><span>g of room temperature water</span><span></span></span></li><li><span class="rk_ingredient_content"><span>1</span><span> </span><span>¼</span><span> tsp of salt</span><span></span></span></li><li><span class="rk_ingredient_content"><span>2</span><span> tbsp of vegetable oil</span><span> to add to the flour</span><span></span></span></li></ul><h3 class="rk_group_heading">blank</h3><ul><li><span class="rk_ingredient_content"><span>5 scallions, diced</span><span></span></span></li><li><span class="rk_ingredient_content"><span>5 tbsp of vegetable oil</span><span></span></span></li><li><span class="rk_ingredient_content"><span>3.5 tbsp of </span><span>high</span><span>-</span><span>protein flour </span><span>AKA bread flour</span><span></span></span></li><li><span class="rk_ingredient_content"><span>1/2 tsp of thirteen spice powder</span><span></span></span></li></ul><h3 class="rk_group_heading">blank</h3><ul><li><span class="rk_ingredient_content"><span>2-3 </span><span>tbsp of vegetable oil to coat the dough</span><span></span></span></li><li><span class="rk_ingredient_content"><span>Additional vegetable oil, for applying the work surface and pan-frying the pancakes</span><span></span></span></li></ul></div></div><div class="rk_column"><div class="rk_directions rk_column"><h2 class="rk_column_heading"><span>Directions</span></h2><ol></ol><h3 class="rk_group_heading">blank</h3><ol><li><div class="rk_direction_content"><p>In a measuring cup, combine the water, salt, and 2 tbsp of cooking oil. Stir until the salt dissolves.</p></div></li><li><div class="rk_direction_content"><p>Gradually pour the mixture into the bread flour in batches. Stir at the same time until all the flour comes together.</p></div></li><li><div class="rk_direction_content"><p>Tip: I recommend using bread flour for this recipe because it has the highest gluten content. Gluten is an elastic protein network that binds starch together and builds the structure of the dough, so it fundamentally determines the texture and quality of your pancakes. I know some of you will ask me, will all-purpose flour work? The answer is year, but the pancakes will be slightly less airy and flaky.  </p></div></li><li><div class="rk_direction_content"><p>If using a stand mixer, knead at medium-low speed for about 8 minutes or until a smooth dough forms. If kneading by hand, knead for 8-10 minutes. The dough is quite sticky so a stand mixer makes the process much easier.</p></div></li><li><div class="rk_direction_content"><p>Once the dough is done kneading, shape it into a round smooth ball. Cut it into 8 even pieces, about 100g each. No need to use a scale but you can if you want to be precise.</p></div></li><li><div class="rk_direction_content"><p>Shape each piece into a smooth ball. Add 2-3 tbsp of oil to a large tray. Place the dough balls in it one by one and use the oil to coat the surface.</p></div></li><li><div class="rk_direction_content"><p>Cover the dough with plastic wrap, push out all the air, and let the dough rest at room temperature for at least 2 hours. Make sure you leave enough space between each all the dough balls. Even though they are coated in oil, they can still stick.</p></div></li><li><div class="rk_direction_content"><p>For make-ahead dough, refrigerate it overnight. Take the dough out of the refrigerator 1 hour before shaping so it can get back to room temperature and regains its flexibility.</p></div></li></ol><h3 class="rk_group_heading">blank</h3><ol><li><div class="rk_direction_content"><p>Finely dice the scallions. Reserve the green parts for later.</p></div></li><li><div class="rk_direction_content"><p>Add the scallion white parts and 5 tbsp pf vegetable to a small saucepan. Cook over low heat for 5-8 minutes, stirring occasionally until the scallion whites become lightly golden. This extra step of caramelizing is the key to infuse your pancakes double the fragrant.</p></div></li><li><div class="rk_direction_content"><p>Turn off the heat, add the high-protein flour and the thirteen-spice powder. Stir until completely smooth. Set it aside.</p></div></li><li><div class="rk_direction_content"><p>Tip: if this flour-oil paste sits for a white, the flour tends to settle at the bottom. Give it a good stir before spreading it onto the dough.</p></div></li></ol><h3 class="rk_group_heading">blank</h3><ol><li><div class="rk_direction_content"><p>Lightly oiled the working surface, the rolling pin, and your hands to prevent sticking.</p></div></li><li><div class="rk_direction_content"><p>Take a piece of the dough and roll it into a large square sheet. Don't worry about making it perfectly straight. Just try to keep the thickness fairly even.</p></div></li><li><div class="rk_direction_content"><p>Imagine the dough sheet is a 3×3 nine-square grid, make a cut at one corner, and leave this section clean. Drizzle some of the yousu onto the remaining eight segments and brush it evenly across the surface. Sprinkle some diced green part of the scallions.</p></div></li><li><div class="rk_direction_content"><p>Use a scraper to loosen the edge of the sheet, carefully lift, and fold to the middle. Do the same to the other side and continue folding the sections over one another according to the nine-grid pattern. Keep the clean section untouched until your have 2 grids left.</p></div></li><li><div class="rk_direction_content"><p>Flip the clean grid and stretch it to wrap the folded dough. Make sure to seal all 4 edges so that later on, when you roll the pancakes, the filling will not leak out.</p></div></li><li><div class="rk_direction_content"><p>You should now have a small square of pastry. Push the four corners towards the center and tuck them underneath. Rotate the dough between your hands and you get a perfect round scallion pancake patty.</p></div></li><li><div class="rk_direction_content"><p>Repeat with the remaining dough.</p></div></li><li><div class="rk_direction_content"><p>Once done, cover the shaped dough and let them rest for 30 minutes. This allows the gluten to relax, making the pancakes much easier to roll without springing back.</p></div></li><li><div class="rk_direction_content"><p>Place one piece of dough on a sheet of parchment paper. Roll it into a panckae about 5-6 inches in diameter.</p></div></li><li><div class="rk_direction_content"><p>If making a large batch, you can freeze them. Place a sheet of parchment paper between each uncooked pancake and freeze them for up to 6 months. Do not use plastic wrap between the pancakes because they will stick. When you are ready to cook them, you can pan-fry them directly without defrosting.</p></div></li><li><div class="rk_direction_content"><p>To cook the pancakes, heat a frying pan over medium low heat and add a thin layer of vegetable oil. Place a pancake in the pan and cook over medium low heat until both sides are beautifully golden brown and crispy, about 6-8 minutes total. Flip and rotate the pancakes frequently for even browning.</p></div></li><li><div class="rk_direction_content"><p>Serve as a side dish.</p></div></li></ol></div></div></div></div></div></div></div></recipe-kit><link rel="preload" as="script" href="https://cdn.shopify.com/extensions/01a01bec-b6ff-7c1a-b3d2-6b099af3f859/recipe-kit-208/assets/recipekit-widget.js">
+<script>if(!window.recipeKitSvelteLoaded){var s=document.createElement('script');s.src='https://cdn.shopify.com/extensions/01a01bec-b6ff-7c1a-b3d2-6b099af3f859/recipe-kit-208/assets/recipekit-widget.js';s.async=true;document.head.appendChild(s);window.recipeKitSvelteLoaded=true;}</script><!-- END app snippet -->
+</div></div><div class="bs-sec">
+        <div class="bs-head"><div><div class="bs-eye">FROM THE SHOP</div><h2>Reader favorites</h2></div><a href="/collections/products">Shop all &rarr;</a></div>
+        <div class="bs-roll" data-bs-roll><div class="bs-card">
+              <a class="bs-link" href="/products/carbon-steel-wok-with-flat-bottom">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/1-2_307ddfdc-9a2e-419c-b205-b96693d9dfc6.jpg?v=1735627825&width=500" alt="12.5 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves (Lid, Spatula and User Guide Video Included)" loading="lazy"></div>
+                <div class="bs-ti">12.5 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$39.99</span></span><button type="button" class="bs-add" data-cka-add="45038734803152">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/stainless-steel-pot-set">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/products/stainlesssteelcookwareset.png?v=1668309420&width=500" alt="9 Piece Stainless Steel Cookware Set" loading="lazy"></div>
+                <div class="bs-ti">9 Piece Stainless Steel Cookware Set</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$249.99</span></span><button type="button" class="bs-add" data-cka-add="44347255455952">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/damascus-kitchen-knife-set">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/products/WeChatImage_20220601090444_ddc9146b-7fa4-4212-993d-4146f0b7256e.jpg?v=1656777233&width=500" alt="3 Piece Damascus Kitchen Knife Set" loading="lazy"></div>
+                <div class="bs-ti">3 Piece Damascus Kitchen Knife Set</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$99.99</span></span><button type="button" class="bs-add" data-cka-add="42826069639376">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/ceramic-chopsticks-set">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/products/5a4972da67a494280d019eaac346578b.jpg?v=1670262730&width=500" alt="Ceramic Chopsticks (10 sets)" loading="lazy"></div>
+                <div class="bs-ti">Ceramic Chopsticks</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$21.99</span></span><button type="button" class="bs-add" data-cka-add="40409582305488">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/asian-clay-pot-for-cooking-ceramic-cookware-4-8-quarts">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/products/SIDE_TILTED.jpg?v=1639533346&width=500" alt="Asian Clay Pot" loading="lazy"></div>
+                <div class="bs-ti">Asian Clay Pot</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$59.99</span></span><button type="button" class="bs-add" data-cka-add="44262316671184">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/chefs-knife">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/WeChatImage_20220615164342.png?v=1699378538&width=500" alt="Chef&#39;s Knife" loading="lazy"></div>
+                <div class="bs-ti">Chef's Knife</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$59.99</span></span><button type="button" class="bs-add" data-cka-add="43663022817488">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/cleaver-knife">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/WeChatImage_20220615164346.png?v=1699457150&width=500" alt="Cleaver Knife" loading="lazy"></div>
+                <div class="bs-ti">Cleaver Knife</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$69.99</span></span><button type="button" class="bs-add" data-cka-add="43663036514512">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/paring-knife">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/WeChatImage_20220615164350.png?v=1699559830&width=500" alt="Paring Knife" loading="lazy"></div>
+                <div class="bs-ti">Paring Knife</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$39.99</span></span><button type="button" class="bs-add" data-cka-add="43667555582160">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/souped-up-recipes-cookbook-168-better-than-takeout-chinese-recipes">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/1_39e34f3c-a4c6-46f8-8213-d5c9b4578a88.jpg?v=1729113183&width=500" alt="168 Better Than Takeout Chinese Recipes" loading="lazy"></div>
+                <div class="bs-ti">168 Better Than Takeout Chinese Recipes</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$29.99</span></span><button type="button" class="bs-add" data-cka-add="44246629089488">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/heavy-duty-claypot-replaces-both-a-dutch-oven-and-stock-pot-2-2-quart">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/1_1_1.jpg?v=1758894262&width=500" alt="Heavy Duty Claypot - Replaces both a dutch oven and stock pot (2.2 Quart)" loading="lazy"></div>
+                <div class="bs-ti">Heavy Duty Claypot - Replaces both a dutch oven and stock pot</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$49.99</span></span><button type="button" class="bs-add" data-cka-add="44732570140880">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/souped-up-recipes-10-inch-carbon-steel-wok-for-electric-induction-and-gas-stoves-lid-and-user-guide-video-included">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/1_340d880b-a9ea-4c0d-a8d8-463408a1a14d.jpg?v=1751465156&width=500" alt="Souped Up Recipes 10 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves (Lid and User Guide Video Included)" loading="lazy"></div>
+                <div class="bs-ti">Souped Up Recipes 10 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$27.39</span></span><button type="button" class="bs-add" data-cka-add="44620532515024">Add</button></div>
+            </div><div class="bs-card">
+              <a class="bs-link" href="/products/13-4-inch-carbon-steel-wok-for-electric-induction-and-gas-stoves-lid-spatula-and-user-guide-video-included">
+                <div class="bs-img"><img src="//curatedkitchenware.com/cdn/shop/files/1-1.jpg?v=1725592451&width=500" alt="13.4 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves (Lid, Spatula and User Guide Video Included)" loading="lazy"></div>
+                <div class="bs-ti">13.4 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves</div>
+              </a>
+              <div class="bs-foot">
+                <span class="bs-pr"><span class=money>$41.99</span></span><button type="button" class="bs-add" data-cka-add="44173120766160">Add</button></div>
+            </div></div>
+      </div><div class="email"><form method="post" action="/contact#cka-news" id="cka-news" accept-charset="UTF-8" class="contact-form"><input type="hidden" name="form_type" value="customer" /><input type="hidden" name="utf8" value="✓" /><input type="hidden" name="contact[tags]" value="newsletter,blog-post"><h2>One new recipe, every week.</h2>
+          <p>Expect recipes and, rarely, the tools I filmed them with. No spam.</p>
+          <div class="row"><input type="email" name="contact[email]" placeholder="you@email.com" aria-label="Email address" required><button type="submit" name="commit">Send me recipes</button></div></form></div></div><div class="related">
+      <h2>Cook This Next</h2>
+      <div class="grid"><a href="/blogs/soupeduprecipes/the-best-zucchini-stir-fry-recipe">
+              <div class="ph"><img src="//curatedkitchenware.com/cdn/shop/articles/20260730120902-thumbnail.png?v=1785689493&width=600" alt="The Best Zucchini Stir Fry Recipe" loading="lazy"></div><div class="cat">Carbon Steel Wok</div><div class="ti">The Best Zucchini Stir Fry Recipe</div>
+            </a><a href="/blogs/soupeduprecipes/the-best-chinese-pork-steamed-bun-baozi-recipe">
+              <div class="ph"><img src="//curatedkitchenware.com/cdn/shop/articles/20260730030832-how-to-make-chinese-steamed-pork-buns-baozi-bao-bun-recipe.png?v=1785681458&width=600" alt="The Best Chinese Pork Steamed Bun Baozi Recipe" loading="lazy"></div><div class="cat">Buns</div><div class="ti">The Best Chinese Pork Steamed Bun Baozi Recipe</div>
+            </a><a href="/blogs/soupeduprecipes/15-minute-chinese-shrimp-mushroom-tofu-soup-easy-healthy-delicious">
+              <div class="ph"><img src="//curatedkitchenware.com/cdn/shop/articles/20260722155443-how-to-make-shrimp-mushroom-tofu-soup-recipe.png?v=1785663782&width=600" alt="15-Minute Chinese Shrimp Mushroom Tofu Soup | Easy, Healthy &amp; Delicious" loading="lazy"></div><div class="cat">Cantonese/Hong Kong</div><div class="ti">15-Minute Chinese Shrimp Mushroom Tofu Soup | Easy, Healthy & Delicious</div>
+            </a></div>
+    </div></div>
+
+<script>
+  (function(){var r=document.getElementById('cka-template--17962709188816__main');if(!r)return;
+    r.addEventListener('click',function(e){
+      var b=e.target.closest('[data-cka-add],[data-cka-cookbook]');if(!b)return;
+      e.preventDefault();
+      var id=b.getAttribute('data-cka-add')||b.getAttribute('data-cka-cookbook');
+      var t=b.textContent;b.disabled=true;b.textContent="Adding…";
+      fetch("\/cart\/add",{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id:id,quantity:1})})
+        .then(function(res){return res.json();})
+        .then(function(){b.textContent="Added ✓";document.dispatchEvent(new CustomEvent('cart:refresh'));setTimeout(function(){b.textContent=t;b.disabled=false;},1600);})
+        .catch(function(){b.textContent=t;b.disabled=false;window.location.href='/cart';});
+    });
+  })();
+</script>
+
+
+</section>
+      </main><style>
+  #ckw-rail{position:fixed;top:50%;right:0;z-index:60;opacity:0;pointer-events:none;transition:opacity .35s ease;}
+  #ckw-rail.is-ready{opacity:1;pointer-events:auto;}
+  #ckw-rail .ckw-row{position:fixed;top:50%;right:0;display:flex;align-items:stretch;transform:translate(326px,-50%);transition:transform .38s cubic-bezier(.4,0,.7,.3);}
+  #ckw-rail.is-open .ckw-row{transform:translate(0,-50%);transition:transform .42s cubic-bezier(.22,.85,.3,1);}
+  #ckw-rail .ckw-tab{align-self:center;background:#0E1B4D;color:#fff;border-radius:10px 0 0 10px;padding:20px 13px;cursor:pointer;box-shadow:-6px 0 22px rgba(14,27,77,.22);display:flex;flex-direction:column;align-items:center;gap:11px;border:0;font-family:inherit;}
+  #ckw-rail .ckw-tab:hover{background:#16265f;}
+  #ckw-rail .ckw-tab .lbl{writing-mode:vertical-rl;font-family:'Fraunces',Georgia,serif;font-variation-settings:"SOFT" 0,"WONK" 0;font-size:16px;font-weight:600;letter-spacing:.04em;white-space:nowrap;}
+  #ckw-rail .ckw-g{position:relative;width:13px;height:13px;flex-shrink:0;display:flex;align-items:center;justify-content:center;line-height:1;color:#C2410C;}
+  #ckw-rail .ckw-g span{position:absolute;display:flex;align-items:center;justify-content:center;line-height:1;transition:opacity .28s ease;}
+  #ckw-rail .ckw-g .t{font-size:9px;}
+  #ckw-rail .ckw-g .s{font-size:11px;}
+  #ckw-rail .ckw-tab .ckw-g{animation:ckw-nudge 3.6s ease-in-out infinite;}
+  #ckw-rail .ckw-tab .ckw-g .t{opacity:1;}
+  #ckw-rail .ckw-tab .ckw-g .s{opacity:0;}
+  #ckw-rail.is-open .ckw-tab .ckw-g{animation:none;}
+  #ckw-rail.is-open .ckw-tab .ckw-g .t{opacity:0;}
+  #ckw-rail.is-open .ckw-tab .ckw-g .s{opacity:1;}
+  @keyframes ckw-nudge{0%,58%{transform:translateX(0)}70%{transform:translateX(-5px)}84%,100%{transform:translateX(0)}}
+  @media (prefers-reduced-motion:reduce){#ckw-rail .ckw-tab .ckw-g{animation:none;}}
+  #ckw-rail .ckw-panel{width:326px;max-height:78vh;overflow-y:auto;background:#fff;border-left:1px solid #E0E0E0;box-shadow:-10px 0 34px rgba(14,27,77,.16);border-radius:10px 0 0 10px;box-sizing:border-box;}
+  #ckw-rail .ckw-head{background:#0E1B4D;color:#fff;padding:18px 20px;border-radius:10px 0 0 0;display:flex;align-items:flex-start;justify-content:space-between;gap:12px;}
+  #ckw-rail .ckw-head .h{font-family:'Fraunces',Georgia,serif;font-variation-settings:"SOFT" 0,"WONK" 0;font-size:19px;font-weight:600;margin-bottom:5px;}
+  #ckw-rail .ckw-head .sub{font-size:12.5px;line-height:1.5;color:rgba(255,255,255,.78);}
+  #ckw-rail .ckw-x{width:26px;height:26px;margin:-3px -6px 0 0;display:flex;align-items:center;justify-content:center;font-size:17px;color:rgba(255,255,255,.7);cursor:pointer;flex-shrink:0;background:none;border:0;}
+  #ckw-rail .ckw-x:hover{color:#fff;}
+  #ckw-rail .ckw-body{padding:6px 16px 16px;}
+  #ckw-rail .ckw-item{display:flex;gap:13px;align-items:center;padding:14px 0;border-bottom:1px solid #F0F1F3;}
+  #ckw-rail .ckw-thumb{width:66px;height:66px;flex-shrink:0;border-radius:8px;background:#F5F5F5;display:flex;align-items:center;justify-content:center;padding:7px;box-sizing:border-box;}
+  #ckw-rail .ckw-thumb img{max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;mix-blend-mode:multiply;display:block;}
+  #ckw-rail .ckw-info{flex:1;min-width:0;}
+  #ckw-rail .ckw-chip{display:inline-block;background:#FFF0D1;color:#8A5A00;font-size:9px;font-weight:700;letter-spacing:.07em;padding:3px 7px;border-radius:100px;margin-bottom:5px;}
+  #ckw-rail .ckw-nm{display:block;font-size:13.5px;font-weight:600;line-height:1.3;color:#0E1B4D;margin-bottom:7px;}
+  #ckw-rail .ckw-buy{display:flex;align-items:center;gap:9px;}
+  #ckw-rail .ckw-pr{font-family:'Fraunces',Georgia,serif;font-variation-settings:"SOFT" 0,"WONK" 0;font-size:15px;font-weight:600;}
+  #ckw-rail .ckw-add{background:#FF9900;color:#0E1B4D;font-size:11px;font-weight:700;padding:6px 11px;border-radius:4px;cursor:pointer;border:0;font-family:inherit;}
+  #ckw-rail .ckw-more{font-size:13px;font-weight:700;color:#0E1B4D;text-decoration:none;}
+  #ckw-rail .ckw-all{display:block;text-align:center;border:1.5px solid #0E1B4D;color:#0E1B4D;font-size:12.5px;font-weight:700;padding:11px;border-radius:5px;margin-top:14px;box-sizing:border-box;text-decoration:none;}
+  #ckw-rail .ckw-all:hover{background:#0E1B4D;color:#fff;}
+  #ckw-rail .ckw-fine{text-align:center;font-size:11px;color:#6B7280;margin-top:10px;}
+  #ckw-scrim{position:fixed;inset:0;background:rgba(14,27,77,.28);z-index:59;opacity:0;pointer-events:none;transition:opacity .3s ease;}
+  @media (max-width:768px){
+    #ckw-rail .ckw-row{transform:translate(290px,-50%);}
+    #ckw-rail .ckw-panel{width:290px;}
+    #ckw-rail.is-open #ckw-scrim,#ckw-scrim.is-on{opacity:1;pointer-events:auto;}
+  }
+</style>
+
+<div id="ckw-rail" aria-hidden="true">
+  <div id="ckw-scrim" data-ckw-close></div>
+  <div class="ckw-row">
+    <button type="button" class="ckw-tab" data-ckw-toggle aria-label="Open shop panel" aria-expanded="false">
+      <span class="ckw-g" aria-hidden="true"><span class="t">&#9664;</span><span class="s">&#9733;</span></span>
+      <span class="lbl">Cook Better</span>
+      <span class="ckw-g" aria-hidden="true"><span class="t">&#9664;</span><span class="s">&#9733;</span></span>
+    </button>
+    <div class="ckw-panel">
+      <div class="ckw-head">
+        <div>
+          <div class="h">Cook Better</div>
+          <div class="sub">The trusted cookware behind my recipes.</div>
+        </div>
+        <button type="button" class="ckw-x" data-ckw-close aria-label="Close">&times;</button>
+      </div>
+      <div class="ckw-body"><div class="ckw-item" data-ckw-product-name="12.5 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves (Lid, Spatula and User Guide Video Included)" data-ckw-product-id="6734609416400" data-ckw-product-price="39.99">
+            <a class="ckw-thumb" href="/products/carbon-steel-wok-with-flat-bottom"><img src="//curatedkitchenware.com/cdn/shop/files/1-2_307ddfdc-9a2e-419c-b205-b96693d9dfc6.jpg?v=1735627825&width=200" alt="12.5 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves (Lid, Spatula and User Guide Video Included)"></a>
+            <div class="ckw-info">
+              <span class="ckw-chip">BEST SELLER</span>
+              <a class="ckw-nm" href="/products/carbon-steel-wok-with-flat-bottom">12.5 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves</a>
+              <div class="ckw-buy"><span class="ckw-pr"><span class=money>$39.99</span></span><button type="button" class="ckw-add" data-ckw-add="45038734803152">Add</button><a class="ckw-more" href="/products/carbon-steel-wok-with-flat-bottom" aria-label="More about: 12.5 Inch Carbon Steel Wok For Electric, Induction and Gas Stoves (Lid, Spatula and User Guide Video Included)">&rarr;</a></div>
+            </div>
+          </div><div class="ckw-item" data-ckw-product-name="3 Piece Damascus Kitchen Knife Set" data-ckw-product-id="7733607366864" data-ckw-product-price="99.99">
+            <a class="ckw-thumb" href="/products/damascus-kitchen-knife-set"><img src="//curatedkitchenware.com/cdn/shop/products/WeChatImage_20220601090444_ddc9146b-7fa4-4212-993d-4146f0b7256e.jpg?v=1656777233&width=200" alt="3 Piece Damascus Kitchen Knife Set"></a>
+            <div class="ckw-info"><span class="ckw-chip">SAVE <span class=money>$69.98</span></span><a class="ckw-nm" href="/products/damascus-kitchen-knife-set">3 Piece Damascus Kitchen Knife Set</a>
+              <div class="ckw-buy"><span class="ckw-pr"><span class=money>$99.99</span></span><button type="button" class="ckw-add" data-ckw-add="42826069639376">Add</button><a class="ckw-more" href="/products/damascus-kitchen-knife-set" aria-label="More about: 3 Piece Damascus Kitchen Knife Set">&rarr;</a></div>
+            </div>
+          </div><div class="ckw-item" data-ckw-product-name="9 Piece Stainless Steel Cookware Set" data-ckw-product-id="7700441268432" data-ckw-product-price="249.99">
+            <a class="ckw-thumb" href="/products/stainless-steel-pot-set"><img src="//curatedkitchenware.com/cdn/shop/products/stainlesssteelcookwareset.png?v=1668309420&width=200" alt="9 Piece Stainless Steel Cookware Set"></a>
+            <div class="ckw-info">
+              <span class="ckw-chip">BUY IT FOR LIFE</span>
+              <a class="ckw-nm" href="/products/stainless-steel-pot-set">9 Piece Stainless Steel Cookware Set</a>
+              <div class="ckw-buy"><span class="ckw-pr"><span class=money>$249.99</span></span><button type="button" class="ckw-add" data-ckw-add="44347255455952">Add</button><a class="ckw-more" href="/products/stainless-steel-pot-set" aria-label="More about: 9 Piece Stainless Steel Cookware Set">&rarr;</a></div>
+            </div>
+          </div><a class="ckw-all" href="/collections/products">Shop all cookware</a>
+        <div class="ckw-fine">Free US shipping, no minimum</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function(){
+    var rail=document.getElementById('ckw-rail');if(!rail)return;
+    var cbCard=document.getElementById('cka-cookbook-card');
+    var recipe=document.querySelector('.recipe-mount')||document.getElementById('recipe');
+    var ready=false;
+    function checkReady(){
+      if(ready)return;
+      var show=false, vh=window.innerHeight;
+      if(cbCard){
+        // Appear only AFTER the cookbook card — once its bottom has scrolled up past the top ~28% of the viewport.
+        show = cbCard.getBoundingClientRect().bottom < vh*0.28;
+      } else if(recipe){
+        // No cookbook card (a post with tool metafields): fall back to the recipe card entering the upper half.
+        show = recipe.getBoundingClientRect().top < vh*0.45;
+      } else {
+        show = window.scrollY > 900;
+      }
+      if(show){ready=true;rail.classList.add('is-ready');window.removeEventListener('scroll',checkReady);}
+    }
+    window.addEventListener('scroll',checkReady,{passive:true});checkReady();
+    function track(name,params){if(typeof window.gtag==='function'){window.gtag('event',name,params||{});}}
+    function itemData(el){var item=el&&el.closest?el.closest('.ckw-item'):null;if(!item)return{};return{item_id:item.getAttribute('data-ckw-product-id')||'',item_name:item.getAttribute('data-ckw-product-name')||'',price:Number(item.getAttribute('data-ckw-product-price'))||0,quantity:1};}
+    function open(){
+      rail.classList.add('is-open');
+      var t=rail.querySelector('[data-ckw-toggle]');if(t){t.setAttribute('aria-expanded','true');t.setAttribute('aria-label',"Close shop panel");}
+      track('recipe_rail_open',{rail_placement:'recipe_side_rail'});
+    }
+    function close(){rail.classList.remove('is-open');var t=rail.querySelector('[data-ckw-toggle]');if(t){t.setAttribute('aria-expanded','false');t.setAttribute('aria-label',"Open shop panel");}}
+    rail.addEventListener('click',function(e){
+      var add=e.target.closest('[data-ckw-add]');
+      if(add){e.preventDefault();var id=add.getAttribute('data-ckw-add');var o=add.textContent;add.disabled=true;add.textContent='…';
+        fetch("\/cart\/add",{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({id:id,quantity:1})})
+          .then(function(r){return r.json();}).then(function(){
+            var item=itemData(add);track('add_to_cart',{currency:((window.Shopify&&Shopify.currency&&Shopify.currency.active)||"USD"),value:item.price,items:[item]});track('recipe_rail_add_to_cart',{rail_placement:'recipe_side_rail',item_name:item.item_name,item_id:item.item_id});
+            add.textContent='✓';document.dispatchEvent(new CustomEvent('cart:refresh'));
+            if(window.Shopify&&window.Shopify.onCartUpdate){} var cd=document.querySelector('[data-cart-drawer],.cart-drawer,#cart-drawer');
+            setTimeout(function(){add.textContent=o;add.disabled=false;},1500);})
+          .catch(function(){add.textContent=o;add.disabled=false;window.location.href='/cart';});
+        return;}
+      if(e.target.closest('[data-ckw-toggle]')){e.preventDefault();rail.classList.contains('is-open')?close():open();return;}
+      if(e.target.closest('[data-ckw-close]')){e.preventDefault();close();return;}
+      var productLink=e.target.closest('.ckw-item a[href]');
+      if(productLink){var item=itemData(productLink);track('recipe_rail_product_click',{rail_placement:'recipe_side_rail',item_name:item.item_name,item_id:item.item_id,link_url:productLink.href});}
+    });
+    document.addEventListener('keydown',function(e){if(e.key==='Escape'&&rail.classList.contains('is-open'))close();});
+  })();
+</script>
+
+<style>
+  .sur-foot{--navy:#0E1B4D;--orange:#FF9900;font-family:'Inter',Helvetica,Arial,sans-serif;background:var(--navy);color:#fff;padding:48px 20px 32px;}
+  .sur-foot a{color:rgba(255,255,255,.7);text-decoration:none;}
+  .sur-foot a:hover{color:#fff;}
+  .sur-foot .cols{display:grid;grid-template-columns:1fr;gap:32px;max-width:1200px;margin:0 auto 40px;}
+  .sur-foot .wm{font-family:'Fraunces',Georgia,serif;font-size:20px;font-weight:600;color:#fff;margin-bottom:12px;}
+  .sur-foot .blurb{font-size:13.5px;line-height:1.65;color:rgba(255,255,255,.66);margin:0 0 20px;max-width:300px;}
+  .sur-foot .social{display:flex;flex-wrap:wrap;gap:10px;}
+  .sur-foot .social a{width:38px;height:38px;border:1px solid rgba(255,255,255,.22);border-radius:5px;display:flex;align-items:center;justify-content:center;}
+  .sur-foot .col h4{font-size:13px;font-weight:600;color:#fff;margin:0 0 14px;font-family:inherit;}
+  .sur-foot .col .lk{display:flex;flex-direction:column;gap:9px;font-size:13.5px;}
+  .sur-foot .copy{border-top:1px solid rgba(255,255,255,.15);padding-top:22px;font-size:12.5px;color:rgba(255,255,255,.5);max-width:1200px;margin:0 auto;}
+  .sur-foot .copy a{color:inherit;}
+  .sur-foot .copy a:hover{color:#fff;text-decoration:underline;text-underline-offset:3px;}
+  @media (min-width:900px){ .sur-foot{padding:60px 80px 40px;} .sur-foot .cols{grid-template-columns:1.4fr 1fr 1fr 1fr;gap:48px;} }
+</style>
+<footer class="sur-foot">
+  <div class="cols">
+    <div>
+      <div class="wm">Souped Up Recipes</div>
+      <p class="blurb">Chinese recipes tested on camera since 2016, and the cookware behind them, made by Curated Kitchenware.</p>
+      <div class="social">
+        <a href="https://www.youtube.com/soupeduprecipes" target="_blank" rel="noopener" aria-label="YouTube"><svg width="17" height="17" viewBox="0 0 24 24" fill="#fff"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.6 12 3.6 12 3.6s-7.5 0-9.4.5A3 3 0 0 0 .5 6.2C0 8.1 0 12 0 12s0 3.9.5 5.8a3 3 0 0 0 2.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 0 0 2.1-2.1c.5-1.9.5-5.8.5-5.8s0-3.9-.5-5.8zM9.5 15.6V8.4l6.3 3.6-6.3 3.6z"/></svg></a>
+        <a href="https://www.facebook.com/soupeduprecipes" target="_blank" rel="noopener" aria-label="Facebook"><svg width="17" height="17" viewBox="0 0 24 24" fill="#fff"><path d="M24 12.07C24 5.4 18.63 0 12 0S0 5.4 0 12.07C0 18.1 4.39 23.1 10.13 24v-8.44H7.08v-3.49h3.05V9.41c0-3.02 1.79-4.69 4.53-4.69 1.31 0 2.68.24 2.68.24v2.95h-1.5c-1.48 0-1.95.92-1.95 1.87v2.25h3.32l-.53 3.49h-2.79V24C19.61 23.1 24 18.1 24 12.07z"/></svg></a>
+        <a href="https://www.pinterest.com/soupeduprecipes" target="_blank" rel="noopener" aria-label="Pinterest"><svg width="17" height="17" viewBox="0 0 24 24" fill="#fff"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.08 3.16 9.42 7.62 11.17-.1-.95-.2-2.4.04-3.44l1.4-5.95s-.36-.72-.36-1.78c0-1.67.97-2.92 2.17-2.92 1.02 0 1.51.77 1.51 1.69 0 1.03-.65 2.56-.99 3.98-.28 1.19.6 2.16 1.77 2.16 2.12 0 3.76-2.24 3.76-5.47 0-2.86-2.06-4.86-5-4.86-3.4 0-5.39 2.55-5.39 5.18 0 1.03.4 2.13.89 2.73.1.12.11.22.08.34l-.33 1.37c-.05.22-.18.29-.4.17-1.5-.7-2.43-2.89-2.43-4.65 0-3.79 2.75-7.27 7.94-7.27 4.17 0 7.41 2.97 7.41 6.94 0 4.14-2.61 7.47-6.23 7.47-1.22 0-2.36-.63-2.75-1.38l-.75 2.85c-.27 1.04-1 2.35-1.49 3.15C9.57 23.82 10.76 24 12 24c6.63 0 12-5.37 12-12S18.63 0 12 0z"/></svg></a>
+        <a href="https://www.tiktok.com/@soupeduprecipes" target="_blank" rel="noopener" aria-label="TikTok"><svg width="17" height="17" viewBox="0 0 24 24" fill="#fff"><path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64c.3 0 .59.04.86.13V9.4a6.33 6.33 0 0 0-1-.05A6.34 6.34 0 0 0 9 22a6.34 6.34 0 0 0 6.34-6.34V8.87a8.16 8.16 0 0 0 4.25 1.2V6.69z"/></svg></a>
+        <a href="https://twitter.com/soupeduprecipes" target="_blank" rel="noopener" aria-label="X"><svg width="15" height="15" viewBox="0 0 24 24" fill="#fff"><path d="M18.9 1.15h3.68l-8.04 9.19L24 22.85h-7.41l-5.8-7.58-6.64 7.58H.46l8.6-9.83L0 1.15h7.59l5.44 7.2 5.87-7.2zm-1.3 19.5h2.04L6.49 3.24H4.3l13.3 17.41z"/></svg></a>
+        <a href="https://www.amazon.com/shops/soupeduprecipes" target="_blank" rel="noopener" aria-label="Amazon shop"><svg width="17" height="17" viewBox="0 0 24 24" fill="#fff"><path d="M14.8 12.6c-.4.3-1 .3-1.5.3-1.1 0-2-.6-2-1.7 0-1.4 1.2-2 2.9-2h.6v1.1c0 .9 0 1.7-.5 2.3zm2.5 1.4c-.2-.2-.3-.4-.3-.9V9.6c0-1.2 0-2.3-.9-3.1-.7-.6-1.8-.8-2.6-.8-1.7 0-3.5.6-3.9 2.6 0 .2.1.3.3.3l1.7.2c.2 0 .3-.2.3-.3.1-.7.7-1.1 1.4-1.1.4 0 .8.1 1 .4.3.4.2.9.2 1.3v.3c-1.1.1-2.5.2-3.5.6-1.2.5-2 1.6-2 3.1 0 2 1.3 3 2.9 3 1.4 0 2.2-.3 3.3-1.4.4.5.5.8 1.2 1.4.2.1.4.1.5 0l1.2-1c.2-.1.1-.4 0-.5-.4-.3-.6-.5-.8-.6zM21.6 18c-2.7 2-6.5 3-9.8 3-4.7 0-9-1.7-12.2-4.6-.3-.2 0-.6.3-.4 3.5 2 7.8 3.2 12.3 3.2 3 0 6.4-.6 9.5-1.9.5-.2.9.3.4.7zm1.1-1.3c-.3-.4-2.2-.2-3.1-.1-.3 0-.3-.2-.1-.3 1.5-1 3.9-.7 4.2-.4.3.4-.1 2.4-1.4 3.4-.2.2-.4.1-.3-.1.3-.7.9-2.2.7-2.5z"/></svg></a>
+      </div>
+    </div>
+    <div class="col"><h4>Recipes</h4><div class="lk"><a href="/blogs/soupeduprecipes">All recipes</a><a href="/blogs/soupeduprecipes/tagged/noodles">Noodles</a><a href="/blogs/soupeduprecipes/tagged/stir-fry">Stir fry</a><a href="/blogs/soupeduprecipes/tagged/soup">Soups</a><a href="/blogs/soupeduprecipes/tagged/rice">Rice</a></div></div>
+    <div class="col"><h4>Shop</h4><div class="lk"><a href="/">Store home</a><a href="/collections/all">All products</a><a href="/products/souped-up-recipes-cookbook-168-better-than-takeout-chinese-recipes">Cookbook</a></div></div>
+    <div class="col"><h4>Company</h4><div class="lk"><a href="/pages/about">About Us</a><a href="/pages/contact-us">Contact</a><a href="/policies/shipping-policy">Shipping</a><a href="/policies/refund-policy">Returns</a></div></div>
+  </div>
+  <div class="copy">&copy; 2026 <a href="/blogs/soupeduprecipes">Souped Up Recipes</a> x <a href="/">Curated Kitchenware</a></div>
+</footer>
+
+<!-- BEGIN sections: overlay-group -->
+
+<!-- END sections: overlay-group --><div id="screenreader-announce" class="sr-only" aria-live="polite" role="status"></div>
+
+      <ul hidden>
+        <li id="a11y-refresh-page-message">Choosing a selection results in a full page refresh.</li>
+        <li id="a11y-selection-message">Press the space key then arrow keys to make a selection.</li>
+      </ul>
+
+      
+      <aside x-data>
+  <template x-teleport="body">
+    <div
+      x-show="$store.modals.leftDrawer.open"
+      @keydown.escape.prevent.stop="$store.modals.close('leftDrawer')"
+      @click="$store.modals.close('leftDrawer')"
+      class="fixed inset-0 z-50"
+      data-color-scheme="primary"
+      id="modals-leftDrawer"
+      @left-drawer-is-open.window="setTimeout(() => { $focus.first() }, 120)"
+    >
+      <div x-show="$store.modals.leftDrawer.open"
+        x-transition:enter="transition ease-out duration-300"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="transition ease-in duration-300"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+        class="fixed inset-0 bg-scheme-text/75"
+       ><!-- Overlay --></div>
+      <div
+        x-show="$store.modals.leftDrawer.open"
+        x-transition:enter="transition ease-out duration-300"
+        x-transition:enter-start="-translate-x-full"
+        x-transition:enter-end="translate-x-0"
+        x-transition:leave="transition ease-in duration-300"
+        x-transition:leave-start="translate-x-0"
+        x-transition:leave-end="-translate-x-full"
+        class="h-full w-full drawer-transition-host"
+      >
+        <div
+          @click.stop
+          x-trap.noscroll.inert="$store.modals.leftDrawer.open"
+          class="relative w-11/12 md:w-7/12 lg:w-5/12 h-full bg-scheme-background text-scheme-text mr-auto overflow-y-auto border-r-section border-border"
+          id="left-drawer-slot"
+          role="dialog"
+          aria-modal="true"
+          :aria-label="getModalLabel('leftDrawer', $el)"
+          tabindex="-1"
+        >
+          <!-- Modal content is teleported here -->
+        </div>
+      </div>
+    </div>
+  </template>
+</aside>
+
+      <aside x-data>
+  <template x-teleport="body">
+    <div
+      x-show="$store.modals.rightDrawer.open"
+      @keydown.escape.prevent.stop="$store.modals.close('rightDrawer')"
+      @click="$store.modals.close('rightDrawer')"
+      class="fixed inset-0 z-50"
+      data-color-scheme="primary"
+      id="modals-rightDrawer"
+      @right-drawer-is-open.window="setTimeout(() => { $focus.first() }, 120)"
+    >
+      <div x-show="$store.modals.rightDrawer.open"
+        x-transition:enter="transition ease-out duration-300"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="transition ease-in duration-300"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+        class="fixed inset-0 bg-scheme-text/75"
+       ><!-- Overlay --></div>
+      <div
+        x-show="$store.modals.rightDrawer.open"
+        x-transition:enter="transition ease-out duration-300"
+        x-transition:enter-start="translate-x-full"
+        x-transition:enter-end="translate-x-0"
+        x-transition:leave="transition ease-in duration-300"
+        x-transition:leave-start="translate-x-0"
+        x-transition:leave-end="translate-x-full"
+        class="h-full w-full"
+      >
+        <div
+          @click.stop
+          x-trap.noscroll.inert="$store.modals.rightDrawer.open"
+          class="relative w-11/12 md:w-7/12 lg:w-5/12 h-full bg-scheme-background ml-auto overflow-hidden border-l-section border-border"
+          id="right-drawer-slot"
+          role="dialog"
+          aria-modal="true"
+          :aria-label="getModalLabel('rightDrawer', $el)"
+          tabindex="-1"
+        >
+          <!-- Modal content is teleported here -->
+        </div>
+      </div>
+    </div>
+  </template>
+</aside>
+
+      <aside x-data>
+  <template x-teleport="body">
+    <div
+      x-show="$store.modals.modal.open"
+      @keydown.escape.prevent.stop="$store.modals.close('modal')"
+      class="fixed inset-0 z-40"
+      id="modals-modal"
+      @modal-is-open.window="setTimeout(() => { $focus.first() }, 120)"
+    >
+      <div id="modal-slot"></div>
+    </div>
+  </template>
+</aside>
+
+      <script src="//curatedkitchenware.com/cdn/shop/t/108/assets/modals.js?v=160051358362553771071786678740" type="module"></script>
+
+      
+<script src="https://cdn.shopify.com/storefront/standard-actions.js" type="module" data-source-attribution="shopify.standard_actions"></script>
+</body>
+  </html>


### PR DESCRIPTION
This site (Shopify, RecipeKit app) doesn't render its ingredient/direction group headings into static HTML at all — the group markers exist but their text is the literal placeholder "blank", with the real headings injected client-side by JS. The real content is available server-side though, in a separate `<script type="application/json" id="recipe-data-*">` block RecipeKit ships for its own editor, with `recipe_ingredients`/`recipe_directions` arrays typed `heading`/`ingredient`/`direction` in document order. This scraper reads that directly.

Everything else (title, times, image, etc.) already works fine via the schema.org fallback, so only `ingredient_groups()` and `instructions()` are overridden.

Tested against a real recipe page; all mandatory and optional assertions pass, full existing test suite (1164 tests) still green.