### PR TITLE
fix: WDR collect ingredients from all Zutaten sections

### DIFF
--- a/recipe_scrapers/wdr.py
+++ b/recipe_scrapers/wdr.py
@@ -15,16 +15,16 @@ class WDR(AbstractScraper):
         return self.soup.find("meta", property="og:title")["content"]
 
     def ingredients(self):
-        header = self.soup.find("h2", string=re.compile(r"^Zutaten.*"))
-
-        # find <li> siblings until the next <h2> tag:
         ingredients = []
-        for sibling in header.find_next_siblings(name=True):
-            if sibling.name == "h2":
-                break
-            items = sibling.find_all("li")
-            if len(items) > 0:
-                ingredients.extend([normalize_string(li.get_text()) for li in items])
+        for header in self.soup.find_all("h2", string=re.compile(r"^Zutaten")):
+            for sibling in header.find_next_siblings(name=True):
+                if sibling.name == "h2":
+                    break
+                items = sibling.find_all("li")
+                if len(items) > 0:
+                    ingredients.extend(
+                        [normalize_string(li.get_text()) for li in items]
+                    )
         return ingredients
 
     def image(self):

--- a/tests/test_data/www1.wdr.de/wdr_3.json
+++ b/tests/test_data/www1.wdr.de/wdr_3.json
@@ -1,0 +1,32 @@
+{
+  "canonical_url": "https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html",
+  "site_name": "WDR",
+  "host": "www1.wdr.de",
+  "language": "de",
+  "title": "Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata",
+  "ingredients": [
+    "2 rote Zwiebeln",
+    "1 TL Salz",
+    "1 TL Zucker",
+    "50 ml Weißweinessig",
+    "150 ml heißes Wasser",
+    "4 dicke Scheiben Ciabatta oder kräftiges Sauerteigbrot",
+    "150 g Gorgonzola",
+    "75 g Cheddar (mittelalt, Block)",
+    "6-8 reife, frische Feigen",
+    "50 g geröstete Walnüsse",
+    "Abrieb von 1 Bio-Zitrone",
+    "4 EL Olivenöl",
+    "1 EL Ahornsirup oder Honig",
+    "6 Zweige frischer Thymian",
+    "1 Prise Salz",
+    "schwarzer Pfeffer aus der Mühle"
+  ],
+  "instructions_list": [
+    "Die roten Zwiebeln schälen und in feine Ringe schneiden oder hobeln. Salz, Zucker und Essig in einem Glas mischen. Die Zwiebeln dazugeben und mit heißem Wasser aufgießen. Das Glas verschließen, kräftig schütteln und mindestens 15-20 Minuten ziehen lassen.",
+    "Den Backofen auf 200 Grad Oberhitze vorheizen. Ein Backblech mit Backpapier auslegen. Die Brotscheiben auf dem Blech verteilen. Gorgonzola grob zerbröseln, Cheddar fein reiben und miteinander vermischen. Die Käsemischung auf den Brotscheiben verteilen und im heißen Ofen 4-5 Minuten schmelzen lassen. Die Feigen waschen und in Stücke brechen oder vierteln.",
+    "Für die Gremolata die Walnüsse ohne Fett in einer Pfanne rösten und grob hacken. Thymian abzupfen und hacken. Nüsse, Thymian, Zitronenabrieb, Olivenöl, Ahornsirup, Salz und schwarzen Pfeffer mischen. Die Brotscheiben auf Teller verteilen, mit den Feigenstücken belegen und mit der Thymian-Walnuss-Gremolata beträufeln. Die eingelegten roten Zwiebeln darüber geben und heiß servieren."
+  ],
+  "description": "Julia Floß kombiniert Feigen mit Käse, Thymian, gerösteten Walnüssen und eingelegten roten Zwiebeln. Köstlich!",
+  "image": "https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-gseagaleriexl.jpg"
+}

--- a/tests/test_data/www1.wdr.de/wdr_3.testhtml
+++ b/tests/test_data/www1.wdr.de/wdr_3.testhtml
@@ -1,0 +1,1161 @@
+<!DOCTYPE html>
+<html lang="de" prefix="og: http://ogp.me/ns#">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<link rel="preconnect" href="//www.wdr.de" />
+<script id="jsCssPathAndVersion">
+var cssPath = '/resources-v5.179.4/css/merged_'
+var webappVersion = '5.179.4';
+</script>
+<script type="text/javascript">
+gWDRMetaDataInfoObject =
+{
+"pageData" : {
+"content_type" : "Artikel",
+"content_id" : "gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100",
+"content_uuid" : "4fa89990-67b3-4b53-a7fa-2cc9ea57cb84",
+"product_name" : "Infostrategie",
+"title" : "Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata ",
+"content_tags" : [ "WDR", "WDR", "Hier und heute", "Julia Floß", "Feigen mit Käse", "Thymian", "geröstete Walnüsse", "eingelegte rote Zwiebeln", "NRW" ],
+"tags" : "WDR, WDR, Hier und heute, Julia Floß, Feigen mit Käse, Thymian, geröstete Walnüsse, eingelegte rote Zwiebeln, NRW",
+"page" : "gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100",
+"publication_time" : "2026-08-17T16:50:00+02:00",
+"last_editorial_update" : "2026-08-17T16:50:00+02:00"
+}
+}
+</script>
+<link rel="preload" as="script" href="/resources-v5.179.4/js/merged_scripts.js"/>
+<script src="/resources-v5.179.4/js/merged_scripts.js"></script>
+<link rel="preload" as="style" href="/resources-v5.179.4/css/merged_base.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/base/merged_reset.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/base/merged_fonts.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/base/merged_header.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/base/merged_feature.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/base/merged_external.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/base/merged_geodata.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/merged_xl.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/merged_l.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/merged_m.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/merged_s.css" />
+<link rel="preload" as="style" href="/resources-v5.179.4/css/merged_xs.css" />
+<link as="style" rel="preload" href="/verbraucher/rezepte/bereich-css-fehlerhafte-lupe-100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/lightbox-fix-css-100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/kw-2025-teaser-css-fix-100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/global-font-fix100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/tickerteaserwdrcss-100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/audiomodul-filter-fix100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/podcast-button_fix_100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/broadcast_preview100.css"/>
+<link as="style" rel="preload" href="/verbraucher/rezepte/bugfix-floating100.css"/>
+
+<script id="ardPlayerJS" src="https://exporte.wdr.de/player/current/ardPlayerInit.min.js"></script>
+<meta name="expires" content="0">
+<meta name="viewport" content="width=device-width, user-scalable=yes, initial-scale=1.0, minimum-scale=1.0"/>
+<meta name="Keywords" content="WDR,WDR, Hier und heute, Julia Floß, Feigen mit Käse, Thymian, geröstete Walnüsse, eingelegte rote Zwiebeln,,NRW"/>
+<meta name="Description" content="Julia Floß kombiniert Feigen mit Käse, Thymian, gerösteten Walnüssen und eingelegten roten Zwiebeln. Köstlich!"/>
+<meta name="Author" content="WDR"/>
+<meta name="DC.Rights" content="Nur WDR"/>
+<meta name="DC.Date" content="2026-08-17T16:50:00+02:00"/>
+<meta name="Publisher" content="wdr.de"/>
+<meta property="og:title" content="Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata"/>
+<meta property="og:description" content="Julia Floß kombiniert Feigen mit Käse, Thymian, gerösteten Walnüssen und eingelegten roten Zwiebeln. Köstlich!"/>
+<meta property="og:type" content="article"/>
+<meta name="robots" content="max-image-preview:large">
+<meta property="og:image" content="https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-gseagaleriexl.jpg"/>
+<meta property="og:image:width" content="1600"/>
+<meta property="og:image:height" content="900"/>
+<meta property="og:image" content="https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-square-m.jpg"/>
+<meta property="og:image:width" content="800"/>
+<meta property="og:image:height" content="800"/>
+<meta property="og:image" content="https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-premiumRebrushGross4x3.jpg"/>
+<meta property="og:image:width" content="1200"/>
+<meta property="og:image:height" content="900"/>
+<meta property="og:url" content="https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html"/>
+<meta property="article:published_time" content="2026-08-17T16:50:00+02:00"/>
+<meta property="article:modified_time" content="2026-08-17T16:50:00+02:00"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:site" content="@WDR"/>
+<meta name="robots" content="index,follow,noarchive,unavailable_after: 2028-08-16T18:22:00+02:00 "/>
+<link rel="amphtml" href="/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.amp"/>
+<link rel="canonical" href="https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html"/>
+<!-- Start: Google-MicroData -->
+<script type="application/ld+json">
+{
+"@context" : "https://schema.org/",
+"@type" : "Article",
+"image" : [ {
+"@type" : "ImageObject",
+"contentUrl" : "https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-gseagaleriexl.jpg",
+"height" : 900,
+"width" : 1600,
+"author" : "WDR",
+"name" : "Gorgonzola-Tartine ",
+"datePublished" : "2026-08-17T18:19+02:00",
+"description" : "Gorgonzola-Tartine "
+} ],
+"headline" : "Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata ",
+"keywords" : [ "WDR", "Hier und heute", "Julia Floß", "Feigen mit Käse", "Thymian", "geröstete Walnüsse", "eingelegte rote Zwiebeln", "" ],
+"mainEntityOfPage" : "https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html",
+"publisher" : {
+"@type" : "NewsMediaOrganization",
+"name" : "WDR",
+"logo" : {
+"@type" : "ImageObject",
+"contentUrl" : "https://www1.wdr.de/resources/img/amp/json_logo_amp.png"
+}
+},
+"description" : "Julia Floß kombiniert Feigen mit Käse, Thymian, gerösteten Walnüssen und eingelegten roten Zwiebeln. Köstlich!",
+"author" : [ {
+"@type" : "Person",
+"name" : "WDR"
+} ],
+"datePublished" : "2026-08-17T16:50:00+02:00",
+"dateModified" : "2026-08-17T16:50:00+02:00",
+"@id" : "https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html",
+"url" : "https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html",
+"isAccessibleForFree" : true,
+"associatedMedia" : [ {
+"@type" : "VideoObject",
+"@id" : "https://www1.wdr.de/mediathek/video/sendungen/hier-und-heute/gorgonzola-tartine-mit-feigen-und-walnuss-gremolata--100.html"
+} ]
+}
+</script>
+<script type="application/ld+json">{
+"@context" : "https://schema.org/",
+"@type" : "BreadcrumbList",
+"itemListElement" : [ {
+"@type" : "ListItem",
+"position" : 1,
+"item" : {
+"@id" : "https://www1.wdr.de/index.html",
+"name" : "WDR"
+}
+}, {
+"@type" : "ListItem",
+"position" : 2,
+"item" : {
+"@id" : "https://www1.wdr.de/verbraucher/index.html",
+"name" : "Verbraucher"
+}
+}, {
+"@type" : "ListItem",
+"position" : 3,
+"item" : {
+"@id" : "https://www1.wdr.de/verbraucher/rezepte/index.html",
+"name" : "Rezepte"
+}
+} ]
+}</script>
+<!-- Ende: Google-MicroData -->
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"Website","name":"Westdeutscher Rundfunk Köln","alternateName":"WDR","url":"https://www1.wdr.de/"}
+</script>
+<title>Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata  - Rezepte - Verbraucher</title>
+<link rel="apple-touch-icon" sizes="180x180" href="/resources-v5.179.4/img/favicon/apple-touch-icon.png">
+<link rel="icon" type="image/png" href="/resources-v5.179.4/img/favicon/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="/resources-v5.179.4/img/favicon/favicon-16x16.png" sizes="16x16">
+<link rel="manifest" href="/resources-v5.179.4/img/favicon/manifest.json">
+<link rel="shortcut icon" href="/resources-v5.179.4/img/favicon/favicon.ico">
+<meta name="msapplication-config" content="/resources-v5.179.4/img/favicon/browserconfig.xml">
+<meta name="theme-color" content="#ffffff">
+<link rel="stylesheet" type="text/css" href="/resources-v5.179.4/css/merged_base.css" media="screen"/>
+<link rel="stylesheet" type="text/css" href="/resources-v5.179.4/css/merged_print.css" media="print"/>
+<noscript>
+<link rel="stylesheet" type="text/css" href="/resources-v5.179.4/css/merged_noScript.css"/>
+</noscript>
+
+<meta name="apple-itunes-app" content="app-id=1350826647"/>
+<meta name="google-play-app" content="app-id=de.WDR.NewsApp"/>
+<meta name="smartbanner:title" content="WDR">
+<meta name="smartbanner:author" content="Westdeutscher Rundfunk">
+<meta name="smartbanner:price" content="Laden">
+<meta name="smartbanner:price-suffix-google" content=" im Store">
+<meta name="smartbanner:button" content="öffnen">
+<meta name="smartbanner:close-label" content="schließen">
+<meta name="smartbanner:icon-google" content="/resources/img/wdr/smartbanner/wdr.jpg">
+<meta name="smartbanner:button-url-google" content="https://play.google.com/store/apps/details?id=de.WDR.NewsApp&hl=de_DE">
+<meta name="smartbanner:enabled-platforms" content="android">
+<meta name="smartbanner:hide-ttl" content="864000000">
+<link rel="stylesheet" href="/resources/css/merged_smartbanner.css">
+<script src="/resources/js/external/smartbanner.min.js" async="async"><!-- --></script>
+<link rel="stylesheet" href="/verbraucher/rezepte/bereich-css-fehlerhafte-lupe-100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/lightbox-fix-css-100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/kw-2025-teaser-css-fix-100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/global-font-fix100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/tickerteaserwdrcss-100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/audiomodul-filter-fix100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/podcast-button_fix_100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/broadcast_preview100.css" type="text/css"/>
+<link rel="stylesheet" href="/verbraucher/rezepte/bugfix-floating100.css" type="text/css"/>
+
+</head>
+<body class="wdr themen viewL hyphenated avInline">
+<a id="goToHead"></a>
+<div id="header" >
+<div class="wrapper">
+<div class="section sectionA" data-ctrl-layoutable="{'id':'laySub','action':{'default':['widthBound'],'s':['disable'],'xs':['disable']}}" data-ctrl-collapsible="{'id':'collHead','action':{'default':['openEntries','closeEntriesOnVanish','enable'],'xs':['closeEntries','closeEntriesOnVanish','enable'],'s':['closeEntries','closeEntriesOnVanish','enable']}}">
+<div data-ctrl-layoutable="{'id':'laySub','action':{'default':['widthBound'],'s':['disable'],'xs':['disable']}}" class="mnHolder">
+<div class="fixedHeader">
+<div class="mnHolder">
+<ul id="skipLinks">
+<li>
+<a class="hidden" href="#goToContent">zum Inhalt</a>
+</li>
+<li>
+<a class="hidden" href="#wdrNavi">zur Navigation</a>
+</li>
+<li>
+<a class="hidden" href="#wdrSuche">zur Suche</a>
+</li>
+</ul>
+<div role="banner" class="logo">
+<a href="/index.html" >
+<img src="/resources/img/wdr/logo/wdr_logo.svg" alt="zu Startseite WDR" title="zu Startseite WDR"/>
+</a>
+</div>
+
+<div class="servicenavi" role="navigation">
+<ul data-ctrl-collhead-h3-body="{}">
+<li class="wetter">
+<a href="/nrw/wetter/index.html" title="Startseite ">
+<span>Wetter</span>
+</a>
+</li>
+<li class="verkehr">
+<a href="/nrw/verkehr/index.html" title="Startseite Verkehr">
+<span>Verkehr</span>
+</a>
+</li>
+</ul>
+</div>
+<div id="wdrSuche" role="search" class="searchBox" data-ctrl-collHead-entry="{'id':'dd68b6f0-7f23-4263-a4fb-6eef57d8a125-id'}">
+<a id="wdrSuchLink" class="hidden"></a>
+<div class="searchToggle" data-ctrl-collHead-dd68b6f0-7f23-4263-a4fb-6eef57d8a125-id-trigger="{'action':{'default':['closeOtherEntries','toggleBody']}}">
+<a href="/suche/index.jsp">Suche</a>
+</div>
+<form name="form_dd68b6f0-7f23-4263-a4fb-6eef57d8a125-id"
+class="searchForm"
+method="get"
+id="wdrSuchForm"
+action="/suche/index.jsp"
+data-ctrl-collHead-dd68b6f0-7f23-4263-a4fb-6eef57d8a125-id-body={}
+data-ctrl-autocomplete="{'cdsUrl': 'https://exporte.wdr.de/ContentDeliveryServicev2/', 'app':'wdrstandardwf'}"
+data-ctrl-formular="{'id':'form_dd68b6f0-7f23-4263-a4fb-6eef57d8a125-id'}">
+<input
+id="searchHeader"
+class="searchInput"
+name="q"
+type="text"
+value=""
+placeholder="im WDR suchen"
+/>
+<a	href="/suche/index.jsp"
+class="searchSubmit"
+data-ctrl-form_dd68b6f0-7f23-4263-a4fb-6eef57d8a125-id-trigger="{'action':{'default':['submit']}}">
+</a>
+</form>
+</div>
+
+<div class="naviToggle menueToggle" data-ctrl-collhead-h0-trigger="{'action':{'default':['closeOtherNavis','toggleBody']}}">
+<a href="#" title="Menü öffnen">Menü</a>
+</div>
+</div>
+</div>
+<div class="naviCont" data-ctrl-collhead-entry="{'id':'h0'}">
+<div class="navis" data-ctrl-collhead-h0-body="{}">
+<div role="navigation" class="subnavi" data-ctrl-navigation="{'id':'csub','action':{'default':['closeEntries','closeEntriesOnVanish']}}">
+<a class="hidden" name="wdrNavi" id="wdrNavi"></a>
+<ul class="ressorts">
+<li data-ctrl-csub-entry="{'id':'a1'}">
+<span class="collapsed subressort " data-ctrl-csub-a1-trigger="{'action':{'default':['closeOtherNavis','toggleBody']}}">
+<a href="/nrw/index.html">
+Mein NRW
+</a>
+</span>
+<ul class="subressorts" style="display: none;" data-ctrl-csub-a1-body="{}" data-ctrl-laySub-entry="{}">
+<li>
+<a href="/nrw/index.html">
+Übersicht Mein NRW
+</a>
+</li>
+<li>
+<a href="/nrw/aachen-eifel/index.html">
+Aachen und Eifel
+</a>
+</li>
+<li>
+<a href="/nrw/bergisches-land/index.html">
+Bergisches Land
+</a>
+</li>
+<li>
+<a href="/nrw/muensterland/index.html">
+Münsterland
+</a>
+</li>
+<li>
+<a href="/nrw/niederrhein/index.html">
+Niederrhein
+</a>
+</li>
+<li>
+<a href="/nrw/ostwestfalen-lippe/index.html">
+Ostwestfalen-Lippe
+</a>
+</li>
+<li>
+<a href="/nrw/rheinland/index.html">
+Rheinland
+</a>
+</li>
+<li>
+<a href="/nrw/ruhrgebiet/index.html">
+Ruhrgebiet
+</a>
+</li>
+<li>
+<a href="/nrw/sauerland-siegerland/index.html">
+Sauer- und Siegerland
+</a>
+</li>
+</ul>
+</li>
+<li>
+<span class="collapsed subressort ">
+<a href="/politik/index.html">
+Politik
+</a>
+</span>
+</li>
+<li>
+<span class="collapsed subressort ">
+<a href="/wirtschaft/index.html">
+Wirtschaft
+</a>
+</span>
+</li>
+<li>
+<span class="collapsed subressort ">
+<a href="/sport/index.html">
+Sport
+</a>
+</span>
+</li>
+<li>
+<span class="collapsed subressort ">
+<a href="/freizeit/index.html">
+Freizeit
+</a>
+</span>
+</li>
+<li>
+<span class="collapsed subressort ">
+<a href="/kultur/index.html">
+Kultur
+</a>
+</span>
+</li>
+</ul>
+</div>
+<noscript>
+<div class="naviChooser" data-nosnippet="true">
+<form action="/system/formnavi.jsp" method="post">
+<p>Detail Navigation:</p>
+<select name="path" class="naviSelect">
+<option value="/">WDR</option>
+<optgroup label="Mein NRW">
+<option value="/nrw">Übersicht Mein NRW</option>
+<option value="/nrw/aachen-eifel">Aachen und Eifel</option>
+<option value="/nrw/bergisches-land">Bergisches Land</option>
+<option value="/nrw/muensterland">Münsterland</option>
+<option value="/nrw/niederrhein">Niederrhein</option>
+<option value="/nrw/ostwestfalen-lippe">Ostwestfalen-Lippe</option>
+<option value="/nrw/rheinland">Rheinland</option>
+<option value="/nrw/ruhrgebiet">Ruhrgebiet</option>
+<option value="/nrw/sauerland-siegerland">Sauer- und Siegerland</option>
+</optgroup>
+<optgroup label="Politik">
+<option value="/politik">Übersicht Politik</option>
+</optgroup>
+<optgroup label="Wirtschaft">
+<option value="/wirtschaft">Übersicht Wirtschaft</option>
+</optgroup>
+<optgroup label="Sport">
+<option value="/sport">Übersicht Sport</option>
+</optgroup>
+<optgroup label="Freizeit">
+<option value="/freizeit">Übersicht Freizeit</option>
+</optgroup>
+<optgroup label="Kultur">
+<option value="/kultur">Übersicht Kultur</option>
+</optgroup>
+</select>
+<input value="Zum Ressort wechseln" type="submit">
+</form>
+</div>
+</noscript>
+
+<div class="masternavi" role="navigation" data-ctrl-navigation="{'id':'clayer','action':{'default':['closeEntries','closeEntriesOnVanish']}, 'refreshOnAdded':'true'}">
+<ul>
+<li class="mt" >
+<a href="/mediathek/index.html">
+ARD Mediathek
+</a>
+</li>
+<li class="audiothek" >
+<a href="/audiothek/index.html">
+ARD Sounds
+</a>
+</li>
+</ul>
+</div>
+
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+
+<div id="content" class="segment" data-page-url="https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html" >
+<div class="wrapper equalHeight" role="main">
+<div class="section sectionA hidden">
+<div class="breadcrumb screenReader">
+<p class="hidden">Sie befinden sich hier: </p>
+<ul>
+<li>
+<a href="/index.html">WDR</a>
+</li>
+<li>
+<a href="/verbraucher/index.html">Verbraucher</a>
+</li>
+<li>
+<a href="/verbraucher/rezepte/index.html">Rezepte</a>
+</li>
+</ul>
+</div>
+</div>
+<a id="goToContent"></a>
+
+<div class="section sectionA sectionBanner">
+<div class="con">
+<div class="modBanner">
+<picture data-resp-img-id="BannerNormal">
+<source srcset="/verbraucher/rezepte178~_v-banner-64-9.jpg" media="(min-width: 1901px)" />
+<source srcset="/verbraucher/rezepte178~_v-gseabannerl.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/verbraucher/rezepte178~_v-gseabannerm.jpg" media="(min-width: 768px) and (max-width: 1009px)" />
+<source srcset="/verbraucher/rezepte178~_v-bannerhochs.jpg" media="(min-width: 480px) and (max-width: 767px)" />
+<source srcset="/verbraucher/rezepte178~_v-bannerhochxs.jpg" media="(max-width: 479px)" />
+<source srcset="/verbraucher/rezepte178~_v-gseabannerl.jpg" />
+<img src="/verbraucher/rezepte178~_v-gseabannerl.jpg" alt="Gemüse" width="1024" title="Gemüse | Bildquelle: Mauritius/Schweda" loading="lazy" class="img" height="144"/>
+</picture>
+</div>
+<div data-ctrl-collapsible="{'id':'navProgram','action':{'default':['openEntries','disable'], 'xs':['closeEntries','closeEntriesOnVanish','enable'],'s':['closeEntries','closeEntriesOnVanish','enable']}}" class="innerNavi">
+<div class="naviSerialProgram" role="navigation" data-ctrl-navprogram-entry="{'id':'nav1'}" data-ctrl-collapsible="{'id':'innerNavi','action':{'default':['closeEntries','closeEntriesOnVanish']}}">
+<div class="menueToggle hasArrow" data-ctrl-navprogram-nav1-trigger="{'action':{'default':['closeOtherEntries','toggleBody']}}" style="position: static; cursor: default;">
+<a href="#" title="Menü öffnen">Men&uuml;</a>
+</div>
+<ul class="menu" data-ctrl-navprogram-nav1-body="{}">
+<li >
+<span class="collapsed subressort" >
+<a href="/verbraucher/rezepte/alle-rezepte/index.html">Rezepte</a>
+</span>
+</li>
+<li >
+<span class="collapsed subressort" >
+<a href="/verbraucher/rezepte/kategorien/index.html">Kategorien</a>
+</span>
+</li>
+<li >
+<span class="collapsed subressort" >
+<a href="/verbraucher/rezepte/koeche/index.html">Köche</a>
+</span>
+</li>
+<li >
+<span class="collapsed subressort" >
+<a href="/verbraucher/rezepte/sendungen/index.html">Sendungen</a>
+</span>
+</li>
+</ul>
+<div class="clearMe"></div>
+</div>
+</div>
+</div>
+</div>
+<!-- wdr -->
+
+
+
+<div class="section sectionZ sectionArticle">
+<article role="article">
+<div class="con"
+>
+<div class="modCon">
+<div class="mod modA modParagraph">
+<div class="boxCon">
+<div class="box"    >
+<div class="mediaCon mediaTop">
+<div class="media mediaA">
+<script type="application/ld+json">
+{
+"@type" : "ImageObject",
+"contentUrl" : "https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-fullhd.jpg",
+"height" : 1080,
+"width" : 1920,
+"author" : "WDR",
+"name" : "Gorgonzola-Tartine ",
+"datePublished" : "2026-08-17T18:19+02:00",
+"description" : "Gorgonzola-Tartine "
+}
+</script>
+<picture data-resp-img-id="ParagraphImageSectionZAufmacher">
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-ARDFotogalerie.jpg" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-gseapremiumxl.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-TeaserAufmacher.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-TeaserAufmacher.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-TeaserNormal.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-gseapremiumxl.jpg" />
+<img src="/fernsehen/hier-und-heute/gorgonzola-tartine-100~_v-gseapremiumxl.jpg" alt="Gorgonzola-Tartine " width="704" title="Gorgonzola-Tartine  | Bildquelle: WDR" loading="lazy" class="img" height="396"/>
+</picture>
+</div>
+</div>
+<h1 class="articleHeader headline small">
+<span class="heading ">Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata </span>
+</h1>
+<p class="stand small">
+<span>Stand: </span>
+<time datetime="2026-08-17T16:50:00+02:00">
+17.08.2026, 16:50 Uhr
+</time>
+</p>
+<a id="articleStart"></a>
+<p class="einleitung small">Julia Floß kombiniert Feigen mit Käse, Thymian, gerösteten Walnüssen und eingelegten roten Zwiebeln. Geeignet als Mittagessen, als besonderes Abendbrot oder als Vorspeise.</p>
+
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="con"
+>
+<div class="modCon">
+<div class="mod modA modParagraph">
+<div class="boxCon">
+<div class="box"    >
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="con">
+<div class="modCon">
+<div class="mod modA modParagraph">
+<div class="boxCon">
+<div class="box">
+<div class="linklist sendehinweis">
+<ul class="list">
+<li class="noLink tv">
+<span class="hidden">Sendehinweis: </span>
+Hier und heute
+| 17. August 2026, 17.00 - 18.00 Uhr
+| WDR
+</li>
+
+</ul>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="con"
+>
+<div class="modCon">
+<div class="mod modA modParagraph">
+<div class="boxCon">
+<div class="box"    >
+<h2 class="subtitle small">Das Rezept</h2>
+<h2 class="subtitle small">Gorgonzola-Tartine mit Feigen, Thymian-Walnuss-Gremolata und eingelegten Zwiebeln</h2>
+<p class="text small">von Julia Floß für vier Portionen</p>
+<h2 class="subtitle small">Zutaten für eingelegte rote Zwiebeln</h2>
+<div class="checklist small"><ul><li>2 rote Zwiebeln</li><li>1 <abbr title="Teelöffel">TL</abbr> Salz</li><li>1 <abbr title="Teelöffel">TL</abbr> Zucker</li><li>50 <abbr title="Milliliter">ml</abbr> Weißweinessig</li><li>150 <abbr title="Milliliter">ml </abbr>heißes Wasser</li></ul></div>
+<h2 class="subtitle small">Zutaten für die Tartine</h2>
+<div class="checklist small"><ul><li>4 dicke Scheiben Ciabatta oder kräftiges Sauerteigbrot</li><li>150 <abbr title="Gramm">g</abbr> Gorgonzola</li><li>75 <abbr title="Gramm">g</abbr> Cheddar (mittelalt, Block)</li><li>6-8 reife, frische Feigen</li></ul></div>
+<h2 class="subtitle small">Zutaten für die Thymian-Walnuss-Zitronen-Gremolata</h2>
+<div class="checklist small"><ul><li>50 <abbr title="Gramm">g</abbr> geröstete Walnüsse</li><li>Abrieb von 1 Bio-Zitrone</li><li>4 <abbr title="Esslöffel">EL</abbr> Olivenöl</li><li>1 <abbr title="Esslöffel">EL</abbr> Ahornsirup oder Honig</li><li>6 Zweige frischer Thymian</li><li>1 Prise Salz</li><li>schwarzer Pfeffer aus der Mühle</li></ul></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="con">
+<div class="modCon">
+<div class="mod modA modHeadline small">
+<div class="boxCon">
+<div class="box">
+<div class="teaser">
+<h3 class="headline">Das Rezept zum Download</h3>
+<div class="linklist">
+<ul class="list">
+<li class="download" >
+<a href="/verbraucher/rezepte/rezept-gorgonzola-tartine-mit-thymian-walnuss-gremolata-100.pdf" title="Gorgonzola-Tartine mit Feigen, Thymian-Walnuss-Gremolata und eingelegten Zwiebeln, download">
+<span>Gorgonzola-Tartine mit Feigen, Thymian-Walnuss-Gremolata und eingelegten Zwiebeln [PDF, 91,3 KB]</span> | <span><strong>download</strong></span>
+</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<div class="con"
+>
+<div class="modCon">
+<div class="mod modA modParagraph">
+<div class="boxCon">
+<div class="box"    >
+<div class="mediaCon mediaBottom small  videoRatio landscape ">
+<div class="media mediaA videoLink">
+<!-- Start: Google-MicroData -->
+<script type="application/ld+json">
+{
+"@context" : "https://schema.org/",
+"@type" : "VideoObject",
+"image" : [ {
+"@type" : "ImageObject",
+"contentUrl" : "https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-gseagaleriexl.jpg",
+"height" : 900,
+"width" : 1600,
+"author" : "WDR",
+"name" : "Gorgonzola-Tartine",
+"datePublished" : "2026-08-17T18:10+02:00",
+"description" : "Gorgonzola-Tartine"
+} ],
+"headline" : "Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata ",
+"keywords" : [ "Hier und heute", "WDR", "Fernsehen", "Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata" ],
+"publisher" : {
+"@type" : "NewsMediaOrganization",
+"name" : "WDR",
+"logo" : {
+"@type" : "ImageObject",
+"contentUrl" : "https://www1.wdr.de/resources/img/amp/json_logo_amp.png"
+}
+},
+"description" : "Julia Floß kombiniert Feigen mit Käse, Thymian, gerösteten Walnüssen und eingelegten roten Zwiebeln. Köstlich!",
+"name" : "Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata ",
+"datePublished" : "2026-08-17T18:21:48+02:00",
+"dateModified" : "2026-08-17T18:21:48+02:00",
+"duration" : "PT13M34S",
+"uploadDate" : "2026-08-17T17:00:00.000+02:00",
+"thumbnailURL" : [ "https://www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-gseagaleriexl.jpg" ],
+"expires" : "2028-08-17T17:00+02:00",
+"@id" : "https://www1.wdr.de/mediathek/video/sendungen/hier-und-heute/gorgonzola-tartine-mit-feigen-und-walnuss-gremolata--100.html",
+"url" : "https://www1.wdr.de/mediathek/video/sendungen/hier-und-heute/gorgonzola-tartine-mit-feigen-und-walnuss-gremolata--100.html",
+"isAccessibleForFree" : true,
+"contentUrl" : "https://wdr-progressive.ard-mcdn.de/media/p/public/weltweit/2026/08/17/275d5767-9017-4c22-a972-f3b3dd2ef4d8/275d5767-9017-4c22-a972-f3b3dd2ef4d8_AVC-1080.mp4"
+}
+</script>
+<!-- Ende: Google-MicroData -->
+<script>
+globalObject.gseaInlineMediaData = globalObject.gseaInlineMediaData || {};
+globalObject.gseaInlineMediaData["sophora-e6806ea3-41fa-4cc0-b0ee-b2960f0e9010"] =
+{
+"mediaVersion" : "1.4.0",
+"mediaType" : "vod",
+"mediaResource" : {
+"dflt" : {
+"videoURL" : "//wdradaptiv-vh.akamaihd.net/i/media/p/public/weltweit/2026/08/17/275d5767-9017-4c22-a972-f3b3dd2ef4d8/275d5767-9017-4c22-a972-f3b3dd2ef4d8_AVC-,270,360,540,720,1080,.mp4.csmil/master.m3u8",
+"mediaFormat" : "hls"
+},
+"alt" : {
+"videoURL" : "//wdr-progressive.ard-mcdn.de/media/p/public/weltweit/2026/08/17/275d5767-9017-4c22-a972-f3b3dd2ef4d8/275d5767-9017-4c22-a972-f3b3dd2ef4d8_AVC-720.mp4",
+"mediaFormat" : "mp4"
+},
+"previewImage" : "//www1.wdr.de/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-%%FORMAT%%.jpg",
+"duration" : 814
+},
+"trackerData" : {
+"trackerClipId" : "sophora-e6806ea3-41fa-4cc0-b0ee-b2960f0e9010",
+"trackerClipMeFoId" : "853076",
+"trackerClipCategory" : "WDR",
+"trackerClipSubcategory" : "Hier und heute",
+"trackerClipTitle" : "Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata ",
+"trackerClipAirTime" : "17.08.2026 17:00",
+"trackerClipIsTrailer" : "0",
+"trackerClipAgfCategory" : "Information",
+"trackerClipIsWebOnly" : "0"
+}
+};
+</script>
+<a href="javascript:void(0);"
+rel="nofollow"
+class="mediaLink video"
+title="Video starten"
+data-extension-ard='{"mediaObj":{"type":"inline","ref":"sophora-e6806ea3-41fa-4cc0-b0ee-b2960f0e9010"}}'
+>
+<picture data-resp-img-id="ParagraphImageSectionZAufmacher">
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-ARDFotogalerie.jpg" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-gseapremiumxl.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-TeaserAufmacher.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-TeaserAufmacher.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-TeaserNormal.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-gseapremiumxl.jpg" />
+<img src="/fernsehen/hier-und-heute/gorgonzola-tartine100~_v-gseapremiumxl.jpg" alt="Gorgonzola-Tartine" width="704" title="Gorgonzola-Tartine | Bildquelle: WDR" loading="lazy" class="" height="396"/>
+</picture>
+<span class="hidden">Video starten, abbrechen mit Escape</span>
+</a>
+</div>
+<div class="mediaInfo">
+<div class="infotext">
+<h2 class="mediaTitle">Gorgonzola-Tartine mit Feigen und Walnuss-Gremolata </h2>
+<p class="mediaAdditionalInfo">
+<span class="mediaSerial">Hier und heute</span><span class="hidden">. </span>
+<span class="mediaDate">17.08.2026</span><span class="hidden">. </span>
+<span class="mediaDuration">13 <abbr title='Minuten'>Min.</abbr> 34 <abbr title='Sekunden'>Sek.</abbr></span><span class="hidden">. </span>
+<span class="mediaExpiry">Verfügbar bis 17.08.2028</span><span class="hidden">. </span>
+<span class="mediaStation">WDR</span><span class="hidden">. </span>
+</p>
+</div>
+</div>
+</div>
+<h2 class="subtitle small">Zubereitung</h2>
+<p class="text small">Die roten Zwiebeln schälen und in feine Ringe schneiden oder hobeln. Salz, Zucker und Essig in einem Glas mischen. Die Zwiebeln dazugeben und mit heißem Wasser aufgießen. Das Glas verschließen, kräftig schütteln und mindestens 15-20 Minuten ziehen lassen.</p>
+<div class="mediaCon mediaRight small">
+<div class="media mediaA">
+<picture data-resp-img-id="ParagraphImageSectionZAustausch" data-ctrl-imagelightbox>
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-gseaclassicxl.jpg" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-ARDAustauschformat.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-ARDAustauschformat.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-ARDAustauschformat.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-TeaserNormal.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-HDready.jpg" media="(max-width: 0px)" data-lightbox="desktop"/>
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-gseapremiumxl.jpg" media="(max-width: 0px)" data-lightbox="mobile"/>
+<source srcset="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-ARDAustauschformat.jpg" />
+<img src="/fernsehen/hier-und-heute/quintessenztippsundtrends-1608~_v-ARDAustauschformat.jpg" alt="Ein angeschnittenes Stück Gorgonzola" width="256" title="Ein angeschnittenes Stück Gorgonzola | Bildquelle: dpa" loading="lazy" class="img" height="144"/>
+</picture>
+<div class="mediaInfo">
+<p class="infotext">
+Den Gorgonzola grob zerbröseln, mit geriebenem Cheddar mischen und auf den Brotscheiben verteilen.
+</p>
+</div>
+</div>
+</div>
+<p class="text small">Den Backofen auf 200 Grad Oberhitze vorheizen. Ein Backblech mit Backpapier auslegen. Die Brotscheiben auf dem Blech verteilen. Gorgonzola grob zerbröseln, Cheddar fein reiben und miteinander vermischen. Die Käsemischung auf den Brotscheiben verteilen und im heißen Ofen 4-5 Minuten schmelzen lassen. Die Feigen waschen und in Stücke brechen oder vierteln.</p>
+<p class="text small">Für die Gremolata die Walnüsse ohne Fett in einer Pfanne rösten und grob hacken. Thymian abzupfen und hacken. Nüsse, Thymian, Zitronenabrieb, Olivenöl, Ahornsirup, Salz und schwarzen Pfeffer mischen. <br/>Die Brotscheiben auf Teller verteilen, mit den Feigenstücken belegen und mit der Thymian-Walnuss-Gremolata beträufeln. Die eingelegten roten Zwiebeln darüber geben und heiß servieren.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="con">
+<div class="modCon">
+<div class="mod modA modHeadline small">
+<div class="boxCon">
+<div class="box">
+<div class="teaser">
+<div class="linklist">
+<ul class="list">
+<li >
+<a href="/fernsehen/hier-und-heute/sendungen/hier-und-heute-newsletter-100.html" title="Rezeptpost-Newsletter abonnieren">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="LinklistenteaserImageSectionZModA">
+<source srcset="/fernsehen/hier-und-heute/kochloeffel-104~_v-ARDAustauschformat.jpg" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/hier-und-heute/kochloeffel-104~_v-ARDGrosserTeaser.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/hier-und-heute/kochloeffel-104~_v-ARDKleinerTeaser.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/kochloeffel-104~_v-ARDKleinerTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/kochloeffel-104~_v-ARDKleinerTeaser.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/kochloeffel-104~_v-ARDGrosserTeaser.jpg" />
+<img src="/fernsehen/hier-und-heute/kochloeffel-104~_v-ARDGrosserTeaser.jpg" alt="Kochlöffel" width="192" title="Kochlöffel | Bildquelle: mauritius images" loading="lazy" class="img" height="108"/>
+</picture>
+</div>
+</div>
+<span>Rezeptpost-Newsletter abonnieren</span> <span>|</span> <strong>mehr</strong>
+</a>
+</li>
+<li >
+<a href="/fernsehen/hier-und-heute/sendungen/uebersicht-kochen-und-backen-100.html" title="Kochen und Backen ">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="LinklistenteaserImageSectionZModA">
+<source srcset="/fernsehen/hier-und-heute/kochen-backen-uebersicht-100~_v-ARDAustauschformat.png" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/hier-und-heute/kochen-backen-uebersicht-100~_v-ARDGrosserTeaser.png" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/hier-und-heute/kochen-backen-uebersicht-100~_v-ARDKleinerTeaser.png" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/kochen-backen-uebersicht-100~_v-ARDKleinerTeaser.png" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/kochen-backen-uebersicht-100~_v-ARDKleinerTeaser.png" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/hier-und-heute/kochen-backen-uebersicht-100~_v-ARDGrosserTeaser.png" />
+<img src="/fernsehen/hier-und-heute/kochen-backen-uebersicht-100~_v-ARDGrosserTeaser.png" alt="Kochen und Backen Übersicht" width="192" title="Kochen und Backen Übersicht | Bildquelle: WDR / Shutterstock/j.chizhe" loading="lazy" class="img" height="108"/>
+</picture>
+</div>
+</div>
+<span>Unsere Rezeptsammlung</span> <span>|</span> <strong>mehr</strong>
+</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+
+
+
+</article>
+</div>
+<div class="section sectionC sectionArticle">
+<div class="con">
+<div class="mod modA">
+<div class="boxCon">
+<div class="box categories">
+<h3 class="ressort">Weitere Themen</h3>
+<div class="teaser">
+<div class="linklist">
+<ul class="list">
+<li>
+<a href="/verbraucher/rezepte/index.html" class="button" title="Rezepte">Rezepte</a>
+</li>
+<li>
+<a href="/verbraucher/rezepte/kategorien/uebersicht-vorspeisen-snacks-100.html" class="button" title="Vorspeisen / Snacks">Vorspeisen / Snacks</a>
+</li>
+<li>
+<a href="/verbraucher/rezepte/kategorien/uebersicht-vegetarisch-100.html" class="button" title="Vegetarisch ">Vegetarisch </a>
+</li>
+<li>
+<a href="/verbraucher/rezepte/koeche/uebersicht-julia-floss-100.html" class="button" title="Julia Floß">Julia Floß</a>
+</li>
+<li>
+<a href="/fernsehen/hier-und-heute/sendungen/uebersicht-kochen-und-backen-100.html" class="button" title="Hier und heute ">Hier und heute </a>
+</li>
+<li>
+<a href="/verbraucher/rezepte/kategorien/uebersicht-gemuese-salate-100.html" class="button" title="Gemüse / Salate ">Gemüse / Salate </a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="con">
+<div class="modCon">
+<div class="mod modA modPicList">
+<div aria-live="polite" class="boxCon">
+<div class="box">
+<h3 class="ressort">Aktuelle Rezepte</h3>
+<div class="teaser">
+<div class="linklist">
+<ul id='relatedContent' class="list">
+<li >
+<a href="/verbraucher/rezepte/sonja-girndt-haeppchen-100.html" title="Baguette Häppchen">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="LinklistenteaserImageSectionCModA">
+<source srcset="/fernsehen/land-und-lecker/sonja-girndt-haeppchen-102~_v-ARDGrosserTeaser.jpg" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/land-und-lecker/sonja-girndt-haeppchen-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/land-und-lecker/sonja-girndt-haeppchen-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/sonja-girndt-haeppchen-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/sonja-girndt-haeppchen-102~_v-ARDKleinerTeaser.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/sonja-girndt-haeppchen-102~_v-ARDKleinerTeaser.jpg" />
+<img src="/fernsehen/land-und-lecker/sonja-girndt-haeppchen-102~_v-ARDKleinerTeaser.jpg" alt="Baguette Häppchen" width="128" title="Baguette Häppchen | Bildquelle: WDR" loading="lazy" class="img" height="72"/>
+</picture>
+</div>
+</div>
+<span>Baguette Häppchen</span> <span>|</span> <strong>mehr</strong>
+</a>
+</li>
+<li >
+<a href="/verbraucher/rezepte/gregor-keller-feigentraum-100.html" title="Feigentraum">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="LinklistenteaserImageSectionCModA">
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-feigentraum-102~_v-ARDGrosserTeaser.jpg" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-feigentraum-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-feigentraum-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-feigentraum-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-feigentraum-102~_v-ARDKleinerTeaser.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-feigentraum-102~_v-ARDKleinerTeaser.jpg" />
+<img src="/fernsehen/land-und-lecker/gregor-keller-feigentraum-102~_v-ARDKleinerTeaser.jpg" alt="Feigentraum" width="128" title="Feigentraum | Bildquelle: WDR" loading="lazy" class="img" height="72"/>
+</picture>
+</div>
+</div>
+<span>Feigentraum</span> <span>|</span> <strong>mehr</strong>
+</a>
+</li>
+<li >
+<a href="/verbraucher/rezepte/gregor-keller-kreauterbutter-100.html" title="Viererlei Kräuterbutter">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="LinklistenteaserImageSectionCModA">
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-kreauterbutter-102~_v-ARDGrosserTeaser.jpg" media="(min-width: 1901px)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-kreauterbutter-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-kreauterbutter-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-kreauterbutter-102~_v-ARDKleinerTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-kreauterbutter-102~_v-ARDKleinerTeaser.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/fernsehen/land-und-lecker/gregor-keller-kreauterbutter-102~_v-ARDKleinerTeaser.jpg" />
+<img src="/fernsehen/land-und-lecker/gregor-keller-kreauterbutter-102~_v-ARDKleinerTeaser.jpg" alt="Viererlei Kräuterbutter" width="128" title="Viererlei Kräuterbutter | Bildquelle: WDR" loading="lazy" class="img" height="72"/>
+</picture>
+</div>
+</div>
+<span>Viererlei Kräuterbutter</span> <span>|</span> <strong>mehr</strong>
+</a>
+</li>
+<li >
+<a href="/verbraucher/rezepte/alle-rezepte/erdnuss-reisnudel-salat-100.html" title="Erdnuss-Reisnudelsalat mit Gewürztofu">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="LinklistenteaserImageSectionCModA">
+<source srcset="/radio/wdr5/sendungen/alles-in-butter/reisnudelsalat-100~_v-ARDGrosserTeaser.jpg" media="(min-width: 1901px)" />
+<source srcset="/radio/wdr5/sendungen/alles-in-butter/reisnudelsalat-100~_v-ARDKleinerTeaser.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/radio/wdr5/sendungen/alles-in-butter/reisnudelsalat-100~_v-ARDKleinerTeaser.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/radio/wdr5/sendungen/alles-in-butter/reisnudelsalat-100~_v-ARDKleinerTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/radio/wdr5/sendungen/alles-in-butter/reisnudelsalat-100~_v-ARDKleinerTeaser.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/radio/wdr5/sendungen/alles-in-butter/reisnudelsalat-100~_v-ARDKleinerTeaser.jpg" />
+<img src="/radio/wdr5/sendungen/alles-in-butter/reisnudelsalat-100~_v-ARDKleinerTeaser.jpg" alt="Reisnudelsalat mit Gemüse und Erdnusssauce" width="128" title="Reisnudelsalat mit Gemüse und Erdnusssauce | Bildquelle: picture alliance / FoodCollection" loading="lazy" class="img" height="72"/>
+</picture>
+</div>
+</div>
+<span>Erdnuss-Reisnudelsalat mit Gewürztofu</span> <span>|</span> <strong>mehr</strong>
+<span class="targetMediaDescriptor">&nbsp;&nbsp;mit Audio</span>
+</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="con">
+<div class="modCon">
+<div class="mod modA">
+<div aria-live="polite" class="boxCon">
+<div class="box">
+
+<div class="teaser hideTeasertext">
+<a href="/verbraucher/rezepte/index.html" title="WDR-Rezepte im Überblick">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="TeaserImageStandardSectionCModA">
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-110~_v-TeaserAufmacher.jpg" media="(min-width: 1901px)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-110~_v-gseaclassicxl.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-110~_v-ARDAustauschformat.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-110~_v-ARDGrosserTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-110~_v-ARDAustauschformat.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-110~_v-gseaclassicxl.jpg" />
+<img src="/verbraucher/rezepte/uebersicht-rezepte-110~_v-gseaclassicxl.jpg" alt="Frau schneidet Gemüse" width="418" title="Frau schneidet Gemüse | Bildquelle: Mauritius" loading="lazy" class="img" height="235"/>
+</picture>
+</div>
+</div>
+<h4 data-more-text="mehr"  class="headline">
+WDR-Rezepte im Überblick
+</h4>
+<p class="teasertext">
+Für ihre Fans lassen sich die WDR-Köche jede Menge leckerer Rezepte einfallen. Auf unserer Übersicht haben wir die aktuellsten zusammengefasst.
+&nbsp;|&nbsp;
+<strong>mehr</strong>
+</p>
+</a>
+</div>
+</div>
+<div class="box">
+
+<div class="teaser hideTeasertext">
+<a href="/verbraucher/rezepte/kategorien/index.html" title="Rezepte nach Themen">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="TeaserImageStandardSectionCModA">
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-themen100~_v-TeaserAufmacher.jpg" media="(min-width: 1901px)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-themen100~_v-gseaclassicxl.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-themen100~_v-ARDAustauschformat.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-themen100~_v-ARDGrosserTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-themen100~_v-ARDAustauschformat.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/verbraucher/rezepte/uebersicht-rezepte-themen100~_v-gseaclassicxl.jpg" />
+<img src="/verbraucher/rezepte/uebersicht-rezepte-themen100~_v-gseaclassicxl.jpg" alt="Rezepte auf einem Buffet" width="418" title="Rezepte auf einem Buffet | Bildquelle: WDR / creativ collection" loading="lazy" class="img" height="235"/>
+</picture>
+</div>
+</div>
+<h4 data-more-text="mehr"  class="headline">
+Rezepte nach Themen
+</h4>
+<p class="teasertext">
+Hier finden Sie alle Rezepte des WDR geordnet nach Themen.
+&nbsp;|&nbsp;
+<strong>mehr</strong>
+</p>
+</a>
+</div>
+</div>
+<div class="box">
+
+<div class="teaser hideTeasertext">
+<a href="/verbraucher/index.html" title="Übersicht - kugelzwei, Reisen und Rezepte">
+<div class="mediaCon">
+<div class="media mediaA">
+<picture data-resp-img-id="TeaserImageStandardSectionCModA">
+<source srcset="/teaser-leuchtturm-verbraucher-102~_v-TeaserAufmacher.jpg" media="(min-width: 1901px)" />
+<source srcset="/teaser-leuchtturm-verbraucher-102~_v-gseaclassicxl.jpg" media="(min-width: 1010px) and (max-width: 1900px)" />
+<source srcset="/teaser-leuchtturm-verbraucher-102~_v-ARDAustauschformat.jpg" media="(min-width: 768px) and (max-width: 1009px) and (max-resolution: 1.49dppx)" />
+<source srcset="/teaser-leuchtturm-verbraucher-102~_v-ARDGrosserTeaser.jpg" media="(min-width: 480px) and (max-width: 767px) and (max-resolution: 1.49dppx)" />
+<source srcset="/teaser-leuchtturm-verbraucher-102~_v-ARDAustauschformat.jpg" media="(max-width: 479px) and (max-resolution: 1.49dppx)" />
+<source srcset="/teaser-leuchtturm-verbraucher-102~_v-gseaclassicxl.jpg" />
+<img src="/teaser-leuchtturm-verbraucher-102~_v-gseaclassicxl.jpg" alt="Illustration Leuchtturm WDR Verbraucher, Montage von Orangenhälften, Minze, Einkaufskorb" width="418" title="Illustration Leuchtturm WDR Verbraucher, Montage von Orangenhälften, Minze, Einkaufskorb | Bildquelle: WDR/pa/Westend61/newspixxvarioimages[M]Schweda" loading="lazy" class="img" height="235"/>
+</picture>
+</div>
+</div>
+<h4 data-more-text="mehr" data-pre-headline="Verbraucher-Homepage" class="headline">
+Übersicht - kugelzwei, Reisen und Rezepte
+</h4>
+<p class="teasertext">
+Inspirationen von kugelzwei sowie aktuelle Rezepte und Reisereportagen aus dem WDR-Programm.
+&nbsp;|&nbsp;
+<strong>mehr</strong>
+</p>
+</a>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="section sectionA">
+<div class="con">
+<div class="socialMedia">
+<div class="mod modSharing">
+<div class="shareCon">
+<ul class="shares clearfix">
+<li class="fb">
+<a rel="noopener nofollow" href="http://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww1.wdr.de%2Fverbraucher%2Frezepte%2Fgorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html%3Fat_medium%3Dwdr.de%26at_campaign%3Dsharing%26at_source%3DFacebook" title="Bei Facebook teilen. Link öffnet in neuem Fenster" target="_blank"><img alt="Bei Facebook teilen" src="/resources/img/base/icon/sharing_fb.svg"></a>
+</li>
+<li class="twitter">
+<a rel="noopener nofollow" href="http://twitter.com/share?url=https%3A%2F%2Fwww1.wdr.de%2Fverbraucher%2Frezepte%2Fgorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html%3Fat_medium%3Dwdr.de%26at_campaign%3Dsharing%26at_source%3DTwitter&text=Gorgonzola-Tartine+mit+Feigen+und+Walnuss-Gremolata+&via=wdr" title="Bei X teilen. Link öffnet in neuem Fenster" target="_blank"><img alt="Bei X teilen" src="/resources/img/base/icon/sharing_x.svg"></a>
+</li>
+<li class="email">
+<a href="mailto:?subject=Linktipp%3A%20Gorgonzola-Tartine%20mit%20Feigen%20und%20Walnuss-Gremolata%20&body=Linktipp%3A%20Gorgonzola-Tartine%20mit%20Feigen%20und%20Walnuss-Gremolata%20%0Ahttps%3A%2F%2Fwww1.wdr.de%2Fverbraucher%2Frezepte%2Fgorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html%3Fat_medium%3Dwdr.de%26at_campaign%3Dsharing%26at_source%3DE-Mail" title="Via E-Mail empfehlen" target="_blank"><img alt="Via E-Mail empfehlen" src="/resources/img/base/icon/sharing_email.svg"></a>
+</li>
+<li class="whatsapp">
+<a rel="noopener nofollow" href="whatsapp://send?text=Linktipp%3A%20Gorgonzola-Tartine%20mit%20Feigen%20und%20Walnuss-Gremolata%20%20https%3A%2F%2Fwww1.wdr.de%2Fverbraucher%2Frezepte%2Fgorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html%3Fat_medium%3Dwdr.de%26at_campaign%3Dsharing%26at_source%3DWhatsapp" title="Via WhatsApp empfehlen" target="_blank"><img alt="Via WhatsApp empfehlen" src="/resources/img/base/icon/sharing_whatsapp.svg"></a>
+</li>
+<li class="print">
+<a href="#" title="Seite drucken" onclick="app.printWindow();
+return false;">
+<img alt="Seite drucken" src="/resources/img/base/icon/sharing_print.svg">
+</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+
+</div>
+</div>
+<div class="section sectionA">
+<div class="breadcrumb">
+<p class="hidden">Sie befinden sich hier: </p>
+<ul>
+<li>
+<a href="/index.html">WDR</a>
+</li>
+<li>
+<a href="/verbraucher/index.html">Verbraucher</a>
+</li>
+<li>
+<a href="/verbraucher/rezepte/index.html">Rezepte</a>
+</li>
+</ul>
+</div>
+<div class="poweruser">
+<span title="Darstellung der Seite">Darstellung:</span>
+<ul>
+<li title="Seite passt sich automatisch Ihrem Gerät an"><a onclick="app.mediaMatcher.forceQuery('auto',0); return false;" href="#">Auto</a></li>
+<li title="Seite in Größe XS anzeigen" data-ctrl-attributeswap="{'action':{'default':{'class':''},'xs':{'class':'active'}}}"><a onclick="app.mediaMatcher.forceQuery(0,48); return false;" href="#">XS</a></li>
+<li title="Seite in Größe S anzeigen" data-ctrl-attributeswap="{'action':{'default':{'class':''},'s':{'class':'active'}}}"><a onclick="app.mediaMatcher.forceQuery(1,48); return false;" href="#">S</a></li>
+<li title="Seite in Größe M anzeigen" data-ctrl-attributeswap="{'action':{'default':{'class':''},'m':{'class':'active'}}}"><a onclick="app.mediaMatcher.forceQuery(2,48); return false;" href="#">M</a></li>
+<li title="Seite in Größe L anzeigen" data-ctrl-attributeswap="{'action':{'default':{'class':''},'l':{'class':'active'}}}"><a onclick="app.mediaMatcher.forceQuery(3,48); return false;" href="#">L</a></li>
+<li title="Seite in Größe XL anzeigen" data-ctrl-attributeswap="{'action':{'default':{'class':''},'xl':{'class':'active'}}}"><a onclick="app.mediaMatcher.forceQuery(4,48); return false;" href="#">XL</a></li>
+</ul>
+<a title="zum Seitenanfang springen" class="button inv" data-ctrl-attributeswap="{'action':{'default':{'href':'#goToHead'},'xs':{'href':'#goToContent'},'s':{'href':'#goToContent'}}}" href="#goToHead">
+<span>zum Seitenanfang</span>
+</a>
+</div>
+
+</div>
+</div>
+</div>
+<div id="footer" data-nosnippet="true">
+<div class="wrapper" role="navigation">
+<div class="section sectionA" data-ctrl-collapsible="{'id':'collfoot','action':{'default':['openEntries','disable'],'xs':['enable','closeEntries'],'s':['enable','closeEntries'],'m':['enable','closeEntries']}}">
+<h2 class="hidden">Links auf weitere Angebotsteile</h2>
+<div class="unitD" data-ctrl-collfoot-entry="{'id':'footerlinks-wdr-112'}" role="tablist">
+<h3 id="footerlinks-wdr-112-tab" data-ctrl-collfoot-footerlinks-wdr-112-trigger="{'action':{'default':['closeOtherEntries','toggleBody']}}" aria-controls="footerlinks-wdr-112-panel" role="tab">Der WDR</h3>
+<ul id="footerlinks-wdr-112-panel" data-ctrl-collfoot-footerlinks-wdr-112-body="{}" aria-labelledby="footerlinks-wdr-112-tab" role="tabpanel">
+<li><a href="/unternehmen/index.html">Unternehmen</a></li>
+<li><a href="/unternehmen/der-wdr/gremien/index.html">Aufsichtsgremien</a></li>
+<li><a href="https://www.rundfunkbeitrag.de/">Rundfunkbeitrag</a></li>
+<li><a href="https://presse.wdr.de/plounge/index.html">Presse</a></li>
+<li><a href="https://www1.wdr.de/unternehmen/der-wdr/karriere/">Karriere</a></li>
+<li><a href="/fernsehen/startseite/index.html">Fernsehen</a></li>
+<li><a href="https://www1.wdr.de/radio/radiolayer-104.html">Radio</a></li>
+<li><a href="/unternehmen/der-wdr/standorte/studios/index.html">Studios in NRW</a></li>
+</ul>
+</div>
+
+<div class="unitD" data-ctrl-collfoot-entry="{'id':'footerlinks-wdr-service-rebrush-100'}" role="tablist">
+<h3 id="footerlinks-wdr-service-rebrush-100-tab" data-ctrl-collfoot-footerlinks-wdr-service-rebrush-100-trigger="{'action':{'default':['closeOtherEntries','toggleBody']}}" aria-controls="footerlinks-wdr-service-rebrush-100-panel" role="tab">Service</h3>
+<ul id="footerlinks-wdr-service-rebrush-100-panel" data-ctrl-collfoot-footerlinks-wdr-service-rebrush-100-body="{}" aria-labelledby="footerlinks-wdr-service-rebrush-100-tab" role="tabpanel">
+<li><a href="https://www.wdr.de/programmvorschau/">Programmvorschau</a></li>
+<li><a href="/ki/ki-wdr/ki-im-wdr-104.html">KI im WDR</a></li>
+<li><a href="/unternehmen/der-wdr/dialog/hotlines-servicenummern100.html">Hotlines</a></li>
+<li><a href="/hilfe/uebersicht-barrierefreiheit-im-WDR-100.html">Barrierefreiheit</a></li>
+<li><a href="/hilfe/leichte-sprache/index.html">Leichte Sprache</a></li>
+<li><a href="/abisz120.html">Themen-Übersicht</a></li>
+<li><a href="/wdrtext/index.html">WDR Text</a></li>
+<li><a href="/korrekturen-100.html">Korrekturen</a></li>
+</ul>
+</div>
+
+<div class="foot">
+<h2 class="hidden">Globale Links</h2>
+<ul class="help">
+<li><a href="/impressum/index.html">Impressum</a>
+</li>
+<li><a href="/kontakt/index.html">Kontakt</a>
+</li>
+<li><a href="/hilfe/kommentarregeln100.html">Netiquette</a>
+</li>
+<li><a href="/hilfe/index.html">Hilfe</a>
+</li>
+<li><a href="/hilfe/datenschutz102.html">Datenschutz</a>
+</li>
+</ul>
+
+<p class="copy">
+<a href="/copyright/index.html" >&copy;
+WDR
+2026</a>
+</p>
+<a href="/index.html" class="logo">
+<img alt="zu Startseite WDR" title="zu Startseite WDR" src="/resources/img/wdr/logo/wdr_logo.svg"/>
+</a>
+</div>
+</div>
+<a href="#goToHead" class="hidden">Zum Anfang</a>
+</div>
+</div>
+
+
+<script src="/verbraucher/rezepte/resizer-kw-25-dimap-iframe100.js"></script>
+<script src="/verbraucher/rezepte/wahlembed-fix100.js"></script>
+<script src="/verbraucher/rezepte/searchFormBugFix100.js"></script>
+<script src="/verbraucher/rezepte/iframeresizer102.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
WDR recipes can have multiple ingredient sections, each introduced by its own `<h2>Zutaten …</h2>` heading. The scraper previously stopped at the first following `<h2>`, so only the first section was imported.

This change iterates all `Zutaten` headings and collects list items from each section.

Fixes incomplete imports for recipes like:
https://www1.wdr.de/verbraucher/rezepte/gorgonzola-tartine-mit-feigen-thymian-walnuss-gremolata-und-eingelegten-zwiebeln-100.html

## Checklist

- [x] Added/updated test HTML + expected JSON under `tests/test_data/www1.wdr.de/`
- [x] Existing WDR fixtures still pass