### PR TITLE
Adds support for recettesetcabas

### DIFF
--- a/recipe_scrapers/__init__.py
+++ b/recipe_scrapers/__init__.py
@@ -501,6 +501,7 @@ from .recept import Recept
 from .receptiindex import ReceptiIndex
 from .receptyprevas import ReceptyPreVas
 from .recetteplus import RecettePlus
+from .recettesetcabas import RecettesEtCabas
 from .recipeforperfection import RecipeForPerfection
 from .recipegirl import RecipeGirl
 from .recipeland import RecipeLand
@@ -1248,6 +1249,7 @@ SCRAPERS = {
     ReceptiIndex.host(): ReceptiIndex,
     ReceptyPreVas.host(): ReceptyPreVas,
     RecettePlus.host(): RecettePlus,
+    RecettesEtCabas.host(): RecettesEtCabas,
     RecipeForPerfection.host(): RecipeForPerfection,
     RecipeGirl.host(): RecipeGirl,
     RecipeLand.host(): RecipeLand,

--- a/recipe_scrapers/recettesetcabas.py
+++ b/recipe_scrapers/recettesetcabas.py
@@ -64,11 +64,11 @@ class RecettesEtCabas(AbstractScraper):
         return groups
 
     def instructions(self):
-        # Recipes can leave the schema instructions empty. Older pages identify
-        # every instruction paragraph by its styling, while newer pages only
-        # distinguish their steps from the introduction by numbering them. The
-        # sections after the first one hold the Thermomix version of the recipe and
-        # the site's own commentary on it.
+        # Recipes can leave the schema instructions empty. Some pages give every
+        # instruction paragraph the same styling, including unnumbered preparation
+        # notes. Others only distinguish their steps from the introduction by
+        # numbering them. The sections after the first one hold the Thermomix version
+        # of the recipe and the site's own commentary on it.
         steps = self.schema.instructions().split("\n")
         if not any(steps):
             recipe_section = self.soup.select_one(
@@ -77,11 +77,27 @@ class RecettesEtCabas(AbstractScraper):
             paragraphs = (
                 recipe_section.find_all("p", recursive=False) if recipe_section else []
             )
-            styled_paragraphs = [
+            numbered_paragraphs = [
                 paragraph
                 for paragraph in paragraphs
-                if "para-style-body" in paragraph.get("class", [])
+                if STEP_NUMBER.match(normalize_string(paragraph.get_text()))
             ]
+            instruction_classes = (
+                numbered_paragraphs[0].get("class", []) if numbered_paragraphs else []
+            )
+            styled_paragraphs = (
+                [
+                    paragraph
+                    for paragraph in paragraphs
+                    if paragraph.get("class", []) == instruction_classes
+                ]
+                if instruction_classes
+                else [
+                    paragraph
+                    for paragraph in paragraphs
+                    if "para-style-body" in paragraph.get("class", [])
+                ]
+            )
             if styled_paragraphs:
                 steps = [
                     step
@@ -90,9 +106,8 @@ class RecettesEtCabas(AbstractScraper):
                 ]
             else:
                 steps = [
-                    step
-                    for paragraph in paragraphs
-                    if STEP_NUMBER.match(step := normalize_string(paragraph.get_text()))
+                    normalize_string(paragraph.get_text())
+                    for paragraph in numbered_paragraphs
                 ]
 
         steps = [STEP_NUMBER.sub("", step) for step in steps if step]

--- a/recipe_scrapers/recettesetcabas.py
+++ b/recipe_scrapers/recettesetcabas.py
@@ -1,0 +1,102 @@
+import re
+
+from ._abstract import AbstractScraper
+from ._exceptions import ElementNotFoundInHtml
+from ._grouping_utils import IngredientGroup
+from ._utils import normalize_string
+
+STEP_NUMBER = re.compile(r"^\d+\s*[.)]\s*")
+
+
+class RecettesEtCabas(AbstractScraper):
+    @classmethod
+    def host(cls):
+        return "recettesetcabas.com"
+
+    def ingredients(self):
+        return [
+            ingredient
+            for group in self.ingredient_groups()
+            for ingredient in group.ingredients
+        ]
+
+    def ingredient_groups(self):
+        # The schema lists the recipe ingredients as semicolon separated text. The
+        # page lists them too, but without their quantities and with a disclaimer
+        # trailing the last item. The pantry staples are only listed in the page.
+        groups = []
+
+        ingredients = [
+            normalize_string(ingredient)
+            for entry in self.schema.ingredients()
+            for ingredient in entry.split(";")
+            if normalize_string(ingredient)
+        ]
+        if ingredients:
+            groups.append(IngredientGroup(ingredients=ingredients))
+
+        pantry = self.soup.select_one(".bloc-desc .col-header:has(.icon-cupboard)")
+        if pantry:
+            heading = pantry.find("h2")
+            pantry_items = pantry.select("ul li")
+            items = [
+                normalize_string(ingredient)
+                for item in pantry_items
+                for ingredient in (
+                    item.get_text().split(",")
+                    if len(pantry_items) == 1
+                    else [item.get_text()]
+                )
+                if normalize_string(ingredient)
+            ]
+            if items:
+                groups.append(
+                    IngredientGroup(
+                        purpose=(
+                            normalize_string(heading.get_text()).rstrip(" :")
+                            if heading
+                            else None
+                        ),
+                        ingredients=items,
+                    )
+                )
+
+        return groups
+
+    def instructions(self):
+        # Recipes can leave the schema instructions empty. Older pages identify
+        # every instruction paragraph by its styling, while newer pages only
+        # distinguish their steps from the introduction by numbering them. The
+        # sections after the first one hold the Thermomix version of the recipe and
+        # the site's own commentary on it.
+        steps = self.schema.instructions().split("\n")
+        if not any(steps):
+            recipe_section = self.soup.select_one(
+                ".bloc-recette > section:first-of-type"
+            )
+            paragraphs = (
+                recipe_section.find_all("p", recursive=False) if recipe_section else []
+            )
+            styled_paragraphs = [
+                paragraph
+                for paragraph in paragraphs
+                if "para-style-body" in paragraph.get("class", [])
+            ]
+            if styled_paragraphs:
+                steps = [
+                    step
+                    for paragraph in styled_paragraphs
+                    if (step := normalize_string(paragraph.get_text()))
+                ]
+            else:
+                steps = [
+                    step
+                    for paragraph in paragraphs
+                    if STEP_NUMBER.match(step := normalize_string(paragraph.get_text()))
+                ]
+
+        steps = [STEP_NUMBER.sub("", step) for step in steps if step]
+        if not steps:
+            raise ElementNotFoundInHtml("Could not find the recipe instructions.")
+
+        return "\n".join(steps)

--- a/recipe_scrapers/recettesetcabas.py
+++ b/recipe_scrapers/recettesetcabas.py
@@ -8,6 +8,22 @@ from ._utils import normalize_string
 STEP_NUMBER = re.compile(r"^\d+\s*[.)]\s*")
 
 
+def _split_instruction_paragraph(paragraph):
+    fragments = [
+        fragment
+        for raw_fragment in paragraph.get_text("\n").splitlines()
+        if (fragment := normalize_string(raw_fragment))
+    ]
+    steps = []
+    for fragment in fragments:
+        if STEP_NUMBER.match(fragment) or not steps:
+            steps.append(fragment)
+        else:
+            steps[-1] = normalize_string(f"{steps[-1]} {fragment}")
+
+    return steps
+
+
 class RecettesEtCabas(AbstractScraper):
     @classmethod
     def host(cls):
@@ -64,24 +80,31 @@ class RecettesEtCabas(AbstractScraper):
         return groups
 
     def instructions(self):
-        # Recipes can leave the schema instructions empty. Some pages give every
-        # instruction paragraph the same styling, including unnumbered preparation
-        # notes. Others only distinguish their steps from the introduction by
-        # numbering them. The sections after the first one hold the Thermomix version
-        # of the recipe and the site's own commentary on it.
+        # Recipes can leave the schema instructions empty or collapse multiple visible
+        # steps into one item. Some pages give every instruction paragraph the same
+        # styling, including unnumbered preparation notes. Others only distinguish
+        # their steps from the introduction by numbering them. The sections after the
+        # first one hold the Thermomix version and the site's own commentary.
         steps = self.schema.instructions().split("\n")
-        if not any(steps):
-            recipe_section = self.soup.select_one(
-                ".bloc-recette > section:first-of-type"
+        recipe_section = self.soup.select_one(".bloc-recette > section:first-of-type")
+        paragraphs = (
+            recipe_section.find_all("p", recursive=False) if recipe_section else []
+        )
+        numbered_paragraphs = [
+            paragraph
+            for paragraph in paragraphs
+            if any(
+                STEP_NUMBER.match(step)
+                for step in _split_instruction_paragraph(paragraph)
             )
-            paragraphs = (
-                recipe_section.find_all("p", recursive=False) if recipe_section else []
-            )
-            numbered_paragraphs = [
-                paragraph
-                for paragraph in paragraphs
-                if STEP_NUMBER.match(normalize_string(paragraph.get_text()))
-            ]
+        ]
+        numbered_step_count = sum(
+            bool(STEP_NUMBER.match(step))
+            for paragraph in numbered_paragraphs
+            for step in _split_instruction_paragraph(paragraph)
+        )
+
+        if not any(steps) or (len(steps) == 1 and numbered_step_count > 1):
             instruction_classes = (
                 numbered_paragraphs[0].get("class", []) if numbered_paragraphs else []
             )
@@ -102,12 +125,13 @@ class RecettesEtCabas(AbstractScraper):
                 steps = [
                     step
                     for paragraph in styled_paragraphs
-                    if (step := normalize_string(paragraph.get_text()))
+                    for step in _split_instruction_paragraph(paragraph)
                 ]
             else:
                 steps = [
-                    normalize_string(paragraph.get_text())
+                    step
                     for paragraph in numbered_paragraphs
+                    for step in _split_instruction_paragraph(paragraph)
                 ]
 
         steps = [STEP_NUMBER.sub("", step) for step in steps if step]

--- a/tests/library/test_recettesetcabas.py
+++ b/tests/library/test_recettesetcabas.py
@@ -1,0 +1,40 @@
+import json
+import pathlib
+import unittest
+
+from bs4 import BeautifulSoup
+
+from recipe_scrapers import scrape_html
+
+
+class RecettesEtCabasTest(unittest.TestCase):
+    test_data = pathlib.Path(
+        "tests/test_data/recettesetcabas.com/recettesetcabas_4.testhtml"
+    )
+    expected_data = pathlib.Path(
+        "tests/test_data/recettesetcabas.com/recettesetcabas_4.json"
+    )
+    url = (
+        "https://www.recettesetcabas.com/recettes/"
+        "3992-ble-pilaf-chou-fleur-abricots-secs-orange"
+    )
+
+    def test_instructions_fall_back_to_unclassified_numbered_paragraphs(self):
+        soup = BeautifulSoup(self.test_data.read_text(encoding="utf-8"), "html.parser")
+        for script in soup.select('script[type="application/ld+json"]'):
+            if not script.string:
+                continue
+            schema = json.loads(script.string)
+            if schema.get("@type") == "Recipe":
+                schema["recipeInstructions"] = []
+                script.string = json.dumps(schema)
+                break
+
+        expected = json.loads(self.expected_data.read_text(encoding="utf-8"))
+        scraper = scrape_html(str(soup), self.url)
+
+        self.assertEqual(expected["instructions_list"], scraper.instructions_list())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_1.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_1.json
@@ -1,0 +1,72 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/5169-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle",
+  "ingredients": [
+    "3 ou 4 Courgettes",
+    "2 burrata",
+    "250g tomates cerises",
+    "100g jambon cru",
+    "30g pignons",
+    "basilic frais",
+    "250g spaetzles (pâtes sèches)",
+    "Huile d’olive",
+    "1 citron ou du vinaigre",
+    "Papier cuisson",
+    "Sel",
+    "Poivre."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "3 ou 4 Courgettes",
+        "2 burrata",
+        "250g tomates cerises",
+        "100g jambon cru",
+        "30g pignons",
+        "basilic frais",
+        "250g spaetzles (pâtes sèches)"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "Huile d’olive",
+        "1 citron ou du vinaigre",
+        "Papier cuisson",
+        "Sel",
+        "Poivre."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions_list": [
+    "Lavez les courgettes puis taillez-les en tagliatelles à l’aide d’un rasoir à légume (ou un économe). Mettez-les dans un saladier avec un bon filet d’huile d’olive, le jus d’un citron ou du vinaigre, du sel, du poivre, et mélangez. Si possible, laissez-les mariner au frigo environ 15min pour qu’elles deviennent bien fondantes.",
+    "Mettez une casserole d’eau salée à bouillir et faites cuire les spaetzle, le temps indiqué sur le paquet.",
+    "Dans une poêle bien chaude et sans matière grasse, faites griller vos pignons pendant quelques minutes en remuant. Egouttez les spaetzle et rafraîchissez-les à l’eau froide (sauf si vous les dégustez à part).",
+    "Dressez vos assiettes : un peu de spaetzle (ou servez-les à part), tagliatelles de courgette, jambon cru, tomates cerises, burrata, pignons de pin, basilic frais ciselé, un filet d’huile d’olive, sel, poivre.",
+    "Dégustez !"
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du de Recettes & Cabas.",
+  "total_time": 35,
+  "cook_time": 20,
+  "prep_time": 15,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "489 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/5169-1-fiche@6A61D86B-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_1.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_1.testhtml
@@ -1,0 +1,1605 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/5169-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/5169-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/5169-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle"><meta property="og:description" content="Découvrez la recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle"><meta property="twitter:description" content="Découvrez la recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.4bbb49a4.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.4bbb49a4.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.4bbb49a4.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.4bbb49a4.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.4bbb49a4.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.4bbb49a4.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.4bbb49a4.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/5169-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/5169-1-fiche@6A61D86B-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2025-07-24",
+      "description": "Découvrez la recette de salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du  de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT15M",      "cookTime": "PT20M",      "totalTime": "PT35M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "489 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"3 ou 4 Courgettes ; 2 burrata ; 250g tomates cerises  ; 100g jambon cru ; 30g pignons ; basilic frais  ; 250g spaetzles (pâtes sèches)"		],
+	  "recipeInstructions": [
+			  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/5169-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle",
+                "name": "Salade De Tagliatelles De Courgettes-Burrata-Pignons Grillés-Spaetzle"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/5169-1-fiche@6A61D86B-salade-de-tagliatelles-de-courgettes-burrata-pignons-grilles-spaetzle.webp" alt="Recette Salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle">
+                                                                <figcaption>Succulente recette facile à préparer de Salade de tagliatelles de courgettes-burrata-pignons grillés-spaetzle, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                        
+                        
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p><em>Courgettes</li>
+                                                                                    <li>Burrata</li>
+                                                                                    <li>Tomates cerises </li>
+                                                                                    <li>Jambon cru</li>
+                                                                                    <li>Pignons</li>
+                                                                                    <li>Basilic</li>
+                                                                                    <li>Pâtes sèches spaetzles</em></p>
+<p><em>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d'origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</em></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Huile d’olive</li>
+                                                                            <li>1 citron ou du vinaigre</li>
+                                                                            <li>Papier cuisson</li>
+                                                                            <li>Sel</li>
+                                                                            <li>Poivre.</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        15 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        20 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <div class="concept_recette_standard">
+    <div class="logo justify-content-center flex">
+        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cavas_circle.svg" class="logo-circle" width="600" alt="Image de recettes à préparer">
+    </div>
+
+    <div class="concept-content">
+        <section id="concept" class="container-xl concept-item tpl-1">
+
+            <div class="concept-title"><p>Vous livre des paniers &#224; cuisiner contenant des recettes vari&#233;es, &#233;quilibr&#233;es et faciles &#224; r&#233;aliser avec les produits associ&#233;s issus des mara&#238;chers, &#233;leveurs et artisans de nos r&#233;gions.</p></div>
+
+            <div class="concept-container">
+                                    <div class="concept-card index-0">
+                        <div class="concept-img">
+                            <figure class="ratio" style="--ratio: 2/1.5">
+                                <img src="https://www.recettesetcabas.com/data/sliders/je-choisis-mes-recettes-47.webp?fmt=1781015945" width="260" height="260" alt="Je choisis mes recettes" loading="lazy">
+                                <figcaption>Je choisis mes recettes</figcaption>
+                            </figure>
+                        </div>
+                        <div class="concept-text">
+                            <div class="h3">Je choisis mes recettes</div>
+                            <div class="mt-4 description"><p>vari&#233;es et faciles &#224; r&#233;aliser&#160;pour 2, 4 ou 6 personnes</p></div>
+                        </div>
+
+
+                    </div>
+                                    <div class="concept-card index-1">
+                        <div class="concept-img">
+                            <figure class="ratio" style="--ratio: 2/1.5">
+                                <img src="https://www.recettesetcabas.com/data/sliders/je-recois-mon-panier-a-cuisiner-48.webp?fmt=1781008328" width="260" height="260" alt="Je reçois mon panier à cuisiner" loading="lazy">
+                                <figcaption>Je reçois mon panier à cuisiner</figcaption>
+                            </figure>
+                        </div>
+                        <div class="concept-text">
+                            <div class="h3">Je reçois mon panier à cuisiner</div>
+                            <div class="mt-4 description"><p>contenant mes recettes et tous les ingr&#233;dients ultra-frais et de saison dos&#233;s en juste quantit&#233;</p></div>
+                        </div>
+
+
+                    </div>
+                                    <div class="concept-card index-2">
+                        <div class="concept-img">
+                            <figure class="ratio" style="--ratio: 2/1.5">
+                                <img src="https://www.recettesetcabas.com/data/sliders/en-30-min-c-est-pret--49.webp?fmt=1727360097" width="260" height="260" alt="En 30 min, c'est prêt !" loading="lazy">
+                                <figcaption>En 30 min, c'est prêt !</figcaption>
+                            </figure>
+                        </div>
+                        <div class="concept-text">
+                            <div class="h3">En 30 min, c'est prêt !</div>
+                            <div class="mt-4 description"><p>Je pr&#233;pare mes repas du quotidien, vari&#233;s et &#233;quilibr&#233;s, en toute simplicit&#233;</p></div>
+                        </div>
+
+
+                    </div>
+                            </div>
+        </section>
+        <div class="container justify-content-center flex">
+            <!-- id="button-cta-recette-2" -->
+                                    <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=10_5169" class="button center" id="button-cta-recette-2"> Recevez votre panier à cuisiner ! </a></p>
+        </div>
+    </div>
+</div>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p><em><strong>L&#8217;Italie toute enti&#232;re s&#8217;invite dans cette assiette l&#233;g&#232;re et gourmande &#224; la fois ! De fines lamelles de courgettes marin&#233;es, une burrata cr&#233;meuse &#224; r&#233;partir sur le plat, et la petite touche finale en plus avec les pignons torr&#233;fi&#233;s ! Un vrai r&#233;gal !</strong></em></p>
+                                            <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"></span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. Lavez les courgettes puis taillez-les en tagliatelles &#224; l&#8217;aide d&#8217;un rasoir &#224; l&#233;gume (ou un &#233;conome). Mettez-les dans un saladier avec un bon filet d&#8217;huile d&#8217;olive, le jus d&#8217;un citron ou du vinaigre, du sel, du poivre, et m&#233;langez. Si possible, laissez-les mariner au frigo environ 15min pour qu&#8217;elles deviennent bien fondantes.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Mettez une casserole d&#8217;eau sal&#233;e &#224; bouillir et faites cuire les spaetzle, le temps indiqu&#233; sur le paquet.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dans une po&#234;le bien chaude et sans mati&#232;re grasse, faites griller vos pignons</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">pendant quelques minutes en remuant. Egouttez les spaetzle et rafra&#238;chissez-les &#224; l&#8217;eau froide (sauf si vous les d&#233;gustez &#224; part).</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dressez vos assiettes : un peu de spaetzle (ou servez-les &#224; part), tagliatelles de courgette, jambon cru, tomates cerises, burrata, pignons de pin, basilic frais cisel&#233;, un filet d&#8217;huile d&#8217;olive, sel, poivre.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">D&#233;gustez !</span></p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p><strong><em>Recette non traduite, voir version traditionnelle</em></strong></p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>489</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 20.13%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">20.13</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 68.46%); left: 20.13%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">48.33</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 92.62%); left: 68.46%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">24.16</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 94.55%); left: 92.62%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">1.93</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100.01%); left: 94.55%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">5.46</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>107.41</span> kcal/<span>449.51</span> kJ</td>
+                                                <td><span>489</span> kcal/<span>2046.394</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>4.39</span>g</td>
+                                                <td><span>20</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>1.32</span>g</td>
+                                                <td><span>6</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>10.54</span>g</td>
+                                                <td><span>48</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>1.54</span>g</td>
+                                                <td><span>7</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>5.27</span>g</td>
+                                                <td><span>24</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.42</span>g</td>
+                                                <td><span>1.9</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>1.19</span>g</td>
+                                                <td><span>5.4</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-b.png" alt="Image du nutriscore de la recette, catégorie B">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text ">
+                                                    <span>Légumes et fruits de saison</span>
+                                                    <span class="highlight"><span>100</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#377d45; right: calc(100% - 100%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Local et circuits courts</span>
+                                                    <span class="highlight"><span>39</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 39%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Produits français</span>
+                                                    <span class="highlight"><span>98</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 98%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>772</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a7e235abf4f6");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            if (!existsCookie('popin_landing')) {
+                    initPopinLanding(3);  //20 secondes
+                }
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_2.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_2.json
@@ -1,0 +1,67 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/2135-aubergines-farcies",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Aubergines farcies",
+  "ingredients": [
+    "aubergines",
+    "avoine",
+    "gruyère râpé",
+    "oignons",
+    "cerfeuil",
+    "huile d'olive",
+    "Sel",
+    "Poivre"
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "aubergines",
+        "avoine",
+        "gruyère râpé",
+        "oignons",
+        "cerfeuil"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "huile d'olive",
+        "Sel",
+        "Poivre"
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions_list": [
+    "Préchauffez le four à 180°C",
+    "Coupez 4 aubergines et ôtez-en la chair en prenant soin de ne pas abîmer la peau (voir le gain de sel). Epluchez l’autre. Coupez la chair des 5 aubergines en petits morceaux",
+    "Pelez et émincez les oignons",
+    "Dans une sauteuse, faites chauffer 2cs.d’huile d’olive. Une fois chaude, faites cuire ensemble les oignons émincés, la chair des aubergines et l’avoine à feu moyen et à couvert pendant 15 à 20min. Salez en cours de cuisson, et ajoutez un petit verre d’eau chaude.",
+    "Faites préchauffer votre four en position grill à 220°",
+    "Lavez, séchez et étêtez le cerfeuil. Ajoutez-le dans la sauteuse; coupez le feu et laissez tiédir",
+    "Mélangez le gruyère râpé avec le reste des ingrédients. Garnissez les aubergines évidées, de cette farce",
+    "Faites gratiner au four quelques minutes en surveillant bien. Servez aussitôt !"
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de aubergines farcies, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes & Cabas.",
+  "total_time": 45,
+  "cook_time": 30,
+  "prep_time": 15,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "377 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/2135-1-fiche@64E35F8C-aubergines-farcies.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_2.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_2.testhtml
@@ -1,0 +1,1600 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de aubergines farcies</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de aubergines farcies, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/2135-aubergines-farcies" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/2135-aubergines-farcies" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/2135-aubergines-farcies" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de aubergines farcies"><meta property="og:description" content="Découvrez la recette de aubergines farcies, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de aubergines farcies"><meta property="twitter:description" content="Découvrez la recette de aubergines farcies, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.4bbb49a4.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.4bbb49a4.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.4bbb49a4.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.4bbb49a4.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.4bbb49a4.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.4bbb49a4.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.4bbb49a4.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/2135-aubergines-farcies";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Aubergines farcies",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/2135-1-fiche@64E35F8C-aubergines-farcies.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2020-07-25",
+      "description": "Découvrez la recette de aubergines farcies, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT15M",      "cookTime": "PT30M",      "totalTime": "PT45M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "377 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"aubergines ; avoine ; gruyère râpé ; oignons ; cerfeuil"		],
+	  "recipeInstructions": [
+		        {
+			  "@type": "HowToStep",
+			  "text": "Préchauffez le four à 180°C"
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Coupez 4 aubergines et ôtez-en la chair en prenant soin de ne pas abîmer la peau (voir le gain de sel). Epluchez l’autre. Coupez la chair des 5 aubergines en petits morceaux"
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Pelez et émincez les oignons"
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Dans une sauteuse, faites chauffer 2cs.d’huile d’olive. Une fois chaude, faites cuire ensemble les oignons émincés, la chair des aubergines et l’avoine à feu moyen et à couvert pendant 15 à 20min. Salez en cours de cuisson, et ajoutez un petit verre d’eau chaude."
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Faites préchauffer votre four en position grill à 220°"
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Lavez, séchez et étêtez le cerfeuil. Ajoutez-le dans la sauteuse; coupez le feu et laissez tiédir"
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Mélangez le gruyère râpé avec le reste des ingrédients. Garnissez les aubergines évidées, de cette farce"
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Faites gratiner au four quelques minutes en surveillant bien. Servez aussitôt !"
+			}        	  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/2135-aubergines-farcies",
+                "name": "Aubergines Farcies"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Aubergines farcies</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Aubergines farcies</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/2135-1-fiche@64E35F8C-aubergines-farcies.webp" alt="Recette Aubergines farcies">
+                                                                <figcaption>Succulente recette facile à préparer de Aubergines farcies, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                                                    <div class="textcenter mb-4 hidden">
+                                Cette recette est l'une des recettes du cabas à cuisiner de la semaine du<span class="bold"> lundi 31 août 2020</span>.
+                            </div>
+                        
+                        
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p>aubergines</li>
+                                                                                    <li>Avoine</li>
+                                                                                    <li>Gruyère râpé</li>
+                                                                                    <li>Oignons</li>
+                                                                                    <li>Cerfeuil</p>
+<p><em>Les recettes qui comportent le logo AB, sont fournies avec des ingrédients BIO. Les autres recettes sont fournies avec des ingrédients conventionnels sélectionnés de préférence en circuits-courts (fruits et légumes, viande, poisson) ou de fabrication française et parfois artisanale (produits frais et secs).</em></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p>huile d'olive</li>
+                                                                            <li>Sel</li>
+                                                                            <li>Poivre</p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        15 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        30 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=3_2135">
+    <div class="concept-content bloc-concept-random">
+        <section id="concept" class="container-xl concept-item tpl-3 tpl-default">
+            <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
+            <div class="content">
+                <p class="concept-title">Fini le gaspillage alimentaire !</p>
+                <span class="button center" id="button-cta-recette-3"> Recevez votre panier à cuisiner ! </span>
+            </div>
+        </section>
+    </div>
+</a>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p>Aubergines farcies</p>
+                                            <p>1. Pr&#233;chauffez le four &#224; 180&#176;C</p>
+<p>2. Coupez 4 <strong>aubergines </strong>et &#244;tez-en la chair en prenant soin de ne pas ab&#238;mer la peau (voir le gain de sel). Epluchez l&#8217;autre. Coupez la chair des 5 <strong>aubergines </strong>en petits morceaux</p>
+<p>3. Pelez et &#233;mincez les <strong>oignons</strong></p>
+<p>4. Dans une sauteuse, faites chauffer 2cs.d&#8217;<strong>huile d&#8217;olive</strong>. Une fois chaude, faites cuire ensemble les <strong>oignons </strong>&#233;minc&#233;s, la chair des <strong>aubergines </strong>et <strong>l&#8217;avoine </strong>&#224; feu moyen et &#224; couvert pendant 15 &#224; 20min. Salez en cours de cuisson, et ajoutez un petit verre d&#8217;eau chaude.</p>
+<p>5. Faites pr&#233;chauffer votre four en position grill &#224; 220&#176;</p>
+<p>6. Lavez, s&#233;chez et &#233;t&#234;tez le <strong>cerfeuil</strong>. Ajoutez-le dans la sauteuse; coupez le feu et laissez ti&#233;dir</p>
+<p>7. M&#233;langez le <strong>gruy&#232;re r&#226;p&#233; </strong>avec le reste des ingr&#233;dients. Garnissez les <strong>aubergines </strong>&#233;vid&#233;es, de cette farce</p>
+<p>8. Faites gratiner au four quelques minutes en surveillant bien. Servez aussit&#244;t !</p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p> Pas de traduction Thermomix </p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p>Vous pouvez classiquement couper les aubergines dans la longueur mais aussi, comme propos&#233; sur la photo, enfaire des &#171;tron&#231;ons&#187; que vous viderez puis garnirez de la m&#234;me fa&#231;on. Vous pouvez &#233;galement varier &#160;en utilisant diff&#233;rentes vari&#233;t&#233;s d&#8217;aubergines dont la couleur de la peau peut aller de violet fonc&#233; &#224; blanc cr&#232;me!</p>
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>377</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 30.95%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">30.95</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 60.06%); left: 30.95%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">29.11</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 83.65%); left: 60.06%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">23.59</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 85.86%); left: 83.65%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">2.21</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100%); left: 85.86%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">14.14</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>99.54</span> kcal/<span>415.84</span> kJ</td>
+                                                <td><span>377</span> kcal/<span>1575</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>5.89</span>g</td>
+                                                <td><span>22.299999</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>2.3</span>g</td>
+                                                <td><span>8.7</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>5.54</span>g</td>
+                                                <td><span>21</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>2.27</span>g</td>
+                                                <td><span>8.6</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>4.49</span>g</td>
+                                                <td><span>17</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.42</span>g</td>
+                                                <td><span>1.6</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>2.69</span>g</td>
+                                                <td><span>10.2</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-a.png" alt="Image du nutriscore de la recette, catégorie A">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text ">
+                                                    <span>Légumes et fruits de saison</span>
+                                                    <span class="highlight"><span>100</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#377d45; right: calc(100% - 100%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>1567</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                                    <section class="container container-recettes-associees">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recettes associées</h2>
+                        <ul>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3579-aubergines-farcies">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3579-1-fiche@64E3652C-aubergines-farcies.webp"
+                                         alt="Recette Aubergines farcies, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Aubergines farcies</figcaption>
+                                    </figure>
+                                    <span class="text">Aubergines farcies</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/2836-buddha-bowl-tomate-aubergine-fromage-cremeux">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/2836-1-fiche@6A1006EF-buddha-bowl-tomate-aubergine-fromage-cremeux.webp"
+                                         alt="Recette Buddha bowl tomate-aubergine, fromage crémeux, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Buddha bowl tomate-aubergine, fromage crémeux</figcaption>
+                                    </figure>
+                                    <span class="text">Buddha bowl tomate-aubergine, fromage crémeux</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/611-curry-aubergines-patates-douces-lentilles-corail-riz">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/611-1-fiche@68DA475E-curry-aubergines-patates-douces-lentilles-corail-riz.webp"
+                                         alt="Recette Curry aubergines-patates douces-lentilles corail - Riz, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Curry aubergines-patates douces-lentilles corail - Riz</figcaption>
+                                    </figure>
+                                    <span class="text">Curry aubergines-patates douces-lentilles corail - Riz</span>
+                                </a>
+                            </li>
+                                                </ul>
+                    </section>
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a7e235adbc70");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            if (!existsCookie('popin_landing')) {
+                    initPopinLanding(3);  //20 secondes
+                }
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_3.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_3.json
@@ -1,0 +1,76 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/2988-blanquette-de-truite-saumonee-et-legumes-anciens-riz",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Blanquette de truite saumonée et légumes anciens - Riz",
+  "ingredients": [
+    "Pavés de truite saumonée Fumet des Dombes",
+    "280g de riz",
+    "300g de topinambours",
+    "300g de panais",
+    "1 oignon",
+    "15cl de vin blanc",
+    "20cl de crème fraîche",
+    "80g de beurre",
+    "80g de farine",
+    "1 cube de bouillon de volaille",
+    "Huile d'olive",
+    "Sel",
+    "Poivre."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "Pavés de truite saumonée Fumet des Dombes",
+        "280g de riz",
+        "300g de topinambours",
+        "300g de panais",
+        "1 oignon",
+        "15cl de vin blanc",
+        "20cl de crème fraîche"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "80g de beurre",
+        "80g de farine",
+        "1 cube de bouillon de volaille",
+        "Huile d'olive",
+        "Sel",
+        "Poivre."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions_list": [
+    "Faites bouillir 1L d'eau (base 4 pers) avec le cube de bouillon de volaille.",
+    "Épluchez et taillez les panais et les topinambours en morceaux de 4 cm environ. Faites-les cuire dans le bouillon pendant 10 à 15 min. Une fois les légumes quasi fondants, retirez-les du feu en les laissant dans le bouillon.",
+    "Émincez l‘oignon et colorez-le légèrement dans une grande casserole avec un filet d'huile d'olive. Une fois cuit, ajoutez la farine et prolongez 1min à feu doux.",
+    "Ajoutez le beurre puis déglacez au vin blanc. Ajoutez le bouillon et les légumes, salez puis versez la crème. Faites cuire à petits frémissements environ 10 min jusqu'à l'obtention d'une sauce nappante. Vérifiez l'assaisonnement.",
+    "Faites cuire le riz dans une casserole d‘eau salée pendant 11 min à couvert.",
+    "Taillez la truite saumonée en cubes de 4 cm environ et plongez-les dans la blanquette chaude 5 min avant de déguster.",
+    "Dressez dans des assiettes creuses la blanquette avec le riz sur le côté."
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de blanquette de truite saumonée et légumes anciens - riz, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 08 novembre 2021 de Recettes & Cabas.",
+  "total_time": 45,
+  "cook_time": 25,
+  "prep_time": 20,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "512 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/2988-1-fiche@697B3D8A-blanquette-de-truite-saumonee-et-legumes-anciens-riz.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_3.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_3.testhtml
@@ -1,0 +1,1628 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de blanquette de truite saumonée et légumes anciens - riz</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de blanquette de truite saumonée et légumes anciens - riz, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 08 novembre 2021 de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/2988-blanquette-de-truite-saumonee-et-legumes-anciens-riz" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/2988-blanquette-de-truite-saumonee-et-legumes-anciens-riz" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/2988-blanquette-de-truite-saumonee-et-legumes-anciens-riz" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de blanquette de truite saumonée et légumes anciens - riz"><meta property="og:description" content="Découvrez la recette de blanquette de truite saumonée et légumes anciens - riz, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 08 novembre 2021 de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de blanquette de truite saumonée et légumes anciens - riz"><meta property="twitter:description" content="Découvrez la recette de blanquette de truite saumonée et légumes anciens - riz, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 08 novembre 2021 de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.4bbb49a4.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.4bbb49a4.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.4bbb49a4.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.4bbb49a4.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.4bbb49a4.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.4bbb49a4.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.4bbb49a4.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/2988-blanquette-de-truite-saumonee-et-legumes-anciens-riz";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Blanquette de truite saumonée et légumes anciens - Riz",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/2988-1-fiche@697B3D8A-blanquette-de-truite-saumonee-et-legumes-anciens-riz.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2021-10-11",
+      "description": "Découvrez la recette de blanquette de truite saumonée et légumes anciens - riz, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 08 novembre 2021 de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT20M",      "cookTime": "PT25M",      "totalTime": "PT45M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "512 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"Pavés de truite saumonée Fumet des Dombes ; 280g de riz ; 300g de topinambours ; 300g de panais ; 1 oignon ; 15cl de vin blanc ; 20cl de crème fraîche"		],
+	  "recipeInstructions": [
+			  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/2988-blanquette-de-truite-saumonee-et-legumes-anciens-riz",
+                "name": "Blanquette De Truite Saumonée Et Légumes Anciens - Riz"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Blanquette de truite saumonée et légumes anciens - Riz</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Blanquette de truite saumonée et légumes anciens - Riz</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/2988-1-fiche@697B3D8A-blanquette-de-truite-saumonee-et-legumes-anciens-riz.webp" alt="Recette Blanquette de truite saumonée et légumes anciens - Riz">
+                                                                <figcaption>Succulente recette facile à préparer de Blanquette de truite saumonée et légumes anciens - Riz, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                                                    <div class="textcenter mb-4 hidden">
+                                Cette recette est l'une des recettes du cabas à cuisiner de la semaine du<span class="bold"> lundi 08 novembre 2021</span>.
+                            </div>
+                        
+                        
+                                                    <div class="textcenter mb-4 hidden">
+                                <span class="icon icon-robot"></span>  Recette traduite pour les robots culinaires
+                            </div>
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p>Pavés de truite saumonée Fumet des Dombes</li>
+                                                                                    <li>Riz</li>
+                                                                                    <li>Topinambours</li>
+                                                                                    <li>Panais</li>
+                                                                                    <li>Oignon</li>
+                                                                                    <li>Vin blanc</li>
+                                                                                    <li>Crème fraîche</p>
+<p><em>Les recettes qui comportent le logo AB, sont fournies avec des ingrédients BIO. Les autres recettes sont fournies avec des ingrédients conventionnels sélectionnés de préférence en circuits-courts (fruits et légumes, viande, poisson) ou de fabrication française et parfois artisanale (produits frais et secs).</em></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">80g de beurre</li>
+                                                                            <li>80g de farine</li>
+                                                                            <li>1 cube de bouillon de volaille</li>
+                                                                            <li>Huile d'olive</li>
+                                                                            <li>Sel</li>
+                                                                            <li>Poivre.</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        20 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        25 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star grey-icon"></span>
+                                                                                                                                                                                <span class="icon icon-active-star grey-icon"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame grey-icon"></span>
+                                                                                                                                                                                <span class="icon icon-flame grey-icon"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=6_2988">
+    <div class="concept-content bloc-concept-random">
+        <section id="concept" class="container-xl concept-item tpl-6 tpl-default">
+            <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
+            <div class="content">
+                <p class="concept-title">Dites adieu à la corvée des courses !</p>
+                <span class="button center" id="button-cta-recette-6"> Recevez votre panier à cuisiner ! </span>
+            </div>
+        </section>
+    </div>
+</a>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p><strong>Une recette propos&#233;e par le candidat de Top Chef 2021 Thomas Chisholm&#160;</strong></p>
+<p><em>" <strong>Une r&#233;interpr&#233;tation d'un classique fran&#231;ais. La blanquette est une recette habituellement r&#233;alis&#233;e avec du veau, ici je vous propose une version au saumon. C'est un bon moyen de consommer moins de viande tout en d&#233;gustant un plat appr&#233;ci&#233; de tous et toutes. La blanquette est un plat en sauce complet, sain et r&#233;confortant que vous pouvez conserver plusieurs jours tr&#232;s facilement ! Le tout est de ne pas surcuire le saumon</strong> ",</em> <strong>Thomas Chisholm</strong></p>
+                                            <p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Faites bouillir 1L d'eau (base 4 pers) avec le cube de bouillon de volaille.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">&#201;pluchez et taillez les panais et les topinambours en morceaux de 4 cm environ. Faites-les cuire dans le bouillon pendant 10 &#224; 15 min. Une fois les l&#233;gumes quasi fondants, retirez-les du feu en les laissant dans le bouillon.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">&#201;mincez l&#8216;oignon et colorez-le l&#233;g&#232;rement dans une grande casserole avec un filet d'huile d'olive. Une fois cuit, ajoutez la farine et prolongez 1min &#224; feu doux.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Ajoutez le beurre puis d&#233;glacez au vin blanc. Ajoutez le bouillon et les l&#233;gumes, salez puis versez la cr&#232;me. Faites cuire &#224; petits fr&#233;missements environ 10 min jusqu'&#224; l'obtention d'une sauce nappante. V&#233;rifiez l'assaisonnement.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Faites cuire le riz dans une casserole d&#8216;eau sal&#233;e pendant 11 min &#224; couvert.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Taillez la truite saumon&#233;e en cubes de 4 cm environ et plongez-les dans la blanquette chaude 5 min avant de d&#233;guster.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">7. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dressez dans des assiettes creuses la blanquette avec le riz sur le c&#244;t&#233;.</span></p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p>1. Faites bouillir 1L d'eau avec le cube de bouillon de volaille.</p>
+<p>2. &#201;pluchez et taillez les panais et les topinambours en morceaux de 4 cm environ. Faites-les cuire dans le bouillon pendant 10 &#224; 15 min. Une fois les l&#233;gumes quasi fondants, retirez-les du feu et laissez dans le bouillon.</p>
+<p>3. &#201;mincez les oignons <strong>5 sec vit&#160; 5 </strong>et colorez-les l&#233;g&#232;rement dans une grande casserole avec 1 filet d'huile d'olive. Une fois cuits, ajoutez la farine et faites cuire 1min.</p>
+<p>4. Ajoutez le beurre puis d&#233;glacez au vin blanc. Ajoutez le bouillon et les l&#233;gumes, salez puis versez la cr&#232;me. Faites cuire &#224; petits fr&#233;missements environ 10 min jusqu'&#224; l'obtention d'une sauce nappante.</p>
+<p>5. Rincez rapidement le bol et mettez 800 g d&#8217;eau sal&#233;e, mettez le riz rinc&#233; dans le panier et <strong>programmez 18 min varoma vit 1 </strong></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Taillez la truite saumon&#233;e en cubes de 4 cm environ et plongez-les dans la blanquette chaude 5 min avant de d&#233;guster.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">7. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dressez dans des assiettes creuses la blanquette avec le riz sur le c&#244;t&#233;.</span></p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p><span class="OYPEnA text-decoration-none text-strikethrough-none">&#8220;Une r&#233;interpr&#233;tation d'un classique fran&#231;ais. La blanquette est une recette habituellement r&#233;alis&#233;e avec du veau, ici je vous propose une version au saumon. C'est un bon moyen de consommer moins de viande tout en d&#233;gustant un plat appr&#233;ci&#233; de tous et toutes. La blanquette est un plat en sauce complet, sain et r&#233;confortant que vous pouvez conserver plusieurs jours tr&#232;s facilement ! Le tout est de ne pas surcuire le saumon.&#8221; Thomas Chisholm.</span></p>
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>512</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 31.59%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">31.59</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 68.62%); left: 31.59%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">37.03</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 92.59%); left: 68.62%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">23.97</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 93.99%); left: 92.59%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">1.4</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 99.99%); left: 93.99%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">6</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>158.84</span> kcal/<span>665.24</span> kJ</td>
+                                                <td><span>512</span> kcal/<span>2144.3</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>9</span>g</td>
+                                                <td><span>29</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>4.65</span>g</td>
+                                                <td><span>15</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>10.55</span>g</td>
+                                                <td><span>34</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>2.79</span>g</td>
+                                                <td><span>9</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>6.83</span>g</td>
+                                                <td><span>22</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.4</span>g</td>
+                                                <td><span>1.3</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>1.71</span>g</td>
+                                                <td><span>5.5</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-c.png" alt="Image du nutriscore de la recette, catégorie C">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text ">
+                                                    <span>Légumes et fruits de saison</span>
+                                                    <span class="highlight"><span>14</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#377d45; right: calc(100% - 14%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Local et circuits courts</span>
+                                                    <span class="highlight"><span>26</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 26%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Produits français</span>
+                                                    <span class="highlight"><span>100</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 100%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>722</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                                    <section class="container container-recettes-associees">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recettes associées</h2>
+                        <ul>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3367-risotto-crevettes-poireaux-chorizo">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3367-1-fiche@6617B15F-risotto-crevettes-poireaux-chorizo.webp"
+                                         alt="Recette Risotto crevettes-poireaux-chorizo, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Risotto crevettes-poireaux-chorizo</figcaption>
+                                    </figure>
+                                    <span class="text">Risotto crevettes-poireaux-chorizo</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3277-crevettes-aux-epices-douces-tomates-cerises-nectarine-riz">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3277-1-fiche@6A635BEB-crevettes-aux-epices-douces-tomates-cerises-nectarine-riz.webp"
+                                         alt="Recette Crevettes aux épices douces tomates cerises-nectarine - riz, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Crevettes aux épices douces tomates cerises-nectarine - riz</figcaption>
+                                    </figure>
+                                    <span class="text">Crevettes aux épices douces tomates cerises-nectarine - riz</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3271-daurade-au-lait-de-coco-et-combawa-poelee-de-topinambours-pommes-de-terre-sg-">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3271-1-fiche@6A0F04C1-daurade-au-lait-de-coco-et-combawa-poelee-de-topinambours-pommes-de-terre-sg-.webp"
+                                         alt="Recette Daurade au lait de coco et combawa, poêlée de  topinambours-pommes de terre (SG), plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Daurade au lait de coco et combawa, poêlée de  topinambours-pommes de terre (SG)</figcaption>
+                                    </figure>
+                                    <span class="text">Daurade au lait de coco et combawa, poêlée de  topinambours-pommes de terre (SG)</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3193-filet-de-merlan-a-l-aigre-doux-riz-sg-">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3193-1-fiche@64E363CC-filet-de-merlan-a-l-aigre-doux-riz-sg-.webp"
+                                         alt="Recette Filet de merlan à l&#039;aigre doux, riz (SG), plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Filet de merlan à l&#039;aigre doux, riz (SG)</figcaption>
+                                    </figure>
+                                    <span class="text">Filet de merlan à l'aigre doux, riz (SG)</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3101-rougail-de-crevettes-riz">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3101-1-fiche@6929658C-rougail-de-crevettes-riz.webp"
+                                         alt="Recette Rougail de crevettes - riz, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Rougail de crevettes - riz</figcaption>
+                                    </figure>
+                                    <span class="text">Rougail de crevettes - riz</span>
+                                </a>
+                            </li>
+                                                </ul>
+                    </section>
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a7e35e66d8cf");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            if (!existsCookie('popin_landing')) {
+                    initPopinLanding(3);  //20 secondes
+                }
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_4.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_4.json
@@ -1,0 +1,70 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/3992-ble-pilaf-chou-fleur-abricots-secs-orange",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Blé pilaf chou fleur- abricots secs- orange",
+  "ingredients": [
+    "250g de blé BIO",
+    "1 chou-fleur BIO",
+    "80g d’abricots secs BIO",
+    "1 oignon BIO",
+    "quelques brins de menthe BIO",
+    "1 orange BIO",
+    "huile d’olive",
+    "sel",
+    "poivre",
+    "1 bouillon cube",
+    "1cs cde poudre de cumin."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "250g de blé BIO",
+        "1 chou-fleur BIO",
+        "80g d’abricots secs BIO",
+        "1 oignon BIO",
+        "quelques brins de menthe BIO",
+        "1 orange BIO"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "huile d’olive",
+        "sel",
+        "poivre",
+        "1 bouillon cube",
+        "1cs cde poudre de cumin."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions": "Faites bouillir 50cl d’eau avec un bouillon cube (base 4 pers).\nPelez et émincez l'oignon. Dans une sauteuse, faites chauffer un bon filet d’huile d’olive. Ajoutez l'oignon, le cumin et faites dorer 5 min à feu doux. Ajoutez le blé pour 5 min de plus.\nPendant ce temps, rincez et séparez les fleurettes du chou-fleur en tout petits morceaux. Coupez les abricots secs en morceaux. Ajoutez-les ainsi que le bouillon, salez, couvrez et laissez cuire 15 à 20 min environ jusqu’à ce que le tout soit cuit. Si nécessaire, ajoutez un peu d’eau en fin de cuisson.\nCoupez l’orange en deux et pressez le jus. Rincez, effeuillez et ciselez la menthe. Une fois le tout cuit, versez le jus d’orange et parsemez de menthe. Régalez-vous !",
+  "instructions_list": [
+    "Faites bouillir 50cl d’eau avec un bouillon cube (base 4 pers).",
+    "Pelez et émincez l'oignon. Dans une sauteuse, faites chauffer un bon filet d’huile d’olive. Ajoutez l'oignon, le cumin et faites dorer 5 min à feu doux. Ajoutez le blé pour 5 min de plus.",
+    "Pendant ce temps, rincez et séparez les fleurettes du chou-fleur en tout petits morceaux. Coupez les abricots secs en morceaux. Ajoutez-les ainsi que le bouillon, salez, couvrez et laissez cuire 15 à 20 min environ jusqu’à ce que le tout soit cuit. Si nécessaire, ajoutez un peu d’eau en fin de cuisson.",
+    "Coupez l’orange en deux et pressez le jus. Rincez, effeuillez et ciselez la menthe. Une fois le tout cuit, versez le jus d’orange et parsemez de menthe. Régalez-vous !"
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de blé pilaf chou fleur- abricots secs- orange, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du de Recettes & Cabas.",
+  "total_time": 35,
+  "cook_time": 20,
+  "prep_time": 15,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/3992-1-fiche@64E36726-ble-pilaf-chou-fleur-abricots-secs-orange.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_4.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_4.testhtml
@@ -1,0 +1,1404 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de blé pilaf chou fleur- abricots secs- orange</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de blé pilaf chou fleur- abricots secs- orange, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/3992-ble-pilaf-chou-fleur-abricots-secs-orange" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/3992-ble-pilaf-chou-fleur-abricots-secs-orange" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/3992-ble-pilaf-chou-fleur-abricots-secs-orange" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de blé pilaf chou fleur- abricots secs- orange"><meta property="og:description" content="Découvrez la recette de blé pilaf chou fleur- abricots secs- orange, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de blé pilaf chou fleur- abricots secs- orange"><meta property="twitter:description" content="Découvrez la recette de blé pilaf chou fleur- abricots secs- orange, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.51d4be57.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.51d4be57.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.51d4be57.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/3992-ble-pilaf-chou-fleur-abricots-secs-orange";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Blé pilaf chou fleur- abricots secs- orange",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/3992-1-fiche@64E36726-ble-pilaf-chou-fleur-abricots-secs-orange.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2023-02-17",
+      "description": "Découvrez la recette de blé pilaf chou fleur- abricots secs- orange, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du  de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT15M",      "cookTime": "PT20M",      "totalTime": "PT35M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": " calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"250g de blé BIO","1 chou-fleur BIO","80g d’abricots secs BIO","1 oignon BIO","quelques brins de menthe BIO","1 orange BIO"		],
+	  "recipeInstructions": [
+		        {
+			  "@type": "HowToStep",
+			  "text": "Faites bouillir 50cl d’eau avec un bouillon cube (base 4 pers)."
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Pelez et émincez l&#039;oignon. Dans une sauteuse, faites chauffer un bon filet d’huile d’olive. Ajoutez l&#039;oignon, le cumin et faites dorer 5 min à feu doux. Ajoutez le blé pour 5 min de plus."
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Pendant ce temps, rincez et séparez les fleurettes du chou-fleur en tout petits morceaux. Coupez les abricots secs en morceaux. Ajoutez-les ainsi que le bouillon, salez, couvrez et laissez cuire 15 à 20 min environ jusqu’à ce que le tout soit cuit. Si nécessaire, ajoutez un peu d’eau en fin de cuisson."
+			},                {
+			  "@type": "HowToStep",
+			  "text": "Coupez l’orange en deux et pressez le jus. Rincez, effeuillez et ciselez la menthe. Une fois le tout cuit, versez le jus d’orange et parsemez de menthe. Régalez-vous !"
+			}        	  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/3992-ble-pilaf-chou-fleur-abricots-secs-orange",
+                "name": "Blé Pilaf Chou Fleur- Abricots Secs- Orange"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Blé pilaf chou fleur- abricots secs- orange</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Blé pilaf chou fleur- abricots secs- orange</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/3992-1-fiche@64E36726-ble-pilaf-chou-fleur-abricots-secs-orange.webp" alt="Recette Blé pilaf chou fleur- abricots secs- orange">
+                                                                <figcaption>Succulente recette facile à préparer de Blé pilaf chou fleur- abricots secs- orange, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                        
+                        
+                                                    <div class="textcenter mb-4 hidden">
+                                <span class="icon icon-robot"></span>  Recette traduite pour les robots culinaires
+                            </div>
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p><span style="font-weight: 400</li>
+                                                                                    <li>">Blé BIO, chou-fleur BIO, abricots secs BIO, oignon BIO, menthe BIO, orange BIO</span></p>
+<p><em>Les recettes qui comportent le logo AB, sont fournies avec des ingrédients BIO. Les autres recettes sont fournies avec des ingrédients conventionnels sélectionnés de préférence en circuits-courts (fruits et légumes, viande, poisson) ou de fabrication française et parfois artisanale (produits frais et secs).</em></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="S1PPyQ">huile d’olive, sel, poivre, 1 bouillon cube, 1cs cde poudre de cumin.</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        15 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        20 minutes
+                                    </span>
+                                </div>
+                                                                                                            </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=8_3992">
+    <div class="concept-content bloc-concept-random">
+        <section id="concept" class="container-xl concept-item tpl-8 tpl-default">
+            <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
+            <div class="content">
+                <p class="concept-title">De bons repas faciles à cuisiner</p>
+                <span class="button center" id="button-cta-recette-8"> Recevez votre panier à cuisiner ! </span>
+            </div>
+        </section>
+    </div>
+</a>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p class="fig-paragraph" style="background: white; vertical-align: baseline; margin: 12.0pt 0cm 12.0pt 0cm;"><em><strong>Parce que chez R&amp;C on aime &#233;veiller votre curiosit&#233; aussi bien que vos papilles ! Une recette originale de notre cheffe L&#233;a, qui va s&#233;duire les v&#233;ggies en qu&#234;te de nouvelles associations et d&#8217;id&#233;es.&#160;</strong></em></p>
+                                            <p>1. Faites bouillir 50cl d&#8217;eau avec un bouillon cube (base 4 pers).</p>
+<p>2. Pelez et &#233;mincez l'oignon. Dans une sauteuse, faites chauffer un bon filet d&#8217;huile d&#8217;olive. Ajoutez l'oignon, le cumin et faites dorer 5 min &#224; feu doux. Ajoutez le bl&#233; pour 5 min de plus.</p>
+<p>3. Pendant ce temps, rincez et s&#233;parez les fleurettes du chou-fleur en tout petits morceaux. Coupez les abricots secs en morceaux. Ajoutez-les ainsi que le bouillon, salez, couvrez et laissez cuire 15 &#224; 20 min environ jusqu&#8217;&#224; ce que le tout soit cuit. Si n&#233;cessaire, ajoutez un peu d&#8217;eau en fin de cuisson.</p>
+<p>4. Coupez l&#8217;orange en deux et pressez le jus. Rincez, effeuillez et ciselez la menthe. Une fois le tout cuit, versez le jus d&#8217;orange et parsemez de menthe. R&#233;galez-vous !</p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p>1. Faites bouillir 50cl d&#8217;eau avec un bouillon cube (base 4 pers).</p>
+<p>2. <span style="font-weight: 400;">Pelez et coupez l'oignon en 2. D&#233;posez-le dans le bol m&#233;langeur et <strong>mixez 12 sec/vit 4</strong>. Ajoutez un filet d&#8217;huile d&#8217;olive et le cumin et poursuivez sans le gobelet doseur <strong>5 min/100&#176;C/sens inverse vit mijotage</strong>. Ajoutez le bl&#233; et poursuivez 5 min de plus.</span></p>
+<p>3. Pendant ce temps, rincez et s&#233;parez les fleurettes du chou-fleur en tout petits morceaux. Coupez les abricots secs en morceaux.<span style="font-weight: 400;">Ajoutez-les ainsi que le bouillon, salez, couvrez et continuez <strong>20 min/100&#176;C/sens inverse vit mijotage</strong>. Si n&#233;cessaire, ajoutez un peu d&#8217;eau en fin de cuisson</span>.</p>
+<p>4. Coupez l&#8217;orange en deux et pressez le jus. Rincez, effeuillez et ciselez la menthe. Une fois le tout cuit, versez le jus d&#8217;orange et parsemez de menthe. R&#233;galez-vous !</p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p><span class="S1PPyQ">Parce que chez R&amp;C on aime &#233;veiller votre curiosit&#233; aussi bien que vos papilles ! Une recette originale qui va s&#233;duire les v&#233;ggies en qu&#234;te de nouvelles associations et d&#8217;id&#233;es.</span><span class="S1PPyQ white-space-prewrap"> </span></p>
+                    </div>
+                </section>
+
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a9602f26f2ab");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_5.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_5.json
@@ -1,0 +1,72 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/2055-truite-saumonee-au-cumin-terrine-de-courgettes",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Truite saumonée au cumin, terrine de courgettes",
+  "ingredients": [
+    "500 g pavés de truite saumonée avec peau",
+    "2 courgettes",
+    "2 cs semoule fine",
+    "15 cl crème",
+    "30 g parmesan râpé",
+    "muscade ( optionnel )",
+    "Cumin en graines",
+    "Sel",
+    "Poivre",
+    "Oeufs (comptez 1 oeuf pour 2 pers)."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "500 g pavés de truite saumonée avec peau",
+        "2 courgettes",
+        "2 cs semoule fine",
+        "15 cl crème",
+        "30 g parmesan râpé"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "muscade ( optionnel )",
+        "Cumin en graines",
+        "Sel",
+        "Poivre",
+        "Oeufs (comptez 1 oeuf pour 2 pers)."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions": "Préchauffez le four à 180°.\nLavez les courgettes, coupez-les en petits dés tout en gardant la peau.\nDans une casserole, faites bouillir 30cl d’eau (base 4 pers). Ajoutez les courgettes et laissez bouillir 3min. Versez la semoule et laissez cuire encore 1 min. Egouttez dans une passoire assez fine.\nPendant ce temps, dans un grand bol culinaire, battez les œufs, la crème, le parmesan, le sel, le poivre et 1/2 cc de muscade (optionnel). Mélangez le tout.\nDans un moule antiadhésif (à défaut, huilez les moules), versez le mélange courgettes-semoule puis par-dessus la préparation œuf-crème. Faites cuire au four 20 min.\nDans un plat à gratin, disposez les pavés de truite, assaisonnez de sel et de graines de cumin. Ajoutez éventuellement un filet d’huile d’olive (même sans, la truite sera savoureuse et plus légère…).\nFaites cuire au four 15 min.en même temps que les terrines de courgettes.\nVeillez à servir la truite dès sa sortie du four, bien chaud. La terrine de courgettes peut quant à elle, se déguster chaude ou tiède.",
+  "instructions_list": [
+    "Préchauffez le four à 180°.",
+    "Lavez les courgettes, coupez-les en petits dés tout en gardant la peau.",
+    "Dans une casserole, faites bouillir 30cl d’eau (base 4 pers). Ajoutez les courgettes et laissez bouillir 3min. Versez la semoule et laissez cuire encore 1 min. Egouttez dans une passoire assez fine.",
+    "Pendant ce temps, dans un grand bol culinaire, battez les œufs, la crème, le parmesan, le sel, le poivre et 1/2 cc de muscade (optionnel). Mélangez le tout.",
+    "Dans un moule antiadhésif (à défaut, huilez les moules), versez le mélange courgettes-semoule puis par-dessus la préparation œuf-crème. Faites cuire au four 20 min.",
+    "Dans un plat à gratin, disposez les pavés de truite, assaisonnez de sel et de graines de cumin. Ajoutez éventuellement un filet d’huile d’olive (même sans, la truite sera savoureuse et plus légère…).",
+    "Faites cuire au four 15 min.en même temps que les terrines de courgettes.",
+    "Veillez à servir la truite dès sa sortie du four, bien chaud. La terrine de courgettes peut quant à elle, se déguster chaude ou tiède."
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de truite saumonée au cumin, terrine de courgettes, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes & Cabas.",
+  "total_time": 45,
+  "cook_time": 20,
+  "prep_time": 25,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "418 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/2055-1-fiche@6A8C46A9-truite-saumonee-au-cumin-terrine-de-courgettes.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_5.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_5.testhtml
@@ -1,0 +1,1624 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de truite saumonée au cumin, terrine de courgettes</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de truite saumonée au cumin, terrine de courgettes, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/2055-truite-saumonee-au-cumin-terrine-de-courgettes" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/2055-truite-saumonee-au-cumin-terrine-de-courgettes" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/2055-truite-saumonee-au-cumin-terrine-de-courgettes" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de truite saumonée au cumin, terrine de courgettes"><meta property="og:description" content="Découvrez la recette de truite saumonée au cumin, terrine de courgettes, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de truite saumonée au cumin, terrine de courgettes"><meta property="twitter:description" content="Découvrez la recette de truite saumonée au cumin, terrine de courgettes, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.51d4be57.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.51d4be57.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.51d4be57.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/2055-truite-saumonee-au-cumin-terrine-de-courgettes";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Truite saumonée au cumin, terrine de courgettes",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/2055-1-fiche@6A8C46A9-truite-saumonee-au-cumin-terrine-de-courgettes.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2020-07-21",
+      "description": "Découvrez la recette de truite saumonée au cumin, terrine de courgettes, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 31 août 2020 de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT25M",      "cookTime": "PT20M",      "totalTime": "PT45M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "418 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"500 g pavés de truite saumonée avec peau ; 2 courgettes ; 2 cs semoule fine ; 15 cl crème ; 30 g parmesan râpé"		],
+	  "recipeInstructions": [
+			  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/2055-truite-saumonee-au-cumin-terrine-de-courgettes",
+                "name": "Truite Saumonée Au Cumin, Terrine De Courgettes"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Truite saumonée au cumin, terrine de courgettes</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Truite saumonée au cumin, terrine de courgettes</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/2055-1-fiche@6A8C46A9-truite-saumonee-au-cumin-terrine-de-courgettes.webp" alt="Recette Truite saumonée au cumin, terrine de courgettes">
+                                                                <figcaption>Succulente recette facile à préparer de Truite saumonée au cumin, terrine de courgettes, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                                                    <div class="textcenter mb-4 hidden">
+                                Cette recette est l'une des recettes du cabas à cuisiner de la semaine du<span class="bold"> lundi 31 août 2020</span>.
+                            </div>
+                        
+                        
+                                                    <div class="textcenter mb-4 hidden">
+                                <span class="icon icon-robot"></span>  Recette traduite pour les robots culinaires
+                            </div>
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p><em>Pavés de truite saumonée</li>
+                                                                                    <li>Courgettes</li>
+                                                                                    <li>Semoule fine</li>
+                                                                                    <li>Parmesan râpé</li>
+                                                                                    <li>Crème</em></p>
+<p><b><em>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d'origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</em></b></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">muscade ( optionnel )</li>
+                                                                            <li>Cumin en graines</li>
+                                                                            <li>Sel</li>
+                                                                            <li>Poivre</li>
+                                                                            <li>Oeufs (comptez 1 oeuf pour 2 pers).</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        25 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        20 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=3_2055">
+    <div class="concept-content bloc-concept-random">
+        <section id="concept" class="container-xl concept-item tpl-3 tpl-default">
+            <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
+            <div class="content">
+                <p class="concept-title">Fini le gaspillage alimentaire !</p>
+                <span class="button center" id="button-cta-recette-3"> Recevez votre panier à cuisiner ! </span>
+            </div>
+        </section>
+    </div>
+</a>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p><strong><em>Une chaire fine et savoureuse, d&#233;couvrez la truite saumon&#233;e de notre fournisseur &#171; le fumet des Dombes &#187;. Relev&#233;e par le parfum subtil des graines de cumin, un vrai bonheur !</em></strong></p>
+<p><strong><em>Et un ingr&#233;dient myst&#232;re qui fera toute la diff&#233;rence pour r&#233;aliser avec succ&#232;s la terrine de courgettes qui se mangera ti&#232;de ou froide selon votre envie&#160;! &#160;</em></strong></p>
+                                            <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Pr&#233;chauffez le four &#224; 180&#176;.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Lavez les courgettes, coupez-les en petits d&#233;s tout en gardant la peau.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dans une casserole, faites bouillir 30cl d&#8217;eau (base 4 pers). Ajoutez les courgettes et laissez bouillir 3min. Versez la semoule et laissez cuire encore 1 min. Egouttez dans une passoire assez fine.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pendant ce temps, dans un grand bol culinaire, battez les &#339;ufs, la cr&#232;me, le parmesan, le sel, le poivre et 1/2 cc de muscade (optionnel). M&#233;langez le tout.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Dans un moule antiadh&#233;sif (&#224; d&#233;faut, huilez les moules), versez le m&#233;lange courgettes-semoule puis par-dessus la pr&#233;paration &#339;uf-cr&#232;me. Faites cuire au four 20 min.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dans un plat &#224; gratin, disposez les pav&#233;s de truite, assaisonnez de sel et de graines de cumin. Ajoutez &#233;ventuellement un filet d&#8217;huile d&#8217;olive (m&#234;me sans, la truite sera savoureuse et plus l&#233;g&#232;re&#8230;).</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Faites cuire au four 15 min.en m&#234;me temps que les terrines de courgettes.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Veillez &#224; servir la truite d&#232;s sa sortie du four, bien chaud. La terrine de courgettes peut quant &#224; elle, se d&#233;guster chaude ou ti&#232;de.</span></p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Pr&#233;chauffez le four &#224; 180&#176;.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Lavez les courgettes, coupez-les en petits d&#233;s tout en gardant la peau.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dans une casserole, faites bouillir 30cl d&#8217;eau (base 4 pers). Ajoutez les courgettes et laissez bouillir 3min. Versez la semoule et laissez cuire encore 1 min. Egouttez dans une passoire assez fine.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pendant ce temps, <strong>dans le bol tmx </strong>mettez les &#339;ufs, la cr&#232;me, le parmesan, le sel, le poivre et 1/2 cc de muscade (optionnel). <strong>M&#233;langez 5 sec vit 5.</strong></span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Dans un moule antiadh&#233;sif (&#224; d&#233;faut, huilez les moules), versez le m&#233;lange courgettes-semoule puis par-dessus la pr&#233;paration &#339;uf-cr&#232;me. Faites cuire au four 20 min.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Dans un plat &#224; gratin, disposez les pav&#233;s de truite, assaisonnez de sel et de graines de cumin. Ajoutez &#233;ventuellement un filet d&#8217;huile d&#8217;olive (m&#234;me sans, la truite sera savoureuse et plus l&#233;g&#232;re&#8230;).</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Faites cuire au four 15 min.en m&#234;me temps que les terrines de courgettes.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify para-style-body"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Veillez &#224; servir la truite d&#232;s sa sortie du four, bien chaud. La terrine de courgettes peut quant &#224; elle, se d&#233;guster chaude ou ti&#232;de.</span></p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p>Vous pouvez r&#233;partir la terrine dans 4 petits moules&#160;individuels souples &#233;galement. Dans ce cas, surveillez le temps de cuisson qui sera plus court !</p>
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>418</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 41.2%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">41.2</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 47.31%); left: 41.2%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">6.11</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 94.19%); left: 47.31%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">46.88</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 95.46%); left: 94.19%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">1.27</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100%); left: 95.46%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">4.54</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>136.05</span> kcal/<span>570.44</span> kJ</td>
+                                                <td><span>418</span> kcal/<span>1752.678</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>9.44</span>g</td>
+                                                <td><span>29</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>4.56</span>g</td>
+                                                <td><span>14</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>1.4</span>g</td>
+                                                <td><span>4.3</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>0.98</span>g</td>
+                                                <td><span>3</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>10.74</span>g</td>
+                                                <td><span>33</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.29</span>g</td>
+                                                <td><span>0.9</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>1.04</span>g</td>
+                                                <td><span>3.2</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-b.png" alt="Image du nutriscore de la recette, catégorie B">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text ">
+                                                    <span>Légumes et fruits de saison</span>
+                                                    <span class="highlight"><span>100</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#377d45; right: calc(100% - 100%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Local et circuits courts</span>
+                                                    <span class="highlight"><span>78</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 78%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Produits français</span>
+                                                    <span class="highlight"><span>97</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 97%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>913</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                                    <section class="container container-recettes-associees">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recettes associées</h2>
+                        <ul>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/4493-filets-de-daurade-grilles-lentilles-corail-aux-courgettes">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/4493-1-fiche@66470F31-filets-de-daurade-grilles-lentilles-corail-aux-courgettes.webp"
+                                         alt="Recette Filets de daurade grillés, lentilles corail aux courgettes, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Filets de daurade grillés, lentilles corail aux courgettes</figcaption>
+                                    </figure>
+                                    <span class="text">Filets de daurade grillés, lentilles corail aux courgettes</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/4074-poisson-a-la-mediterraneenne-puree-de-courgettes">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/4074-1-fiche@64E36784-poisson-a-la-mediterraneenne-puree-de-courgettes.webp"
+                                         alt="Recette Poisson à la méditérranéenne, purée de courgettes, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Poisson à la méditérranéenne, purée de courgettes</figcaption>
+                                    </figure>
+                                    <span class="text">Poisson à la méditérranéenne, purée de courgettes</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3646-tarte-courgettes-saumon-frais-basilic-carpaccio-de-tomates">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3646-1-fiche@64E36579-tarte-courgettes-saumon-frais-basilic-carpaccio-de-tomates.webp"
+                                         alt="Recette Tarte courgettes saumon frais basilic - Carpaccio de tomates, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Tarte courgettes saumon frais basilic - Carpaccio de tomates</figcaption>
+                                    </figure>
+                                    <span class="text">Tarte courgettes saumon frais basilic - Carpaccio de tomates</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3635-saumon-grille-sauce-vierge-terrine-de-courgettes">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3635-1-fiche@64E36571-saumon-grille-sauce-vierge-terrine-de-courgettes.webp"
+                                         alt="Recette Saumon grillé, sauce vierge, terrine de courgettes, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Saumon grillé, sauce vierge, terrine de courgettes</figcaption>
+                                    </figure>
+                                    <span class="text">Saumon grillé, sauce vierge, terrine de courgettes</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3477-colin-en-viennoise-courgettes-parfumees">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3477-1-fiche@64E364D2-colin-en-viennoise-courgettes-parfumees.webp"
+                                         alt="Recette Colin en viennoise, courgettes parfumées, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Colin en viennoise, courgettes parfumées</figcaption>
+                                    </figure>
+                                    <span class="text">Colin en viennoise, courgettes parfumées</span>
+                                </a>
+                            </li>
+                                                </ul>
+                    </section>
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a9604b63c1fc");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_6.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_6.json
@@ -1,0 +1,76 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Hamburgers au cheddar, bacon et salade",
+  "ingredients": [
+    "4 pains burger artisanaux",
+    "4 steaks hachés tradition bouchère (-15% M.G.)",
+    "origine Auvergne-Rhône-Alpes",
+    "4 tranches de cheddar",
+    "4 tranches de bacon",
+    "1 oignon ou échalote",
+    "Quelques feuilles de salade",
+    "4cs de mayonnaise (optionnel)",
+    "2cs de vin blanc (optionnel)",
+    "De quoi faire une vinaigrette",
+    "Sel",
+    "Poivre."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "4 pains burger artisanaux",
+        "4 steaks hachés tradition bouchère (-15% M.G.)",
+        "origine Auvergne-Rhône-Alpes",
+        "4 tranches de cheddar",
+        "4 tranches de bacon",
+        "1 oignon ou échalote",
+        "Quelques feuilles de salade"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "4cs de mayonnaise (optionnel)",
+        "2cs de vin blanc (optionnel)",
+        "De quoi faire une vinaigrette",
+        "Sel",
+        "Poivre."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions": "Épluchez l’oignon ou l’échalote, émincez-le finement et faites-le revenir dans une poêle avec un filet d’huile d’olive.\nQuand l’oignon est coloré, déglacez au vin blanc (optionnel) et laissez confire à feu doux.\nPréchauffez le four à 180°C.\nPréparez la salade et la vinaigrette.\nDans une grande poêle, faites dorer le bacon quelques minutes, réservez. Dans la même poêle faites cuire les steaks 2 à 4 min. d’un coté, salez et poivrez. Retournez-les et mettez une tranche de cheddar sur les steaks pour qu’elle fonde pendant la cuisson.\nPendant ce temps, ouvrez les pains burger et faites-les chauffer quelques minutes au four.\nPréparez les hamburgers en étalant 1cs de mayonnaise (optionnel) sur les moitiés de pain du dessous, ajoutez de la salade avec un filet d’huile d’olive, le steak haché avec le cheddar, le bacon, la compotée d’oignons, recouvrez.\nServez les burgers accompagnés de salade verte.",
+  "instructions_list": [
+    "Épluchez l’oignon ou l’échalote, émincez-le finement et faites-le revenir dans une poêle avec un filet d’huile d’olive.",
+    "Quand l’oignon est coloré, déglacez au vin blanc (optionnel) et laissez confire à feu doux.",
+    "Préchauffez le four à 180°C.",
+    "Préparez la salade et la vinaigrette.",
+    "Dans une grande poêle, faites dorer le bacon quelques minutes, réservez. Dans la même poêle faites cuire les steaks 2 à 4 min. d’un coté, salez et poivrez. Retournez-les et mettez une tranche de cheddar sur les steaks pour qu’elle fonde pendant la cuisson.",
+    "Pendant ce temps, ouvrez les pains burger et faites-les chauffer quelques minutes au four.",
+    "Préparez les hamburgers en étalant 1cs de mayonnaise (optionnel) sur les moitiés de pain du dessous, ajoutez de la salade avec un filet d’huile d’olive, le steak haché avec le cheddar, le bacon, la compotée d’oignons, recouvrez.",
+    "Servez les burgers accompagnés de salade verte."
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du de Recettes & Cabas.",
+  "total_time": 25,
+  "cook_time": 10,
+  "prep_time": 15,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "692 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/5834-1-fiche@6A902FD9-hamburgers-au-cheddar-bacon-et-salade.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_6.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_6.json
@@ -1,72 +1,74 @@
 {
   "author": "Recettes et Cabas",
-  "canonical_url": "https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/170-tartines-de-rillettes-de-saumon-salade-fraicheur",
   "site_name": "Recettes & Cabas",
   "host": "recettesetcabas.com",
   "language": "fr-FR",
-  "title": "Hamburgers au cheddar, bacon et salade",
+  "title": "Tartines de rillettes de saumon - Salade fraicheur",
   "ingredients": [
-    "4 pains burger artisanaux",
-    "4 steaks hachés tradition bouchère (-15% M.G.)",
-    "origine Auvergne-Rhône-Alpes",
-    "4 tranches de cheddar",
-    "4 tranches de bacon",
-    "1 oignon ou échalote",
-    "Quelques feuilles de salade",
-    "4cs de mayonnaise (optionnel)",
-    "2cs de vin blanc (optionnel)",
-    "De quoi faire une vinaigrette",
+    "300g de filets de saumon frais",
+    "150g de saumon fumé",
+    "1 pot de fromage blanc",
+    "1 citron jaune ou vert",
+    "quelques brins d’aneth",
+    "1 pain de campagne",
+    "1 salade verte",
+    "1 tomate.",
+    "Huile d’olive",
     "Sel",
-    "Poivre."
+    "Poivre",
+    "De quoi faire une vinaigrette",
+    "papier cuisson."
   ],
   "ingredient_groups": [
     {
       "ingredients": [
-        "4 pains burger artisanaux",
-        "4 steaks hachés tradition bouchère (-15% M.G.)",
-        "origine Auvergne-Rhône-Alpes",
-        "4 tranches de cheddar",
-        "4 tranches de bacon",
-        "1 oignon ou échalote",
-        "Quelques feuilles de salade"
+        "300g de filets de saumon frais",
+        "150g de saumon fumé",
+        "1 pot de fromage blanc",
+        "1 citron jaune ou vert",
+        "quelques brins d’aneth",
+        "1 pain de campagne",
+        "1 salade verte",
+        "1 tomate."
       ],
       "purpose": null
     },
     {
       "ingredients": [
-        "4cs de mayonnaise (optionnel)",
-        "2cs de vin blanc (optionnel)",
-        "De quoi faire une vinaigrette",
+        "Huile d’olive",
         "Sel",
-        "Poivre."
+        "Poivre",
+        "De quoi faire une vinaigrette",
+        "papier cuisson."
       ],
       "purpose": "Ingrédients du placard"
     }
   ],
-  "instructions": "Épluchez l’oignon ou l’échalote, émincez-le finement et faites-le revenir dans une poêle avec un filet d’huile d’olive.\nQuand l’oignon est coloré, déglacez au vin blanc (optionnel) et laissez confire à feu doux.\nPréchauffez le four à 180°C.\nPréparez la salade et la vinaigrette.\nDans une grande poêle, faites dorer le bacon quelques minutes, réservez. Dans la même poêle faites cuire les steaks 2 à 4 min. d’un coté, salez et poivrez. Retournez-les et mettez une tranche de cheddar sur les steaks pour qu’elle fonde pendant la cuisson.\nPendant ce temps, ouvrez les pains burger et faites-les chauffer quelques minutes au four.\nPréparez les hamburgers en étalant 1cs de mayonnaise (optionnel) sur les moitiés de pain du dessous, ajoutez de la salade avec un filet d’huile d’olive, le steak haché avec le cheddar, le bacon, la compotée d’oignons, recouvrez.\nServez les burgers accompagnés de salade verte.",
+  "instructions": "Préchauffez le four à 200°.\nMettez le saumon frais à cuire au four 10 min. dans un plat adapté ou sur du papier cuisson (sans le saler).\nHachez finement le saumon fumé (ou coupez-le au couteau en tout petits morceaux).\nDans un saladier, mélangez le saumon fumé, le saumon frais cuit émietté, le fromage blanc, le jus d’un demi citron, quelques brins d’aneth ciselé, un filet d’huile d’olive, et le poivre. Goûtez et rectifiez éventuellement l’assaisonnement.\nLavez et préparez la salade et la vinaigrette.\nCoupez la tomate en morceaux et ajoutez-les à la salade, mélangez avec la vinaigrette.\nTranchez le pain et faites-le griller.\nDégustez les rillettes sur le pain grillé avec la salade.",
   "instructions_list": [
-    "Épluchez l’oignon ou l’échalote, émincez-le finement et faites-le revenir dans une poêle avec un filet d’huile d’olive.",
-    "Quand l’oignon est coloré, déglacez au vin blanc (optionnel) et laissez confire à feu doux.",
-    "Préchauffez le four à 180°C.",
-    "Préparez la salade et la vinaigrette.",
-    "Dans une grande poêle, faites dorer le bacon quelques minutes, réservez. Dans la même poêle faites cuire les steaks 2 à 4 min. d’un coté, salez et poivrez. Retournez-les et mettez une tranche de cheddar sur les steaks pour qu’elle fonde pendant la cuisson.",
-    "Pendant ce temps, ouvrez les pains burger et faites-les chauffer quelques minutes au four.",
-    "Préparez les hamburgers en étalant 1cs de mayonnaise (optionnel) sur les moitiés de pain du dessous, ajoutez de la salade avec un filet d’huile d’olive, le steak haché avec le cheddar, le bacon, la compotée d’oignons, recouvrez.",
-    "Servez les burgers accompagnés de salade verte."
+    "Préchauffez le four à 200°.",
+    "Mettez le saumon frais à cuire au four 10 min. dans un plat adapté ou sur du papier cuisson (sans le saler).",
+    "Hachez finement le saumon fumé (ou coupez-le au couteau en tout petits morceaux).",
+    "Dans un saladier, mélangez le saumon fumé, le saumon frais cuit émietté, le fromage blanc, le jus d’un demi citron, quelques brins d’aneth ciselé, un filet d’huile d’olive, et le poivre. Goûtez et rectifiez éventuellement l’assaisonnement.",
+    "Lavez et préparez la salade et la vinaigrette.",
+    "Coupez la tomate en morceaux et ajoutez-les à la salade, mélangez avec la vinaigrette.",
+    "Tranchez le pain et faites-le griller.",
+    "Dégustez les rillettes sur le pain grillé avec la salade."
   ],
   "category": "Plat",
   "yields": "4 servings",
-  "description": "Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du de Recettes & Cabas.",
-  "total_time": 25,
+  "description": "Découvrez la recette de tartines de rillettes de saumon - salade fraicheur, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 27 juin 2022 de Recettes & Cabas.",
+  "total_time": 30,
   "cook_time": 10,
-  "prep_time": 15,
+  "prep_time": 20,
   "cuisine": "Française",
   "ratings": 5.0,
   "ratings_count": 5,
   "nutrients": {
-    "calories": "692 calories"
+    "calories": "397 calories"
   },
-  "image": "https://www.recettesetcabas.com/data/recettes/5834-1-fiche@6A902FD9-hamburgers-au-cheddar-bacon-et-salade.webp",
+  "image": "https://www.recettesetcabas.com/data/recettes/170-1-fiche@6A5DE802-tartines-de-rillettes-de-saumon-salade-fraicheur.webp",
   "keywords": [
     "authentique",
     "facile",

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_6.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_6.testhtml
@@ -6,8 +6,8 @@
 <head>
     
 <meta charset="UTF-8">
-<title>Recette de hamburgers au cheddar, bacon et salade</title>
-<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas.">
+<title>Recette de tartines de rillettes de saumon - salade fraicheur</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de tartines de rillettes de saumon - salade fraicheur, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 27 juin 2022 de Recettes &amp; Cabas.">
 <meta name="keywords" content="">
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -15,12 +15,12 @@
 <meta name="identifier-url" content="https://www.recettesetcabas.com/" />
 <meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
 
-            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade" />
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/170-tartines-de-rillettes-de-saumon-salade-fraicheur" />
     
-            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade" />
-        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade" />
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/170-tartines-de-rillettes-de-saumon-salade-fraicheur" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/170-tartines-de-rillettes-de-saumon-salade-fraicheur" />
     
-<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de hamburgers au cheddar, bacon et salade"><meta property="og:description" content="Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de hamburgers au cheddar, bacon et salade"><meta property="twitter:description" content="Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de tartines de rillettes de saumon - salade fraicheur"><meta property="og:description" content="Découvrez la recette de tartines de rillettes de saumon - salade fraicheur, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 27 juin 2022 de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de tartines de rillettes de saumon - salade fraicheur"><meta property="twitter:description" content="Découvrez la recette de tartines de rillettes de saumon - salade fraicheur, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du lundi 27 juin 2022 de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -51,7 +51,7 @@
     var robot = "";
     var robot_titre = "";
     var page_name = "Recettes";
-    var page_path = "/recettes/5834-hamburgers-au-cheddar-bacon-et-salade";
+    var page_path = "/recettes/170-tartines-de-rillettes-de-saumon-salade-fraicheur";
             var clarity_id = "nbw1j162j3";
     </script>
 
@@ -128,18 +128,18 @@
     {
       "@context": "https://schema.org/",
       "@type": "Recipe",
-      "name": "Hamburgers au cheddar, bacon et salade",
+      "name": "Tartines de rillettes de saumon - Salade fraicheur",
       "image": [
-		"https://www.recettesetcabas.com/data/recettes/5834-1-fiche@6A902FD9-hamburgers-au-cheddar-bacon-et-salade.webp"
+		"https://www.recettesetcabas.com/data/recettes/170-1-fiche@6A5DE802-tartines-de-rillettes-de-saumon-salade-fraicheur.webp"
       ],
       "author": {
         "@type": "Organization",
         "name": "Recettes et Cabas"
       },
-      "datePublished": "2026-07-28",
-      "description": "Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du  de Recettes & Cabas.",
+      "datePublished": "2018-07-05",
+      "description": "Découvrez la recette de tartines de rillettes de saumon - salade fraicheur, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du lundi 27 juin 2022 de Recettes & Cabas.",
       "recipeCuisine": "Française",
-      "prepTime": "PT15M",      "cookTime": "PT10M",      "totalTime": "PT25M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "prepTime": "PT20M",      "cookTime": "PT10M",      "totalTime": "PT30M",	  "keywords": "authentique, facile, équilibrée, Plat",
       "recipeYield": [
 		  "4",
 		  "portion"
@@ -147,7 +147,7 @@
       "recipeCategory": "Plat",
       "nutrition": {
         "@type": "NutritionInformation",
-        "calories": "692 calories"
+        "calories": "397 calories"
       },
       "aggregateRating": {
         "@type": "AggregateRating",
@@ -155,9 +155,12 @@
         "ratingCount": "5"
       },
 		"recipeIngredient": [
-			"4 pains burger artisanaux ; 4 steaks hachés tradition bouchère (-15% M.G.)","origine Auvergne-Rhône-Alpes ; 4 tranches de cheddar ; 4 tranches de bacon ; 1 oignon ou échalote ; Quelques feuilles de salade"		],
+			"300g de filets de saumon frais ; 150g de saumon fumé ; 1 pot de fromage blanc ; 1 citron jaune ou vert ; quelques brins d’aneth ; 1 pain de campagne ; 1 salade verte ; 1 tomate."		],
 	  "recipeInstructions": [
-			  ]
+		        {
+			  "@type": "HowToStep",
+			  "text": " Préchauffez le four à 200°. Mettez le saumon frais à cuire au four 10 min. dans un plat adapté ou sur du papier cuisson (sans le saler). Hachez finement le saumon fumé (ou coupez-le au couteau en tout petits morceaux). Dans un saladier, mélangez le saumon fumé, le saumon frais cuit émietté, le fromage blanc, le jus d’un demi citron, quelques brins d’aneth ciselé, un filet d’huile d’olive, et le poivre. Goûtez et rectifiez éventuellement l’assaisonnement. Lavez et préparez la salade et la vinaigrette. Coupez la tomate en morceaux et ajoutez-les à la salade, mélangez avec la vinaigrette. Tranchez le pain et faites-le griller. Dégustez les rillettes sur le pain grillé avec la salade."
+			}        	  ]
     }
     </script>
 
@@ -435,8 +438,8 @@
             "position": 3,
             "item":
             {
-                "@id": "https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade",
-                "name": "Hamburgers Au Cheddar, Bacon Et Salade"
+                "@id": "https://www.recettesetcabas.com/recettes/170-tartines-de-rillettes-de-saumon-salade-fraicheur",
+                "name": "Tartines De Rillettes De Saumon - Salade Fraicheur"
             }
         }
                     ]
@@ -445,14 +448,14 @@
 
 <nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
     <div class="container">
-        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Hamburgers au cheddar, bacon et salade</span></span></span>    </div>
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Tartines de rillettes de saumon - Salade fraicheur</span></span></span>    </div>
 </nav>
 
                 <h1 class="h1 title">
                                         <span class="h3 fontsize40">
                         <span class="txt hidden"><p>Recette</p></span>
                     </span><br>
-                <span>Hamburgers au cheddar, bacon et salade</span>
+                <span>Tartines de rillettes de saumon - Salade fraicheur</span>
             </h1>
         </div>
 
@@ -461,12 +464,18 @@
                     <div class="bloc-img">
                         <div class="img_recette_detail">
                             <figure>
-                                                                    <img src="https://www.recettesetcabas.com/data/recettes/5834-1-fiche@6A902FD9-hamburgers-au-cheddar-bacon-et-salade.webp" alt="Recette Hamburgers au cheddar, bacon et salade">
-                                                                <figcaption>Succulente recette facile à préparer de Hamburgers au cheddar, bacon et salade, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/170-1-fiche@6A5DE802-tartines-de-rillettes-de-saumon-salade-fraicheur.webp" alt="Recette Tartines de rillettes de saumon - Salade fraicheur">
+                                                                <figcaption>Succulente recette facile à préparer de Tartines de rillettes de saumon - Salade fraicheur, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
                             </figure>
                         </div>
+                                                    <div class="textcenter mb-4 hidden">
+                                Cette recette est l'une des recettes du cabas à cuisiner de la semaine du<span class="bold"> lundi 27 juin 2022</span>.
+                            </div>
                         
                         
+                                                    <div class="textcenter mb-4 hidden">
+                                <span class="icon icon-robot"></span>  Recette traduite pour les robots culinaires
+                            </div>
                                             </div>
 
                     <div class="bloc-desc green_block mb-5 two_blocks">
@@ -476,13 +485,14 @@
                                     <h2 class="h3 d-inline-flex">Ingrédients :</h2>
                                 </div>
                                 <ul>
-                                                                                                                       <li><p>Pains burger artisanaux, Boulanger-Pâtissier Maison Bettant (69) <span class="fontstyle0"></li>
-                                                                                    <li>Steaks hachés tradition bouchère (-15% M.G.), origine Auvergne-Rhône-Alpes</li>
-                                                                                    <li>Cheddar</li>
-                                                                                    <li>Bacon</li>
-                                                                                    <li>Oignon ou échalote</li>
-                                                                                    <li>Feuilles de salade </span></p>
-<p><b><em>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d'origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</em></b></p></li>
+                                                                                                                       <li><p>Filets de saumon frais</li>
+                                                                                    <li>Saumon fumé</li>
+                                                                                    <li>Fromage blanc</li>
+                                                                                    <li>Citron</li>
+                                                                                    <li>Brins d'aneth</li>
+                                                                                    <li>Pain de campagne</li>
+                                                                                    <li>Salade verte</li>
+                                                                                    <li>Tomate.<em><br /><br /><strong>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d'origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</strong><br /></em></p></li>
                                                                                                             </ul>
                                                     </div>
 
@@ -492,11 +502,11 @@
                                     <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
                                 </div>
                                 <ul>
-                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4cs de mayonnaise (optionnel)</li>
-                                                                            <li>2cs de vin blanc (optionnel)</li>
-                                                                            <li>De quoi faire une vinaigrette</li>
+                                                                            <li><p>Huile d’olive</li>
                                                                             <li>Sel</li>
-                                                                            <li>Poivre.</span></p></li>
+                                                                            <li>Poivre</li>
+                                                                            <li>De quoi faire une vinaigrette</li>
+                                                                            <li><span class="JsGRdQ">papier cuisson.</span></p></li>
                                                                     </ul>
                             </div>
                                                 <div class="col-header col-notations">
@@ -504,7 +514,7 @@
                                     <span class="icon icon-bowl"></span>
                                     <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
                                     <span class="notations_values">
-                                        15 minutes
+                                        20 minutes
                                     </span>
                                 </div>
                                                                                         <div>
@@ -522,7 +532,7 @@
                                                                                                                                                                                 <span class="icon icon-active-star"></span>
                                                                                                                                                                                 <span class="icon icon-active-star"></span>
                                                                                                                                                                                 <span class="icon icon-active-star"></span>
-                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star grey-icon"></span>
                                                                                                                         </span>
                                 </div>
                                                                                         <div>
@@ -533,7 +543,7 @@
                                                                                                                                                                                 <span class="icon icon-flame"></span>
                                                                                                                                                                                 <span class="icon icon-flame"></span>
                                                                                                                                                                                 <span class="icon icon-flame"></span>
-                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame grey-icon"></span>
                                                                                                                         </span>
                                 </div>
                                                     </div>
@@ -542,7 +552,7 @@
             </div>
 
                         
-                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=4_5834">
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=4_170">
     <div class="concept-content bloc-concept-random">
         <section id="concept" class="container-xl concept-item tpl-4 tpl-default">
             <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
@@ -558,15 +568,8 @@
                 <section class="mb-5 container">
                     <span class="icon icon-book"></span>
                     <h2 class="h3 d-inline-flex">La recette</h2>
-                    <p><em><strong>Attention Best of en vue ! Un incontournable de R&amp;C pour vous faire oublier un peu la rentr&#233;e: De la gourmandise avec le Cheddar, du go&#251;t avec le bacon, un pain burger artisanal de notre boulanger et une viande de b&#339;uf premium ! Il n&#8217;en faut pas plus pour atteindre les sommets ! Les gourmets vont se r&#233;galer !</strong></em></p>
-                                            <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">&#201;pluchez l&#8217;oignon ou l&#8217;&#233;chalote, &#233;mincez-le finement et faites-le revenir dans une po&#234;le avec un filet d&#8217;huile d&#8217;olive.</span></p>
-<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Quand l&#8217;oignon est color&#233;, d&#233;glacez au vin blanc (optionnel) et laissez confire &#224; feu doux.</span></p>
-<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pr&#233;chauffez le four &#224; 180&#176;C.</span></p>
-<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pr&#233;parez la salade et la vinaigrette.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span></p>
-<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Dans une grande po&#234;le, faites dorer le bacon quelques minutes, r&#233;servez. Dans la m&#234;me po&#234;le faites cuire les steaks 2 &#224; 4 min. d&#8217;un cot&#233;, salez et poivrez. Retournez-les et mettez une tranche de cheddar sur les steaks pour qu&#8217;elle fonde pendant la cuisson.</span></p>
-<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pendant ce temps, ouvrez les pains burger et faites-les chauffer quelques minutes au four.</span></p>
-<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">7.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pr&#233;parez les hamburgers en &#233;talant 1cs de mayonnaise (optionnel) sur les moiti&#233;s de pain du dessous, ajoutez de la salade avec un filet d&#8217;huile d&#8217;olive, le steak hach&#233; avec le cheddar, le bacon, la compot&#233;e d&#8217;oignons, recouvrez.</span></p>
-<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">8.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Servez les burgers accompagn&#233;s de salade verte.</span></p>
+                    <p><em>La recette classique des rillettes de saumon comporte du beurre, voici une version plus l&#233;g&#232;re mais cependant d&#233;licieuse car pr&#233;par&#233;e avec des produits de premier choix ! Vous appr&#233;cierez notamment le fameux saumon fum&#233; artisanalement par notre poissonnier. Une belle promesse de fraicheur et de g&#233;n&#233;rosit&#233; !</em></p>
+                                            <p>&#160;Pr&#233;chauffez le four &#224; 200&#176;.<br /><br />1. Mettez le saumon frais &#224; cuire au four 10 min. dans un plat adapt&#233; ou sur du papier cuisson (sans le saler).<br /><br />2. Hachez finement le saumon fum&#233; (ou coupez-le au couteau en tout petits morceaux).<br /><br />3. Dans un saladier, m&#233;langez le saumon fum&#233;, le saumon frais cuit &#233;miett&#233;, le fromage blanc, le jus d&#8217;un demi citron, quelques brins d&#8217;aneth cisel&#233;, un filet d&#8217;huile d&#8217;olive, et le poivre. Go&#251;tez et rectifiez &#233;ventuellement l&#8217;assaisonnement.<br /><br />4. Lavez et pr&#233;parez la salade et la vinaigrette.<br /><br />5. Coupez la tomate en morceaux et ajoutez-les &#224; la salade, m&#233;langez avec la vinaigrette.<br /><br />6. Tranchez le pain et faites-le griller.<br /><br />7. D&#233;gustez les rillettes sur le pain grill&#233; avec la salade.</p>
                     
                     <div class="text-center mt-5 mb-5">
                         <!-- id="button-cta-recette-3" -->
@@ -585,7 +588,14 @@
                     <div class="tab-content" id="nav-tabContent">
                         <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
                             <div style="margin:20px 0;">
-                                                                    <p><em><strong>Recette non traduite, voir version traditionnelle</strong></em></p>
+                                                                    <p>1. Pr&#233;chauffez le four &#224; 200&#176;. Mettez le saumon frais &#224; cuire au four 10 min. dans un plat adapt&#233; ou sur du papier cuisson (sans le saler).</p>
+<p>2.<strong> Programmez le thermomix vitesse 8 </strong>et jetez l&#8217;aneth par le trou du couvercle.</p>
+<p>3. Ajoutez le saumon fum&#233;, le saumon frais cuit, le fromage blanc, le jus d&#8217;un demi citron, un filet d&#8217;huile d&#8217;olive, le poivre et programmez <strong>10 sec vitesse 5.</strong> <span class="JsGRdQ">&#160;Go&#251;tez et rectifiez &#233;ventuellement l&#8217;assaisonnement.</span></p>
+<p>4. Lavez et pr&#233;parez la salade et la vinaigrette.&#160;</p>
+<p>5. Coupez la tomate en morceaux et ajoutez-les &#224; la salade, m&#233;langez avec la vinaigrette.&#160;</p>
+<p>6. Tranchez le pain et faites-le griller.</p>
+<p>7. D&#233;gustez les rillettes sur le pain grill&#233; avec la salade.</p>
+<p></p>
                                                             </div>
                         </div>
                     </div>
@@ -595,7 +605,7 @@
                             <span class="icon icon-salt"></span>
                             <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
                         </div>
-                        <p><span class="OYPEnA text-decoration-none text-strikethrough-none">Une version plus gourmande pour cet hamburger de rentr&#233;e toujours avec les pains de fabrication artisanale de chez notre p&#226;tissier encore meilleurs toast&#233;s. N&#8217;h&#233;sitez pas &#224; ajouter d&#8217;autres ingr&#233;dients de votre frigo : avocats&#8230; et laissez chacun composer son propre burger !</span></p>
+                        <p>La recette classique des rillettes de saumon comporte du beurre, voici une version plus healthy mais cependant d&#233;licieuse car pr&#233;par&#233;e avec des produits de premier choix ! Vous appr&#233;cierez notamment le fameux saumon fum&#233; artisanalement par notre poissonnier.</p>
                     </div>
                 </section>
 
@@ -609,22 +619,22 @@
                             <div class="nutrition_content">
                                 <div class="row">
                                     <div class="infos-nutri col-12 col-md-8">
-                                        <div class="h6">Calories : <span>692</span> kcal</div>
+                                        <div class="h6">Calories : <span>397</span> kcal</div>
                                                                                     <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
-                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 23.45%);">
-                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">23.45</span>%</span></span>
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 21.32%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">21.32</span>%</span></span>
                                                     </div>
-                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 60.96%); left: 23.45%;">
-                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">37.51</span>%</span></span>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 56.59%); left: 21.32%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">35.27</span>%</span></span>
                                                     </div>
-                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 93.19%); left: 60.96%;">
-                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">32.23</span>%</span></span>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 91.71%); left: 56.59%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">35.12</span>%</span></span>
                                                     </div>
-                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 95.45%); left: 93.19%;">
-                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">2.26</span>%</span></span>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 94.98%); left: 91.71%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">3.27</span>%</span></span>
                                                     </div>
-                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100%); left: 95.45%;">
-                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">4.55</span>%</span></span>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100%); left: 94.98%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">5.02</span>%</span></span>
                                                     </div>
                                                                                             </div>
                                                                                 <div class="sep-horizontal"></div>
@@ -639,43 +649,43 @@
                                             <tbody>
                                             <tr>
                                                 <td class="highlight">Énergie</td>
-                                                <td><span>201.48</span> kcal/<span>843.74</span> kJ</td>
-                                                <td><span>692</span> kcal/<span>2897.838</span> kJ</td>
+                                                <td><span>133.9</span> kcal/<span>561.49</span> kJ</td>
+                                                <td><span>397</span> kcal/<span>1664.814</span> kJ</td>
                                             </tr>
                                             <tr>
                                                 <td class="highlight">Lipides</td>
-                                                <td><span>9.32</span>g</td>
-                                                <td><span>32</span>g</td>
+                                                <td><span>5.73</span>g</td>
+                                                <td><span>17</span>g</td>
                                             </tr>
                                             <tr>
                                                 <td class="highlight">Dont acides gras saturés</td>
-                                                <td><span>2.91</span>g</td>
-                                                <td><span>10</span>g</td>
+                                                <td><span>1.01</span>g</td>
+                                                <td><span>3</span>g</td>
                                             </tr>
                                             <tr>
                                                 <td class="highlight">Glucides</td>
-                                                <td><span>14.91</span>g</td>
-                                                <td><span>51.2</span>g</td>
+                                                <td><span>9.48</span>g</td>
+                                                <td><span>28.1</span>g</td>
                                             </tr>
                                             <tr>
                                                 <td class="highlight">Dont sucres</td>
-                                                <td><span>2.04</span>g</td>
-                                                <td><span>7</span>g</td>
+                                                <td><span>1.01</span>g</td>
+                                                <td><span>3</span>g</td>
                                             </tr>
                                             <tr>
                                                 <td class="highlight">Protéines</td>
-                                                <td><span>12.81</span>g</td>
-                                                <td><span>44</span>g</td>
+                                                <td><span>9.44</span>g</td>
+                                                <td><span>28</span>g</td>
                                             </tr>
                                             <tr>
                                                 <td class="highlight">Sel</td>
-                                                <td><span>0.9</span>g</td>
-                                                <td><span>3.1</span>g</td>
+                                                <td><span>0.88</span>g</td>
+                                                <td><span>2.6</span>g</td>
                                             </tr>
                                             <tr>
                                                 <td class="highlight">Fibres</td>
-                                                <td><span>1.81</span>g</td>
-                                                <td><span>6.2</span>g</td>
+                                                <td><span>1.35</span>g</td>
+                                                <td><span>4</span>g</td>
                                             </tr>
                                             </tbody>
                                         </table>
@@ -683,7 +693,7 @@
                                     <div class="infos-origines col-12 col-md-4">
                                         <div class="img_container_origines">
                                             <div class="nutriscore-libelle">NUTRI-SCORE : </div>
-                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-c.png" alt="Image du nutriscore de la recette, catégorie C">
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-b.png" alt="Image du nutriscore de la recette, catégorie B">
                                         </div>
                                         <h3 class="h5">Origines</h3>
                                                                                     <div class="origines-container">
@@ -698,25 +708,25 @@
                                                                                                                             <div class="origines-container">
                                                 <div class="origines-container-text">
                                                     <span>Local et circuits courts</span>
-                                                    <span class="highlight"><span>85</span>%</span>
+                                                    <span class="highlight"><span>48</span>%</span>
                                                 </div>
                                                 <div class="progress-bar-origines-container">
-                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 85%)"></div>
+                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 48%)"></div>
                                                 </div>
                                             </div>
                                                                                                                             <div class="origines-container">
                                                 <div class="origines-container-text">
                                                     <span>Produits français</span>
-                                                    <span class="highlight"><span>97</span>%</span>
+                                                    <span class="highlight"><span>50</span>%</span>
                                                 </div>
                                                 <div class="progress-bar-origines-container">
-                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 97%)"></div>
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 50%)"></div>
                                                 </div>
                                             </div>
                                                                                                                                                                     <div class="origines-container">
                                                 <div class="origines-container-text">
                                                     <span>Empreinte CO2</span>
-                                                    <span class="highlight"><span>5004</span>g</span>
+                                                    <span class="highlight"><span>996</span>g</span>
                                                 </div>
                                             </div>
                                                                                 <div class="sep-horizontal"></div>
@@ -765,33 +775,53 @@
                         <h2 class="h3 d-inline-flex">Recettes associées</h2>
                         <ul>
                                                     <li>
-                                <a href="https://www.recettesetcabas.com/recettes/3107-steak-hache-de-veau-a-la-duxelle-de-champignons-poelee-de-legumes-anciens-sg-">
+                                <a href="https://www.recettesetcabas.com/recettes/4647-sandwich-club-au-saumon-fume-frites-de-patates-douces">
                                     <figure>
-                                        <img src="https://www.recettesetcabas.com/data/recettes/3107-1-fiche@64E36375-steak-hache-de-veau-a-la-duxelle-de-champignons-poelee-de-legumes-anciens-sg-.webp"
-                                         alt="Recette Steak haché de veau à la duxelle de champignons, poêlée de légumes anciens (SG), plaisir de cuisiner au quotidien." />
-                                        <figcaption>Recette Steak haché de veau à la duxelle de champignons, poêlée de légumes anciens (SG)</figcaption>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/4647-1-fiche@67FE560C-sandwich-club-au-saumon-fume-frites-de-patates-douces.webp"
+                                         alt="Recette Sandwich club au saumon fumé - Frites de patates douces, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Sandwich club au saumon fumé - Frites de patates douces</figcaption>
                                     </figure>
-                                    <span class="text">Steak haché de veau à la duxelle de champignons, poêlée de légumes anciens (SG)</span>
+                                    <span class="text">Sandwich club au saumon fumé - Frites de patates douces</span>
                                 </a>
                             </li>
                                                     <li>
-                                <a href="https://www.recettesetcabas.com/recettes/2379-hamburger-a-la-tomme-de-savoie-bacon-et-salade">
+                                <a href="https://www.recettesetcabas.com/recettes/4559-saumon-fumee-et-pommes-de-terre-grenailles-sauce-fromage-blanc-citron-aneth">
                                     <figure>
-                                        <img src="https://www.recettesetcabas.com/data/recettes/2379-1-fiche@67C71C9C-hamburger-a-la-tomme-de-savoie-bacon-et-salade.webp"
-                                         alt="Recette Hamburger à la tomme de Savoie, bacon et salade, plaisir de cuisiner au quotidien." />
-                                        <figcaption>Recette Hamburger à la tomme de Savoie, bacon et salade</figcaption>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/4559-1-fiche@668BAF1A-saumon-fumee-et-pommes-de-terre-grenailles-sauce-fromage-blanc-citron-aneth.webp"
+                                         alt="Recette Saumon fumée et pommes de terre grenailles, sauce fromage blanc citron-aneth, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Saumon fumée et pommes de terre grenailles, sauce fromage blanc citron-aneth</figcaption>
                                     </figure>
-                                    <span class="text">Hamburger à la tomme de Savoie, bacon et salade</span>
+                                    <span class="text">Saumon fumée et pommes de terre grenailles, sauce fromage blanc citron-aneth</span>
                                 </a>
                             </li>
                                                     <li>
-                                <a href="https://www.recettesetcabas.com/recettes/621-hamburger-maison-comte-bacon-salade">
+                                <a href="https://www.recettesetcabas.com/recettes/4452-blinis-nordiques-au-saumon-fume-salade">
                                     <figure>
-                                        <img src="https://www.recettesetcabas.com/data/recettes/621-1-fiche@68B02A69-hamburger-maison-comte-bacon-salade.webp"
-                                         alt="Recette Hamburger maison comté-bacon, salade, plaisir de cuisiner au quotidien." />
-                                        <figcaption>Recette Hamburger maison comté-bacon, salade</figcaption>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/4452-1-fiche@6613C88A-blinis-nordiques-au-saumon-fume-salade.webp"
+                                         alt="Recette Blinis nordiques au saumon fumé, salade, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Blinis nordiques au saumon fumé, salade</figcaption>
                                     </figure>
-                                    <span class="text">Hamburger maison comté-bacon, salade</span>
+                                    <span class="text">Blinis nordiques au saumon fumé, salade</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3594-blinis-nordiques-au-saumon-fume-avocats">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3594-1-fiche@64E36539-blinis-nordiques-au-saumon-fume-avocats.webp"
+                                         alt="Recette Blinis nordiques au saumon fumé, avocats, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Blinis nordiques au saumon fumé, avocats</figcaption>
+                                    </figure>
+                                    <span class="text">Blinis nordiques au saumon fumé, avocats</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3267-crepes-bretonnes-au-saumon-fume-fromage-blanc-tomates-cerises-et-roquette-sg-">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3267-1-fiche@64E36409-crepes-bretonnes-au-saumon-fume-fromage-blanc-tomates-cerises-et-roquette-sg-.webp"
+                                         alt="Recette Crêpes bretonnes au saumon fumé, fromage blanc, tomates cerises et roquette (SG), plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Crêpes bretonnes au saumon fumé, fromage blanc, tomates cerises et roquette (SG)</figcaption>
+                                    </figure>
+                                    <span class="text">Crêpes bretonnes au saumon fumé, fromage blanc, tomates cerises et roquette (SG)</span>
                                 </a>
                             </li>
                                                 </ul>
@@ -945,7 +975,7 @@
                             <script type="text/javascript">
                                 document.addEventListener("DOMContentLoaded", function() {
                                     window.setTimeout(function(){
-                                        $("#form_newsletter_key_secu_kxr").val("6a9610acb72b9");
+                                        $("#form_newsletter_key_secu_kxr").val("6a98234b58ede");
                                     }, 5000);
                                 });
                             </script>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_6.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_6.testhtml
@@ -1,0 +1,1591 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de hamburgers au cheddar, bacon et salade</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de hamburgers au cheddar, bacon et salade"><meta property="og:description" content="Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de hamburgers au cheddar, bacon et salade"><meta property="twitter:description" content="Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.51d4be57.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.51d4be57.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.51d4be57.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/5834-hamburgers-au-cheddar-bacon-et-salade";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Hamburgers au cheddar, bacon et salade",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/5834-1-fiche@6A902FD9-hamburgers-au-cheddar-bacon-et-salade.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2026-07-28",
+      "description": "Découvrez la recette de hamburgers au cheddar, bacon et salade, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du  de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT15M",      "cookTime": "PT10M",      "totalTime": "PT25M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "692 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"4 pains burger artisanaux ; 4 steaks hachés tradition bouchère (-15% M.G.)","origine Auvergne-Rhône-Alpes ; 4 tranches de cheddar ; 4 tranches de bacon ; 1 oignon ou échalote ; Quelques feuilles de salade"		],
+	  "recipeInstructions": [
+			  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/5834-hamburgers-au-cheddar-bacon-et-salade",
+                "name": "Hamburgers Au Cheddar, Bacon Et Salade"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Hamburgers au cheddar, bacon et salade</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Hamburgers au cheddar, bacon et salade</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/5834-1-fiche@6A902FD9-hamburgers-au-cheddar-bacon-et-salade.webp" alt="Recette Hamburgers au cheddar, bacon et salade">
+                                                                <figcaption>Succulente recette facile à préparer de Hamburgers au cheddar, bacon et salade, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                        
+                        
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p>Pains burger artisanaux, Boulanger-Pâtissier Maison Bettant (69) <span class="fontstyle0"></li>
+                                                                                    <li>Steaks hachés tradition bouchère (-15% M.G.), origine Auvergne-Rhône-Alpes</li>
+                                                                                    <li>Cheddar</li>
+                                                                                    <li>Bacon</li>
+                                                                                    <li>Oignon ou échalote</li>
+                                                                                    <li>Feuilles de salade </span></p>
+<p><b><em>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d'origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</em></b></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4cs de mayonnaise (optionnel)</li>
+                                                                            <li>2cs de vin blanc (optionnel)</li>
+                                                                            <li>De quoi faire une vinaigrette</li>
+                                                                            <li>Sel</li>
+                                                                            <li>Poivre.</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        15 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        10 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=4_5834">
+    <div class="concept-content bloc-concept-random">
+        <section id="concept" class="container-xl concept-item tpl-4 tpl-default">
+            <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
+            <div class="content">
+                <p class="concept-title">Mangez varié et équilibré !</p>
+                <span class="button center" id="button-cta-recette-4"> Recevez votre panier à cuisiner ! </span>
+            </div>
+        </section>
+    </div>
+</a>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p><em><strong>Attention Best of en vue ! Un incontournable de R&amp;C pour vous faire oublier un peu la rentr&#233;e: De la gourmandise avec le Cheddar, du go&#251;t avec le bacon, un pain burger artisanal de notre boulanger et une viande de b&#339;uf premium ! Il n&#8217;en faut pas plus pour atteindre les sommets ! Les gourmets vont se r&#233;galer !</strong></em></p>
+                                            <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">&#201;pluchez l&#8217;oignon ou l&#8217;&#233;chalote, &#233;mincez-le finement et faites-le revenir dans une po&#234;le avec un filet d&#8217;huile d&#8217;olive.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Quand l&#8217;oignon est color&#233;, d&#233;glacez au vin blanc (optionnel) et laissez confire &#224; feu doux.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pr&#233;chauffez le four &#224; 180&#176;C.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pr&#233;parez la salade et la vinaigrette.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Dans une grande po&#234;le, faites dorer le bacon quelques minutes, r&#233;servez. Dans la m&#234;me po&#234;le faites cuire les steaks 2 &#224; 4 min. d&#8217;un cot&#233;, salez et poivrez. Retournez-les et mettez une tranche de cheddar sur les steaks pour qu&#8217;elle fonde pendant la cuisson.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pendant ce temps, ouvrez les pains burger et faites-les chauffer quelques minutes au four.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">7.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pr&#233;parez les hamburgers en &#233;talant 1cs de mayonnaise (optionnel) sur les moiti&#233;s de pain du dessous, ajoutez de la salade avec un filet d&#8217;huile d&#8217;olive, le steak hach&#233; avec le cheddar, le bacon, la compot&#233;e d&#8217;oignons, recouvrez.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">8.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Servez les burgers accompagn&#233;s de salade verte.</span></p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p><em><strong>Recette non traduite, voir version traditionnelle</strong></em></p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p><span class="OYPEnA text-decoration-none text-strikethrough-none">Une version plus gourmande pour cet hamburger de rentr&#233;e toujours avec les pains de fabrication artisanale de chez notre p&#226;tissier encore meilleurs toast&#233;s. N&#8217;h&#233;sitez pas &#224; ajouter d&#8217;autres ingr&#233;dients de votre frigo : avocats&#8230; et laissez chacun composer son propre burger !</span></p>
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>692</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 23.45%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">23.45</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 60.96%); left: 23.45%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">37.51</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 93.19%); left: 60.96%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">32.23</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 95.45%); left: 93.19%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">2.26</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100%); left: 95.45%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">4.55</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>201.48</span> kcal/<span>843.74</span> kJ</td>
+                                                <td><span>692</span> kcal/<span>2897.838</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>9.32</span>g</td>
+                                                <td><span>32</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>2.91</span>g</td>
+                                                <td><span>10</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>14.91</span>g</td>
+                                                <td><span>51.2</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>2.04</span>g</td>
+                                                <td><span>7</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>12.81</span>g</td>
+                                                <td><span>44</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.9</span>g</td>
+                                                <td><span>3.1</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>1.81</span>g</td>
+                                                <td><span>6.2</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-c.png" alt="Image du nutriscore de la recette, catégorie C">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text ">
+                                                    <span>Légumes et fruits de saison</span>
+                                                    <span class="highlight"><span>100</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#377d45; right: calc(100% - 100%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Local et circuits courts</span>
+                                                    <span class="highlight"><span>85</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 85%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Produits français</span>
+                                                    <span class="highlight"><span>97</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 97%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>5004</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                                    <section class="container container-recettes-associees">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recettes associées</h2>
+                        <ul>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/3107-steak-hache-de-veau-a-la-duxelle-de-champignons-poelee-de-legumes-anciens-sg-">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/3107-1-fiche@64E36375-steak-hache-de-veau-a-la-duxelle-de-champignons-poelee-de-legumes-anciens-sg-.webp"
+                                         alt="Recette Steak haché de veau à la duxelle de champignons, poêlée de légumes anciens (SG), plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Steak haché de veau à la duxelle de champignons, poêlée de légumes anciens (SG)</figcaption>
+                                    </figure>
+                                    <span class="text">Steak haché de veau à la duxelle de champignons, poêlée de légumes anciens (SG)</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/2379-hamburger-a-la-tomme-de-savoie-bacon-et-salade">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/2379-1-fiche@67C71C9C-hamburger-a-la-tomme-de-savoie-bacon-et-salade.webp"
+                                         alt="Recette Hamburger à la tomme de Savoie, bacon et salade, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Hamburger à la tomme de Savoie, bacon et salade</figcaption>
+                                    </figure>
+                                    <span class="text">Hamburger à la tomme de Savoie, bacon et salade</span>
+                                </a>
+                            </li>
+                                                    <li>
+                                <a href="https://www.recettesetcabas.com/recettes/621-hamburger-maison-comte-bacon-salade">
+                                    <figure>
+                                        <img src="https://www.recettesetcabas.com/data/recettes/621-1-fiche@68B02A69-hamburger-maison-comte-bacon-salade.webp"
+                                         alt="Recette Hamburger maison comté-bacon, salade, plaisir de cuisiner au quotidien." />
+                                        <figcaption>Recette Hamburger maison comté-bacon, salade</figcaption>
+                                    </figure>
+                                    <span class="text">Hamburger maison comté-bacon, salade</span>
+                                </a>
+                            </li>
+                                                </ul>
+                    </section>
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a9610acb72b9");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_7.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_7.json
@@ -1,0 +1,66 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/5833-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Filet de merlu pané aux flocons d'avoine, frites de patates douces",
+  "ingredients": [
+    "Filet de merlu poissonnier Grandguillaume (69)",
+    "120g de flocons d'avoine BIO",
+    "1.2kg de patates douces",
+    "2 gousses d'ail",
+    "Huile neutre ou d’olive",
+    "3cs de farine, 2 œufs",
+    "Herbes sèches (thym origan) ou épice de votre choix",
+    "Sel et poivre."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "Filet de merlu poissonnier Grandguillaume (69)",
+        "120g de flocons d'avoine BIO",
+        "1.2kg de patates douces",
+        "2 gousses d'ail"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "Huile neutre ou d’olive",
+        "3cs de farine, 2 œufs",
+        "Herbes sèches (thym origan) ou épice de votre choix",
+        "Sel et poivre."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions": "Préchauffez le four à 210° à chaleur tournante. Epluchez les patates douces et coupez-les en bâtonnets de la forme de frites. Mettez-les dans un saladier et ajoutez le sel, le poivre, une épice ou une herbe sèche au choix (optionnel) et un bon filet d’huile d’olive.\nMélangez pour que les frites soient bien enrobées. Etalez-les en une couche sur la plaque du four recouverte de papier cuisson. Enfournez pour 25 à 30 min.\nPendant ce temps, préparez trois assiettes creuses et mettez : dans la première, les flocons d’avoine ; dans la deuxième, les œufs battus en omelette ; dans la troisième, la farine.\nSalez et poivrez les filets de poisson puis passez-les dans la farine, puis dans l’œuf battu et enfin dans les flocons d’avoine. Appuyez avec les doigts pour faire adhérer cette panure.\nFaites chauffer un filet d'huile dans une grande poêle et faites dorer le poisson pané 3 à 5 min. de chaque côté, selon l’épaisseur, et à feu doux pour ne pas brûler les céréales.\nServez aussitôt, avec les frites de patates douces.",
+  "instructions_list": [
+    "Préchauffez le four à 210° à chaleur tournante. Epluchez les patates douces et coupez-les en bâtonnets de la forme de frites. Mettez-les dans un saladier et ajoutez le sel, le poivre, une épice ou une herbe sèche au choix (optionnel) et un bon filet d’huile d’olive.",
+    "Mélangez pour que les frites soient bien enrobées. Etalez-les en une couche sur la plaque du four recouverte de papier cuisson. Enfournez pour 25 à 30 min.",
+    "Pendant ce temps, préparez trois assiettes creuses et mettez : dans la première, les flocons d’avoine ; dans la deuxième, les œufs battus en omelette ; dans la troisième, la farine.",
+    "Salez et poivrez les filets de poisson puis passez-les dans la farine, puis dans l’œuf battu et enfin dans les flocons d’avoine. Appuyez avec les doigts pour faire adhérer cette panure.",
+    "Faites chauffer un filet d'huile dans une grande poêle et faites dorer le poisson pané 3 à 5 min. de chaque côté, selon l’épaisseur, et à feu doux pour ne pas brûler les céréales.",
+    "Servez aussitôt, avec les frites de patates douces."
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de filet de merlu pané aux flocons d'avoine, frites de patates douces, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du de Recettes & Cabas.",
+  "total_time": 45,
+  "cook_time": 25,
+  "prep_time": 20,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "499 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/5833-1-fiche@6A9540DA-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_7.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_7.testhtml
@@ -1,0 +1,1541 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de filet de merlu pané aux flocons d&#039;avoine, frites de patates douces</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de filet de merlu pané aux flocons d&#039;avoine, frites de patates douces, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/5833-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/5833-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/5833-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de filet de merlu pané aux flocons d&#039;avoine, frites de patates douces"><meta property="og:description" content="Découvrez la recette de filet de merlu pané aux flocons d&#039;avoine, frites de patates douces, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de filet de merlu pané aux flocons d&#039;avoine, frites de patates douces"><meta property="twitter:description" content="Découvrez la recette de filet de merlu pané aux flocons d&#039;avoine, frites de patates douces, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.51d4be57.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.51d4be57.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.51d4be57.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/5833-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Filet de merlu pané aux flocons d&#039;avoine, frites de patates douces",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/5833-1-fiche@6A9540DA-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2026-07-28",
+      "description": "Découvrez la recette de filet de merlu pané aux flocons d'avoine, frites de patates douces, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du  de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT20M",      "cookTime": "PT25M",      "totalTime": "PT45M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "499 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"Filet de merlu poissonnier Grandguillaume (69) ; 120g de flocons d&#039;avoine BIO ; 1.2kg de patates douces ; 2 gousses d&#039;ail"		],
+	  "recipeInstructions": [
+			  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/5833-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces",
+                "name": "Filet De Merlu Pané Aux Flocons D&#039;avoine, Frites De Patates Douces"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Filet de merlu pané aux flocons d'avoine, frites de patates douces</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Filet de merlu pané aux flocons d'avoine, frites de patates douces</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/5833-1-fiche@6A9540DA-filet-de-merlu-pane-aux-flocons-d-avoine-frites-de-patates-douces.webp" alt="Recette Filet de merlu pané aux flocons d&#039;avoine, frites de patates douces">
+                                                                <figcaption>Succulente recette facile à préparer de Filet de merlu pané aux flocons d'avoine, frites de patates douces, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                        
+                        
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p><span class="fontstyle0">Filet de merlu poissonnier Grandguillaume (69)</li>
+                                                                                    <li>Flocons d'avoine BIO </span><span class="fontstyle0"></li>
+                                                                                    <li>Patates douces</li>
+                                                                                    <li>Ail</span></p>
+<p><strong><em>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d’origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</em></strong></p>
+<p><em> </em></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Huile neutre ou d’olive</li>
+                                                                            <li>3cs de farine, 2 œufs</li>
+                                                                            <li>Herbes sèches (thym origan) ou épice de votre choix</li>
+                                                                            <li>Sel et poivre.</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        20 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        25 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star grey-icon"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame grey-icon"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=3_5833">
+    <div class="concept-content bloc-concept-random">
+        <section id="concept" class="container-xl concept-item tpl-3 tpl-default">
+            <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
+            <div class="content">
+                <p class="concept-title">Fini le gaspillage alimentaire !</p>
+                <span class="button center" id="button-cta-recette-3"> Recevez votre panier à cuisiner ! </span>
+            </div>
+        </section>
+    </div>
+</a>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p><em><strong>Le poisson pan&#233;, c&#8217;est bien meilleur quand c&#8217;est fait maison, surtout avec une panure aux flocons d&#8217;avoine qui apporte un d&#233;licieux croustillant et une petite note c&#233;r&#233;ali&#232;re l&#233;g&#232;rement toast&#233;e. Avec des frites de patates douces en accompagnement, nous voil&#224; plong&#233;s dans la rentr&#233;e avec douceur et gourmandise !</strong></em></p>
+                                            <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pr&#233;chauffez le four &#224; 210&#176; &#224; chaleur tournante. Epluchez les patates douces et</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">coupez-les en b&#226;tonnets de la forme de frites. Mettez-les dans un saladier et ajoutez le sel, le poivre, une &#233;pice ou une herbe s&#232;che au choix (optionnel) et un bon filet d&#8217;huile d&#8217;olive.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">M&#233;langez pour que les frites soient bien enrob&#233;es. Etalez-les en une couche sur la plaque du four recouverte de papier cuisson. Enfournez pour 25 &#224; 30 min.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pendant ce temps, pr&#233;parez trois assiettes creuses et mettez : dans la premi&#232;re, les flocons d&#8217;avoine ; dans la deuxi&#232;me, les &#339;ufs battus en omelette ; dans la troisi&#232;me, la farine.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Salez et poivrez les filets de poisson puis passez-les dans la farine, puis dans l&#8217;&#339;uf battu et enfin dans les flocons d&#8217;avoine. Appuyez avec les doigts pour faire adh&#233;rer cette panure.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Faites chauffer un filet d'huile dans une grande po&#234;le et faites dorer le poisson pan&#233; 3 &#224; 5 min. de chaque c&#244;t&#233;, selon l&#8217;&#233;paisseur, et &#224; feu doux pour ne pas br&#251;ler les c&#233;r&#233;ales.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">. Servez aussit&#244;t, avec les frites de patates douces.</span></p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p><strong><em>Recette non traduite, voir version traditionnelle</em></strong></p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p><span class="OYPEnA text-decoration-none text-strikethrough-none">Le poisson pan&#233;, c'est bien meilleur quand c'est fait maison surtout avec des c&#233;r&#233;ales ! Les flocons de 5 c&#233;r&#233;ales utilis&#233;s dans cette recette sont compos&#233;s d&#8217;avoine, de bl&#233;, d&#8217;orge, de seigle et de riz, le tout 100% bio. Vous pouvez utiliser cette panure sur toute sorte de poisson ou m&#234;me des &#233;minc&#233;s de volaille. Des tomates &#224; la proven&#231;ale simplifi&#233;es en accompagnement et nous voil&#224; plong&#233;s dans la saison estivale !</span></p>
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>499</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 7.57%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">7.57</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 60.07%); left: 7.57%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">52.5</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 90.4%); left: 60.07%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">30.33</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 91.41%); left: 90.4%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">1.01</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100%); left: 91.41%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">8.59</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>120.46</span> kcal/<span>504.2</span> kJ</td>
+                                                <td><span>499</span> kcal/<span>2088.653</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>2.17</span>g</td>
+                                                <td><span>9</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>0.48</span>g</td>
+                                                <td><span>2</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>15.04</span>g</td>
+                                                <td><span>62.3</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>3.38</span>g</td>
+                                                <td><span>14</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>8.69</span>g</td>
+                                                <td><span>36</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.29</span>g</td>
+                                                <td><span>1.2</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>2.46</span>g</td>
+                                                <td><span>10.2</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-a.png" alt="Image du nutriscore de la recette, catégorie A">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text ">
+                                                    <span>Légumes et fruits de saison</span>
+                                                    <span class="highlight"><span>2</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#377d45; right: calc(100% - 2%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Produits français</span>
+                                                    <span class="highlight"><span>43</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 43%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>1495</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a9610acde276");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_8.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_8.json
@@ -1,0 +1,76 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/3672-pizza-margherita-aux-tomates-cerises-salade",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Pizza margherita aux tomates cerises - Salade",
+  "ingredients": [
+    "2 pâtes à pizza artisanales",
+    "env. 350g sauce tomate",
+    "2 boules de mozzarella",
+    "375g de tomates cerises",
+    "quelques feuilles de basilic",
+    "salade",
+    "Huile d’olive",
+    "Sel",
+    "Poivre",
+    "Origan ou autre herbes de Provence",
+    "Papier cuisson",
+    "De quoi faire une vinaigrette."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "2 pâtes à pizza artisanales",
+        "env. 350g sauce tomate",
+        "2 boules de mozzarella",
+        "375g de tomates cerises",
+        "quelques feuilles de basilic",
+        "salade"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "Huile d’olive",
+        "Sel",
+        "Poivre",
+        "Origan ou autre herbes de Provence",
+        "Papier cuisson",
+        "De quoi faire une vinaigrette."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions": "Préchauffez le four à 220°.\nEtalez la(les) pâte(s) à pizza à la main (voir au recto) sur une plaque allant au four préalablement recouverte de papier cuisson.\nTartinez chaque pâte de sauce tomate. Coupez les tomates cerise en deux et disposez-les sur la pizza.\nTranchez finement la mozzarella. Répartissez les tranches sur la pizza. Saupoudrez d’origan (ou autre herbes de Provence).\nVersez un filet d'huile d'olive, salez et poivrez.\nEnfournez pour 20 min. en bas du four.\nPendant ce temps préparez la salade et la sauce vinaigrette.\nVérifiez la cuisson de la pizza. A la sortie du four, déposez quelques feuilles de basilic ciselée et servez aussitôt la pizza accompagnée de la salade.",
+  "instructions_list": [
+    "Préchauffez le four à 220°.",
+    "Etalez la(les) pâte(s) à pizza à la main (voir au recto) sur une plaque allant au four préalablement recouverte de papier cuisson.",
+    "Tartinez chaque pâte de sauce tomate. Coupez les tomates cerise en deux et disposez-les sur la pizza.",
+    "Tranchez finement la mozzarella. Répartissez les tranches sur la pizza. Saupoudrez d’origan (ou autre herbes de Provence).",
+    "Versez un filet d'huile d'olive, salez et poivrez.",
+    "Enfournez pour 20 min. en bas du four.",
+    "Pendant ce temps préparez la salade et la sauce vinaigrette.",
+    "Vérifiez la cuisson de la pizza. A la sortie du four, déposez quelques feuilles de basilic ciselée et servez aussitôt la pizza accompagnée de la salade."
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de pizza margherita aux tomates cerises - salade, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du de Recettes & Cabas.",
+  "total_time": 40,
+  "cook_time": 20,
+  "prep_time": 20,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "566 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/3672-1-fiche@6A903166-pizza-margherita-aux-tomates-cerises-salade.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_8.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_8.testhtml
@@ -1,0 +1,1557 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de pizza margherita aux tomates cerises - salade</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de pizza margherita aux tomates cerises - salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/3672-pizza-margherita-aux-tomates-cerises-salade" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/3672-pizza-margherita-aux-tomates-cerises-salade" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/3672-pizza-margherita-aux-tomates-cerises-salade" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de pizza margherita aux tomates cerises - salade"><meta property="og:description" content="Découvrez la recette de pizza margherita aux tomates cerises - salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de pizza margherita aux tomates cerises - salade"><meta property="twitter:description" content="Découvrez la recette de pizza margherita aux tomates cerises - salade, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.51d4be57.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.51d4be57.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.51d4be57.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/3672-pizza-margherita-aux-tomates-cerises-salade";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Pizza margherita aux tomates cerises - Salade",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/3672-1-fiche@6A903166-pizza-margherita-aux-tomates-cerises-salade.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2022-07-28",
+      "description": "Découvrez la recette de pizza margherita aux tomates cerises - salade, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du  de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT20M",      "cookTime": "PT20M",      "totalTime": "PT40M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "566 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"2 pâtes à pizza artisanales ; env. 350g sauce tomate  ; 2 boules de mozzarella ; 375g de tomates cerises ; quelques feuilles de basilic ; salade"		],
+	  "recipeInstructions": [
+			  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/3672-pizza-margherita-aux-tomates-cerises-salade",
+                "name": "Pizza Margherita Aux Tomates Cerises - Salade"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Pizza margherita aux tomates cerises - Salade</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Pizza margherita aux tomates cerises - Salade</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/3672-1-fiche@6A903166-pizza-margherita-aux-tomates-cerises-salade.webp" alt="Recette Pizza margherita aux tomates cerises - Salade">
+                                                                <figcaption>Succulente recette facile à préparer de Pizza margherita aux tomates cerises - Salade, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                        
+                        
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p><span class="fontstyle0">Pâte à pizza artisanale, boulanger le Pain d'Antan (69)</li>
+                                                                                    <li>Sauce tomate</li>
+                                                                                    <li>Boules de mozzarella</li>
+                                                                                    <li>Tomates cerises</li>
+                                                                                    <li>Feuilles de basilic</li>
+                                                                                    <li>Salade </span></p>
+<p><b><em></em></b></p>
+<p><b><em>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d'origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</em></b></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Huile d’olive</li>
+                                                                            <li>Sel</li>
+                                                                            <li>Poivre</li>
+                                                                            <li>Origan ou autre herbes de Provence</li>
+                                                                            <li>Papier cuisson</li>
+                                                                            <li>De quoi faire une vinaigrette.</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        20 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        20 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=8_3672">
+    <div class="concept-content bloc-concept-random">
+        <section id="concept" class="container-xl concept-item tpl-8 tpl-default">
+            <img src="https://www.recettesetcabas.com/img/cta_concept/visuel-mobile.jpg" alt="Recettes et  cabas - panier à cuisiner" />
+            <div class="content">
+                <p class="concept-title">De bons repas faciles à cuisiner</p>
+                <span class="button center" id="button-cta-recette-8"> Recevez votre panier à cuisiner ! </span>
+            </div>
+        </section>
+    </div>
+</a>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p><em><strong>Pour une escapade &#224; l&#8217;italienne, une recette qui va r&#233;galer toute la famille !!! &#160;Rien de plus savoureux que la pizza maison qui sort du four ! Une p&#226;te artisanale de notre boulanger, pour un croustillant incomparable, du basilic frais, des tomates et de la mozzarella, pour se sentir encore un peu en vacances ! Mama mia comme c&#8217;est bon !</strong></em></p>
+                                            <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Pr&#233;chauffez le four &#224; 220&#176;.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Etalez la(les) p&#226;te(s) &#224; pizza &#224; la main (voir au recto) sur une plaque allant au four pr&#233;alablement recouverte de papier cuisson.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Tartinez chaque p&#226;te de sauce tomate. Coupez les tomates cerise en deux et disposez-les sur la pizza.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Tranchez finement la mozzarella. R&#233;partissez les tranches sur la pizza. Saupoudrez d&#8217;origan (ou autre herbes de Provence).</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Versez un filet d'huile d'olive, salez et poivrez.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Enfournez pour 20 min. en bas du four.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Pendant ce temps pr&#233;parez la salade et la sauce vinaigrette.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">7. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">V&#233;rifiez la cuisson de la pizza. A la sortie du four, d&#233;posez quelques feuilles de basilic cisel&#233;e et servez aussit&#244;t la pizza accompagn&#233;e de la salade.</span></p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p><strong><em>Recette non traduite, voir version traditionnelle</em></strong></p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p class="cvGsUA direction-ltr align-justify para-style-body"><span class="OYPEnA font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Pour &#233;taler la p&#226;te fa&#231;on pizza&#239;olo : &#233;talez-la avec vos mains &#224; plat, soulevez-la plusieurs fois par les bords pour l&#8217;&#233;tirer, aplatissez-la &#224; nouveau en la faisant tourner. N&#8217;essayez pas de l&#8217;&#233;taler au rouleau &#224; p&#226;tisserie !</span><span class="OYPEnA font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none white-space-prewrap"> </span><span class="OYPEnA font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Voici l'une des pizzas devenue la plus populaire au monde, et qui tient son nom de la reine Margherita, pour qui cette recette &#224; &#233;t&#233; cr&#233;&#233;e dans les ann&#233;es 1890 en Italie. Propos&#233;e ici avec une d&#233;licieuse p&#226;te artisanale de boulanger qui fera toute la diff&#233;rence (nous en avons test&#233; plusieurs c&#8217;est la meilleure !)</span></p>
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>566</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 19.6%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">19.6</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 74.6%); left: 19.6%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">55</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 92.5%); left: 74.6%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">17.9</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 94.8%); left: 92.5%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">2.3</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 99.99%); left: 94.8%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">5.19</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>153.39</span> kcal/<span>641.77</span> kJ</td>
+                                                <td><span>566</span> kcal/<span>2368.144</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>6.23</span>g</td>
+                                                <td><span>23</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>2.17</span>g</td>
+                                                <td><span>8</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>17.48</span>g</td>
+                                                <td><span>64.5</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>2.17</span>g</td>
+                                                <td><span>8</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>5.69</span>g</td>
+                                                <td><span>21</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.73</span>g</td>
+                                                <td><span>2.7</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>1.65</span>g</td>
+                                                <td><span>6.1</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-c.png" alt="Image du nutriscore de la recette, catégorie C">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text ">
+                                                    <span>Légumes et fruits de saison</span>
+                                                    <span class="highlight"><span>100</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#377d45; right: calc(100% - 100%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Local et circuits courts</span>
+                                                    <span class="highlight"><span>50</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 50%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Produits français</span>
+                                                    <span class="highlight"><span>68</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 68%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>517</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a9610ad0bdf9");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_9.json
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_9.json
@@ -1,0 +1,71 @@
+{
+  "author": "Recettes et Cabas",
+  "canonical_url": "https://www.recettesetcabas.com/recettes/3921-poulet-satay-riz-thai",
+  "site_name": "Recettes & Cabas",
+  "host": "recettesetcabas.com",
+  "language": "fr-FR",
+  "title": "Poulet Satay - Riz thaî",
+  "ingredients": [
+    "Env. 500g de blancs de poulet",
+    "20cl de lait de coco",
+    "2cs de beurre de cacahuètes",
+    "1cc de pâte de curry",
+    "280g de riz long grain parfumés Thaï",
+    "Huile neutre",
+    "1cc de sucre",
+    "1cs de curry",
+    "1 pincée de piment d'Espelette (optionnel)",
+    "Papier cuisson et petites brochettes en bois (optionnel)."
+  ],
+  "ingredient_groups": [
+    {
+      "ingredients": [
+        "Env. 500g de blancs de poulet",
+        "20cl de lait de coco",
+        "2cs de beurre de cacahuètes",
+        "1cc de pâte de curry",
+        "280g de riz long grain parfumés Thaï"
+      ],
+      "purpose": null
+    },
+    {
+      "ingredients": [
+        "Huile neutre",
+        "1cc de sucre",
+        "1cs de curry",
+        "1 pincée de piment d'Espelette (optionnel)",
+        "Papier cuisson et petites brochettes en bois (optionnel)."
+      ],
+      "purpose": "Ingrédients du placard"
+    }
+  ],
+  "instructions": "A faire mariner la veille ou 2h avant si possible.\nDécoupez le poulet en lamelles assez fines, placez-le dans un petit saladier avec un filet d'huile, la sauce soja sucrée, le curry en poudre, le piment (optionnel), du sel et du poivre. Mélangez, filmez et réservez au frais.\nFaites chauffer le four à 180° (ou cuisson à la plancha ou à la poêle).\nFaites cuire le riz dans une casserole d’eau salée, 11 min. à partir de l’ébullition.\nDans une petite casserole, mettez le mélange beurre de cacahuète et pâte de curry avec le sucre et le lait de coco, faites chauffez 3 min à feu doux en mélangeant.\nMettez les lanières de poulet sur des petites brochettes en bois (optionnel) puis disposez-les sur la plaque du four recouverte de papier cuisson ou dans un grand plat. Enfournez pour 10 min, retournez-les à mi-cuisson (ou faites cuire à la plancha ou à la poêle).\nVérifiez la cuisson et servez le poulet avec la sauce satay, accompagné du riz thaï.",
+  "instructions_list": [
+    "A faire mariner la veille ou 2h avant si possible.",
+    "Découpez le poulet en lamelles assez fines, placez-le dans un petit saladier avec un filet d'huile, la sauce soja sucrée, le curry en poudre, le piment (optionnel), du sel et du poivre. Mélangez, filmez et réservez au frais.",
+    "Faites chauffer le four à 180° (ou cuisson à la plancha ou à la poêle).",
+    "Faites cuire le riz dans une casserole d’eau salée, 11 min. à partir de l’ébullition.",
+    "Dans une petite casserole, mettez le mélange beurre de cacahuète et pâte de curry avec le sucre et le lait de coco, faites chauffez 3 min à feu doux en mélangeant.",
+    "Mettez les lanières de poulet sur des petites brochettes en bois (optionnel) puis disposez-les sur la plaque du four recouverte de papier cuisson ou dans un grand plat. Enfournez pour 10 min, retournez-les à mi-cuisson (ou faites cuire à la plancha ou à la poêle).",
+    "Vérifiez la cuisson et servez le poulet avec la sauce satay, accompagné du riz thaï."
+  ],
+  "category": "Plat",
+  "yields": "4 servings",
+  "description": "Découvrez la recette de poulet satay - riz thaî, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du de Recettes & Cabas.",
+  "total_time": 30,
+  "cook_time": 10,
+  "prep_time": null,
+  "cuisine": "Française",
+  "ratings": 5.0,
+  "ratings_count": 5,
+  "nutrients": {
+    "calories": "542 calories"
+  },
+  "image": "https://www.recettesetcabas.com/data/recettes/3921-1-fiche@6A95472C-poulet-satay-riz-thai.webp",
+  "keywords": [
+    "authentique",
+    "facile",
+    "équilibrée",
+    "Plat"
+  ]
+}

--- a/tests/test_data/recettesetcabas.com/recettesetcabas_9.testhtml
+++ b/tests/test_data/recettesetcabas.com/recettesetcabas_9.testhtml
@@ -1,0 +1,1605 @@
+<!DOCTYPE HTML>
+<!--[if IE 9 ]>
+<html dir="ltr" lang="fr-FR" class="ie9 no-js" xmlns:og="https://ogp.me/ns#" > <![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!-->
+<html dir="ltr" lang="fr-FR" class="no-js" xmlns:og="https://ogp.me/ns#"><!--<![endif]-->
+<head>
+    
+<meta charset="UTF-8">
+<title>Recette de poulet satay - riz thaî</title>
+<meta name="description" content="Recettes &amp; Cabas - Découvrez la recette de poulet satay - riz thaî, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas.">
+<meta name="keywords" content="">
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="google-site-verification" content="62tTdZk3gGQJFmRSFlJuh6bUsAJfSp3a2HO3S37fejQ" />
+<meta name="identifier-url" content="https://www.recettesetcabas.com/" />
+<meta name="copyright" content="Copyright &copy; Recettes & Cabas. Tous droits réservés." />
+
+            <link rel="canonical" href="https://www.recettesetcabas.com/recettes/3921-poulet-satay-riz-thai" />
+    
+            <link rel="alternate" hreflang="x-default" href="https://www.recettesetcabas.com/recettes/3921-poulet-satay-riz-thai" />
+        <link rel="alternate" hreflang="fr" href="https://www.recettesetcabas.com/recettes/3921-poulet-satay-riz-thai" />
+    
+<!-- Primary Meta Tags --><meta name="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta name="author" content="Recettes & Cabas"><!-- Schema.org for Google --><meta itemprop="image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><!-- Open Graph / Facebook --><meta property="og:type" content="website"><meta property="og:site_name" content="Recettes & Cabas"><meta property="og:locale" content="fr_fr"><meta property="og:title" content="Recette de poulet satay - riz thaî"><meta property="og:description" content="Découvrez la recette de poulet satay - riz thaî, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><!-- Twitter --><meta property="twitter:card" content="summary_large_image"><meta property="twitter:title" content="Recette de poulet satay - riz thaî"><meta property="twitter:description" content="Découvrez la recette de poulet satay - riz thaî, pas à pas. Cette recette est l&#039;une des recettes du cabas à cuisiner de la semaine du  de Recettes &amp; Cabas."><meta property="twitter:image" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:image:src" content="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg"><meta property="twitter:site" content="Recettes & Cabas"><meta property="twitter:creator" content="Recettes & Cabas">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.recettesetcabas.com/img/favicons/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.recettesetcabas.com/img/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.recettesetcabas.com/img/favicons/favicon-16x16.png">
+<link rel="manifest" href="https://www.recettesetcabas.com/img/favicons/site.webmanifest">
+<meta name="msapplication-TileColor" content="#da532c">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="preload" href="https://www.recettesetcabas.com/css/plugins.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="https://www.recettesetcabas.com/css/global.min.51d4be57.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="stylesheet" type="text/css" href="https://www.recettesetcabas.com/css/theme.min.51d4be57.css" media="all" />
+
+
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins.min.51d4be57.js"></script>
+    <script defer type="text/javascript" src="https://www.recettesetcabas.com/js/plugins-spe.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/global.min.51d4be57.js"></script>
+<script defer type="text/javascript" src="https://www.recettesetcabas.com/js/Url.51d4be57.js"></script>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function(){
+        Url.init({"admin":"https:\/\/admin.recettesetcabas.com","front":"https:\/\/www.recettesetcabas.com","data":"https:\/\/www.recettesetcabas.com\/data","css":"https:\/\/www.recettesetcabas.com\/css","fonts":"https:\/\/www.recettesetcabas.com\/fonts","img":"https:\/\/www.recettesetcabas.com\/img","js":"https:\/\/www.recettesetcabas.com\/js","theme":"https:\/\/www.recettesetcabas.com\/themes\/revox","photos":"https:\/\/www.recettesetcabas.com\/data\/imgProduit","marketing":"https:\/\/www.recettesetcabas.com\/data\/imgMarketing"});
+    });
+        var nom_projet = "Recettes & Cabas";
+    var formule = "";
+    var formule_titre = "";
+    var robot = "";
+    var robot_titre = "";
+    var page_name = "Recettes";
+    var page_path = "/recettes/3921-poulet-satay-riz-thai";
+            var clarity_id = "nbw1j162j3";
+    </script>
+
+<style>
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Light'), local('Raleway-Light'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Raleway';
+        src: local('Raleway Regular'), local('Raleway-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Raleway-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Light'), local('Poppins-Light'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Light.woff2) format('woff2');
+        font-weight: 300;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Regular'), local('Poppins-Regular'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Regular.woff2) format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Medium'), local('Poppins-Medium'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Medium.woff2) format('woff2');
+        font-weight: 500;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Poppins';
+        src: local('Poppins Bold'), local('Poppins-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Poppins-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern SemiBold'), local('Rasbern-SemiBold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-SemiBold.woff2) format('woff2');
+        font-weight: 600;
+        font-style: normal;
+        font-display: swap;
+    }
+    @font-face {
+        font-family: 'Rasbern';
+        src: local('Rasbern Bold'), local('Rasbern-Bold'),
+        url(https://www.recettesetcabas.com/fonts/Rasbern-Bold.woff2) format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+    }
+</style>
+
+
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org/",
+      "@type": "Recipe",
+      "name": "Poulet Satay - Riz thaî",
+      "image": [
+		"https://www.recettesetcabas.com/data/recettes/3921-1-fiche@6A95472C-poulet-satay-riz-thai.webp"
+      ],
+      "author": {
+        "@type": "Organization",
+        "name": "Recettes et Cabas"
+      },
+      "datePublished": "2023-01-19",
+      "description": "Découvrez la recette de poulet satay - riz thaî, pas à pas. Cette recette est l'une des recettes du cabas à cuisiner de la semaine du  de Recettes & Cabas.",
+      "recipeCuisine": "Française",
+      "prepTime": "PT20 (+ 2h marinade)M",      "cookTime": "PT10M",      "totalTime": "PT30M",	  "keywords": "authentique, facile, équilibrée, Plat",
+      "recipeYield": [
+		  "4",
+		  "portion"
+		],
+      "recipeCategory": "Plat",
+      "nutrition": {
+        "@type": "NutritionInformation",
+        "calories": "542 calories"
+      },
+      "aggregateRating": {
+        "@type": "AggregateRating",
+        "ratingValue": "5",
+        "ratingCount": "5"
+      },
+		"recipeIngredient": [
+			"Env. 500g de blancs de poulet ; 20cl de lait de coco; 2cs de beurre de cacahuètes","1cc de pâte de curry; 280g de riz long grain parfumés Thaï"		],
+	  "recipeInstructions": [
+			  ]
+    }
+    </script>
+
+	<style>
+
+	.buttons-cta {
+	padding: 0 0 30px 0;
+	text-align: center;
+}
+
+.buttons-cta a {
+	margin: 0 5px;
+	text-transform: uppercase;
+	font-weight: 700;
+	font-size: 1.5rem;
+}
+.h3.fontsize60{
+    font-style: italic;
+}
+.logo-circle{
+    margin-top: 3rem;
+    margin-bottom: -1px;
+}
+</style>
+
+
+        <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Brand",
+        "url": "https://www.recettesetcabas.com/",
+        "logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+    }
+    </script>
+    <script>var base_url = "https://www.recettesetcabas.com/";</script>
+</head>
+<body id="Recettes" class="page_Recettes">
+
+<!-- Code avis garantis -->
+<script id="grc-widgets" src="https://widgets.guaranteed-reviews.com/static/widgets.min.js" data-public-key="a645b9e6a3e2b80684ad8ee64916fce1" data-lang="auto"></script>
+
+<!--- Popin SEO -->
+<div class="hidden">
+    <div id="desc_h" class="container">
+        <div class="padding40">
+                            
+                    </div>
+    </div>
+</div>
+
+<!-- Kpopin -->
+<aside id="cd-nav" class="cd-nav pattern01 hidden">
+    <div class="cd-navigation-wrapper">
+        <a class="cd-nav-trigger">Fermer / Ouvrir
+            <span class="cd-nav-icon"></span>
+        </a>
+        <div id="kpop_contain" class="kpop-contain js-kpop-contain">
+        </div>
+    </div>
+</aside>
+<!--/ Kpopin -->
+
+
+<!-- Les deux divs qui suivent sont obligatoires au fonctionnement du menu mobile (mp-pusher & scroller) -->
+<div class="mp-pusher" id="mp-pusher">
+
+    <!-- content_body -->
+    <div id="cd-main" class="content_body cd-main scroller">
+
+        <!-- Mobile menu -->
+        <nav id="menu-desktop" class="mp-menu mp-cover">
+            <div class="mobile_header visible-xs">
+                <div id="logo_mh">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" width="350" height="88" alt="Recettes & Cabas">
+                    </a>
+                    <div class="button button-color4 js-link" data-href="https://www.recettesetcabas.com/espace-client" id="button-espace-1">
+                                                Se connecter
+                                            </div>
+                </div>
+                <div id="mh_close">
+                    <span class="symbol symbol-close"></span>
+                </div>
+            </div>
+
+
+
+            <div class="mp-level mp-level-open">
+                <ul class="level1">
+
+                                            <li class="js-has-submenu">
+                            Commander</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Panier à cuisiner</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Offrir</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/bon-cadeau">Bons Cadeaux</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/panier-gourmand-1">Coffrets gourmands</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Comment ça marche ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/concept">Le concept</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/livraison">La livraison</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/parrainage">Fidélité et parrainage</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Qui sommes-nous ?</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/page/qui-sommes-nous">L'équipe</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/valeurs-engagements">Valeurs et engagements</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/page/producteurs">Les producteurs</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/blog/">Blog</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/presse">Presse</a></li>
+                                                            </ul>
+                                                                    <li class="js-has-submenu">
+                            Aide</a>
+                                                                                        <div class="icon icon-arrow-right"></div>
+                                                    </li>
+                                                    <ul class="level2">
+                                                                    <li><a href="https://www.recettesetcabas.com/faq">FAQ</a></li>
+                                                                    <li><a href="https://www.recettesetcabas.com/contactez-nous">Nous contacter</a></li>
+                                                            </ul>
+                                                                <li class="sep-horizontal"></li>
+
+                    <li class="panier_link_mobile">
+                        <a href="tel:04 82 53 56 31" class="button button-color4 click-tel" rel="nofollow" target="_blank">
+                            <span class="tel">04 82 53 56 31</span>
+                        </a>
+                    </li>
+
+                    <li class="whatsapp_link_mobile">    <p class="button-content whatsapp-mobile">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Menu_mobile', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+</li>
+
+                </ul>
+            </div>
+        </nav>
+        <!--/ Mobile menu -->
+
+        <header id="header" class="header_top">
+            <nav id="acces" role="navigation" class="d-none d-sm-block">
+    <ul id="accesmenu" class="d-flex align-items-center first_level">
+        <li id="acces000" class="d-none"><a href="#contenu" accesskey="s" rel="nofollow">Aller au contenu</a></li>
+        <li id="accesm" class="d-none">
+            <a href="#mh" rel="nofollow" data-anim="false">Allez &agrave; la navigation</a></li>
+            </ul>
+</nav>
+
+
+                                    <div class="line1 hidden">
+                <div class="container">
+                    <div>
+                        <a href="https://www.recettesetcabas.com/blog/" target="_blank">
+                            <span class="icon icon-coeur"></span>
+                            <span>BLOG</span>
+                        </a>
+                    </div>
+					<div>
+						<a href="tel:0482535631" class="click-tel" rel="nofollow" target="_blank">
+                        <span class="icon icon-telephone2"></span>
+                        <span class="tel">04 82 53 56 31</span>
+						</a>
+					</div>
+                </div>
+            </div>
+            <div class="line2 container">
+                <div id="menu_launcher">
+                    <span class="picto-menu"></span>
+                </div>
+                <div id="logo" itemscope itemtype="http://schema.org/Brand">
+                    <a href="https://www.recettesetcabas.com/" accesskey="1" title="Accueil Recettes & Cabas" itemprop="url">
+                        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg"
+                             alt="Recettes & Cabas" itemprop="logo" width="274" height="68">
+                    </a>
+                </div>
+
+
+                <div class="header-tunnel">
+                    <div class="step-tunnel step-tunnel1 active">
+                                                    <a class="num-tunnel" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">
+                                <span>1</span>
+                            </a>
+                            <a class="text" title="Je choisis mes recettes" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner">Je choisis mes recettes</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel2">
+                                                    <a class="num-tunnel" title="Je me connecte'}" href="https://www.recettesetcabas.com/panier"><span>2</span></a>
+                            <a class="text" href="https://www.recettesetcabas.com/panier">Je me connecte</a>
+                                                <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel3">
+                        <a class="num-tunnel" title="Livraison" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1"><span>3</span></a>
+                        <a class="text" href="https://www.recettesetcabas.com/panier/transporteur?liv_etape=1">Livraison</a>
+                        <div class="sep"></div>
+                    </div>
+                    <div class="step-tunnel step-tunnel4">
+                        <div class="num-tunnel" title="Paiement">4</div>
+                        <div class="text">Paiement</div>
+                    </div>
+                </div>
+
+                <nav id="primary_nav_wrap"><ul class="first_level"><li class="dropdown "><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"  ><span class="text-menu-access ">Commander</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" ><span class="text">Panier à cuisiner</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/bon-cadeau"  ><span class="text-menu-access ">Offrir</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/bon-cadeau" ><span class="text">Bons Cadeaux</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/panier-gourmand-1" ><span class="text">Coffrets gourmands</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/concept"  ><span class="text-menu-access ">Comment ça marche ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/concept" ><span class="text">Le concept</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/livraison" ><span class="text">La livraison</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/parrainage" ><span class="text">Fidélité et parrainage</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/page/qui-sommes-nous"  ><span class="text-menu-access ">Qui sommes-nous ?</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/qui-sommes-nous" ><span class="text">L'équipe</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/valeurs-engagements" ><span class="text">Valeurs et engagements</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/page/producteurs" ><span class="text">Les producteurs</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/blog/" ><span class="text">Blog</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/presse" ><span class="text">Presse</span></a></li></ul></div></div></li><li class="dropdown "><a href="https://www.recettesetcabas.com/faq"  ><span class="text-menu-access ">Aide</span></a><div class="second_level"><div class="d-flex align-items-center"><ul><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/faq" ><span class="text">FAQ</span></a></li><li class="s_menu  text-center p-3"><a href="https://www.recettesetcabas.com/contactez-nous" ><span class="text">Nous contacter</span></a></li></ul></div></div></li></ul></nav>
+                <div class="panier">
+                                            <div class="client_header_c noLogged">
+                            <span class="js-link espace_client_link not_connected" data-href="https://www.recettesetcabas.com/espace-client/connexion" title="Mon espace client" id="button-espace-2">
+                                <span class="button button-outline-color4 texte_connexion">
+                                    Se connecter
+                                </span>
+                                <span class="icon icon-compte" title="Mon espace client"></span>
+                            </span>
+                        </div>
+
+                        <span class="js-link header_panier_c" data-href="https://www.recettesetcabas.com/panier" title="Mon panier" id="button-panier-1">
+                            <span class="icon icon-cabas-v2"></span>
+                            <span class="text-cabas">
+                                0
+                            </span>
+                        </span>
+                    
+
+
+                </div>
+            </div>
+			<div id="hello" class="container">
+							</div>
+        </header>
+
+        <div id="contenu">
+
+                        
+    <div id="recette_detail" class="main_page" oncopy="return false;" onpaste="return false;" oncut="return false;" style="user-select: none;" ondragstart="return false;" onselectstart="return false;" oncontextmenu="return false;">
+        <div>
+            <script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/",
+                "name": "Accueil"
+            }
+        },
+                        {
+            "@type": "ListItem",
+            "position": 2,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes",
+                "name": "Recettes"
+            }
+        },
+                {
+            "@type": "ListItem",
+            "position": 3,
+            "item":
+            {
+                "@id": "https://www.recettesetcabas.com/recettes/3921-poulet-satay-riz-thai",
+                "name": "Poulet Satay - Riz Thaî"
+            }
+        }
+                    ]
+}
+</script>
+
+<nav id="chemin" itemscope itemtype="https://schema.org/BreadcrumbList">
+    <div class="container">
+        <span class="item"><a class="bread_link" href="https://www.recettesetcabas.com/"><span>Recettes & Cabas</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><a class="bread_link " href="https://www.recettesetcabas.com/recettes"><span>Recettes</span></a>&nbsp;</span><span class="breadcrumb_sep"> > </span><span class="item"><span class="bread_link"><span itemprop="name">Poulet Satay - Riz thaî</span></span></span>    </div>
+</nav>
+
+                <h1 class="h1 title">
+                                        <span class="h3 fontsize40">
+                        <span class="txt hidden"><p>Recette</p></span>
+                    </span><br>
+                <span>Poulet Satay - Riz thaî</span>
+            </h1>
+        </div>
+
+                    <div class="bloc-recette container">
+                    <div class="bloc-2-item">
+                    <div class="bloc-img">
+                        <div class="img_recette_detail">
+                            <figure>
+                                                                    <img src="https://www.recettesetcabas.com/data/recettes/3921-1-fiche@6A95472C-poulet-satay-riz-thai.webp" alt="Recette Poulet Satay - Riz thaî">
+                                                                <figcaption>Succulente recette facile à préparer de Poulet Satay - Riz thaî, fini le manque d’idée pour vos repas et la corvée des courses interminables après le travail.</figcaption>
+                            </figure>
+                        </div>
+                        
+                        
+                                                    <div class="textcenter mb-4 hidden">
+                                <span class="icon icon-robot"></span>  Recette traduite pour les robots culinaires
+                            </div>
+                                            </div>
+
+                    <div class="bloc-desc green_block mb-5 two_blocks">
+                        <div class="col-header">
+                                                            <div>
+                                    <span class="icon icon-chef"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients :</h2>
+                                </div>
+                                <ul>
+                                                                                                                       <li><p><span class="fontstyle0">Blanc de poulet origine Auvergne-Rhône-Alpes</li>
+                                                                                    <li>Lait de coco</li>
+                                                                                    <li>Beurre de cacahuètes</li>
+                                                                                    <li>Pâte de curry</li>
+                                                                                    <li>Riz long grain parfumé</li>
+                                                                                    <li>Sauce soja sucré</span></p>
+<p><em><br /><b>Nos recettes sont fournies avec des ingrédients non transformés sélectionnés de préférence en circuits-courts et d'origine Auvergne-Rhône-Alpes (fruits et légumes, viande, volaille) ou France. Les recettes qui comportent le logo MA REGION SES TERROIRS garantissent une majorité d’ingrédients agréés par cette marque. Un produit MA REGION SES TERROIRS est cultivé ou élevé à 100% en Auvergne-Rhône-Alpes.</b><br /></em></p></li>
+                                                                                                            </ul>
+                                                    </div>
+
+                                                    <div class="col-header">
+                                <div>
+                                    <span class="icon icon-cupboard"></span>
+                                    <h2 class="h3 d-inline-flex">Ingrédients du placard :</h2>
+                                </div>
+                                <ul>
+                                                                            <li><p><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Huile neutre</li>
+                                                                            <li>1cc de sucre</li>
+                                                                            <li>1cs de curry</li>
+                                                                            <li>1 pincée de piment d'Espelette (optionnel)</li>
+                                                                            <li>Papier cuisson et petites brochettes en bois (optionnel).</span></p></li>
+                                                                    </ul>
+                            </div>
+                                                <div class="col-header col-notations">
+                                                            <div>
+                                    <span class="icon icon-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de préparation :</h2>
+                                    <span class="notations_values">
+                                        20 (+ 2h marinade) minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cook"></span>
+                                    <h2 class="h3 d-inline-flex">Temps de cuisson :</h2>
+                                    <span class="notations_values">
+                                        10 minutes
+                                    </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-super-bowl"></span>
+                                    <h2 class="h3 d-inline-flex">Facilité :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                                                                                <span class="icon icon-active-star"></span>
+                                                                                                                        </span>
+                                </div>
+                                                                                        <div>
+                                    <span class="icon icon-cereal"></span>
+                                    <h2 class="h3 d-inline-flex">Equilibre du repas :</h2>
+                                    <span class="notations_values">
+                                                                                                                                    <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                                                                                <span class="icon icon-flame"></span>
+                                                                                                                        </span>
+                                </div>
+                                                    </div>
+                    </div>
+                </div>
+            </div>
+
+                        
+                            <div class="concept_recette_standard">
+    <div class="logo justify-content-center flex">
+        <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cavas_circle.svg" class="logo-circle" width="600" alt="Image de recettes à préparer">
+    </div>
+
+    <div class="concept-content">
+        <section id="concept" class="container-xl concept-item tpl-1">
+
+            <div class="concept-title"><p>Vous livre des paniers &#224; cuisiner contenant des recettes vari&#233;es, &#233;quilibr&#233;es et faciles &#224; r&#233;aliser avec les produits associ&#233;s issus des mara&#238;chers, &#233;leveurs et artisans de nos r&#233;gions.</p></div>
+
+            <div class="concept-container">
+                                    <div class="concept-card index-0">
+                        <div class="concept-img">
+                            <figure class="ratio" style="--ratio: 2/1.5">
+                                <img src="https://www.recettesetcabas.com/data/sliders/je-choisis-mes-recettes-47.webp?fmt=1781015945" width="260" height="260" alt="Je choisis mes recettes" loading="lazy">
+                                <figcaption>Je choisis mes recettes</figcaption>
+                            </figure>
+                        </div>
+                        <div class="concept-text">
+                            <div class="h3">Je choisis mes recettes</div>
+                            <div class="mt-4 description"><p>vari&#233;es et faciles &#224; r&#233;aliser&#160;pour 2, 4 ou 6 personnes</p></div>
+                        </div>
+
+
+                    </div>
+                                    <div class="concept-card index-1">
+                        <div class="concept-img">
+                            <figure class="ratio" style="--ratio: 2/1.5">
+                                <img src="https://www.recettesetcabas.com/data/sliders/je-recois-mon-panier-a-cuisiner-48.webp?fmt=1781008328" width="260" height="260" alt="Je reçois mon panier à cuisiner" loading="lazy">
+                                <figcaption>Je reçois mon panier à cuisiner</figcaption>
+                            </figure>
+                        </div>
+                        <div class="concept-text">
+                            <div class="h3">Je reçois mon panier à cuisiner</div>
+                            <div class="mt-4 description"><p>contenant mes recettes et tous les ingr&#233;dients ultra-frais et de saison dos&#233;s en juste quantit&#233;</p></div>
+                        </div>
+
+
+                    </div>
+                                    <div class="concept-card index-2">
+                        <div class="concept-img">
+                            <figure class="ratio" style="--ratio: 2/1.5">
+                                <img src="https://www.recettesetcabas.com/data/sliders/en-30-min-c-est-pret--49.webp?fmt=1727360097" width="260" height="260" alt="En 30 min, c'est prêt !" loading="lazy">
+                                <figcaption>En 30 min, c'est prêt !</figcaption>
+                            </figure>
+                        </div>
+                        <div class="concept-text">
+                            <div class="h3">En 30 min, c'est prêt !</div>
+                            <div class="mt-4 description"><p>Je pr&#233;pare mes repas du quotidien, vari&#233;s et &#233;quilibr&#233;s, en toute simplicit&#233;</p></div>
+                        </div>
+
+
+                    </div>
+                            </div>
+        </section>
+        <div class="container justify-content-center flex">
+            <!-- id="button-cta-recette-2" -->
+                                    <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner?cta=10_3921" class="button center" id="button-cta-recette-2"> Recevez votre panier à cuisiner ! </a></p>
+        </div>
+    </div>
+</div>            
+            <div class="bloc-recette">
+
+                <section class="mb-5 container">
+                    <span class="icon icon-book"></span>
+                    <h2 class="h3 d-inline-flex">La recette</h2>
+                    <p><em><strong>Voici une version simplifi&#233;e du poulet satay, recette d&#8217;origine indon&#233;sienne tr&#232;s pris&#233;e par les asiatiques. La marinade fait &#233;videmment toute la diff&#233;rence, avec le lait de coco, le beurre de cacahu&#232;te, la p&#226;te de curry et le citron vert&#160;! Pour un d&#233;paysement gustatif total, on peut l&#8217;agr&#233;menter de coriandre fraiche et de cacahu&#232;tes grill&#233;es&#160;!</strong></em></p>
+                                            <p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">A faire mariner la veille ou 2h avant si possible.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">1. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">D&#233;coupez le poulet en lamelles assez fines, placez-le dans un petit saladier avec un filet d'huile, la sauce soja sucr&#233;e, le curry en poudre, le piment (optionnel), du sel et du poivre. M&#233;langez, filmez et r&#233;servez au frais.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">2</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">. Faites chauffer le four &#224; 180&#176; (ou cuisson &#224; la plancha ou &#224; la po&#234;le).</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">3. </span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">Faites cuire le riz dans une casserole d&#8217;eau sal&#233;e, 11 min. &#224; partir de l&#8217;&#233;bullition.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">4.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Dans une petite casserole, mettez le m&#233;lange beurre de cacahu&#232;te et p&#226;te de curry avec le sucre et le lait de coco, faites chauffez 3 min &#224; feu doux en m&#233;langeant.</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">5.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> Mettez les lani&#232;res de poulet sur des petites brochettes en bois (optionnel) puis disposez-les sur la plaque du four recouverte de papier cuisson ou dans un grand plat. Enfournez pour 10 min, retournez-les &#224; mi-cuisson (ou faites cuire &#224; la plancha ou &#224; la po&#234;le).</span></p>
+<p class="cvGsUA block-font-kerning-none block-font-feature-liga-off block-font-feature-clig-off block-font-feature-calt-off direction-ltr align-justify"><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">6.</span><span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none"> V&#233;rifiez la cuisson et servez le poulet avec la sauce satay, accompagn&#233; du riz tha&#239;.</span></p>
+                    
+                    <div class="text-center mt-5 mb-5">
+                        <!-- id="button-cta-recette-3" -->
+                        <p class="color1"><strong>Fini le manque d'inspiration, je d&#233;couvre les recettes &#224; commander avec leurs ingr&#233;dients</strong></p>
+<p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-3">Je d&#233;couvre les paniers recettes</a></p>
+                    </div>
+
+                </section>
+
+                <section class="container recette-robot">
+
+                    <div class="nav nav-tabs mb-5 mt-5">
+                        <span class="icon icon-book"></span>
+                        <h2 class="h3 d-inline-flex">Recette Thermomix</h2>
+                    </div>
+                    <div class="tab-content" id="nav-tabContent">
+                        <div class="tab-pane fade active show" id="nav-Thermomix" role="tabpanel" aria-labelledby="nav-Thermomix">
+                            <div style="margin:20px 0;">
+                                                                    <p class="_04xlpA direction-ltr align-justify para-style-body"><span class="S1PPyQ">A faire mariner la veille ou 2h avant si possible.</span></p>
+<p class="_04xlpA direction-ltr align-justify para-style-body"><span class="S1PPyQ">1. </span><span class="S1PPyQ">D&#233;coupez le poulet en lamelles assez fines, placez-le dans un petit saladier avec un filet d'huile, le curry, le piment (optionnel), du sel et du poivre. M&#233;langez, filmez et r&#233;servez au frais.</span></p>
+<p class="_04xlpA direction-ltr align-justify para-style-body"><span class="S1PPyQ">2</span><span class="S1PPyQ">. Faites chauffer le four &#224; 180&#176;<span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">(ou la plancha).</span></span></p>
+<p class="_04xlpA direction-ltr align-justify para-style-body"><span class="S1PPyQ">3. Mettez le riz <strong>dans le panier</strong>, rincez-le et <strong>programmez</strong> <strong>20 min. varoma vitesse 1</strong></span><span class="S1PPyQ">.</span></p>
+<p class="_04xlpA direction-ltr align-justify para-style-body"><span class="S1PPyQ">4.</span><span class="S1PPyQ"> Dans une casserole, mettez le m&#233;lange p&#226;te de curry et beurre de cacahu&#232;te avec le sucre et le lait de coco, faites chauffez 3 min &#224; feu doux en m&#233;langeant.</span></p>
+<p class="_04xlpA direction-ltr align-justify para-style-body"><span class="S1PPyQ">5.</span><span class="S1PPyQ"> Mettez les lani&#232;res de poulet sur des petites brochettes en bois (optionnel) puis disposez-les sans les superposer sur la plaque du four recouverte de papier cuisson ou dans un grand plat. Enfournez pour 10 min, retournez-les &#224; mi-cuisson <span class="a_GcMg font-feature-liga-off font-feature-clig-off font-feature-calt-off text-decoration-none text-strikethrough-none">(ou faites cuire &#224; la plancha ou &#224; la po&#234;le).</span></span></p>
+<p class="_04xlpA direction-ltr align-justify para-style-body"><span class="S1PPyQ">6.</span><span class="S1PPyQ"> V&#233;rifiez la cuisson et servez le poulet avec la sauce satay, accompagn&#233; du riz tha&#239;.</span></p>
+<p class="cvGsUA direction-ltr align-justify para-style-body"></p>
+<p class="_04xlpA direction-ltr align-justify para-style-body"></p>
+                                                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-salt"></span>
+                            <h2 class="h3 d-inline-flex">Notre grain de sel</h2>
+                        </div>
+                        <p><span class="S1PPyQ">Voici une version simplifi&#233;e du poulet satay, recette d&#8217;origine indon&#233;sienne tr&#232;s pris&#233;e par les asiatiques et souvent propos&#233;e en occident dans les restaurants. Le poulet peut &#234;tre dispos&#233; sur des brochettes et &#234;tre cuit &#224; la plancha. Dans cette recette on vous propose de le faire dorer au four, cela fonctionne tr&#232;s bien aussi. On peut l&#8217;agr&#233;menter de coriandre fraiche et de cacahu&#232;tes grill&#233;es. Bon voyage et excellente d&#233;couverte !</span></p>
+                    </div>
+                </section>
+
+                                <section class="container recette-nutri">
+                    <div class="nutrition_container mb-5">
+                        <div class="nav nav-tabs mb-5 mt-5">
+                            <span class="icon icon-diet"></span>
+                            <h2 class="h3 d-inline-flex">Informations nutritionnelles</h2>
+                        </div>
+                        <div class="tab-desc">
+                            <div class="nutrition_content">
+                                <div class="row">
+                                    <div class="infos-nutri col-12 col-md-8">
+                                        <div class="h6">Calories : <span>542</span> kcal</div>
+                                                                                    <div class="progress-bar-nutrition-container progress-bar-nutrition-desktop">
+                                                                                                    <div class="progress-bar-nutrition lipides-bar" style="right: calc(100% - 13.17%);">
+                                                        <span class="progress-bar-nutrition-text">Lipides <span class="highlight"><span class="js_recette_popin_recs_mat_grasse_pourcent">13.17</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition glucides-bar" style="right: calc(100% - 66.56%); left: 13.17%;">
+                                                        <span class="progress-bar-nutrition-text">Glucides <span class="highlight"><span class="js_recette_popin_recs_glucides_pourcent">53.39</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition proteines-bar" style="right: calc(100% - 98.17%); left: 66.56%;">
+                                                        <span class="progress-bar-nutrition-text">Protéines <span class="highlight"><span class="js_recette_popin_recs_proteines_pourcent">31.61</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition sel-bar" style="right: calc(100% - 98.44%); left: 98.17%;">
+                                                        <span class="progress-bar-nutrition-text">Sel <span class="highlight"><span class="js_recette_popin_recs_sel_pourcent">0.27</span>%</span></span>
+                                                    </div>
+                                                                                                                                                    <div class="progress-bar-nutrition fibres-bar" style="right: calc(100% - 100.01%); left: 98.44%;">
+                                                        <span class="progress-bar-nutrition-text">Fibres <span class="highlight"><span class="js_recette_popin_recs_fibres_pourcent">1.57</span>%</span></span>
+                                                    </div>
+                                                                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <table class="table_nutrition">
+                                            <thead>
+                                            <tr>
+                                                <td></td>
+                                                <td class="highlight">pour 100g</td>
+                                                <td class="highlight">une portion</td>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <tr>
+                                                <td class="highlight">Énergie</td>
+                                                <td><span>160.83</span> kcal/<span>673.91</span> kJ</td>
+                                                <td><span>542</span> kcal/<span>2271.075</span> kJ</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Lipides</td>
+                                                <td><span>4.45</span>g</td>
+                                                <td><span>15</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont acides gras saturés</td>
+                                                <td><span>2.67</span>g</td>
+                                                <td><span>9</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Glucides</td>
+                                                <td><span>18.04</span>g</td>
+                                                <td><span>60.8</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Dont sucres</td>
+                                                <td><span>1.19</span>g</td>
+                                                <td><span>4</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Protéines</td>
+                                                <td><span>10.68</span>g</td>
+                                                <td><span>36</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Sel</td>
+                                                <td><span>0.09</span>g</td>
+                                                <td><span>0.3</span>g</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="highlight">Fibres</td>
+                                                <td><span>0.53</span>g</td>
+                                                <td><span>1.8</span>g</td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="infos-origines col-12 col-md-4">
+                                        <div class="img_container_origines">
+                                            <div class="nutriscore-libelle">NUTRI-SCORE : </div>
+                                            <img src="https://www.recettesetcabas.com/img/theme/nutriscore-a.png" alt="Image du nutriscore de la recette, catégorie A">
+                                        </div>
+                                        <h3 class="h5">Origines</h3>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Local et circuits courts</span>
+                                                    <span class="highlight"><span>30</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#d44427; right: calc(100% - 30%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                            <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Produits français</span>
+                                                    <span class="highlight"><span>31</span>%</span>
+                                                </div>
+                                                <div class="progress-bar-origines-container">
+                                                    <div class="progress-bar-origines" style="background-color:#e1832f; right: calc(100% - 31%)"></div>
+                                                </div>
+                                            </div>
+                                                                                                                                                                    <div class="origines-container">
+                                                <div class="origines-container-text">
+                                                    <span>Empreinte CO2</span>
+                                                    <span class="highlight"><span>898</span>g</span>
+                                                </div>
+                                            </div>
+                                                                                <div class="sep-horizontal"></div>
+                                        <div class="etiquettable_label">
+                                            Calculs des informations nutritionnelles et sourcing réalisés par
+                                            <div class="img_etiquettable_container">
+                                                <img src="https://www.recettesetcabas.com/img/theme/logo_etiquettable.webp" alt="logo Etiquettable">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </section>
+                
+
+                                <section class="green_block">
+                    <div id="newsletter"  class="form_newsletter align-self-center newsletter-container container-800">
+                        <div class="center-text">
+                            <div class="h3"><em>Nos recettes coup de c&#339;ur</em></div>
+<p style="text-align: center; font-size: 2rem;">Recevez le livret des recettes pr&#233;f&#233;r&#233;es de nos adeptes</p>
+                        </div>
+                        <form action="https://www.recettesetcabas.com/?Action=recettes&Etape=inscriptionNewsletter" method="POST">
+                            <div class="justify-content-center align-items-center flex">
+                                <input type="email" class="newsletter-email input-large" placeholder="Saisissez votre email" name="email" id="email" required/>
+                                <button class="submit text-xl-center bold color2" type="submit" title="Je crée un compte" id="button-cta-recette-4">OK</button>
+                            </div>
+                            <div class="bloc-cgv d-flex" style="line-height: 1;">
+                                <input type="checkbox" id="input-newsletter" class="input input-newsletter mr-4" name="newsletter" required>
+                                <label for="input-newsletter">
+                                    <em class="fontsize80">
+                                        <p>Je reconnais avoir pris connaissance de la politique de confidentialit&#233;. *</p>
+                                    </em>
+                                </label>
+                            </div>
+                        </form>
+
+                                            </div>
+                </section>
+
+
+                
+                <div class="mt-5 mb-5">
+                    <h2 class="h2 title-underline"><p class="hidden">Je compose un cabas &#224; cuisiner</p></h2>
+                    <div class="h3 title-underline"></div>
+                    <div class="button_cabas_container">
+                        <!-- id="button-cta-recette-5" -->
+                        <p><a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" class="button" id="button-cta-recette-5"> Je teste un panier </a></p>
+                    </div>
+                </div>
+
+                <div class="align-center-c mt-5 mb-5">
+                    <a href="https://www.recettesetcabas.com/recettes" class="button button-color2 mb-5">Retour aux recettes</a>
+                </div>
+            </div>
+
+        
+</div>
+
+
+        </div>
+
+        <div>
+            <div id="footer">
+    <section class="footer_content">
+        <div class="menu_footer container-xl">
+                            <ul class="niveau1">
+                                            <li class="accordion_item n-0">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse0" aria-expanded="false" aria-controls="collapse0" class="h3 collapse-link">
+                                <span >Nos cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Nos cabas</span>
+                            </a>
+                                                            <ul id="collapse0" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/composer-panier-a-cuisiner"   >
+													                                                    <span class="text">Je compose mon panier à cuisiner</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/concept"   >
+													                                                    <span class="text">Le concept</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/coffrets-gourmands"   >
+													                                                    <span class="text">Coffrets gourmands</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/bon-cadeau"   >
+													                                                    <span class="text">Bons cadeaux</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/recettes"   >
+													                                                    <span class="text">Nos recettes</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/valeurs-engagements"   >
+													                                                    <span class="text">Valeurs et engagements</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">Foire aux questions</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-0"></li>
+                                            <li class="accordion_item n-1">
+                            <a href="" role="button" data-toggle="collapse" data-target="#collapse1" aria-expanded="false" aria-controls="collapse1" class="h3 collapse-link">
+                                <span >Recettes & cabas</span> <span class="icon icon-arrow-right"></span>
+                            </a>
+                            <a href="" class="h3">
+                                <span >Recettes & cabas</span>
+                            </a>
+                                                            <ul id="collapse1" class="niveau2">
+                                                                                                                        <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/livraison"   >
+													                                                    <span class="text">La livraison</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/qui-sommes-nous"   >
+													                                                    <span class="text">Qui sommes-nous ?</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/presse"   >
+													                                                    <span class="text">Presse</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/page/parrainage"   >
+													                                                    <span class="text">Parrainage et fidélité</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/blog/"  target="_blank" >
+													                                                    <span class="text">Blog</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/depositaire"   >
+													                                                    <span class="text">Dépositaire agglo LYON</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/relais"   >
+													                                                    <span class="text">Point relais reste de la France</span>
+													</a>												                                            </li>
+                                                                                                                                                                <li class="">
+																																						<a href="https://www.recettesetcabas.com/faq"   >
+													                                                    <span class="text">FAQ</span>
+													</a>												                                            </li>
+                                                                                                            </ul>
+                                                    </li>
+                        <li class="sep-horizontal-mobile n-1"></li>
+                                        <li class="accordion_item logo-tickets-footer">
+                        <span class="h3">
+                            Titres restaurants acceptés
+                        </span>
+                        <div class="logo-tickets-img mb-5">
+                            <img src="https://www.recettesetcabas.com/img/theme/tickets-footer.webp" width="180" height="106" alt="logo titres restaurants acceptés" loading="lazy">
+                        </div>
+                        <div class="reseaux_footer">
+                            <div class="h3">Suivez-nous !</div>
+                                                            <div class="reseaux_links">
+                                                                                                                        <a href="https://www.instagram.com/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-instagram"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','instagram','Footer');">
+                                                <span class="hidden">instagram</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.facebook.com/recettesetcabas" rel="nofollow" target="_blank" class="icon icon-facebook"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','facebook','Footer');">
+                                                <span class="hidden">facebook</span>
+                                            </a>
+                                                                                                                                                                <a href="https://twitter.com/RecettesCabas" rel="nofollow" target="_blank" class="icon icon-twitter"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','twitter','Footer');">
+                                                <span class="hidden">twitter</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.linkedin.com/company/recettes-et-cabas/" rel="nofollow" target="_blank" class="icon icon-linkedin"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','linkedin','Footer');">
+                                                <span class="hidden">linkedin</span>
+                                            </a>
+                                                                                                                                                                <a href="https://www.pinterest.fr/recettes_et_cabas/" rel="nofollow" target="_blank" class="icon icon-pinterest"
+                                                onclick="kTa('send','event', 'reseaux-sociaux','pinterest','Footer');">
+                                                <span class="hidden">pinterest</span>
+                                            </a>
+                                                                                                                                                                                                                                                                    </div>
+                                                    </div>
+                        <div class="sep-horizontal-mobile"></div>
+                    </li>
+                    <li>
+                        <form class="newsletter_footer valid-form" action="#footer" method="post" name="newsletter-form">
+                            <input type="hidden" id="form_newsletter_key_secu_kxr" name="key_secu_kxr"/>
+                            <script type="text/javascript">
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    window.setTimeout(function(){
+                                        $("#form_newsletter_key_secu_kxr").val("6a9610ad2d3c8");
+                                    }, 5000);
+                                });
+                            </script>
+
+                            <div class="h3">Newsletter</div>
+                            <div class="newsletter_container">
+                                <input type="email" name="email_nwl" id="email_nwl" placeholder="Votre email" required>
+                                <button type="submit">OK</button>
+                            </div>
+                            <div id="msg_newsletter">
+                                                                <script>var msg_newsletter;</script>
+                                
+                            </div>
+                        </form>
+
+                        <div class="sep-horizontal-mobile"></div>
+
+                        <div class="contact_container">
+                            <div class="h3">Nous contacter</div>
+
+                                                                    <span class="text-left link link-tel lien-off js-lien-off2" data-href="tel:0482535631" target="_blank"
+                                       onclick="kTa('send', 'event', 'Contact', 'Appel_telephonique', 'Footer', '0482535631');">
+                                        <span class="icon icon-telephone"></span>
+                                        <span class="value number">04 82 53 56 31</span>
+                                    </span>
+                                                                    <p class="button-content whatsapp-footer">
+        <span class="button button-whatsapp text-left link-whatsapp lien-off js-lien-off2"
+              data-href="https://wa.me/330763475861?text=Vous%20souhaitez%20discuter%20avec%20l%27%C3%A9quipe%20Recettes%20%26%20Cabas" target="_blank"
+              onclick="kTa('send', 'event', 'Contact', 'Appel_whatsapp', 'Footer', '0763475861');">
+            <span class="icon icon-whatsapp"></span>
+            <span class="value number">Discuter sur Whatsapp</span>
+        </span>
+    </p>
+                            </div>
+
+                            <a href="https://www.recettesetcabas.com/contactez-nous" class="link" id="button-contact-footer-1">
+                                <span class="icon icon-email"></span>
+                                <span class="txt">Nous écrire</span>
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+                        <div class="footer_bottom">
+                <p style="font-size: 12px;">Interdiction de vente de boissons alcooliques aux mineurs de moins de 18 ans.<br />La preuve de majorit&#233; de l'acheteur est exig&#233;e au moment de la vente en ligne CODE DE LA SANTE PUBLIQUE, ART. L. 3342-1 et L. 3353-3.</p>
+<p style="font-size: 12px;">L'abus d'alcool est dangereux pour la sant&#233;. Sachez consommer avec mod&#233;ration.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="copyrights">
+        <span>@2022 Recettes et Cabas</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/mentions-legales">Mentions légales</span>
+        <span class="sep-vertical"></span>
+        <span class="js-link" data-href="https://www.recettesetcabas.com/page/cgv">CGV</span>
+        <span class="sep-vertical"></span>
+        <a href="javascript:Kookies.moreOptions();" class="Kookies">Gestion des cookies</a>
+    </section>
+
+    <!-- signature kyxar -->
+<div class="kyxar">
+	<a href='https://www.kyxar.fr/' target="_blank" title="Creation et hebergement kyxar (Romans - Drome)" class="lienkyxar" rel="nofollow">
+		<span class="none transition"><span>webdesign > creation web > developpement > SEO</span></span>Site by Kyxar
+	</a>
+</div>
+<script>
+    window.addEventListener("DOMContentLoaded", function() {
+	
+        $('body').on('click', '.js-link', function () {
+            window.location.href = $(this).attr("data-href");
+        });
+		
+        if ($('.cd-main > .alert').length > 0){
+            $('.cd-main > .alert').animate({
+                opacity: .0
+            }, 8000, function() {
+                $('.cd-main > .alert').hide();
+            });
+        }
+    }) ;
+</script>
+
+        </div>
+
+        <div id="gotop">
+            <span class="icon icon-arrow-up"></span>
+        </div>
+
+                <div class="sticky-compose">
+            <a class="sticky-compose-content" href="https://www.recettesetcabas.com/composer-panier-a-cuisiner" title="Composer son cabas" id="button-sticky-compose" onclick="kTa('send','event', 'cta','button-sticky-compose','Recettes_');">
+                <span class="icon icon-plus"></span>
+                <span class="text">Je compose<br>mon cabas</span>
+                <span class="icon icon-cabas-v2"></span>
+            </a>
+        </div>
+        
+        <div id="right_banner"
+             style=' '>
+        </div>
+
+    </div>
+    <!--/ content_body -->
+
+</div>
+
+<!-- Cookies -->
+
+
+
+    <aside id="cookies-content-popin" class="msg-content hidden" data-nosnippet>
+        <div class="logo-cookies">
+            <img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo"
+                 width="350"/>
+        </div>
+        <div class="h4">UTILISATION DES COOKIES</div>
+        <div class="alert-txt">
+                        <p><span class="aheight">Nous utilisons des cookies afin de nous permettre de nous souvenir de vous et de comprendre la mani&#232;re dont vous utilisez le site.<br /></span></p>
+            <br>
+            <span data-href="aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz"
+                  class="lien-off js-lien-off"><strong>En savoir plus ></strong></span>
+        </div>
+        <div class="alert-close">
+            <span onclick="javascript:Kookies.refuse();" class="refused lien-off"
+                  title="Refuser">Continuer sans accepter</span>
+            <span onclick="javascript:Kookies.moreOptions();" class="set-up lien-off"
+                  title="Paramétrer mes choix">Paramétrer mes choix</span>
+            <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+                  title="Accepter">Accepter tous les cookies</span>
+        </div>
+
+        <div id="cookies-options" class="hidden">
+    <p class="h3">Vos paramètres de gestion des cookies</p>
+
+    <div class="h4"></div>
+
+    <div id="cookies-options-list">
+    </div>
+    <div class="alert-close">
+        <span onclick="javascript:Kookies.save();" class="preference lien-off"
+              title="Enregistrer mes préférences">Enregistrer mes préférences</span>
+        <span onclick="javascript:Kookies.accept();" class="accepted lien-off"
+              title="Tout accepter">Tout accepter</span>
+    </div>
+    <p class="mt-2">
+        <em>
+            Vous pouvez à tout moment modifier vos préférences en vous rendant dans la section « Gestion des cookies » en bas de page.
+            <br/>
+            Pour consulter notre Politique de confidentialité et d'utilisation des cookies,
+            <span data-href='aHR0cHM6Ly93d3cucmVjZXR0ZXNldGNhYmFzLmNvbS9wYWdlL3BvbGl0aXF1ZS1kZS1jb29raWVz'
+                    class='link_cookies lien-off js-lien-off'>cliquez ici</span>
+        </em>
+    </p>
+</div>        <div id="cookies-details-type" class="hidden">
+    <div class="cookies-detail-content">
+        <span class="cookies-detail">
+            Voir la liste des cookies<span class="cookies-detail-chevron">></span>
+        </span>
+        <table class="table-responsive">
+            <thead>
+            <tr>
+                <th>
+                    Service
+                </th>
+                <th>
+                    Nom
+                </th>
+                <th>
+                    Domaine
+                </th>
+                <th>
+                    Expiration
+                </th>
+                <th>
+                    Description
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr id="cookies-details-line-type">
+                <td data-type-col="service" class="textcenter">
+                    XXX <!--  contenu remplacé en JS dans kookies.js -->
+                </td>
+                <td data-type-col="nom" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="domaine" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="expiration" class="textcenter">
+                    XXX
+                </td>
+                <td data-type-col="description">
+                    XXX
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>    </aside>
+
+<script type="text/javascript">
+    window.addEventListener('load', function () {
+        Kookies.init({
+            container: 'cookies-content-popin'
+            , // 1 mode barre , 2 mode popin
+            groups: {"fonctionnels":{"code":"fonctionnels","titre":"Cookies fonctionnels","description":"Ils sont n\u00e9cessaires pour assurer le fonctionnement optimal du site et sont donc activ\u00e9s en permanence. Ils sont g\u00e9n\u00e9ralement activ\u00e9s en r\u00e9ponse \u00e0 des actions que vous effectuez et qui correspondent \u00e0 une demande de services, comme la configuration de vos pr\u00e9f\u00e9rences de confidentialit\u00e9, la connexion ou le remplissage de formulaires.","toggle":false,"toggle_defaut":true,"liste_details":[{"rcd_id":"1","societe_service":"Fonctionnel","nom":"PHPSESSID","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Cookie de session<\/p>"},{"rcd_id":"2","societe_service":"Fonctionnel","nom":"ktrack","domaine":"recettesetcabas.com","expiration":"12 mois","description":"<p>Cookie qui m&#233;morise le choix des cookies autoris&#233;s ou non sur le site&#160;<\/p>"},{"rcd_id":"3","societe_service":"Fonctionnel","nom":"client","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"},{"rcd_id":"4","societe_service":"Fonctionnel","nom":"client_key","domaine":"recettesetcabas.com","expiration":"Session","description":"<p>Espace client&#160;<\/p>"}]},"publicitaires":{"code":"publicitaires","titre":"Cookies de ciblage","description":"Ces cookies permettent d'analyser votre navigation et de d\u00e9finir vos centres d'int\u00e9r\u00eats pour vous proposer des publicit\u00e9s plus pertinentes au moyen de cookies. Les d\u00e9sactiver n'a aucun impact sur le volume de publicit\u00e9 affich\u00e9e mais seront moins cibl\u00e9es.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"11","societe_service":"Campaign Manager, Display & Video 360, Google Ads,","nom":"id","domaine":"doubleclick.net","expiration":"13 mois","description":"<p>Functionality, Advertising<\/p>"},{"rcd_id":"12","societe_service":"Google Ads","nom":"_gcl_gb","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"13","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"},{"rcd_id":"14","societe_service":"Google Ads","nom":"_gac_gb_","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Analytics, Advertising<\/p>"}]},"statistiques":{"code":"statistiques","titre":"Cookies de performance et statistiques","description":"Ils nous permettent de d\u00e9terminer le nombre de visites et les sources du trafic sur notre site web, afin d'en mesurer, d'en am\u00e9liorer les performances et \u00e9valuer la pertinence de nos contenus. Ces cookies ne collectent aucune information permettant de vous identifier - toute l'information collect\u00e9e est anonyme. Aucun de ces cookies n'est utilis\u00e9 \u00e0 des fins publicitaires.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"5","societe_service":"Google","nom":"_gat","domaine":"recettesetcabas.com","expiration":"1 minute","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour limiter le taux de demande<\/p>"},{"rcd_id":"6","societe_service":"Google","nom":"_gid","domaine":"recettesetcabas.com","expiration":"24 heures","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Utilis&#233; pour distinguer les utilisateurs.<\/p>"},{"rcd_id":"7","societe_service":"Google","nom":"_ga","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p class=\"cookies_option_description\" style=\"display: block;\">Permet de mesurer la fr&#233;quentation du site et le comportement des utilisateurs<\/p>"},{"rcd_id":"8","societe_service":"Hotjar","nom":"Hotjar_user","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p><span>D&#233;fini quand un utilisateur arrive pour la premi&#232;re fois sur une page.<\/span><\/p>\r\n<p><span>Persiste l'&#160;<\/span><span>ID utilisateur Hotjar<\/span><span>&#160;qui est unique &#224; ce site.<\/span><\/p>\r\n<p><span>Garantit que les donn&#233;es des visites ult&#233;rieures sur le m&#234;me site sont attribu&#233;es au m&#234;me ID utilisateur.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"9","societe_service":"Hotjar","nom":"Hotjar_session","domaine":"recettesetcabas.com","expiration":"30 minutes","description":"<p><span>Contient les donn&#233;es de session en cours.<\/span><\/p>\r\n<p><span>Garantit que les requ&#234;tes suivantes dans la fen&#234;tre de session sont attribu&#233;es &#224; la m&#234;me session.<\/span><\/p>\r\n<p><span>Type de donn&#233;es JSON.<\/span><\/p>"},{"rcd_id":"15","societe_service":"Matomo","nom":"Matomo Analytics","domaine":"recettesetcabas.com","expiration":"2 ans","description":"<p>Collecte des statistiques sur les visiteurs (et leur parcours d'utilisation).<\/p>\r\n<p>Objet : Analyse du trafic<\/p>\r\n<p><\/p>"},{"rcd_id":"16","societe_service":"Microsoft","nom":"Clarity","domaine":"recettesetcabas.com","expiration":"365 jours","description":"<p>Collecte des statistiques sur les visiteurs et leur parcours d'utilisation<\/p>"}]},"tiers":{"code":"tiers","titre":"Cookies m\u00e9dias et social","description":"Ils sont li\u00e9s aux services fournis par des tierces parties, comme les boutons \"J'aime\" ou \"Partager\". Ces tierces parties fournissent leurs services s'ils reconnaissent que vous avez visit\u00e9 notre site.","toggle":true,"toggle_defaut":false,"liste_details":[{"rcd_id":"10","societe_service":"Meta Platforms, Inc.","nom":"_fbp","domaine":"recettesetcabas.com","expiration":"90 jours","description":"<p>Utilis&#233; par Facebook pour fournir une s&#233;rie de produits publicitaires tels que les offres en temps r&#233;el d'annonceurs tiers.<\/p>"}]}},
+            mode: 2,
+            cookie_wall: 0,
+            texte_intro_popin: ""
+        });
+        
+        $(document).ready(function () {
+            Kookies.load();
+        });
+    });
+</script>
+
+
+<!--/ Cookies -->
+
+    <div id="popin_landing" class="popin-landing popin-landing-region hidden">
+    <p class="text-partenariat" style="text-align: center;">Nouveau partenariat</p>
+<div id="logo_popin" class="logo_popin"><span class="logo-content"> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-recettes_et_cabas.svg" alt="Recettes &amp; Cabas" width="245" height="61" class="logo-1" /> <span class="sep-logo"></span> <img src="https://www.recettesetcabas.com/data/fm/landing/region/logo-region.svg" alt="Recettes &amp; Cabas" width="245" height="88" class="logo-2" /> </span></div>
+<p style="text-align: center;" class="txt-1">De bons repas faciles &#224; cuisiner avec les produits</p>
+<p style="text-align: center;" class="txt-2">"Ma R&#233;gion, Ses terroirs".</p>
+<p style="text-align: center;" class="button-content"><a href="https://www.recettesetcabas.com/panier-a-cuisiner-region-auvergne-rhone-alpes?bdr_code=LAREGION" id="btn-landing-popin-region" class="btn btn-landing-popin-region btn-landing">Je d&#233;couvre les recettes</a></p>
+</div>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                    }, false);
+    </script>
+
+
+
+        
+
+
+    <div id="popin-parrainage" class="popin-parrainage hidden">
+    <p class="textcenter mb-5"><img src="https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.svg" alt="Recettes & Cabas" itemprop="logo" width="350" height="88"></p>
+    <p></p>
+<h2>Vous avez &#233;t&#233; parrain&#233;.e par un.e ami.e, bienvenue chez Recettes &amp; Cabas !<br /><br /></h2>
+<h3>Vous b&#233;n&#233;ficiez de 40&#8364; r&#233;partis sur vos 2 premi&#232;res commandes.</h3>
+<h3>Une premi&#232;re r&#233;duction de 20&#8364; figurera automatiquement dans votre panier.</h3>
+<h3>Vous recevrez votre 2&#232;me code de 20&#8364; apr&#232;s votre 1&#232;re commande.</h3>
+<p>&#160;&#160;</p>
+<p class="textcenter"><a href="#" class="button" data-fancybox-close="">OK </a></p>
+</div>
+
+<script>
+    let open_parrain_popup = 0;
+</script>
+    <script type="text/javascript">
+        document.addEventListener("DOMContentLoaded", function () {
+                            initPopinParrainage(0.5);  // 0.5 seconde
+                    }, false);
+    </script>
+
+
+
+        <div id="popin-cp" class="popin-cp hidden">
+    <p>Vous &#234;tes en train de passer une nouvelle commande alors que vous &#234;tes en formule de Commandes Planifi&#233;es.&#160;</p>
+<p>Rendez-vous dans votre Espace Client pour s&#233;lectionner vos recettes de la semaine prochaine ou mettre en pause.</p>
+</div>
+    
+
+<div id="svg_container" class="hidden">
+</div>
+
+<div id="overlay">
+</div>
+
+<script type="text/javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        $('html').removeClass('no-js');
+    }, false);
+</script>
+
+
+
+
+
+<script type="application/ld+json">{"@context": "http://schema.org","@type": "LocalBusiness","name": "Recettes et cabas","logo": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.png","image": "https://www.recettesetcabas.com/img/theme/logo.recettes_et_cabas.reseaux_v2.jpg","isAccessibleForFree": true,"currenciesAccepted": "EUR","paymentAccepted":"Cash, Credit Card","address":{"@type": "PostalAddress","streetAddress" : "12 Chemin des gorges","addressLocality" : "DARDILLY","postalCode" : "69570","addressCountry": "France"},"geo":{"@type": "GeoCoordinates","latitude": "45.828900","longitude": "4.790923"},"telephone": "0482535631","email":     "contact@recettesetcabas.fr","priceRange": "$","sameAs" : ["https://www.instagram.com/recettes_et_cabas/","https://www.facebook.com/recettesetcabas","https://twitter.com/RecettesCabas","https://www.linkedin.com/company/recettes-et-cabas/","https://www.pinterest.fr/recettes_et_cabas/",""],"hasMap": "https://goo.gl/maps/mbKyFsZne17M4aJw6","url": "https://www.recettesetcabas.com/"}</script>
+
+
+<script>
+
+    //définition des variables zoho pour ne pas etre dans la conditionnelle
+    
+    var $zoho=$zoho || {};$zoho.salesiq = $zoho.salesiq ||
+        {widgetcode:"4fe68646a842c7af183fb402fc3edcde6c97f3fcdeecfdd7439b49d1d28bf6eaf4892385512b2997f1aa4a5f44511195", values:{},ready:function(){}};
+    
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const isMobile = window.matchMedia("only screen and (max-width: 640px)").matches;
+        if (!isMobile) {
+            Kookies.addAcceptCallback('tiers', function () {
+                <!-- code de suivi et messagerie Zoho  -->
+                
+                var d=document;s=d.createElement("script");s.type="text/javascript";s.id="zsiqscript";s.defer=true;s.src="https://salesiq.zoho.com/widget";t=d.getElementsByTagName("script")[0];t.parentNode.insertBefore(s,t);
+                // insert div for instant messenger
+                var z=d.createElement("div");z.id='zsiqwidget';b=d.getElementsByTagName("body")[0];b.appendChild(z);
+                
+                <!-- /code de suivi et messagerie Zoho  -->
+            });
+        }
+
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                /* hotjar */
+                
+                (function (h, o, t, j, a, r) {
+                    h.hj = h.hj || function (){(h.hj.q=h.hj.q||[]).push(arguments)};
+                    h._hjSettings ={hjid:3072165,hjsv:6};
+                    a = o.getElementsByTagName('head')[0];
+                    r = o.createElement('script');
+                    r.async = 1;
+                    r.defer = 1;
+                    r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+                    a.appendChild(r);
+                })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+                
+            });
+        
+                                
+            /* clarity */
+            
+            (function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.defer=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+            })(window, document, "clarity", "script", "nbw1j162j3");
+            
+            log_ta('Consent : Clarity default');
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                window.clarity('consent');
+                log_ta('Consent : Clarity accept');
+            });
+            Kookies.addDeclineCallback('statistiques', function () {
+                window.clarity('consent', false);
+                log_ta('Consent : Clarity decline');
+            });
+        
+
+
+    }, false);
+</script>
+<!-- code de suivi trackers analytics  -->
+<script>
+        function log_ta(str)
+    {
+            }
+    </script>
+
+                        <script defer fetchprioroty="low" src="https://www.googletagmanager.com/gtag/js?id=G-RVVDFKHEVG"></script>
+            <script type="text/javascript">
+            
+                var permission_statistiques = 'denied';
+                var permission_publicitaires = 'denied';
+                var permission_fonctionnels = 'granted';
+                      
+                // Initialize ktrack variables
+                
+                
+                // Define dataLayer and the gtag function.
+                window.dataLayer = window.dataLayer || [];
+                function gtag() {
+                    dataLayer.push(arguments);
+                }
+
+                gtag('consent', 'default', {
+                    'analytics_storage': permission_statistiques, //accès au stockage pour les balises d'analyse
+                    'ad_storage': permission_publicitaires, // accès au stockage pour les scripts publicitaires
+                    'ad_user_data': permission_publicitaires, // accès aux données utilisateur pour les scripts publicitaires
+                    'ad_personalization' : permission_publicitaires, // personnalisation des annonces
+                    'wait_for_update': 500,
+                    'region': ['FR'],
+                });
+
+                log_ta('Consent : GA4 default');
+
+                gtag('js', new Date());
+                gtag('config', 'G-RVVDFKHEVG', {'allow_enhanced_conversions':true});
+
+                document.addEventListener('DOMContentLoaded', function () {
+                    Kookies.addAllCallback((permissions) => {
+                        let permission_statistiques = permissions.hasOwnProperty('statistiques') ? permissions['statistiques'] : undefined;
+                        let permission_publicitaires = permissions.hasOwnProperty('publicitaires') ? permissions['publicitaires'] : undefined;
+
+                        if (permission_statistiques !== undefined || permission_publicitaires !== undefined) {
+                            gtag('consent', 'update', {
+                                'analytics_storage': permission_statistiques ? 'granted' : 'denied',
+                                'ad_storage': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_user_data': permission_publicitaires ? 'granted' : 'denied',
+                                'ad_personalization': permission_publicitaires ? 'granted' : 'denied',
+                                'functionality_storage': 'granted', // Permet le stockage qui prend en charge les fonctionnalités du site Web ou de l'application (par exemple, les paramètres linguistiques).
+                                'personalization_storage' : 'granted', // Permet le stockage lié à la personnalisation (exemple, les recommandations de vidéos)
+                                'security_storage': 'granted' // Permet le stockage lié à la sécurité (par exemple, la fonctionnalité d'authentification, la prévention des fraudes et les autres systèmes de protection des utilisateurs).
+                            });
+
+                            log_ta('Consent : GA4 update');
+                        }
+                    });
+                });
+            </script>
+                        <script type="text/javascript">
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.defer=true;j.src=
+                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                })(window,document,'script','dataLayer','GTM-MPDKNVN');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                    // Envois status à GTM
+                    let sendKookieUpdateEvent = function () {
+                        dataLayer.push({
+                            'event': 'kookie_update'
+                        });
+                        log_ta('Consent : GTM');
+                    };
+                    Kookies.addAcceptCallback('statistiques', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('statistiques', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('publicitaires', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('publicitaires', sendKookieUpdateEvent);
+                    
+                    Kookies.addAcceptCallback('tiers', sendKookieUpdateEvent);
+                    Kookies.addDeclineCallback('tiers', sendKookieUpdateEvent);
+
+                    log_ta('Consent : GTM default');
+                });
+            </script>
+                        <script type="text/javascript">
+                var _paq = window._paq = window._paq || [];
+                
+                // require user tracking consent before processing data
+                _paq.push(['requireConsent']);
+
+                // OR require user cookie consent before storing and using any cookies
+                _paq.push(['requireCookieConsent']);
+                
+                _paq.push(['trackPageView']);        
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                    var u="https://analytics.net-it-be.com/";
+                    _paq.push(['setTrackerUrl', u+'matomo.php']);
+                    _paq.push(['setSiteId', '76']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+            
+                log_ta('Consent : Matomo default');
+                
+                document.addEventListener('DOMContentLoaded', function () {
+                                        
+                     Kookies.addDeclineCallback('statistiques', function () {
+                         
+                        // revoke tracking consent
+                        _paq.push(['forgetConsentGiven']);
+                        
+                        // OR revoke cookie consent
+                        _paq.push(['forgetCookieConsentGiven']);
+                                                
+                        log_ta('Consent : Matomo decline');
+                    });
+
+                    Kookies.addAcceptCallback('statistiques', function () {
+                        
+                        // do not call this once user has removed their consent
+                        _paq.push(['setConsentGiven']);
+        
+                        // OR this method if you are using cookie consent
+                        _paq.push(['setCookieConsentGiven']);
+
+                        log_ta('Consent : Matomo accept');
+                    });
+                    
+                });
+                
+            </script>
+    
+<script>
+
+        
+    
+
+
+    var trackers_actives = ["GoogleAnalytics4","GoogleTagManager","Matomo"];
+
+    document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+                
+
+                                                                
+                                
+                                
+                                kTa('set', 'dimension4', 'non');
+                kTa('set', 'dimension2', '0');
+                gtag('set', 'dimension4', 'non');
+                gtag('set', 'dimension2', '0');
+
+
+                
+                // Remontent les toasts
+                
+            } );
+
+        }, 50);
+    } )
+
+
+
+    
+        
+
+
+        // addToCartAnalytics
+        function addToCartAnalytics (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            gtag("event", "add_to_cart", {
+                currency: "EUR",
+                value: prix_vente,
+                items: [
+                    {
+                        item_id: "500000",
+                        item_name: "Recettes",
+                        item_brand: "Recettes & Cabas",
+                        item_category: "Menu",
+                        item_variant: "non",
+                        price: prix_pers_repas,
+                        quantity: nb_personnes * nb_recettes_selectionnees
+                    }
+                ]
+            });
+
+            kTa('send', 'event', 'recette', 'GA4 k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+
+
+</script>
+
+
+
+
+
+
+
+
+
+    <script>
+                window.dataLayer = window.dataLayer || [];
+
+                
+                
+
+    
+        // addToCartAnalytics
+        function addToCartTms (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            window.dataLayer.push( {
+                event: 'add_to_cart',
+
+                ecommerce: {
+
+                    currency: "EUR",
+                    value: prix_vente,
+                    items: [
+                        {
+                            item_id: "500000",
+                            item_name: "Recettes",
+                            item_brand: "Recettes & Cabas",
+                            item_category: "Menu",
+                            item_variant: "non",
+                            price: prix_pers_repas,
+                            quantity: nb_personnes * nb_recettes_selectionnees
+                        }
+                    ]
+                }
+            } );
+            setTimeout(function() {
+                kTa('send', 'event', 'recette', 'GTM k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+            }, 200);
+
+        }
+
+    </script>
+
+
+
+
+
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            //setTimeout(function() {
+
+            Kookies.addAcceptCallback('statistiques', function () {
+
+                
+                                _paq.push(['setCustomDimension', 1, 'non']);
+                _paq.push(['setCustomDimension', 2, '0']);
+
+
+            
+            } );
+            //}, 50);
+        }, false);
+
+    
+        // addToCartAnalytics
+        function addToCartMatomo (nb_personnes, nb_recettes_selectionnees, prix_vente, prix_pers_repas) {
+
+            _paq.push(['addEcommerceItem',
+                "500000", // (Obligatoire) Identifiant du produit (SKU)
+                "Recettes", // (Optionnel) Nom du produit
+                "Menu", // (Optionnel) Catégorie du produit ou un tableau de 5 catégories maximum.
+                prix_pers_repas, // (Optionnel) Prix du produit
+                nb_personnes * nb_recettes_selectionnees // (Optionnel) Quantité du produit (la valeur par défaut est 1)
+            ]);
+
+
+            kTa('send', 'event', 'recette', 'Matomo k_add_to_cart', nb_personnes + ' personnes', nb_recettes_selectionnees + ' recette(s)', 'Total : ' + prix_vente + '€', prix_pers_repas + '€/assiette');
+
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+
+</body>
+</html>


### PR DESCRIPTION
Adds support for recipes on recettesetcabas.com.

The scraper reads the main ingredients from JSON-LD and adds pantry ingredients as a separate group. When schema instructions are missing or collapse several HTML steps into one, it falls back to the recipe section without including introductory text, Thermomix instructions, or site commentary.

Tested against nine stored fixtures and 32 live recipe pages. Full suite: 1,173 tests passing.

If fixture size is a concern, I can drop the redundant pages and keep only the cases needed to cover each parsing path.
